### PR TITLE
Fix error handling

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -15,7 +15,7 @@ __all__ = [
     "SetWorkflowUUID",
     "WorkflowHandle",
     "WorkflowStatus",
-    "WorkflowString",
+    "WorkflowStatusString",
     "load_config",
     "error",
 ]

--- a/dbos/context.py
+++ b/dbos/context.py
@@ -209,7 +209,7 @@ def get_local_dbos_context() -> Optional[DBOSContext]:
 
 def assert_current_dbos_context() -> DBOSContext:
     rv = get_local_dbos_context()
-    assert rv
+    assert rv, "No DBOS context found"
     return rv
 
 

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -635,7 +635,7 @@ class DBOS:
                 if ctx and ctx.is_within_workflow():
                     assert (
                         ctx.is_workflow()
-                    ), "Communicator must be called within a workflow."
+                    ), "Communicators must be called from within workflows"
                     with DBOSAssumeRole(rr):
                         return invoke_comm(*args, **kwargs)
                 else:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -394,7 +394,7 @@ class DBOS:
                     return self._execute_workflow(status, func, *args, **kwargs)
                 except Exception as e:
                     DBOS.logger.error(
-                        f"Exception encountered in asynchronous workflow: {repr(e)}"
+                        f"Exception encountered in asynchronous workflow: {traceback.format_exc()}"
                     )
                     raise e
 
@@ -481,7 +481,9 @@ class DBOS:
                                             )
                                     output = func(*args, **kwargs)
                                     txn_output["output"] = utils.serialize(output)
-                                    assert ctx.sql_session is not None
+                                    assert (
+                                        ctx.sql_session is not None
+                                    ), "Cannot find a database connection"
                                     ApplicationDatabase.record_transaction_output(
                                         ctx.sql_session, txn_output
                                     )
@@ -518,7 +520,9 @@ class DBOS:
                 #  Not in a workflow (we will start the single op workflow)
                 ctx = get_local_dbos_context()
                 if ctx and ctx.is_within_workflow():
-                    assert ctx.is_workflow()
+                    assert (
+                        ctx.is_workflow()
+                    ), "Transaction must be called within a workflow."
                     with DBOSAssumeRole(rr):
                         return invoke_tx(*args, **kwargs)
                 else:
@@ -621,11 +625,17 @@ class DBOS:
             def wrapper(*args: Any, **kwargs: Any) -> Any:
                 rr: Optional[str] = check_required_roles(func, fi)
                 # Entering communicator is allowed:
+                #  In a communicator already, just call the original function directly.
                 #  In a workflow (that is not in a transaction / comm already)
                 #  Not in a workflow (we will start the single op workflow)
                 ctx = get_local_dbos_context()
+                if ctx and ctx.is_communicator():
+                    # Call the original function directly
+                    return func(*args, **kwargs)
                 if ctx and ctx.is_within_workflow():
-                    assert ctx.is_workflow()
+                    assert (
+                        ctx.is_workflow()
+                    ), "Communicator must be called within a workflow."
                     with DBOSAssumeRole(rr):
                         return invoke_comm(*args, **kwargs)
                 else:
@@ -701,7 +711,7 @@ class DBOS:
 
         ctx = get_local_dbos_context()
         if ctx and ctx.is_within_workflow():
-            assert ctx.is_workflow()
+            assert ctx.is_workflow(), "send() must be called within a workflow"
             return do_send(destination_uuid, message, topic)
         else:
             wffn = self.workflow_info_map.get(TEMP_SEND_WF_NAME)
@@ -712,7 +722,7 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None:
             # Must call it within a workflow
-            assert cur_ctx.is_workflow()
+            assert cur_ctx.is_workflow(), "recv() must be called within a workflow"
             attributes: TracedAttributes = {
                 "name": "recv",
             }
@@ -743,7 +753,7 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None:
             # Must call it within a workflow
-            assert cur_ctx.is_workflow()
+            assert cur_ctx.is_workflow(), "set_event() must be called within a workflow"
             attributes: TracedAttributes = {
                 "name": "set_event",
             }
@@ -761,7 +771,7 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None and cur_ctx.is_within_workflow():
             # Call it within a workflow
-            assert cur_ctx.is_workflow()
+            assert cur_ctx.is_workflow(), "get_event() must be called within a workflow"
             attributes: TracedAttributes = {
                 "name": "get_event",
             }
@@ -868,7 +878,9 @@ class DBOS:
     @classproperty
     def sql_session(cls) -> Session:
         ctx = assert_current_dbos_context()
-        assert ctx.is_transaction()
+        assert (
+            ctx.is_transaction()
+        ), "sql_session is only available within a transaction."
         rv = ctx.sql_session
         assert rv
         return rv
@@ -876,13 +888,17 @@ class DBOS:
     @classproperty
     def workflow_id(cls) -> str:
         ctx = assert_current_dbos_context()
-        assert ctx.is_within_workflow()
+        assert (
+            ctx.is_within_workflow()
+        ), "workflow_id is only available within a workflow, transaction, or communicator."
         return ctx.workflow_uuid
 
     @classproperty
     def parent_workflow_id(cls) -> str:
         ctx = assert_current_dbos_context()
-        assert ctx.is_within_workflow()
+        assert (
+            ctx.is_within_workflow()
+        ), "parent_workflow_id is only available within a workflow."
         return ctx.parent_workflow_uuid
 
     @classproperty

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -522,7 +522,7 @@ class DBOS:
                 if ctx and ctx.is_within_workflow():
                     assert (
                         ctx.is_workflow()
-                    ), "Transaction must be called within a workflow."
+                    ), "Transactions must be called from within workflows"
                     with DBOSAssumeRole(rr):
                         return invoke_tx(*args, **kwargs)
                 else:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -711,7 +711,7 @@ class DBOS:
 
         ctx = get_local_dbos_context()
         if ctx and ctx.is_within_workflow():
-            assert ctx.is_workflow(), "send() must be called within a workflow"
+            assert ctx.is_workflow(), "send() must be called from within a workflow"
             return do_send(destination_uuid, message, topic)
         else:
             wffn = self.workflow_info_map.get(TEMP_SEND_WF_NAME)
@@ -722,7 +722,7 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None:
             # Must call it within a workflow
-            assert cur_ctx.is_workflow(), "recv() must be called within a workflow"
+            assert cur_ctx.is_workflow(), "recv() must be called from within a workflow"
             attributes: TracedAttributes = {
                 "name": "recv",
             }
@@ -738,7 +738,7 @@ class DBOS:
                 )
         else:
             # Cannot call it from outside of a workflow
-            raise DBOSException("recv() must be called within a workflow")
+            raise DBOSException("recv() must be called from within a workflow")
 
     def sleep(self, seconds: float) -> None:
         attributes: TracedAttributes = {
@@ -753,7 +753,9 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None:
             # Must call it within a workflow
-            assert cur_ctx.is_workflow(), "set_event() must be called within a workflow"
+            assert (
+                cur_ctx.is_workflow()
+            ), "set_event() must be called from within a workflow"
             attributes: TracedAttributes = {
                 "name": "set_event",
             }
@@ -763,7 +765,7 @@ class DBOS:
                 )
         else:
             # Cannot call it from outside of a workflow
-            raise DBOSException("set_event() must be called within a workflow")
+            raise DBOSException("set_event() must be called from within a workflow")
 
     def get_event(
         self, workflow_uuid: str, key: str, timeout_seconds: float = 60
@@ -771,7 +773,9 @@ class DBOS:
         cur_ctx = get_local_dbos_context()
         if cur_ctx is not None and cur_ctx.is_within_workflow():
             # Call it within a workflow
-            assert cur_ctx.is_workflow(), "get_event() must be called within a workflow"
+            assert (
+                cur_ctx.is_workflow()
+            ), "get_event() must be called from within a workflow"
             attributes: TracedAttributes = {
                 "name": "get_event",
             }

--- a/dbos/recovery.py
+++ b/dbos/recovery.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import traceback
 from typing import TYPE_CHECKING, List
 
 from dbos.context import SetWorkflowRecovery
@@ -25,6 +26,6 @@ def startup_recovery_thread(dbos: "DBOS", workflow_ids: List[str]) -> None:
             time.sleep(1)
         except Exception as e:
             dbos.logger.error(
-                f"Exception encountered when recovering workflows: {repr(e)}"
+                f"Exception encountered when recovering workflows: {traceback.format_exc()}"
             )
             raise e

--- a/dbos/scheduler/scheduler.py
+++ b/dbos/scheduler/scheduler.py
@@ -1,4 +1,5 @@
 import threading
+import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -26,7 +27,7 @@ def scheduler_loop(
                 func(nextExecTime, datetime.now(timezone.utc))
             except Exception as e:
                 dbos_logger.error(
-                    f"Exception encountered in scheduled workflow: {repr(e)}"
+                    f"Exception encountered in scheduled workflow: {traceback.format_exc()}"
                 )
                 pass  # Let the thread keep running
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -239,6 +239,10 @@ def test_temp_workflow(dbos: DBOS) -> None:
         comm_counter += 1
         return var
 
+    @dbos.communicator()
+    def call_communicator(var: str) -> str:
+        return test_communicator(var)
+
     assert get_local_dbos_context() is None
     res = test_transaction("var2")
     assert res == "var21"
@@ -259,6 +263,10 @@ def test_temp_workflow(dbos: DBOS) -> None:
 
     assert txn_counter == 1
     assert comm_counter == 1
+
+    res = call_communicator("var2")
+    assert res == "var2"
+    assert comm_counter == 2
 
 
 def test_temp_workflow_errors(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -787,7 +787,7 @@ def test_send_recv(dbos: DBOS) -> None:
     # Test recv outside of a workflow
     with pytest.raises(Exception) as exc_info:
         dbos.recv("test1")
-    assert "recv() must be called within a workflow" in str(exc_info.value)
+    assert "recv() must be called from within a workflow" in str(exc_info.value)
 
 
 def test_send_recv_temp_wf(dbos: DBOS) -> None:
@@ -896,4 +896,4 @@ def test_set_get_events(dbos: DBOS) -> None:
     # Test setEvent outside of a workflow
     with pytest.raises(Exception) as exc_info:
         dbos.set_event("key1", "value1")
-    assert "set_event() must be called within a workflow" in str(exc_info.value)
+    assert "set_event() must be called from within a workflow" in str(exc_info.value)


### PR DESCRIPTION
- Print traceback for async workflow executions. Otherwise, the error message itself is hard to debug.
- Make assertions more descriptive by providing the actual error message.
- Allow communicators to directly call other communicator functions. Still don't allow transactions to call other transactions.
- Fix a minor typo in __init__.py.