### PR TITLE
Remove pesky stuff

### DIFF
--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -557,8 +557,7 @@ class DBOSConfiguredInstance:
 #   it looks like startup was abandoned or a call was forgotten...
 def log_exit_info() -> None:
     if _dbos_global_registry is None:
-        print("DBOS exiting with no DBOS in existence")
-        dbos_logger.info("DBOS exiting with no DBOS in existence")
+        # Probably used as or for a support module
         return
     if _dbos_global_instance is None:
         print("DBOS exiting; functions were registered but DBOS() was not called")
@@ -570,8 +569,6 @@ def log_exit_info() -> None:
         print("DBOS exiting; DBOS exists but launch() was not called")
         dbos_logger.warning("DBOS exiting; DBOS exists but launch() was not called")
         return
-    print("DBOS exiting; DBOS has been run.")
-    dbos_logger.info("DBOS exiting; DBOS has been run.")
 
 
 # Register the exit hook

--- a/tests/atexit_no_dbos.py
+++ b/tests/atexit_no_dbos.py
@@ -1,1 +1,0 @@
-from dbos import DBOS

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -77,10 +77,7 @@ def test_dbos_singleton() -> None:
         res = DBOSSendRecv.test_send_workflow(handle.get_workflow_uuid(), "testtopic")
         assert res == dest_uuid
 
-    begin_time = time.time()
     assert handle.get_result() == "test2-test1-test3"
-    duration = time.time() - begin_time
-    assert duration < 3.0  # Shouldn't take more than 3 seconds to run
 
     # Events
     wfuuid = str("sendwf1")
@@ -132,18 +129,6 @@ def test_dbos_singleton_negative() -> None:
     assert "launch" in str(exc_info.value)
 
     DBOS.destroy()
-
-
-def test_dbos_atexit_unused() -> None:
-    # Run the .py as a separate process
-    result = subprocess.run(
-        [sys.executable, path.join("tests", "atexit_no_dbos.py")],
-        capture_output=True,
-        text=True,
-    )
-
-    # Assert that the output contains the warning message
-    assert "DBOS exiting with no DBOS in existence" in result.stdout
 
 
 def test_dbos_atexit_no_dbos() -> None:


### PR DESCRIPTION
The printouts on exit were covering cases that didn't warrant any attention (such as importing dbos module without ever making a DBOS), and generated confusion.  Removed those as they weren't the interesting ones.

Also removed an assert about how long something takes to run, as it is flaky in the test runner, and was cut+paste from another test, so no reason to have a redundant copy of that assert.

