### PR TITLE
Allow access to DBOS.config before DBOS()

### DIFF
--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -243,14 +243,14 @@ class DBOS:
         dbos_tracer.config(config)
         dbos_logger.info("Initializing DBOS")
         self.config: ConfigFile = config
-        self._launched = False
+        self._launched: bool = False
         self._sys_db: Optional[SystemDatabase] = None
         self._app_db: Optional[ApplicationDatabase] = None
-        self._registry = _get_or_create_dbos_registry()
+        self._registry: _DBOSRegistry = _get_or_create_dbos_registry()
         self._registry.dbos = self
         self._admin_server: Optional[AdminServer] = None
         self.stop_events: List[threading.Event] = []
-        self.fastapi = fastapi
+        self.fastapi: Optional["FastAPI"] = fastapi
         self._executor: Optional[ThreadPoolExecutor] = None
         if self.fastapi is not None:
             from dbos.fastapi import setup_fastapi_middleware
@@ -494,9 +494,9 @@ class DBOS:
 
     @classproperty
     def config(cls) -> ConfigFile:
-        dbos = _get_dbos_instance()
-        if dbos is not None:
-            return dbos.config
+        global _dbos_global_instance
+        if _dbos_global_instance is not None:
+            return _dbos_global_instance.config
         reg = _get_or_create_dbos_registry()
         if reg.config is not None:
             return reg.config

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -133,6 +133,7 @@ class _DBOSRegistry:
         self.instance_info_map: dict[str, object] = {}
         self.pollers: list[_RegisteredJob] = []
         self.dbos: Optional[DBOS] = None
+        self.config: Optional[ConfigFile] = None
 
     def register_wf_function(self, name: str, wrapped_func: F) -> None:
         self.workflow_info_map[name] = wrapped_func
@@ -193,11 +194,21 @@ class DBOS:
         launch: bool = True,
     ) -> DBOS:
         global _dbos_global_instance
+        global _dbos_global_registry
         if _dbos_global_instance is None:
+            if (
+                _dbos_global_registry is not None
+                and _dbos_global_registry.config is not None
+            ):
+                if config is not None and config is not _dbos_global_registry.config:
+                    raise DBOSException(
+                        f"DBOS configured multiple times with conflicting information"
+                    )
+                config = _dbos_global_registry.config
             _dbos_global_instance = super().__new__(cls)
             _dbos_global_instance.__init__(fastapi=fastapi, config=config, launch=launch)  # type: ignore
         else:
-            if (_dbos_global_instance.config is not config) or (
+            if (config is not None and _dbos_global_instance.config is not config) or (
                 _dbos_global_instance.fastapi is not fastapi
             ):
                 raise DBOSException(
@@ -480,6 +491,18 @@ class DBOS:
     @classproperty
     def logger(cls) -> Logger:
         return dbos_logger  # TODO get from context if appropriate...
+
+    @classproperty
+    def config(cls) -> ConfigFile:
+        dbos = _get_dbos_instance()
+        if dbos is not None:
+            return dbos.config
+        reg = _get_or_create_dbos_registry()
+        if reg.config is not None:
+            return reg.config
+        config = load_config()
+        reg.config = config
+        return config
 
     @classproperty
     def sql_session(cls) -> Session:


### PR DESCRIPTION
This works on the principle that if you are accessing DBOS.config in your app, it is coming from the default config methodology and that config won't then be specified in DBOS() call.