### PR TITLE
Handle workflow conflict error

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -36,4 +36,4 @@ Their version number is `<next-release-version>a<number-of-git-commits-since-rel
 
 ### Publishing
 
-TODO: Add a GHA to publish from a branch.
+Run the [`Publish to PyPI`](./.github/workflows/publish.yml) GitHub action on the target branch.

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -427,8 +427,10 @@ class DBOS:
         try:
             output = func(*args, **kwargs)
         except DBOSWorkflowConflictUUIDError as wferror:
-            # TODO: handle this properly by waiting/returning the output
-            raise wferror
+            # Retrieve the workflow handle and wait for the result.
+            wf_handle: WorkflowHandle[R] = self.retrieve_workflow(DBOS.workflow_id)
+            output = wf_handle.get_result()
+            return output
         except Exception as error:
             status["status"] = "ERROR"
             status["error"] = utils.serialize(error)

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -426,7 +426,7 @@ class DBOS:
     ) -> R:
         try:
             output = func(*args, **kwargs)
-        except DBOSWorkflowConflictUUIDError as wferror:
+        except DBOSWorkflowConflictUUIDError:
             # Retrieve the workflow handle and wait for the result.
             wf_handle: WorkflowHandle[R] = self.retrieve_workflow(DBOS.workflow_id)
             output = wf_handle.get_result()

--- a/make_release.py
+++ b/make_release.py
@@ -13,12 +13,14 @@ def make_release(version_number: Optional[str] = None) -> None:
     if repo.is_dirty():
         raise Exception("Local git repository is not clean")
     if repo.active_branch.name != "main":
-        raise Exception("Can only make a release from main")    
-    remote_branch = repo.references[f'origin/{repo.active_branch.name}']
+        raise Exception("Can only make a release from main")
+    remote_branch = repo.references[f"origin/{repo.active_branch.name}"]
     local_commit = repo.active_branch.commit
     remote_commit = remote_branch.commit
     if local_commit != remote_commit:
-        raise Exception(f"Your local branch {repo.active_branch.name} is not up to date with origin.")
+        raise Exception(
+            f"Your local branch {repo.active_branch.name} is not up to date with origin."
+        )
 
     if version_number is None:
         version_number = guess_next_version(repo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,19 +64,27 @@ def cleanup_test_databases(config: ConfigFile, postgres_db_engine: sa.Engine) ->
 
     with postgres_db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
-        connection.execute(sa.text(f"""
+        connection.execute(
+            sa.text(
+                f"""
             SELECT pg_terminate_backend(pg_stat_activity.pid)
             FROM pg_stat_activity
             WHERE pg_stat_activity.datname = '{app_db_name}'
             AND pid <> pg_backend_pid()
-        """))
+        """
+            )
+        )
         connection.execute(sa.text(f"DROP DATABASE IF EXISTS {app_db_name}"))
-        connection.execute(sa.text(f"""
+        connection.execute(
+            sa.text(
+                f"""
             SELECT pg_terminate_backend(pg_stat_activity.pid)
             FROM pg_stat_activity
             WHERE pg_stat_activity.datname = '{sys_db_name}'
             AND pid <> pg_backend_pid()
-        """))
+        """
+            )
+        )
         connection.execute(sa.text(f"DROP DATABASE IF EXISTS {sys_db_name}"))
 
     # Clean up environment variables

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -71,7 +71,6 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
                 time.sleep(1)
 
 
-
 def test_long_workflow(dbos: DBOS) -> None:
     """
     This runs every hour and does nothing. Goal is to verify that it shuts down properly.

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,7 +1,10 @@
+import threading
 import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Tuple
+
+from sqlalchemy import text
 
 from dbos import DBOS, SetWorkflowUUID
 
@@ -25,3 +28,81 @@ def test_concurrent_workflows(dbos: DBOS) -> None:
             futures.append((id, executor.submit(test_thread, id)))
         for id, future in futures:
             assert id == future.result()
+
+
+def test_concurrent_conflict_uuid(dbos: DBOS) -> None:
+
+    condition = threading.Condition()
+    comm_count = 0
+    txn_count = 0
+
+    @dbos.communicator()
+    def test_communicator() -> str:
+        nonlocal comm_count
+        comm_count += 1
+        condition.acquire()
+        if comm_count == 1:
+            # Wait for the other one to notify
+            condition.wait()
+        else:
+            condition.notify()
+        condition.release()
+        return DBOS.workflow_id
+
+    @dbos.workflow()
+    def test_workflow() -> str:
+        res = test_communicator()
+        return res
+
+    def test_comm_thread(id: str) -> str:
+        with SetWorkflowUUID(id):
+            return test_communicator()
+
+    # Need to set isolation level to a lower one, otherwise it gets serialization error instead (we already handle it correctly by automatic retries).
+    @dbos.transaction(isolation_level="REPEATABLE READ")
+    def test_transaction() -> str:
+        DBOS.sql_session.execute(text("SELECT 1")).fetchall()
+        nonlocal txn_count
+        txn_count += 1
+        condition.acquire()
+        if txn_count == 1:
+            # Wait for the other one to notify
+            condition.wait()
+        else:
+            condition.notify()
+        condition.release()
+        return DBOS.workflow_id
+
+    def test_txn_thread(id: str) -> str:
+        with SetWorkflowUUID(id):
+            return test_transaction()
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowUUID(wfuuid):
+        wf_handle1 = dbos.start_workflow(test_workflow)
+
+    with SetWorkflowUUID(wfuuid):
+        wf_handle2 = dbos.start_workflow(test_workflow)
+
+    # These two workflows should run concurrently, but both should succeed.
+    assert wf_handle1.get_result() == wfuuid
+    assert wf_handle2.get_result() == wfuuid
+
+    # Make sure temp workflows can handle conflicts as well.
+    comm_count = 0
+    wfuuid = str(uuid.uuid4())
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future1 = executor.submit(test_comm_thread, wfuuid)
+        future2 = executor.submit(test_comm_thread, wfuuid)
+
+        assert future1.result() == wfuuid
+        assert future2.result() == wfuuid
+
+    # Make sure temp transactions can handle conflicts as well.
+    wfuuid = str(uuid.uuid4())
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future1 = executor.submit(test_txn_thread, wfuuid)
+        future2 = executor.submit(test_txn_thread, wfuuid)
+
+        assert future1.result() == wfuuid
+        assert future2.result() == wfuuid

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -629,9 +629,7 @@ def test_without_fastapi(dbos: DBOS) -> None:
     try:
         for module_name in dict(sys.modules.items()):
             module = sys.modules[module_name]
-            if module_name == "dbos" or module_name.startswith(
-                "dbos."
-            ):
+            if module_name == "dbos" or module_name.startswith("dbos."):
                 importlib.reload(module)
     finally:
         sys.meta_path.remove(blocker)


### PR DESCRIPTION
This PR implements the correct way to handle `DBOSWorkflowConflictUUIDError`. Instead of raising an error, the conflicted workflow would retrieve a handle and wait for the result.