### PR TITLE
Configurable communicator retries

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,4 +1,3 @@
-from .context import CommunicatorConfig as CommunicatorConfig
 from .context import SetWorkflowUUID as SetWorkflowUUID
 from .dbos import DBOS as DBOS
 from .dbos_config import ConfigFile as ConfigFile

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,3 +1,4 @@
+from .context import CommunicatorConfig as CommunicatorConfig
 from .context import SetWorkflowUUID as SetWorkflowUUID
 from .dbos import DBOS as DBOS
 from .dbos_config import ConfigFile as ConfigFile

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -56,7 +56,7 @@ from dbos.context import (
     get_local_dbos_context,
 )
 from dbos.error import (
-    DBOSCommunicatorMaxRetriedError,
+    DBOSCommunicatorMaxRetriesExceededError,
     DBOSException,
     DBOSNonExistentWorkflowError,
     DBOSRecoveryError,
@@ -616,7 +616,7 @@ class DBOS:
                                     },
                                 )
                                 if attempt == local_max_attempts:
-                                    error = DBOSCommunicatorMaxRetriedError()
+                                    error = DBOSCommunicatorMaxRetriesExceededError()
                                 else:
                                     time.sleep(local_interval_seconds)
                                     local_interval_seconds = min(

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from functools import wraps
 from logging import Logger
 from typing import (
@@ -112,6 +113,15 @@ class CommunicatorProtocol(Protocol):
 
 
 Communicator = TypeVar("Communicator", bound=CommunicatorProtocol)
+
+
+# Mirror the CommunicatorConfig from TS.
+@dataclass
+class CommunicatorConfig:
+    retries_allowed: bool = True
+    interval_seconds: float = 1.0
+    max_attempts: int = 3
+    backoff_factor: float = 2.0
 
 
 def get_dbos_func_name(f: Any) -> str:
@@ -552,7 +562,9 @@ class DBOS:
 
         return decorator
 
-    def communicator(self) -> Callable[[Communicator], Communicator]:
+    def communicator(
+        self, config: CommunicatorConfig = CommunicatorConfig()
+    ) -> Callable[[Communicator], Communicator]:
         def decorator(func: Communicator) -> Communicator:
 
             def invoke_comm(*args: Any, **kwargs: Any) -> Any:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import time
+import traceback
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import wraps
 from logging import Logger
@@ -79,7 +80,6 @@ from .system_database import (
 if TYPE_CHECKING:
     from .fastapi import Request
 
-import traceback
 
 P = ParamSpec("P")  # A generic type for workflow parameters
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values

--- a/dbos/error.py
+++ b/dbos/error.py
@@ -21,6 +21,7 @@ class DBOSErrorCode(Enum):
     WorkflowFunctionNotFound = 4
     NonExistentWorkflowError = 5
     DuplicateWorkflowEventError = 6
+    CommunicatorMaxRetried = 7
 
 
 class DBOSWorkflowConflictUUIDError(DBOSException):
@@ -68,4 +69,12 @@ class DBOSDuplicateWorkflowEventError(DBOSException):
         super().__init__(
             f"Workflow {workflow_uuid} has already emitted an event with key {key}",
             dbos_error_code=DBOSErrorCode.DuplicateWorkflowEventError.value,
+        )
+
+
+class DBOSCommunicatorMaxRetriedError(DBOSException):
+    def __init__(self) -> None:
+        super().__init__(
+            "Communicator reached maximum retries.",
+            dbos_error_code=DBOSErrorCode.CommunicatorMaxRetried.value,
         )

--- a/dbos/error.py
+++ b/dbos/error.py
@@ -21,7 +21,7 @@ class DBOSErrorCode(Enum):
     WorkflowFunctionNotFound = 4
     NonExistentWorkflowError = 5
     DuplicateWorkflowEventError = 6
-    CommunicatorMaxRetried = 7
+    CommunicatorMaxRetriesExceeded = 7
 
 
 class DBOSWorkflowConflictUUIDError(DBOSException):
@@ -72,9 +72,9 @@ class DBOSDuplicateWorkflowEventError(DBOSException):
         )
 
 
-class DBOSCommunicatorMaxRetriedError(DBOSException):
+class DBOSCommunicatorMaxRetriesExceededError(DBOSException):
     def __init__(self) -> None:
         super().__init__(
             "Communicator reached maximum retries.",
-            dbos_error_code=DBOSErrorCode.CommunicatorMaxRetried.value,
+            dbos_error_code=DBOSErrorCode.CommunicatorMaxRetriesExceeded.value,
         )

--- a/templates/hello/dbos-config.yaml
+++ b/templates/hello/dbos-config.yaml
@@ -1,7 +1,7 @@
 # To enable auto-completion and validation for this file in VSCode, install the RedHat YAML extension
 # https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/dbos-inc/dbos-transact/main/dbos-config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dbos-inc/dbos-transact-py/main/dbos/dbos-config.schema.json
 
 name: hello-python
 language: python

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 import pytest
 import sqlalchemy as sa
 
-from dbos import DBOS, CommunicatorConfig, ConfigFile, SetWorkflowUUID
+from dbos import DBOS, ConfigFile, SetWorkflowUUID
 from dbos.context import get_local_dbos_context
 from dbos.error import DBOSCommunicatorMaxRetriedError
 from dbos.system_database import GetWorkflowsInput, WorkflowStatusString
@@ -280,7 +280,7 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
         comm_counter += 1
         raise Exception(var)
 
-    @dbos.communicator(CommunicatorConfig(retries_allowed=True))
+    @dbos.communicator(retries_allowed=True)
     def test_retried_communicator(var: str) -> str:
         nonlocal retried_comm_counter
         retried_comm_counter += 1

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 from dbos import DBOS, ConfigFile, SetWorkflowUUID
 from dbos.context import get_local_dbos_context
-from dbos.error import DBOSCommunicatorMaxRetriedError
+from dbos.error import DBOSCommunicatorMaxRetriesExceededError
 from dbos.system_database import GetWorkflowsInput, WorkflowStatusString
 from dbos.workflow import WorkflowHandle
 
@@ -294,7 +294,7 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
         test_communicator("cval")
     assert "cval" == str(exc_info.value)
 
-    with pytest.raises(DBOSCommunicatorMaxRetriedError) as exc_info:
+    with pytest.raises(DBOSCommunicatorMaxRetriesExceededError) as exc_info:
         test_retried_communicator("rval")
 
     assert txn_counter == 1

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -10,9 +10,9 @@ from typing import Any, Optional
 import pytest
 import sqlalchemy as sa
 
-from dbos import DBOS, ConfigFile, SetWorkflowUUID
+from dbos import DBOS, CommunicatorConfig, ConfigFile, SetWorkflowUUID
 from dbos.context import get_local_dbos_context
-from dbos.error import DBOSException
+from dbos.error import DBOSCommunicatorMaxRetriedError
 from dbos.system_database import GetWorkflowsInput, WorkflowStatusString
 from dbos.workflow import WorkflowHandle
 
@@ -262,6 +262,7 @@ def test_temp_workflow(dbos: DBOS) -> None:
 def test_temp_workflow_errors(dbos: DBOS) -> None:
     txn_counter: int = 0
     comm_counter: int = 0
+    retried_comm_counter: int = 0
 
     cur_time: str = datetime.datetime.now().isoformat()
     gwi: GetWorkflowsInput = GetWorkflowsInput()
@@ -279,6 +280,12 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
         comm_counter += 1
         raise Exception(var)
 
+    @dbos.communicator(CommunicatorConfig(retries_allowed=True))
+    def test_retried_communicator(var: str) -> str:
+        nonlocal retried_comm_counter
+        retried_comm_counter += 1
+        raise Exception(var)
+
     with pytest.raises(Exception) as exc_info:
         test_transaction("tval")
     assert "tval" == str(exc_info.value)
@@ -287,8 +294,12 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
         test_communicator("cval")
     assert "cval" == str(exc_info.value)
 
+    with pytest.raises(DBOSCommunicatorMaxRetriedError) as exc_info:
+        test_retried_communicator("rval")
+
     assert txn_counter == 1
     assert comm_counter == 1
+    assert retried_comm_counter == 3
 
 
 def test_recovery_workflow(dbos: DBOS) -> None:


### PR DESCRIPTION
This PR implements configurable communicator retries.

Its behavior is mostly identical to TS, except that `retries_allowed` is set to `False` by default.

Also fix a minor typo in the json schema URL.