### PR TITLE
Move workflow stuff to core

### DIFF
--- a/dbos/core.py
+++ b/dbos/core.py
@@ -1,16 +1,13 @@
+import sys
 import traceback
 from concurrent.futures import Future
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    ParamSpec,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, TypeVar, cast
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec, TypeAlias
+else:
+    from typing import ParamSpec, TypeAlias
 
 from dbos import utils
 from dbos.context import (

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -1,9 +1,24 @@
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, ParamSpec, TypeVar
 
 from dbos import utils
-from dbos.error import DBOSNonExistentWorkflowError, DBOSWorkflowConflictUUIDError
-from dbos.system_database import WorkflowStatusInternal
+from dbos.context import (
+    DBOSContext,
+    DBOSContextEnsure,
+    DBOSContextSwap,
+    EnterDBOSWorkflow,
+    OperationType,
+    SetWorkflowUUID,
+    TracedAttributes,
+    assert_current_dbos_context,
+)
+from dbos.error import (
+    DBOSNonExistentWorkflowError,
+    DBOSRecoveryError,
+    DBOSWorkflowConflictUUIDError,
+    DBOSWorkflowFunctionNotFoundError,
+)
+from dbos.system_database import WorkflowInputs, WorkflowStatusInternal
 from dbos.workflow import WorkflowHandle, WorkflowStatus
 
 if TYPE_CHECKING:
@@ -47,6 +62,43 @@ class _WorkflowHandlePolling(WorkflowHandle[R]):
         return stat
 
 
+def _init_workflow(
+    dbos: "DBOS",
+    ctx: DBOSContext,
+    inputs: WorkflowInputs,
+    wf_name: str,
+    class_name: Optional[str],
+    config_name: Optional[str],
+) -> WorkflowStatusInternal:
+    wfid = (
+        ctx.workflow_uuid
+        if len(ctx.workflow_uuid) > 0
+        else ctx.id_assigned_for_next_workflow
+    )
+    status: WorkflowStatusInternal = {
+        "workflow_uuid": wfid,
+        "status": "PENDING",
+        "name": wf_name,
+        "class_name": class_name,
+        "config_name": config_name,
+        "output": None,
+        "error": None,
+        "app_id": ctx.app_id,
+        "app_version": ctx.app_version,
+        "executor_id": ctx.executor_id,
+        "request": (utils.serialize(ctx.request) if ctx.request is not None else None),
+        "recovery_attempts": None,
+    }
+    dbos.sys_db.update_workflow_status(status, False, ctx.in_recovery)
+
+    # If we have an instance name, the first arg is the instance and do not serialize
+    if class_name is not None:
+        inputs = {"args": inputs["args"][1:], "kwargs": inputs["kwargs"]}
+    dbos.sys_db.update_workflow_inputs(wfid, utils.serialize(inputs))
+
+    return status
+
+
 def _execute_workflow(
     dbos: "DBOS",
     status: WorkflowStatusInternal,
@@ -58,7 +110,7 @@ def _execute_workflow(
         output = func(*args, **kwargs)
     except DBOSWorkflowConflictUUIDError:
         # Retrieve the workflow handle and wait for the result.
-        wf_handle: WorkflowHandle[R] = dbos.retrieve_workflow(DBOS.workflow_id)
+        wf_handle: WorkflowHandle[R] = dbos.retrieve_workflow(status["workflow_uuid"])
         output = wf_handle.get_result()
         return output
     except Exception as error:
@@ -71,3 +123,77 @@ def _execute_workflow(
     status["output"] = utils.serialize(output)
     dbos.sys_db.update_workflow_status(status)
     return output
+
+
+def _execute_workflow_wthread(
+    dbos: "DBOS",
+    status: WorkflowStatusInternal,
+    func: "Workflow[P, R]",
+    ctx: DBOSContext,
+    *args: Any,
+    **kwargs: Any,
+) -> R:
+    attributes: TracedAttributes = {
+        "name": func.__name__,
+        "operationType": OperationType.WORKFLOW.value,
+    }
+    with DBOSContextSwap(ctx):
+        with EnterDBOSWorkflow(attributes):
+            try:
+                return _execute_workflow(dbos, status, func, *args, **kwargs)
+            except Exception as e:
+                dbos.logger.error(
+                    f"Exception encountered in asynchronous workflow: {repr(e)}"
+                )
+                raise e
+
+
+def execute_workflow_uuid(dbos: "DBOS", workflow_uuid: str) -> WorkflowHandle[Any]:
+    status = dbos.sys_db.get_workflow_status(workflow_uuid)
+    if not status:
+        raise DBOSRecoveryError(workflow_uuid, "Workflow status not found")
+    inputs = dbos.sys_db.get_workflow_inputs(workflow_uuid)
+    if not inputs:
+        raise DBOSRecoveryError(workflow_uuid, "Workflow inputs not found")
+    wf_func = dbos.workflow_info_map.get(status["name"], None)
+    if not wf_func:
+        raise DBOSWorkflowFunctionNotFoundError(
+            workflow_uuid, "Workflow function not found"
+        )
+    with DBOSContextEnsure():
+        ctx = assert_current_dbos_context()
+        request = status["request"]
+        ctx.request = utils.deserialize(request) if request is not None else None
+        if status["config_name"] is not None:
+            config_name = status["config_name"]
+            class_name = status["class_name"]
+            iname = f"{class_name}/{config_name}"
+            if iname not in dbos.instance_info_map:
+                raise DBOSWorkflowFunctionNotFoundError(
+                    workflow_uuid,
+                    f"Cannot execute workflow because instance '{iname}' is not registered",
+                )
+            with SetWorkflowUUID(workflow_uuid):
+                return dbos.start_workflow(
+                    wf_func,
+                    dbos.instance_info_map[iname],
+                    *inputs["args"],
+                    **inputs["kwargs"],
+                )
+        elif status["class_name"] is not None:
+            class_name = status["class_name"]
+            if class_name not in dbos.class_info_map:
+                raise DBOSWorkflowFunctionNotFoundError(
+                    workflow_uuid,
+                    f"Cannot execute workflow because class '{class_name}' is not registered",
+                )
+            with SetWorkflowUUID(workflow_uuid):
+                return dbos.start_workflow(
+                    wf_func,
+                    dbos.class_info_map[class_name],
+                    *inputs["args"],
+                    **inputs["kwargs"],
+                )
+        else:
+            with SetWorkflowUUID(workflow_uuid):
+                return dbos.start_workflow(wf_func, *inputs["args"], **inputs["kwargs"])

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -171,7 +171,7 @@ def _execute_workflow_wthread(
                 raise e
 
 
-def execute_workflow_uuid(dbos: "DBOS", workflow_uuid: str) -> WorkflowHandle[Any]:
+def _execute_workflow_uuid(dbos: "DBOS", workflow_uuid: str) -> WorkflowHandle[Any]:
     status = dbos.sys_db.get_workflow_status(workflow_uuid)
     if not status:
         raise DBOSRecoveryError(workflow_uuid, "Workflow status not found")

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -16,7 +16,6 @@ from typing import (
     Literal,
     Optional,
     Protocol,
-    Tuple,
     Type,
     TypeVar,
     cast,
@@ -25,23 +24,16 @@ from typing import (
 from opentelemetry.trace import Span
 
 from dbos.core import (
-    _execute_workflow,
     _execute_workflow_uuid,
-    _execute_workflow_wthread,
-    _init_workflow,
     _start_workflow,
     _workflow_wrapper,
-    _WorkflowHandleFuture,
     _WorkflowHandlePolling,
 )
 from dbos.decorators import classproperty
 from dbos.recovery import recover_pending_workflows, startup_recovery_thread
 from dbos.registrations import (
     DBOSClassInfo,
-    get_config_name,
-    get_dbos_class_name,
     get_dbos_func_name,
-    get_func_info,
     get_or_create_class_info,
     get_or_create_func_info,
     set_dbos_func_name,
@@ -67,11 +59,8 @@ import dbos.utils as utils
 from dbos.admin_sever import AdminServer
 from dbos.context import (
     DBOSAssumeRole,
-    DBOSContext,
-    EnterDBOSChildWorkflow,
     EnterDBOSCommunicator,
     EnterDBOSTransaction,
-    EnterDBOSWorkflow,
     OperationType,
     TracedAttributes,
     assert_current_dbos_context,
@@ -81,7 +70,6 @@ from dbos.error import (
     DBOSCommunicatorMaxRetriesExceededError,
     DBOSException,
     DBOSNonExistentWorkflowError,
-    DBOSWorkflowFunctionNotFoundError,
 )
 from dbos.workflow import WorkflowHandle, WorkflowStatus
 
@@ -92,7 +80,6 @@ from .system_database import (
     GetEventWorkflowContext,
     OperationResultInternal,
     SystemDatabase,
-    WorkflowInputs,
 )
 
 # Most DBOS functions are just any callable F, so decorators / wrappers work on F

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -26,13 +26,13 @@ from opentelemetry.trace import Span
 
 from dbos.core import (
     _execute_workflow,
+    _execute_workflow_uuid,
     _execute_workflow_wthread,
     _init_workflow,
     _start_workflow,
     _workflow_wrapper,
     _WorkflowHandleFuture,
     _WorkflowHandlePolling,
-    execute_workflow_uuid,
 )
 from dbos.decorators import classproperty
 from dbos.recovery import recover_pending_workflows, startup_recovery_thread
@@ -601,7 +601,7 @@ class DBOS:
         """
         This function is used to execute a workflow by a UUID for recovery.
         """
-        return execute_workflow_uuid(self, workflow_uuid)
+        return _execute_workflow_uuid(self, workflow_uuid)
 
     def recover_pending_workflows(
         self, executor_ids: List[str] = ["local"]

--- a/dbos/recovery.py
+++ b/dbos/recovery.py
@@ -1,9 +1,11 @@
+import os
 import threading
 import time
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from dbos.context import SetWorkflowRecovery
 from dbos.error import DBOSWorkflowFunctionNotFoundError
+from dbos.workflow import WorkflowHandle
 
 if TYPE_CHECKING:
     from dbos.dbos import DBOS
@@ -28,3 +30,25 @@ def startup_recovery_thread(dbos: "DBOS", workflow_ids: List[str]) -> None:
                 f"Exception encountered when recovering workflows: {repr(e)}"
             )
             raise e
+
+
+def recover_pending_workflows(
+    dbos: "DBOS", executor_ids: List[str] = ["local"]
+) -> List[WorkflowHandle[Any]]:
+    workflow_handles: List[WorkflowHandle[Any]] = []
+    for executor_id in executor_ids:
+        if executor_id == "local" and os.environ.get("DBOS__VMID"):
+            dbos.logger.debug(
+                f"Skip local recovery because it's running in a VM: {os.environ.get('DBOS__VMID')}"
+            )
+        dbos.logger.debug(f"Recovering pending workflows for executor: {executor_id}")
+        workflow_ids = dbos.sys_db.get_pending_workflows(executor_id)
+        dbos.logger.debug(f"Pending workflows: {workflow_ids}")
+
+        for workflowID in workflow_ids:
+            with SetWorkflowRecovery():
+                handle = dbos.execute_workflow_uuid(workflowID)
+            workflow_handles.append(handle)
+
+    dbos.logger.info("Recovered pending workflows")
+    return workflow_handles


### PR DESCRIPTION
Moves a few hundred lines out of DBOS facade into core.py

This is a checkpoint, we'd do the same to comm / tx / send / recv / etc.

Design note:
  At the moment, a "DBOS" instance called 'dbos' is getting passed into these functions.  That object is really remembering the system db, logger, registry of functions, etc... in the future I think we would quickly change that to an instance of something other than `DBOS`... but that'd be for later, probably part of the use of DBOS for decorators etc. 