### PR TITLE
Implement send, recv, and sleep

### DIFF
--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -384,6 +384,18 @@ class DBOS:
 
         return decorator
 
+    def send(
+        self, destination_uuid: str, message: Any, topic: Optional[str] = None
+    ) -> None:
+        with EnterDBOSCommunicator() as ctx:
+            self.sys_db.send(
+                ctx.workflow_uuid,
+                ctx.curr_comm_function_id,
+                destination_uuid,
+                message,
+                topic,
+            )
+
     def execute_workflow_uuid(self, workflow_uuid: str) -> WorkflowHandle[Any]:
         """
         This function is used to execute a workflow by a UUID for recovery.

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -136,7 +136,7 @@ class DBOS:
         self.sys_db.destroy()
         self.app_db.destroy()
         self.admin_server.stop()
-        self.executor.shutdown()
+        self.executor.shutdown(cancel_futures=True)
 
     def workflow(self) -> Callable[[Workflow[P, R]], Workflow[P, R]]:
         def decorator(func: Workflow[P, R]) -> Workflow[P, R]:

--- a/dbos_transact/error.py
+++ b/dbos_transact/error.py
@@ -19,6 +19,7 @@ class DBOSErrorCode(Enum):
     RecoveryError = 2
     InitializationError = 3
     WorkflowFunctionNotFound = 4
+    NonExistentWorkflowError = 5
 
 
 class DBOSWorkflowConflictUUIDError(DBOSException):
@@ -50,4 +51,12 @@ class DBOSWorkflowFunctionNotFoundError(DBOSException):
         super().__init__(
             f"Workflow function not found for workflow UUID {workflow_uuid}: {message}",
             dbos_error_code=DBOSErrorCode.WorkflowFunctionNotFound.value,
+        )
+
+
+class DBOSNonExistentWorkflowError(DBOSException):
+    def __init__(self, destination_uuid: str):
+        super().__init__(
+            f"Sent to non-existent destination workflow UUID: {destination_uuid}",
+            dbos_error_code=DBOSErrorCode.NonExistentWorkflowError.value,
         )

--- a/dbos_transact/migrations/versions/a3b18ad34abe_added_triggers.py
+++ b/dbos_transact/migrations/versions/a3b18ad34abe_added_triggers.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
         """
       CREATE OR REPLACE FUNCTION dbos.notifications_function() RETURNS TRIGGER AS $$
       DECLARE
-          payload text := NEW.destination_uuid || '::' || NEW.topic;
+          payload text := NEW.destination_uuid || '::' || COALESCE(NEW.topic, '');
       BEGIN
           PERFORM pg_notify('dbos_notifications_channel', payload);
           RETURN NEW;

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -113,16 +113,12 @@ class SystemDatabase:
         command.upgrade(alembic_cfg, "head")
 
         # Start the notification listener
-        self.notification_client = self.engine.connect()
-        self.notification_client.execute(sa.text("LISTEN dbos_notifications_channel"))
-
-    @staticmethod
-    def _pg_notify(**kw: Any) -> None:
-        print(kw)
+        # self.notification_client = self.engine.connect()
+        # self.notification_client.execute(sa.text("LISTEN dbos_notifications_channel"))
 
     # Destroy the pool when finished
     def destroy(self) -> None:
-        self.notification_client.close()
+        # self.notification_client.close()
         self.engine.dispose()
 
     def update_workflow_status(self, status: WorkflowStatusInternal) -> None:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:519825b766d899086270d92c0f6535b70327f9868c8694ab213afff6c8fcc4ec"
+content_hash = "sha256:aae0ccd12b82b51b3e483b291019e22aca67f084fb9cebb44a1967cb4bd6c8d3"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -1317,6 +1317,17 @@ groups = ["dev"]
 files = [
     {file = "types-psutil-6.0.0.20240621.tar.gz", hash = "sha256:1be027326c42ff51ebd65255a5146f9dc57e5cf8c4f9519a88b3f3f6a7fcd00e"},
     {file = "types_psutil-6.0.0.20240621-py3-none-any.whl", hash = "sha256:b02f05d2c4141cd5926d82d8b56e4292a4d8f483d8a3400b73edf153834a3c64"},
+]
+
+[[package]]
+name = "types-psycopg2"
+version = "2.9.21.20240417"
+requires_python = ">=3.8"
+summary = "Typing stubs for psycopg2"
+groups = ["dev"]
+files = [
+    {file = "types-psycopg2-2.9.21.20240417.tar.gz", hash = "sha256:05db256f4a459fb21a426b8e7fca0656c3539105ff0208eaf6bdaf406a387087"},
+    {file = "types_psycopg2-2.9.21.20240417-py3-none-any.whl", hash = "sha256:644d6644d64ebbe37203229b00771012fb3b3bddd507a129a2e136485990e4f8"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "requests>=2.32.3",
     "types-requests>=2.32.0.20240712",
     "fastapi>=0.112.0",
+    "types-psycopg2>=2.9.21.20240417",
 ]
 
 [tool.black]

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -380,3 +380,4 @@ def test_send_recv(dbos: DBOS) -> None:
 
     handle = dbos.start_workflow(test_recv_workflow, "testtopic")
     test_send_workflow(handle.workflow_uuid, "testtopic")
+    assert handle.get_result() == "test"


### PR DESCRIPTION
This PR implements send, recv, and durable sleep. recv timeout is also durable, so it can wake up at the correct time.

Details:
- Use `threading.condition` to notify the receiver thread.
- Since sqlalchemy doesn't expose a raw psycopg2 connection, the notification client needs to be a separate psycopg2 client, not from the sqlalchemy engine's pool.