### PR TITLE
Implement setEvent and getEvent

### DIFF
--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -58,6 +58,7 @@ from .application_database import ApplicationDatabase, TransactionResultInternal
 from .dbos_config import ConfigFile, load_config
 from .logger import config_logger, dbos_logger
 from .system_database import (
+    GetEventWorkflowContext,
     OperationResultInternal,
     SystemDatabase,
     WorkflowInputs,
@@ -473,6 +474,34 @@ class DBOS:
             return
         with EnterDBOSCommunicator(attributes) as ctx:
             self.sys_db.sleep(ctx.workflow_uuid, ctx.curr_comm_function_id, seconds)
+
+    def set_event(self, key: str, value: Any) -> None:
+        with EnterDBOSCommunicator() as ctx:
+            self.sys_db.set_event(
+                ctx.workflow_uuid, ctx.curr_comm_function_id, key, value
+            )
+
+    def get_event(
+        self, workflow_uuid: str, key: str, timeout_seconds: float = 60
+    ) -> Any:
+        cur_ctx = get_local_dbos_context()
+        if cur_ctx is not None:
+            # Call it within a workflow
+            assert cur_ctx.is_workflow()
+            with EnterDBOSCommunicator() as ctx:
+                ctx.function_id += 1
+                timeout_function_id = ctx.function_id
+                caller_ctx: GetEventWorkflowContext = {
+                    "workflow_uuid": ctx.workflow_uuid,
+                    "function_id": ctx.curr_comm_function_id,
+                    "timeout_function_id": timeout_function_id,
+                }
+                return self.sys_db.get_event(
+                    workflow_uuid, key, timeout_seconds, caller_ctx
+                )
+        else:
+            # Directly call it outside of a workflow
+            return self.sys_db.get_event(workflow_uuid, key, timeout_seconds)
 
     def execute_workflow_uuid(self, workflow_uuid: str) -> WorkflowHandle[Any]:
         """

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -488,7 +488,10 @@ class DBOS:
         if cur_ctx is not None:
             # Must call it within a workflow
             assert cur_ctx.is_workflow()
-            with EnterDBOSCommunicator() as ctx:
+            attributes: TracedAttributes = {
+                "name": "set_event",
+            }
+            with EnterDBOSCommunicator(attributes) as ctx:
                 self.sys_db.set_event(
                     ctx.workflow_uuid, ctx.curr_comm_function_id, key, value
                 )
@@ -503,7 +506,10 @@ class DBOS:
         if cur_ctx is not None:
             # Call it within a workflow
             assert cur_ctx.is_workflow()
-            with EnterDBOSCommunicator() as ctx:
+            attributes: TracedAttributes = {
+                "name": "get_event",
+            }
+            with EnterDBOSCommunicator(attributes) as ctx:
                 ctx.function_id += 1
                 timeout_function_id = ctx.function_id
                 caller_ctx: GetEventWorkflowContext = {

--- a/dbos_transact/error.py
+++ b/dbos_transact/error.py
@@ -20,6 +20,7 @@ class DBOSErrorCode(Enum):
     InitializationError = 3
     WorkflowFunctionNotFound = 4
     NonExistentWorkflowError = 5
+    DuplicateWorkflowEventError = 6
 
 
 class DBOSWorkflowConflictUUIDError(DBOSException):
@@ -59,4 +60,12 @@ class DBOSNonExistentWorkflowError(DBOSException):
         super().__init__(
             f"Sent to non-existent destination workflow UUID: {destination_uuid}",
             dbos_error_code=DBOSErrorCode.NonExistentWorkflowError.value,
+        )
+
+
+class DBOSDuplicateWorkflowEventError(DBOSException):
+    def __init__(self, workflow_uuid: str, key: str):
+        super().__init__(
+            f"Workflow {workflow_uuid} has already emitted an event with key {key}",
+            dbos_error_code=DBOSErrorCode.DuplicateWorkflowEventError.value,
         )

--- a/dbos_transact/tracer.py
+++ b/dbos_transact/tracer.py
@@ -21,19 +21,20 @@ class DBOSTracer:
         self.executor_id = os.environ.get("DBOS__VMID", "local")
 
     def config(self, config: ConfigFile) -> None:
-        provider = TracerProvider()
-        if os.environ.get("DBOS__CONSOLE_TRACES", None) is not None:
-            processor = BatchSpanProcessor(ConsoleSpanExporter())
-            provider.add_span_processor(processor)
-        otlp_traces_endpoint = (
-            config.get("telemetry", {}).get("OTLPExporter", {}).get("tracesEndpoint")  # type: ignore
-        )
-        if otlp_traces_endpoint:
-            processor = BatchSpanProcessor(
-                OTLPSpanExporter(endpoint=otlp_traces_endpoint)
+        if not isinstance(trace.get_tracer_provider(), TracerProvider):
+            provider = TracerProvider()
+            if os.environ.get("DBOS__CONSOLE_TRACES", None) is not None:
+                processor = BatchSpanProcessor(ConsoleSpanExporter())
+                provider.add_span_processor(processor)
+            otlp_traces_endpoint = (
+                config.get("telemetry", {}).get("OTLPExporter", {}).get("tracesEndpoint")  # type: ignore
             )
-            provider.add_span_processor(processor)
-        trace.set_tracer_provider(provider)
+            if otlp_traces_endpoint:
+                processor = BatchSpanProcessor(
+                    OTLPSpanExporter(endpoint=otlp_traces_endpoint)
+                )
+                provider.add_span_processor(processor)
+            trace.set_tracer_provider(provider)
 
     def start_span(
         self, attributes: "TracedAttributes", parent: Optional[Span] = None

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -10,6 +10,7 @@ import pytest
 import sqlalchemy as sa
 
 from dbos_transact import DBOS, ConfigFile, SetWorkflowUUID
+from dbos_transact.error import DBOSException
 
 
 def test_simple_workflow(dbos: DBOS) -> None:
@@ -473,6 +474,11 @@ def test_send_recv(dbos: DBOS) -> None:
         assert duration < 0.3
         assert timeoutres is None
 
+    # Test recv outside of a workflow
+    with pytest.raises(Exception) as exc_info:
+        dbos.recv("test1")
+    assert "recv() must be called within a workflow" in str(exc_info.value)
+
 
 def test_set_get_events(dbos: DBOS) -> None:
     @dbos.workflow()
@@ -534,3 +540,8 @@ def test_set_get_events(dbos: DBOS) -> None:
     duration = time.time() - begin_time
     assert duration > 0.7
     assert res is None
+
+    # Test setEvent outside of a workflow
+    with pytest.raises(Exception) as exc_info:
+        dbos.set_event("key1", "value1")
+    assert "set_event() must be called within a workflow" in str(exc_info.value)


### PR DESCRIPTION
Mirror the logic in Transact-TS.

setEvent can only be called from within a workflow, getEvent can be called either outside of a workflow or within a workflow (not in Transaction or Communicator). If the getEvent is called in a workflow, we guarantee OAOO and durable timeout.