### PR TITLE
Fix buffer flushes

### DIFF
--- a/dbos/application_database.py
+++ b/dbos/application_database.py
@@ -3,6 +3,7 @@ from typing import Optional, TypedDict, cast
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as pg
 import sqlalchemy.exc as sa_exc
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
 from dbos.error import DBOSWorkflowConflictIDError
@@ -95,8 +96,10 @@ class ApplicationDatabase:
                     ),
                 )
             )
-        except sa_exc.IntegrityError:
-            raise DBOSWorkflowConflictIDError(output["workflow_uuid"])
+        except DBAPIError as dbapi_error:
+            if dbapi_error.orig.pgcode == "23505":  # type: ignore
+                raise DBOSWorkflowConflictIDError(output["workflow_uuid"])
+            raise dbapi_error
         except Exception as e:
             raise e
 
@@ -118,8 +121,10 @@ class ApplicationDatabase:
                         ),
                     )
                 )
-        except sa_exc.IntegrityError:
-            raise DBOSWorkflowConflictIDError(output["workflow_uuid"])
+        except DBAPIError as dbapi_error:
+            if dbapi_error.orig.pgcode == "23505":  # type: ignore
+                raise DBOSWorkflowConflictIDError(output["workflow_uuid"])
+            raise dbapi_error
         except Exception as e:
             raise e
 

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -142,7 +142,7 @@ def _init_workflow(
 
     if temp_wf_type != "transaction":
         # Synchronously record the status and inputs for workflows and single-step workflows
-        # We also have to do this for non-transaction workflows because of the foreign key constraint on the operation outputs table
+        # We also have to do this for single-step workflows because of the foreign key constraint on the operation outputs table
         dbos.sys_db.update_workflow_status(status, False, ctx.in_recovery)
         dbos.sys_db.update_workflow_inputs(wfid, utils.serialize(inputs))
     else:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -251,6 +251,10 @@ def test_temp_workflow(dbos: DBOS) -> None:
     res = test_step("var")
     assert res == "var"
 
+    # Flush workflow inputs buffer shouldn't fail due to foreign key violation.
+    # It should properly skip the transaction inputs.
+    dbos.sys_db._flush_workflow_inputs_buffer()
+
     # Wait for buffers to flush
     dbos.sys_db.wait_for_buffer_flush()
     wfs = dbos.sys_db.get_workflows(gwi)


### PR DESCRIPTION
- Solve the issue where inputs buffer flush failed due to foreign key violation. Keep track of single-transaction temp workflows to guarantee we always insert their status before inputs.
- Make DB error handling more specific. Because both unique constraint and foreign key constraint violations will be an `IntegrityError`. But we want to handle them separately.
- Fix some race conditions in our tests.