### PR TITLE
Retrieve workflow, get status

### DIFF
--- a/dbos_transact/dbos.py
+++ b/dbos_transact/dbos.py
@@ -156,8 +156,11 @@ class WorkflowHandleFuture(WorkflowHandle[R]):
     def get_result(self) -> R:
         return self.future.result()
 
-    def get_status(self) -> Optional[WorkflowStatus]:
-        return self.dbos.get_workflow_status(self.workflow_uuid)
+    def get_status(self) -> WorkflowStatus:
+        stat = self.dbos.get_workflow_status(self.workflow_uuid)
+        if stat is None:
+            raise DBOSNonExistentWorkflowError(self.workflow_uuid)
+        return stat
 
 
 class PollingWorkflowHandle(WorkflowHandle[R]):
@@ -170,8 +173,11 @@ class PollingWorkflowHandle(WorkflowHandle[R]):
         res: R = self.dbos.sys_db.await_workflow_result(self.workflow_uuid)
         return res
 
-    def get_status(self) -> Optional[WorkflowStatus]:
-        return self.dbos.get_workflow_status(self.workflow_uuid)
+    def get_status(self) -> WorkflowStatus:
+        stat = self.dbos.get_workflow_status(self.workflow_uuid)
+        if stat is None:
+            raise DBOSNonExistentWorkflowError(self.workflow_uuid)
+        return stat
 
 
 IsolationLevel = Literal[

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -75,32 +75,22 @@ class GetEventWorkflowContext(TypedDict):
 
 class GetWorkflowsInput:
     def __init__(self) -> None:
-        self.name = None
-        self.authenticated_user = None
-        self.start_time = None
-        self.end_time = None
-        self.status = None
-        self.application_version = None
-        self.limit = None
-
-    name: Optional[str]  # The name of the workflow function
-    authenticated_user: Optional[str]  # The user who ran the workflow.
-    start_time: Optional[str]  # Timestamp in ISO 8601 format
-    end_time: Optional[str]  # Timestamp in ISO 8601 format
-    status: Optional[WorkflowStatuses]
-    application_version: Optional[
-        str
-    ]  # The application version that ran this workflow.
-    limit: Optional[
-        int
-    ]  # Return up to this many workflows IDs. IDs are ordered by workflow creation time.
+        self.name: Optional[str] = None  # The name of the workflow function
+        self.authenticated_user: Optional[str] = None  # The user who ran the workflow.
+        self.start_time: Optional[str] = None  # Timestamp in ISO 8601 format
+        self.end_time: Optional[str] = None  # Timestamp in ISO 8601 format
+        self.status: Optional[WorkflowStatuses] = None
+        self.application_version: Optional[str] = (
+            None  # The application version that ran this workflow. = None
+        )
+        self.limit: Optional[int] = (
+            None  # Return up to this many workflows IDs. IDs are ordered by workflow creation time.
+        )
 
 
 class GetWorkflowsOutput:
     def __init__(self, workflow_uuids: List[str]):
         self.workflow_uuids = workflow_uuids
-
-    workflow_uuids: List[str]
 
 
 class WorkflowInformation(TypedDict, total=False):

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -338,11 +338,19 @@ class SystemDatabase:
                 ).fetchone()
                 if row is not None:
                     status = row[0]
-                    if status == str(WorkflowStatusString.SUCCESS):
-                        return {"output": row[1], "workflow_uuid": workflow_uuid}
+                    if status == str(WorkflowStatusString.SUCCESS.value):
+                        return {
+                            "status": status,
+                            "output": row[1],
+                            "workflow_uuid": workflow_uuid,
+                        }
 
-                    elif status == str(WorkflowStatusString.ERROR):
-                        return {"error": row[1], "workflow_uuid": workflow_uuid}
+                    elif status == str(WorkflowStatusString.ERROR.value):
+                        return {
+                            "status": status,
+                            "error": row[1],
+                            "workflow_uuid": workflow_uuid,
+                        }
 
                 else:
                     pass  # CB: I guess we're assuming the WF will show up eventually.
@@ -354,9 +362,9 @@ class SystemDatabase:
         if not stat:
             return None
         status: str = stat["status"]
-        if status == str(WorkflowStatusString.SUCCESS):
+        if status == str(WorkflowStatusString.SUCCESS.value):
             return utils.deserialize(stat["output"])
-        elif status == str(WorkflowStatusString.ERROR):
+        elif status == str(WorkflowStatusString.ERROR.value):
             raise utils.deserialize(stat["error"])
         return None
 

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -352,7 +352,7 @@ class SystemDatabase:
                     elif status == str(WorkflowStatusString.ERROR.value):
                         return {
                             "status": status,
-                            "error": row[1],
+                            "error": row[2],
                             "workflow_uuid": workflow_uuid,
                         }
 

--- a/dbos_transact/system_database.py
+++ b/dbos_transact/system_database.py
@@ -274,6 +274,26 @@ class SystemDatabase:
             }
             return status
 
+    def get_workflow_status_within_wf(
+        self, workflow_uuid: str, calling_wf: str, calling_wf_fn: int
+    ) -> Optional[WorkflowStatusInternal]:
+        res = self.check_operation_execution(calling_wf, calling_wf_fn)
+        if res is not None:
+            if res["output"]:
+                resstat: WorkflowStatusInternal = utils.deserialize(res["output"])
+                return resstat
+            return None
+        stat = self.get_workflow_status(workflow_uuid)
+        self.record_operation_result(
+            {
+                "workflow_uuid": calling_wf,
+                "function_id": calling_wf_fn,
+                "output": utils.serialize(stat),
+                "error": None,
+            }
+        )
+        return stat
+
     def get_workflow_status_w_outputs(
         self, workflow_uuid: str
     ) -> Optional[WorkflowStatusInternal]:

--- a/dbos_transact/workflow.py
+++ b/dbos_transact/workflow.py
@@ -1,7 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from dataclasses import dataclass
+from typing import Generic, List, Optional, TypeVar
 
 R = TypeVar("R", covariant=True)
+
+
+@dataclass
+class WorkflowStatus:
+    workflow_uuid: str
+    status: str
+    name: str
+    class_name: Optional[str]
+    config_name: Optional[str]
+    authenticated_user: Optional[str]
+    assumed_role: Optional[str]
+    authenticatedRoles: Optional[List[str]]
 
 
 class WorkflowHandle(Generic[R], ABC):
@@ -16,4 +29,7 @@ class WorkflowHandle(Generic[R], ABC):
         """Should be handled in the subclasses"""
         raise Exception()
 
-    # TODO get status
+    @abstractmethod
+    def get_status(self) -> Optional[WorkflowStatus]:
+        """Should be handled in the subclasses"""
+        raise Exception()

--- a/dbos_transact/workflow.py
+++ b/dbos_transact/workflow.py
@@ -30,6 +30,6 @@ class WorkflowHandle(Generic[R], ABC):
         raise Exception()
 
     @abstractmethod
-    def get_status(self) -> Optional[WorkflowStatus]:
+    def get_status(self) -> WorkflowStatus:
         """Should be handled in the subclasses"""
         raise Exception()

--- a/dbos_transact/workflow.py
+++ b/dbos_transact/workflow.py
@@ -1,17 +1,19 @@
-from concurrent.futures import Future
+from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
-R = TypeVar("R")
+R = TypeVar("R", covariant=True)
 
 
-class WorkflowHandle(Generic[R]):
-
-    def __init__(self, workflow_uuid: str, future: Future[R]):
+class WorkflowHandle(Generic[R], ABC):
+    def __init__(self, workflow_uuid: str):
         self.workflow_uuid = workflow_uuid
-        self.future = future
 
     def get_workflow_uuid(self) -> str:
         return self.workflow_uuid
 
+    @abstractmethod
     def get_result(self) -> R:
-        return self.future.result()
+        """Should be handled in the subclasses"""
+        raise Exception()
+
+    # TODO get status

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -70,6 +70,7 @@ def test_admin_recovery(dbos: DBOS) -> None:
             "app_id": None,
             "app_version": None,
             "request": None,
+            "recovery_attempts": None,
         }
     )
     status = dbos.sys_db.get_workflow_status(wfuuid)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -489,8 +489,11 @@ def test_retrieve_workflow(dbos: DBOS) -> None:
         dbos.sleep(secs)
         raise Exception("Wake Up!")
 
+    dest_uuid = "aaaa"
     with pytest.raises(Exception) as exc_info:
-        dbos.retrieve_workflow("aaaa")
+        dbos.retrieve_workflow(dest_uuid)
+    pattern = f"Sent to non-existent destination workflow UUID: {dest_uuid}"
+    assert pattern in str(exc_info.value)
 
     # These return
     sleep_wfh = dbos.start_workflow(test_sleep_workflow, 1.5)
@@ -523,12 +526,14 @@ def test_retrieve_workflow(dbos: DBOS) -> None:
 
     with pytest.raises(Exception) as exc_info:
         sleep_pwfh.get_result()
+    assert str(exc_info.value) == "Wake Up!"
     istat = sleep_pwfh.get_status()
     assert istat
     assert istat.status == str(WorkflowStatusString.ERROR.value)
 
     with pytest.raises(Exception) as exc_info:
         sleep_wfh.get_result()
+    assert str(exc_info.value) == "Wake Up!"
     istat = sleep_wfh.get_status()
     assert istat
     assert istat.status == str(WorkflowStatusString.ERROR.value)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -552,9 +552,12 @@ def test_retrieve_workflow_in_workflow(dbos: DBOS) -> None:
         assert fstat2
         return fstat1.status + fres + fstat2.status
 
+    @dbos.workflow()
     def test_workflow_status_b() -> str:
+        assert DBOS.workflow_id == "parent_b"
         with SetWorkflowUUID("run_this_once_b"):
             wfh = dbos.start_workflow(test_sleep_workflow, 1.5)
+        assert DBOS.workflow_id == "parent_b"
 
         fstat1 = wfh.get_status()
         assert fstat1

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -76,6 +76,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "app_id": None,
             "app_version": None,
             "request": None,
+            "recovery_attempts": None,
         }
     )
 


### PR DESCRIPTION
Add a get_status and retrieve_workflow API, which work from handles that are not in posession of the task's future.
Fix start_workflow to not update the workflow status back to PENDING if it was already launched
More tests