### PR TITLE
Transaction auto retry + support isolation levels

### DIFF
--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -438,6 +438,7 @@ class DBOS:
                                         max_retry_wait_seconds,
                                     )
                                     continue
+                                raise dbapi_error
                             except Exception as error:
                                 # Don't record the error if it was already recorded
                                 if not has_recorded_error:

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -388,8 +388,6 @@ class DBOS:
                         while True:
                             has_recorded_error = False
                             try:
-                                # TODO: support multiple isolation levels
-                                # TODO: handle serialization errors properly
                                 with session.begin():
                                     # This must be the first statement in the transaction!
                                     session.connection(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 
 from dbos_transact import DBOS, ConfigFile, SetWorkflowUUID
 from dbos_transact.context import get_local_dbos_context
-from dbos_transact.error import DBOSException
 from dbos_transact.system_database import GetWorkflowsInput
 
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -29,7 +29,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
         DBOS.logger.info("I'm test_workflow")
         return res + res2
 
-    @dbos.transaction()
+    @dbos.transaction(isolation_level="REPEATABLE READ")
     def test_transaction(var2: str) -> str:
         rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
         nonlocal txn_counter
@@ -222,7 +222,7 @@ def test_temp_workflow(dbos: DBOS) -> None:
     gwi: GetWorkflowsInput = GetWorkflowsInput()
     gwi.start_time = cur_time
 
-    @dbos.transaction()
+    @dbos.transaction(isolation_level="READ COMMITTED")
     def test_transaction(var2: str) -> str:
         rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
         nonlocal txn_counter

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -4,24 +4,19 @@ from dbos_transact import DBOS
 
 
 def test_transaction_errors(dbos: DBOS) -> None:
-    txn_counter: int = 0
-
-    @dbos.workflow()
-    def test_workflow(max_retry: int) -> int:
-        res = test_transaction(max_retry)
-        return res
+    retry_counter: int = 0
 
     @dbos.transaction()
-    def test_transaction(max_retry: int) -> int:
-        nonlocal txn_counter
-        if txn_counter < max_retry:
-            txn_counter += 1
+    def test_retry_transaction(max_retry: int) -> int:
+        nonlocal retry_counter
+        if retry_counter < max_retry:
+            retry_counter += 1
             base_err = BaseException()
             base_err.pgcode = "40001"  # type: ignore
             err = DBAPIError("Serialization test error", {}, base_err)
             raise err
         return max_retry
 
-    res = test_workflow(10)
+    res = test_retry_transaction(10)
     assert res == 10
-    assert txn_counter == 10
+    assert retry_counter == 10

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1,0 +1,27 @@
+from sqlalchemy.exc import DBAPIError
+
+from dbos_transact import DBOS
+
+
+def test_transaction_errors(dbos: DBOS) -> None:
+    txn_counter: int = 0
+
+    @dbos.workflow()
+    def test_workflow(max_retry: int) -> int:
+        res = test_transaction(max_retry)
+        return res
+
+    @dbos.transaction()
+    def test_transaction(max_retry: int) -> int:
+        nonlocal txn_counter
+        if txn_counter < max_retry:
+            txn_counter += 1
+            base_err = BaseException()
+            base_err.pgcode = "40001"  # type: ignore
+            err = DBAPIError("Serialization test error", {}, base_err)
+            raise err
+        return max_retry
+
+    res = test_workflow(10)
+    assert res == 10
+    assert txn_counter == 10


### PR DESCRIPTION
- Keep retrying a transaction if it failed with a serialization error.
- Support multiple isolation levels, passed through the `transaction` decorator.