### PR TITLE
Fix a race condition in recv

### DIFF
--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -607,7 +607,8 @@ class SystemDatabase:
                 workflow_uuid, timeout_function_id, timeout_seconds, skip_sleep=True
             )
             condition.wait(timeout=actual_timeout)
-            condition.release()
+        condition.release()
+        self.notifications_map.pop(payload)
 
         # Transactionally consume and return the message if it's in the database, otherwise return null.
         with self.engine.begin() as c:
@@ -652,7 +653,6 @@ class SystemDatabase:
                 },
                 conn=c,
             )
-        self.notifications_map.pop(payload)
         return message
 
     def _notification_listener(self) -> None:
@@ -783,6 +783,11 @@ class SystemDatabase:
                 else:
                     raise Exception("No output recorded in the last get_event")
 
+        payload = f"{target_uuid}::{key}"
+        condition = threading.Condition()
+        self.workflow_events_map[payload] = condition
+        condition.acquire()
+
         # Check if the key is already in the database. If not, wait for the notification.
         init_recv: Sequence[Any]
         with self.engine.begin() as c:
@@ -793,10 +798,6 @@ class SystemDatabase:
             value = utils.deserialize(init_recv[0][0])
         else:
             # Wait for the notification
-            payload = f"{target_uuid}::{key}"
-            condition = threading.Condition()
-            self.workflow_events_map[payload] = condition
-            condition.acquire()
             actual_timeout = timeout_seconds
             if caller_ctx is not None:
                 # Support OAOO sleep for workflows
@@ -807,14 +808,14 @@ class SystemDatabase:
                     skip_sleep=True,
                 )
             condition.wait(timeout=actual_timeout)
-            condition.release()
-            self.workflow_events_map.pop(payload)
 
             # Read the value from the database
             with self.engine.begin() as c:
                 final_recv = c.execute(get_sql).fetchall()
                 if len(final_recv) > 0:
                     value = utils.deserialize(final_recv[0][0])
+        condition.release()
+        self.workflow_events_map.pop(payload)
 
         # Record the output if it's in a workflow
         if caller_ctx is not None:

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -597,8 +597,9 @@ class SystemDatabase:
             # Wait for the notification
             payload = f"{workflow_uuid}::{topic}"
             condition = threading.Condition()
-            self.notifications_map[payload] = condition
+            # Must acquire first before adding to the map. Otherwise, the notification listener may notify it before the condition is acquired and waited.
             condition.acquire()
+            self.notifications_map[payload] = condition
             # Support OAOO sleep
             actual_timeout = self.sleep(
                 workflow_uuid, timeout_function_id, timeout_seconds, skip_sleep=True

--- a/tests/classdefs.py
+++ b/tests/classdefs.py
@@ -93,17 +93,8 @@ class DBOSSendRecv:
     @staticmethod
     @DBOS.workflow()
     def test_recv_workflow(topic: str) -> str:
-        begin_time = time.time()
         msg1 = DBOS.recv(topic, timeout_seconds=10)
-        duration = time.time() - begin_time
-        print(f"Duration 1: {duration}")
-        begin_time = time.time()
         msg2 = DBOS.recv(timeout_seconds=10)
-        duration = time.time() - begin_time
-        print(f"Duration 2: {duration}")
-        begin_time = time.time()
         msg3 = DBOS.recv(timeout_seconds=10)
-        duration = time.time() - begin_time
-        print(f"Duration 3: {duration}")
         DBOSSendRecv.recv_counter += 1
         return "-".join([str(msg1), str(msg2), str(msg3)])

--- a/tests/classdefs.py
+++ b/tests/classdefs.py
@@ -1,6 +1,3 @@
-import time
-from typing import Optional
-
 import sqlalchemy as sa
 
 # Public API

--- a/tests/classdefs.py
+++ b/tests/classdefs.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional
 
 import sqlalchemy as sa
@@ -92,8 +93,17 @@ class DBOSSendRecv:
     @staticmethod
     @DBOS.workflow()
     def test_recv_workflow(topic: str) -> str:
+        begin_time = time.time()
         msg1 = DBOS.recv(topic, timeout_seconds=10)
+        duration = time.time() - begin_time
+        print(f"Duration 1: {duration}")
+        begin_time = time.time()
         msg2 = DBOS.recv(timeout_seconds=10)
+        duration = time.time() - begin_time
+        print(f"Duration 2: {duration}")
+        begin_time = time.time()
         msg3 = DBOS.recv(timeout_seconds=10)
+        duration = time.time() - begin_time
+        print(f"Duration 3: {duration}")
         DBOSSendRecv.recv_counter += 1
         return "-".join([str(msg1), str(msg2), str(msg3)])

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -77,7 +77,11 @@ def test_dbos_singleton() -> None:
         res = DBOSSendRecv.test_send_workflow(handle.get_workflow_uuid(), "testtopic")
         assert res == dest_uuid
 
+    begin_time = time.time()
     assert handle.get_result() == "test2-test1-test3"
+    duration = time.time() - begin_time
+    print(f"Total Duration: {duration}")
+    assert duration < 3.0
 
     # Events
     wfuuid = str("sendwf1")

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -13,7 +13,7 @@ from dbos.context import DBOSContextEnsure, assert_current_dbos_context
 from tests.conftest import default_config
 
 
-def test_dbos_singleton() -> None:
+def test_dbos_singleton(cleanup_test_databases: None) -> None:
     # Initialize singleton
     DBOS.destroy()  # In case of other tests leaving it
 
@@ -80,7 +80,6 @@ def test_dbos_singleton() -> None:
     begin_time = time.time()
     assert handle.get_result() == "test2-test1-test3"
     duration = time.time() - begin_time
-    print(f"Total Duration: {duration}")
     assert duration < 3.0
 
     # Events
@@ -112,7 +111,7 @@ def test_dbos_singleton() -> None:
     DBOS.destroy()
 
 
-def test_dbos_singleton_negative() -> None:
+def test_dbos_singleton_negative(cleanup_test_databases: None) -> None:
     # Initialize singleton
     DBOS.destroy()  # In case of other tests leaving it
 
@@ -135,7 +134,7 @@ def test_dbos_singleton_negative() -> None:
     DBOS.destroy()
 
 
-def test_dbos_atexit_no_dbos() -> None:
+def test_dbos_atexit_no_dbos(cleanup_test_databases: None) -> None:
     # Run the .py as a separate process
     result = subprocess.run(
         [sys.executable, path.join("tests", "atexit_no_ctor.py")],
@@ -147,7 +146,7 @@ def test_dbos_atexit_no_dbos() -> None:
     assert "DBOS exiting; functions were registered" in result.stdout
 
 
-def test_dbos_atexit_no_launch() -> None:
+def test_dbos_atexit_no_launch(cleanup_test_databases: None) -> None:
     # Run the .py as a separate process
     result = subprocess.run(
         [sys.executable, path.join("tests", "atexit_no_launch.py")],


### PR DESCRIPTION
This PR fixes a race condition in recv() where the receiver is not properly notified by the listener and can cause unnecessary timeouts.
- Register the condition to the notifications map before checking the database.
- Acquire the condition before adding it to the map. Otherwise, the listener may notify it before the wait, and the notification would be lost, causing unnecessary sleep/timeout.

Also fixed the issue where test_singleton didn't clean up the test database.