### PR TITLE
move cli from package to module

### DIFF
--- a/dbos/cli.py
+++ b/dbos/cli.py
@@ -66,7 +66,7 @@ def start() -> None:
 
 @app.command()
 def create() -> None:
-    pass
+    typer.echo(f"dbos create coming soon")
 
 
 @app.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 license = {text = "MIT"}
 
 [project.scripts]
-dbos = "dbos.cli.cli:app"
+dbos = "dbos.cli:app"
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
this simplifies calling dbos cli as a module (`python3 -m dbos.cli <args>` vs `python3 -m dbos.cli.cli <args>`)