### PR TITLE
get_dbos_database_url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -5,7 +5,7 @@ from .dbos import DBOSConfiguredInstance as DBOSConfiguredInstance
 from .dbos import WorkflowHandle as WorkflowHandle
 from .dbos import WorkflowStatus as WorkflowStatus
 from .dbos_config import ConfigFile as ConfigFile
-from .dbos_config import load_config
+from .dbos_config import get_dbos_database_url, load_config
 from .system_database import WorkflowStatusString as WorkflowStatusString
 
 __all__ = [
@@ -17,5 +17,6 @@ __all__ = [
     "WorkflowStatus",
     "WorkflowStatusString",
     "load_config",
+    "get_dbos_database_url",
     "error",
 ]

--- a/templates/hello/alembic/env.py
+++ b/templates/hello/alembic/env.py
@@ -1,10 +1,9 @@
-import os
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import URL, engine_from_config, pool
+from sqlalchemy import engine_from_config, pool
 
-from dbos import load_config
+from dbos import get_dbos_database_url
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -15,21 +14,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Load DBOS Config and parse the database URL
-dbos_config_path = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "dbos-config.yaml"
-)
-
-dbos_config = load_config(dbos_config_path)
-db_url = URL.create(
-    "postgresql",
-    username=dbos_config["database"]["username"],
-    password=dbos_config["database"]["password"],
-    host=dbos_config["database"]["hostname"],
-    port=dbos_config["database"]["port"],
-    database=dbos_config["database"]["app_db_name"],
-)
-config.set_main_option("sqlalchemy.url", db_url.render_as_string(hide_password=False))
+# programmatically set the sqlalchemy.url field from DBOS Config
+config.set_main_option("sqlalchemy.url", get_dbos_database_url())
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
added `get_dbos_database_url` function to return dbos-config connection info as a URL. This makes setting the sqlalchemy.url field of alembic a single line of code. 

Other changes:
* snake_case `config_file_path` param in load_config
* change black pre-commit hook to use python3 instead of python3.10