### PR TITLE
Fix Logs

### DIFF
--- a/dbos_transact/admin_sever.py
+++ b/dbos_transact/admin_sever.py
@@ -46,10 +46,6 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         self._end_headers()
 
     def do_GET(self) -> None:
-        dbos_logger.debug(
-            "GET request,\nPath: %s\nHeaders:\n%s\n", str(self.path), str(self.headers)
-        )
-
         if self.path == health_check_path:
             self.send_response(200)
             self._end_headers()
@@ -63,12 +59,6 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             self.headers["Content-Length"]
         )  # <--- Gets the size of data
         post_data = self.rfile.read(content_length)  # <--- Gets the data itself
-        dbos_logger.debug(
-            "POST request,\nPath: %s\nHeaders:\n%s\n\nBody:\n%s\n",
-            str(self.path),
-            str(self.headers),
-            post_data.decode("utf-8"),
-        )
 
         if self.path == workflow_recovery_path:
             executor_ids: List[str] = json.loads(post_data.decode("utf-8"))

--- a/dbos_transact/admin_sever.py
+++ b/dbos_transact/admin_sever.py
@@ -71,3 +71,6 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         else:
             self.send_response(404)
             self._end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return  # Disable admin server request logging

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -177,6 +177,8 @@ class DBOS:
         set_dbos_func_name(send_temp_workflow, TEMP_SEND_WF_NAME)
         self.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf)
         dbos_logger.info("DBOS initialized")
+        for handler in dbos_logger.handlers:
+            handler.flush()
 
     def destroy(self) -> None:
         self._run_startup_recovery_thread = False

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -176,7 +176,7 @@ class DBOS:
         temp_send_wf = self.workflow_wrapper(send_temp_workflow)
         set_dbos_func_name(send_temp_workflow, TEMP_SEND_WF_NAME)
         self.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf)
-        dbos_logger.info("DBOS successfully initialized")
+        dbos_logger.info("DBOS initialized")
 
     def destroy(self) -> None:
         self._run_startup_recovery_thread = False

--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -148,7 +148,7 @@ class DBOS:
             config = load_config()
         config_logger(config)
         dbos_tracer.config(config)
-        dbos_logger.info("Initializing DBOS!")
+        dbos_logger.info("Initializing DBOS")
         self.config = config
         self.sys_db = SystemDatabase(config)
         self.app_db = ApplicationDatabase(config)
@@ -176,6 +176,7 @@ class DBOS:
         temp_send_wf = self.workflow_wrapper(send_temp_workflow)
         set_dbos_func_name(send_temp_workflow, TEMP_SEND_WF_NAME)
         self.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf)
+        dbos_logger.info("DBOS successfully initialized")
 
     def destroy(self) -> None:
         self._run_startup_recovery_thread = False

--- a/dbos_transact/logger.py
+++ b/dbos_transact/logger.py
@@ -74,6 +74,3 @@ def config_logger(config: ConfigFile) -> None:
             # Attach DBOS-specific attributes to all log entries.
             log_transformer = DBOSLogTransformer()
             dbos_logger.addFilter(log_transformer)
-
-            logger_names = list(logging.root.manager.loggerDict.keys())
-            print(logger_names)

--- a/dbos_transact/logger.py
+++ b/dbos_transact/logger.py
@@ -56,7 +56,10 @@ def config_logger(config: ConfigFile) -> None:
             )
             set_logger_provider(log_provider)
             log_provider.add_log_record_processor(
-                BatchLogRecordProcessor(OTLPLogExporter(endpoint=otlp_logs_endpoint))
+                BatchLogRecordProcessor(
+                    OTLPLogExporter(endpoint=otlp_logs_endpoint),
+                    export_timeout_millis=5000,
+                )
             )
             otlp_handler = LoggingHandler(logger_provider=log_provider)
             dbos_logger.addHandler(otlp_handler)

--- a/dbos_transact/logger.py
+++ b/dbos_transact/logger.py
@@ -74,3 +74,8 @@ def config_logger(config: ConfigFile) -> None:
             # Attach DBOS-specific attributes to all log entries.
             log_transformer = DBOSLogTransformer()
             dbos_logger.addFilter(log_transformer)
+
+            # Attach the OTel logger and transformer to the root logger
+            root_logger = logging.getLogger()
+            root_logger.addHandler(otlp_handler)
+            root_logger.addFilter(log_transformer)

--- a/dbos_transact/logger.py
+++ b/dbos_transact/logger.py
@@ -53,7 +53,7 @@ def config_logger(config: ConfigFile) -> None:
             config.get("telemetry", {}).get("OTLPExporter", {}).get("logsEndpoint")  # type: ignore
         )
         if otlp_logs_endpoint:
-            # Configure the DBOS logger to also log to the OTel endpoint.
+            # Also log to the OTLP endpoint if provided
             log_provider = PatchedOTLPLoggerProvider(
                 Resource.create(
                     attributes={
@@ -75,7 +75,7 @@ def config_logger(config: ConfigFile) -> None:
             log_transformer = DBOSLogTransformer()
             dbos_logger.addFilter(log_transformer)
 
-            # Attach the OTel logger and transformer to the root logger
+            # Attach the OTLP logger and transformer to the root logger
             root_logger = logging.getLogger()
             root_logger.addHandler(otlp_handler)
             root_logger.addFilter(log_transformer)


### PR DESCRIPTION
- Address issues caused by an OTLP bug which were causing slow startups in DBOS Cloud due to a timeout
- Improve logging messages
- Attach OTLP to the root logger so non-DBOS logs are also visible from the Cloud.