### PR TITLE
FastAPI Integration

### DIFF
--- a/dbos_transact/context.py
+++ b/dbos_transact/context.py
@@ -4,7 +4,10 @@ import os
 import uuid
 from contextvars import ContextVar
 from types import TracebackType
-from typing import Literal, Optional, Type
+from typing import TYPE_CHECKING, Literal, Optional, Type
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 from sqlalchemy.orm import Session
 
@@ -18,6 +21,8 @@ class DBOSContext:
         self.app_id = os.environ.get("DBOS__APPID", "")
 
         self.logger = dbos_logger
+
+        self.request: Optional["Request"] = None
 
         self.id_assigned_for_next_workflow: str = ""
 

--- a/dbos_transact/context.py
+++ b/dbos_transact/context.py
@@ -7,7 +7,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Literal, Optional, Type
 
 if TYPE_CHECKING:
-    from fastapi import Request
+    from .fastapi import Request
 
 from sqlalchemy.orm import Session
 

--- a/dbos_transact/context.py
+++ b/dbos_transact/context.py
@@ -305,6 +305,3 @@ class EnterDBOSTransaction:
         assert ctx.is_transaction()
         ctx.end_transaction()
         return False  # Did not handle
-
-
-# TODO Enter Child WF

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from fastapi import FastAPI
+    from fastapi import FastAPI, Request
 from sqlalchemy.orm import Session
 
 if sys.version_info < (3, 10):
@@ -459,6 +459,11 @@ class DBOS:
         ctx = assert_current_dbos_context()
         assert ctx.is_within_workflow()
         return ctx.parent_workflow_uuid
+
+    @classproperty
+    def request(cls) -> Optional["Request"]:
+        ctx = assert_current_dbos_context()
+        return ctx.request
 
     def _startup_recovery_thread(self, workflow_ids: List[str]) -> None:
         """

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from logging import Logger
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generic,
@@ -16,7 +17,9 @@ from typing import (
     cast,
 )
 
-from fastapi import FastAPI
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
 from sqlalchemy.orm import Session
 
 if sys.version_info < (3, 10):
@@ -109,7 +112,7 @@ def classproperty(func: Callable[..., G]) -> ClassPropertyDescriptor[G]:
 
 class DBOS:
     def __init__(
-        self, fastapi: Optional[FastAPI] = None, config: Optional[ConfigFile] = None
+        self, fastapi: Optional["FastAPI"] = None, config: Optional[ConfigFile] = None
     ) -> None:
         if config is None:
             config = load_config()

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -124,6 +124,10 @@ class DBOS:
         self.executor = ThreadPoolExecutor(max_workers=64)
         self.admin_server = AdminServer(dbos=self)
         self._run_startup_recovery_thread = True
+        if fastapi is not None:
+            from dbos_transact.fastapi import setup_fastapi_middleware
+
+            setup_fastapi_middleware(fastapi)
         if not os.environ.get("DBOS__VMID"):
             workflow_ids = self.sys_db.get_pending_workflows("local")
             self.executor.submit(self._startup_recovery_thread, workflow_ids)

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI
 from sqlalchemy.orm import Session
 
 if sys.version_info < (3, 10):
@@ -56,6 +56,9 @@ from .system_database import (
     WorkflowInputs,
     WorkflowStatusInternal,
 )
+
+if TYPE_CHECKING:
+    from .fastapi import Request
 
 P = ParamSpec("P")  # A generic type for workflow parameters
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -19,7 +19,6 @@ from typing import (
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
-
 from sqlalchemy.orm import Session
 
 if sys.version_info < (3, 10):

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -251,7 +251,9 @@ class DBOS:
             "app_id": ctx.app_id,
             "app_version": ctx.app_version,
             "executor_id": ctx.executor_id,
-            "request": utils.serialize(ctx.request),
+            "request": (
+                utils.serialize(ctx.request) if ctx.request is not None else None
+            ),
         }
         self.sys_db.update_workflow_status(status)
 
@@ -420,8 +422,7 @@ class DBOS:
         with DBOSContextEnsure():
             ctx = assert_current_dbos_context()
             request = status["request"]
-            assert request is not None
-            ctx.request = utils.deserialize(request)
+            ctx.request = utils.deserialize(request) if request is not None else None
             with SetWorkflowUUID(workflow_uuid):
                 return self.start_workflow(wf_func, *inputs["args"], **inputs["kwargs"])
 

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -211,7 +211,11 @@ class DBOS:
                     cur_ctx.workflow_uuid + "-" + str(cur_ctx.function_id)
                 )
 
-        new_wf_ctx = DBOSContext() if cur_ctx is None else cur_ctx.create_child()
+        new_wf_ctx = (
+            DBOSContext()
+            if cur_ctx is None
+            else cur_ctx.create_child() if cur_ctx.is_within_workflow() else cur_ctx
+        )
         new_wf_ctx.id_assigned_for_next_workflow = new_wf_ctx.assign_workflow_id()
 
         status = self._init_workflow(

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
 )
 
+from fastapi import FastAPI
 from sqlalchemy.orm import Session
 
 if sys.version_info < (3, 10):
@@ -107,7 +108,9 @@ def classproperty(func: Callable[..., G]) -> ClassPropertyDescriptor[G]:
 
 
 class DBOS:
-    def __init__(self, config: Optional[ConfigFile] = None) -> None:
+    def __init__(
+        self, fastapi: Optional[FastAPI] = None, config: Optional[ConfigFile] = None
+    ) -> None:
         if config is None:
             config = load_config()
         config_logger(config)

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -8,6 +8,10 @@ from .logger import dbos_logger
 
 
 class Request:
+    """
+    A serializable subset of the FastAPI request object
+    """
+
     def __init__(self, req: FastAPIRequest):
         self.headers = req.headers
         self.path_params = req.path_params

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 from fastapi import FastAPI
 from fastapi import Request as FastAPIRequest
 
-from .context import DBOSContextEnsure, assert_current_dbos_context
+from .context import DBOSContextEnsure, SetWorkflowUUID, assert_current_dbos_context
 from .logger import dbos_logger
 
 
@@ -27,10 +27,10 @@ def setup_fastapi_middleware(app: FastAPI) -> None:
     async def dbos_fastapi_middleware(
         request: FastAPIRequest, call_next: Callable[..., Any]
     ) -> Any:
-        dbos_logger.info("dbos")
         with DBOSContextEnsure():
             ctx = assert_current_dbos_context()
             ctx.request = Request(request)
-            response = await call_next(request)
-        dbos_logger.info("also dbos")
+            workflow_id = request.headers.get("dbos-idempotency-key", "")
+            with SetWorkflowUUID(workflow_id):
+                response = await call_next(request)
         return response

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -2,6 +2,7 @@ from typing import Any, Callable
 
 from fastapi import FastAPI, Request
 
+from .context import DBOSContextEnsure
 from .logger import dbos_logger
 
 
@@ -11,6 +12,7 @@ def setup_fastapi_middleware(app: FastAPI) -> None:
         request: Request, call_next: Callable[..., Any]
     ) -> Any:
         dbos_logger.info("dbos")
-        response = await call_next(request)
+        with DBOSContextEnsure():
+            response = await call_next(request)
         dbos_logger.info("also dbos")
         return response

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -1,0 +1,16 @@
+from typing import Any, Callable
+
+from fastapi import FastAPI, Request
+
+from .logger import dbos_logger
+
+
+def setup_fastapi_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def dbos_fastapi_middleware(
+        request: Request, call_next: Callable[..., Any]
+    ) -> Any:
+        dbos_logger.info("dbos")
+        response = await call_next(request)
+        dbos_logger.info("also dbos")
+        return response

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -1,20 +1,32 @@
 from typing import Any, Callable
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
+from fastapi import Request as FastAPIRequest
 
 from .context import DBOSContextEnsure, assert_current_dbos_context
 from .logger import dbos_logger
 
 
+class Request:
+    def __init__(self, req: FastAPIRequest):
+        self.headers = req.headers
+        self.path_params = req.path_params
+        self.query_params = req.query_params
+        self.url = req.url
+        self.base_url = req.base_url
+        self.client = req.client
+        self.cookies = req.cookies
+
+
 def setup_fastapi_middleware(app: FastAPI) -> None:
     @app.middleware("http")
     async def dbos_fastapi_middleware(
-        request: Request, call_next: Callable[..., Any]
+        request: FastAPIRequest, call_next: Callable[..., Any]
     ) -> Any:
         dbos_logger.info("dbos")
         with DBOSContextEnsure():
             ctx = assert_current_dbos_context()
-            ctx.request = request
+            ctx.request = Request(request)
             response = await call_next(request)
         dbos_logger.info("also dbos")
         return response

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -9,7 +9,7 @@ from .logger import dbos_logger
 
 class Request:
     """
-    A serializable subset of the FastAPI request object
+    A serializable subset of the FastAPI Request object
     """
 
     def __init__(self, req: FastAPIRequest):

--- a/dbos_transact/fastapi.py
+++ b/dbos_transact/fastapi.py
@@ -2,7 +2,7 @@ from typing import Any, Callable
 
 from fastapi import FastAPI, Request
 
-from .context import DBOSContextEnsure
+from .context import DBOSContextEnsure, assert_current_dbos_context
 from .logger import dbos_logger
 
 
@@ -13,6 +13,8 @@ def setup_fastapi_middleware(app: FastAPI) -> None:
     ) -> Any:
         dbos_logger.info("dbos")
         with DBOSContextEnsure():
+            ctx = assert_current_dbos_context()
+            ctx.request = request
             response = await call_next(request)
         dbos_logger.info("also dbos")
         return response

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -41,6 +41,7 @@ class WorkflowStatusInternal(TypedDict):
     executor_id: Optional[str]
     app_version: Optional[str]
     app_id: Optional[str]
+    request: Optional[str]  # JSON (jsonpickle)
 
 
 class RecordedResult(TypedDict):
@@ -125,6 +126,7 @@ class SystemDatabase:
                     executor_id=status["executor_id"],
                     application_version=status["app_version"],
                     application_id=status["app_id"],
+                    request=status["request"],
                 )
                 .on_conflict_do_update(
                     index_elements=["workflow_uuid"],
@@ -144,6 +146,7 @@ class SystemDatabase:
                 sa.select(
                     SystemSchema.workflow_status.c.status,
                     SystemSchema.workflow_status.c.name,
+                    SystemSchema.workflow_status.c.request,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -157,6 +160,7 @@ class SystemDatabase:
                 "app_id": None,
                 "app_version": None,
                 "executor_id": None,
+                "request": row[2],
             }
             return status
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:519825b766d899086270d92c0f6535b70327f9868c8694ab213afff6c8fcc4ec"
+content_hash = "sha256:c2230bddda54d58f5b3cdff54be63e6a1c45c6c5fcb6215741a7bc08cba28f57"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -352,6 +352,53 @@ files = [
     {file = "greenlet-3.0.3-cp39-cp39-win32.whl", hash = "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e"},
     {file = "greenlet-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067"},
     {file = "greenlet-3.0.3.tar.gz", hash = "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491"},
+]
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+requires_python = ">=3.7"
+summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+groups = ["dev"]
+dependencies = [
+    "typing-extensions; python_version < \"3.8\"",
+]
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.5"
+requires_python = ">=3.8"
+summary = "A minimal low-level HTTP client."
+groups = ["dev"]
+dependencies = [
+    "certifi",
+    "h11<0.15,>=0.13",
+]
+files = [
+    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
+    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+groups = ["dev"]
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+    "sniffio",
+]
+files = [
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "requests>=2.32.3",
     "types-requests>=2.32.0.20240712",
     "fastapi>=0.112.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.black]

--- a/templates/hello/main.py
+++ b/templates/hello/main.py
@@ -7,23 +7,19 @@ app = FastAPI()
 dbos = DBOS(app)
 
 
+@app.get("/greeting/{name}")
 @dbos.workflow()
-def example_workflow(var: str) -> str:
+def example_workflow(name: str) -> dict[str, str]:
     DBOS.logger.info("Running workflow!")
-    return example_transaction(var)
+    output = example_transaction(name)
+    return {"name": output}
 
 
 @dbos.transaction()
-def example_transaction(var: str) -> str:
+def example_transaction(name: str) -> str:
     rows = DBOS.sql_session.execute(
         sa.text(
             "INSERT INTO dbos_hello (name, greet_count) VALUES ('dbos', 1) ON CONFLICT (name) DO UPDATE SET greet_count = dbos_hello.greet_count + 1 RETURNING greet_count;"
         )
     ).all()
-    return var + str(rows[0][0])
-
-
-@app.get("/greeting/{name}")
-def hello_dbos(name: str) -> dict[str, str]:
-    output = example_workflow(name)
-    return {"name": output}
+    return name + str(rows[0][0])

--- a/templates/hello/main.py
+++ b/templates/hello/main.py
@@ -3,8 +3,8 @@ from fastapi import FastAPI
 
 from dbos_transact import DBOS
 
-dbos = DBOS()
 app = FastAPI()
+dbos = DBOS(app)
 
 
 @dbos.workflow()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def dbos(
     os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None
     os.environ.pop("DBOS__APPVERSION") if "DBOS__APPVERSION" in os.environ else None
     os.environ.pop("DBOS__APPID") if "DBOS__APPID" in os.environ else None
-    dbos = DBOS(config)
+    dbos = DBOS(config=config)
     yield dbos
     dbos.destroy()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import glob
 import os
 import subprocess
-from typing import Any, Generator
+from typing import Any, Generator, Tuple
 
 import pytest
 import sqlalchemy as sa
+from fastapi import FastAPI
 
 from dbos_transact import DBOS, ConfigFile
 
@@ -57,9 +58,7 @@ def postgres_db_engine() -> sa.Engine:
 
 
 @pytest.fixture()
-def dbos(
-    config: ConfigFile, postgres_db_engine: sa.Engine
-) -> Generator[DBOS, Any, None]:
+def cleanup_test_databases(config: ConfigFile, postgres_db_engine: sa.Engine) -> None:
     app_db_name = config["database"]["app_db_name"]
     sys_db_name = f"{app_db_name}_dbos_sys"
 
@@ -72,8 +71,24 @@ def dbos(
     os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None
     os.environ.pop("DBOS__APPVERSION") if "DBOS__APPVERSION" in os.environ else None
     os.environ.pop("DBOS__APPID") if "DBOS__APPID" in os.environ else None
+
+
+@pytest.fixture()
+def dbos(
+    config: ConfigFile, cleanup_test_databases: None
+) -> Generator[DBOS, Any, None]:
     dbos = DBOS(config=config)
     yield dbos
+    dbos.destroy()
+
+
+@pytest.fixture()
+def dbos_fastapi(
+    config: ConfigFile, cleanup_test_databases: None
+) -> Generator[Tuple[DBOS, FastAPI], Any, None]:
+    app = FastAPI()
+    dbos = DBOS(fastapi=app, config=config)
+    yield dbos, app
     dbos.destroy()
 
 

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -69,6 +69,7 @@ def test_admin_recovery(dbos: DBOS) -> None:
             "executor_id": None,
             "app_id": None,
             "app_version": None,
+            "request": None,
         }
     )
     status = dbos.sys_db.get_workflow_status(wfuuid)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -188,7 +188,7 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
     )
 
     dbos.destroy()
-    dbos.__init__(config)  # type: ignore
+    dbos.__init__(config=config)  # type: ignore
 
     @dbos.workflow()  # type: ignore
     def test_workflow(var: str) -> str:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -242,6 +242,7 @@ def test_recovery_workflow(dbos: DBOS) -> None:
             "executor_id": None,
             "app_id": None,
             "app_version": None,
+            "request": None,
         }
     )
 
@@ -279,6 +280,7 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
             "executor_id": None,
             "app_id": None,
             "app_version": None,
+            "request": None,
         }
     )
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -339,7 +339,7 @@ def test_start_workflow(dbos: DBOS) -> None:
 
 def test_without_fastapi(dbos: DBOS) -> None:
     """
-    Since DBOS does not depend on FastAPI directly, verify DBOS works in an environment with FastAPI.
+    Since DBOS does not depend on FastAPI directly, verify DBOS works in an environment without FastAPI.
     """
     # Unimport FastAPI
     for module_name in list(sys.modules.keys()):

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -368,3 +368,9 @@ def test_without_fastapi(dbos: DBOS) -> None:
                 importlib.reload(module)
     finally:
         sys.meta_path.remove(blocker)
+
+    @dbos.workflow()
+    def test_workflow(var: str) -> str:
+        return var
+
+    assert test_workflow("bob") == "bob"

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -245,7 +245,7 @@ def test_start_workflow(dbos: DBOS) -> None:
     assert wf_counter == 3
 
 
-def test_fastapi_imports(dbos: DBOS) -> None:
+def test_without_fastapi(dbos: DBOS) -> None:
     """
     Since DBOS does not depend on FastAPI directly, verify DBOS works in an environment with FastAPI.
     """

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -246,10 +246,15 @@ def test_start_workflow(dbos: DBOS) -> None:
 
 
 def test_fastapi_imports(dbos: DBOS) -> None:
+    """
+    Since DBOS does not depend on FastAPI directly, verify DBOS works in an environment with FastAPI.
+    """
+    # Unimport FastAPI
     for module_name in list(sys.modules.keys()):
         if module_name == "fastapi" or module_name.startswith("fastapi."):
             del sys.modules[module_name]
 
+    # Throw an error if FastAPI is imported
     class FastAPIBlocker(MetaPathFinder):
         def find_spec(
             self, fullname: str, path: Any = None, target: Any = None
@@ -260,6 +265,8 @@ def test_fastapi_imports(dbos: DBOS) -> None:
 
     blocker = FastAPIBlocker()
     sys.meta_path.insert(0, blocker)
+
+    # Reload all DBOS modules, verifying none import FastAPI
     try:
         for module_name in dict(sys.modules.items()):
             module = sys.modules[module_name]

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,5 +1,10 @@
+import importlib
+import sys
 import time
 import uuid
+from importlib.abc import MetaPathFinder
+from importlib.machinery import ModuleSpec
+from typing import Any, Optional
 
 import pytest
 import sqlalchemy as sa
@@ -238,3 +243,29 @@ def test_start_workflow(dbos: DBOS) -> None:
         assert test_workflow("bob", "bob") == "bob1bob"
     assert txn_counter == 1
     assert wf_counter == 3
+
+
+def test_fastapi_imports(dbos: DBOS) -> None:
+    for module_name in list(sys.modules.keys()):
+        if module_name == "fastapi" or module_name.startswith("fastapi."):
+            del sys.modules[module_name]
+
+    class FastAPIBlocker(MetaPathFinder):
+        def find_spec(
+            self, fullname: str, path: Any = None, target: Any = None
+        ) -> Optional[ModuleSpec]:
+            if fullname == "fastapi" or fullname.startswith("fastapi."):
+                raise ImportError(f"Illegal FastAPI import detected: {fullname}")
+            return None
+
+    blocker = FastAPIBlocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        for module_name in dict(sys.modules.items()):
+            module = sys.modules[module_name]
+            if module_name == "dbos_transact" or module_name.startswith(
+                "dbos_transact."
+            ):
+                importlib.reload(module)
+    finally:
+        sys.meta_path.remove(blocker)

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,0 +1,35 @@
+from typing import Tuple
+
+import sqlalchemy as sa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dbos_transact.dbos import DBOS
+
+
+def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
+    dbos, app = dbos_fastapi
+    client = TestClient(app)
+
+    @app.get("/{var}/{var2}")
+    def endpoint(var: str, var2: str) -> str:
+        return test_workflow(var, var2)
+
+    @dbos.workflow()
+    def test_workflow(var1: str, var2: str) -> str:
+        res1 = test_transaction(var1)
+        res2 = test_communicator(var2)
+        return res1 + res2
+
+    @dbos.transaction()
+    def test_transaction(var: str) -> str:
+        rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
+        return var + str(rows[0][0])
+
+    @dbos.communicator()
+    def test_communicator(var: str) -> str:
+        return var
+
+    response = client.get("/bob/bob")
+    assert response.status_code == 200
+    assert response.text == '"bob1bob"'

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -14,6 +14,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     @app.get("/{var1}/{var2}")
     @dbos.workflow()
     def test_workflow(var1: str, var2: str) -> str:
+        assert DBOS.request is not None
         res1 = test_transaction(var1)
         res2 = test_communicator(var2)
         return res1 + res2

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -11,10 +11,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     dbos, app = dbos_fastapi
     client = TestClient(app)
 
-    @app.get("/{var}/{var2}")
-    def endpoint(var: str, var2: str) -> str:
-        return test_workflow(var, var2)
-
+    @app.get("/{var1}/{var2}")
     @dbos.workflow()
     def test_workflow(var1: str, var2: str) -> str:
         res1 = test_transaction(var1)

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -40,7 +40,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     client = TestClient(app)
 
     @dbos.workflow()
-    def test_workflow(var1: str) -> dict[str, str]:
+    def test_workflow(var1: str) -> tuple[str, str]:
         assert DBOS.request is not None
         return var1, DBOS.workflow_id
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -39,22 +39,16 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     dbos, app = dbos_fastapi
     client = TestClient(app)
 
-    wfuuid = str(uuid.uuid4())
-
+    @app.get("/{var1}")
     @dbos.workflow()
-    def test_workflow(var1: str, var2: str) -> str:
+    def test_workflow(var1: str) -> dict[str, str]:
         assert DBOS.request is not None
-        return var1 + var2
+        return {"output": var1 + DBOS.workflow_id}
 
-    @app.get("/{var1}/{var2}")
-    def endpoint(var1: str, var2: str) -> str:
-        assert DBOS.request is not None
-        with SetWorkflowUUID(wfuuid):
-            return test_workflow(var1, var2)
-
-    response = client.get("/bob/bob")
+    wfuuid = str(uuid.uuid4())
+    response = client.get("/bob", headers={"dbos-idempotency-key": wfuuid})
     assert response.status_code == 200
-    assert response.text == '"bobbob"'
+    assert response.json() == {"output": f"bob{wfuuid}"}
 
     # Change the workflow status to pending
     dbos.sys_db.update_workflow_status(
@@ -74,4 +68,4 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     # Recovery should execute the workflow again but skip the transaction
     workflow_handles = dbos.recover_pending_workflows()
     assert len(workflow_handles) == 1
-    assert workflow_handles[0].get_result() == "bobbob"
+    assert workflow_handles[0].get_result() == {"output": f"bob{wfuuid}"}

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -60,7 +60,7 @@ def test_custom_sysdb_name_migration(
         connection.execute(sa.text(f"DROP DATABASE IF EXISTS {sysdb_name}"))
 
     # Test migrating up
-    dbos = DBOS(config)
+    dbos = DBOS(config=config)
 
     # Make sure all tables exist
     with dbos.sys_db.engine.connect() as connection:


### PR DESCRIPTION
- Create a context for FastAPI requests
- Record (a serializable subset of) the request in the context, and then in the system database
- Enable idempotency key headers
- Avoid a hard dependency on FastAPI