### PR TITLE
Role Based Security test / PoC

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,4 +1,5 @@
 from . import error as error
+from .context import DBOSContextEnsure as DBOSContextEnsure
 from .context import SetWorkflowID as SetWorkflowID
 from .dbos import DBOS as DBOS
 from .dbos import DBOSConfiguredInstance as DBOSConfiguredInstance
@@ -13,6 +14,7 @@ __all__ = [
     "ConfigFile",
     "DBOS",
     "DBOSConfiguredInstance",
+    "DBOSContextEnsure",
     "GetWorkflowsInput",
     "SetWorkflowID",
     "WorkflowHandle",

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,14 +1,8 @@
 from . import error as error
-from .context import DBOSContextEnsure as DBOSContextEnsure
-from .context import SetWorkflowID as SetWorkflowID
-from .dbos import DBOS as DBOS
-from .dbos import DBOSConfiguredInstance as DBOSConfiguredInstance
-from .dbos import WorkflowHandle as WorkflowHandle
-from .dbos import WorkflowStatus as WorkflowStatus
-from .dbos_config import ConfigFile as ConfigFile
-from .dbos_config import get_dbos_database_url, load_config
-from .system_database import GetWorkflowsInput as GetWorkflowsInput
-from .system_database import WorkflowStatusString as WorkflowStatusString
+from .context import DBOSContextEnsure, SetWorkflowID
+from .dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
+from .dbos_config import ConfigFile, get_dbos_database_url, load_config
+from .system_database import GetWorkflowsInput, WorkflowStatusString
 
 __all__ = [
     "ConfigFile",

--- a/dbos/context.py
+++ b/dbos/context.py
@@ -220,13 +220,13 @@ class DBOSContextEnsure:
     def __init__(self) -> None:
         self.created_ctx = False
 
-    def __enter__(self) -> DBOSContextEnsure:
+    def __enter__(self) -> DBOSContext:
         # Code to create a basic context
         ctx = get_local_dbos_context()
         if ctx is None:
             self.created_ctx = True
             set_local_dbos_context(DBOSContext())
-        return self
+        return assert_current_dbos_context()
 
     def __exit__(
         self,

--- a/dbos/context.py
+++ b/dbos/context.py
@@ -42,6 +42,7 @@ class TracedAttributes(TypedDict, total=False):
     applicationID: Optional[str]
     applicationVersion: Optional[str]
     executorID: Optional[str]
+    authenticatedUser: Optional[str]
 
 
 class DBOSContext:
@@ -162,6 +163,7 @@ class DBOSContext:
         attributes["operationUUID"] = (
             self.workflow_id if len(self.workflow_id) > 0 else None
         )
+        attributes["authenticatedUser"] = self.authenticated_user
         span = dbos_tracer.start_span(
             attributes, parent=self.spans[-1] if len(self.spans) > 0 else None
         )
@@ -181,6 +183,8 @@ class DBOSContext:
     ) -> None:
         self.authenticated_user = user
         self.authenticated_roles = roles
+        if user is not None and len(self.spans) > 0:
+            self.spans[-1].set_attribute("authenticatedUser", user)
 
 
 ##############################################################

--- a/dbos/context.py
+++ b/dbos/context.py
@@ -40,6 +40,8 @@ class TracedAttributes(TypedDict, total=False):
     applicationVersion: Optional[str]
     executorID: Optional[str]
     authenticatedUser: Optional[str]
+    authenticatedUserRoles: Optional[str]
+    authenticatedUserAssumedRole: Optional[str]
 
 
 class DBOSContext:
@@ -161,6 +163,12 @@ class DBOSContext:
             self.workflow_id if len(self.workflow_id) > 0 else None
         )
         attributes["authenticatedUser"] = self.authenticated_user
+        attributes["authenticatedUserRoles"] = (
+            ",".join(self.authenticated_roles)
+            if self.authenticated_roles is not None
+            else ""
+        )
+        attributes["authenticatedUserAssumedRole"] = self.assumed_role
         span = dbos_tracer.start_span(
             attributes, parent=self.spans[-1] if len(self.spans) > 0 else None
         )
@@ -182,6 +190,9 @@ class DBOSContext:
         self.authenticated_roles = roles
         if user is not None and len(self.spans) > 0:
             self.spans[-1].set_attribute("authenticatedUser", user)
+            self.spans[-1].set_attribute(
+                "authenticatedUserRoles", ",".join(roles) if roles is not None else ""
+            )
 
 
 ##############################################################

--- a/dbos/context.py
+++ b/dbos/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import uuid
 from contextvars import ContextVar
@@ -164,7 +165,7 @@ class DBOSContext:
         )
         attributes["authenticatedUser"] = self.authenticated_user
         attributes["authenticatedUserRoles"] = (
-            ",".join(self.authenticated_roles)
+            json.dumps(self.authenticated_roles)
             if self.authenticated_roles is not None
             else ""
         )
@@ -191,7 +192,7 @@ class DBOSContext:
         if user is not None and len(self.spans) > 0:
             self.spans[-1].set_attribute("authenticatedUser", user)
             self.spans[-1].set_attribute(
-                "authenticatedUserRoles", ",".join(roles) if roles is not None else ""
+                "authenticatedUserRoles", json.dumps(roles) if roles is not None else ""
             )
 
 

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import time
 import traceback
@@ -146,7 +147,7 @@ def _init_workflow(
         "recovery_attempts": None,
         "authenticated_user": ctx.authenticated_user,
         "authenticated_roles": (
-            ",".join(ctx.authenticated_roles) if ctx.authenticated_roles else None
+            json.dumps(ctx.authenticated_roles) if ctx.authenticated_roles else None
         ),
         "assumed_role": ctx.assumed_role,
     }

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -3,7 +3,17 @@ import time
 import traceback
 from concurrent.futures import Future
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
 from dbos.application_database import ApplicationDatabase, TransactionResultInternal
 
@@ -134,6 +144,11 @@ def _init_workflow(
         "executor_id": ctx.executor_id,
         "request": (utils.serialize(ctx.request) if ctx.request is not None else None),
         "recovery_attempts": None,
+        "authenticated_user": ctx.authenticated_user,
+        "authenticated_roles": (
+            ",".join(ctx.authenticated_roles) if ctx.authenticated_roles else None
+        ),
+        "assumed_role": ctx.assumed_role,
     }
 
     # If we have a class name, the first arg is the instance and do not serialize

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -690,6 +690,27 @@ class DBOS:
         ctx = assert_current_dbos_context()
         return ctx.request
 
+    @classproperty
+    def authenticated_user(cls) -> Optional[str]:
+        """Return the current authenticated user, if any, associated with the current context."""
+        ctx = assert_current_dbos_context()
+        return ctx.authenticated_user
+
+    @classproperty
+    def authenticated_roles(cls) -> Optional[List[str]]:
+        """Return the roles granted to the current authenticated user, if any, associated with the current context."""
+        ctx = assert_current_dbos_context()
+        return ctx.authenticated_roles
+
+    @classmethod
+    def set_authentication(
+        cls, authenticated_user: Optional[str], authenticated_roles: Optional[List[str]]
+    ) -> None:
+        """Set the current authenticated user and granted roles into the current context."""
+        ctx = assert_current_dbos_context()
+        ctx.authenticated_user = authenticated_user
+        ctx.authenticated_roles = authenticated_roles
+
 
 @dataclass
 class WorkflowStatus:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import json
 import os
 import sys
 import threading
@@ -527,7 +528,7 @@ class DBOS:
             authenticated_user=stat["authenticated_user"],
             assumed_role=stat["assumed_role"],
             authenticated_roles=(
-                stat["authenticated_roles"].split(",")
+                json.loads(stat["authenticated_roles"])
                 if stat["authenticated_roles"] is not None
                 else None
             ),

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -516,9 +516,13 @@ class DBOS:
             recovery_attempts=stat["recovery_attempts"],
             class_name=stat["class_name"],
             config_name=stat["config_name"],
-            authenticated_user=None,
-            assumed_role=None,
-            authenticatedRoles=None,
+            authenticated_user=stat["authenticated_user"],
+            assumed_role=stat["assumed_role"],
+            authenticated_roles=(
+                stat["authenticated_roles"].split(",")
+                if stat["authenticated_roles"] is not None
+                else None
+            ),
         )
 
     @classmethod
@@ -693,7 +697,7 @@ class WorkflowStatus:
         config_name(str): For instance member functions, the name of the class instance for the execution
         authenticated_user(str): The user who invoked the workflow
         assumed_role(str): The access role used by the user to allow access to the workflow function
-        authenticatedRoles(List[str]): List of all access roles available to the authenticated user
+        authenticated_roles(List[str]): List of all access roles available to the authenticated user
         recovery_attempts(int): Number of times the workflow has been restarted (usually by recovery)
 
     """
@@ -705,7 +709,7 @@ class WorkflowStatus:
     config_name: Optional[str]
     authenticated_user: Optional[str]
     assumed_role: Optional[str]
-    authenticatedRoles: Optional[List[str]]
+    authenticated_roles: Optional[List[str]]
     recovery_attempts: Optional[int]
 
 

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -266,6 +266,24 @@ class DBOS:
         self.fastapi: Optional["FastAPI"] = fastapi
         self._executor: Optional[ThreadPoolExecutor] = None
         if self.fastapi is not None:
+            from fastapi.responses import JSONResponse
+
+            @self.fastapi.exception_handler(DBOSException)
+            async def role_error_handler(
+                request: Request, exc: DBOSException
+            ) -> JSONResponse:
+                status_code = 500
+                if exc.status_code is not None:
+                    status_code = exc.status_code
+                return JSONResponse(
+                    status_code=status_code,
+                    content={
+                        "message": str(exc.message),
+                        "dbos_error_code": str(exc.dbos_error_code),
+                        "dbos_error": str(exc.__class__.__name__),
+                    },
+                )
+
             from dbos.fastapi import setup_fastapi_middleware
 
             setup_fastapi_middleware(self.fastapi)

--- a/dbos/dbos_config.py
+++ b/dbos/dbos_config.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from importlib import resources
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 import yaml
 from jsonschema import ValidationError, validate

--- a/dbos/error.py
+++ b/dbos/error.py
@@ -17,6 +17,7 @@ class DBOSException(Exception):
     def __init__(self, message: str, dbos_error_code: Optional[int] = None):
         self.message = message
         self.dbos_error_code = dbos_error_code
+        self.status_code: Optional[int] = None
         super().__init__(self.message)
 
     def __str__(self) -> str:
@@ -104,6 +105,7 @@ class DBOSNotAuthorizedError(DBOSException):
             msg,
             dbos_error_code=DBOSErrorCode.NotAuthorized.value,
         )
+        self.status_code = 403
 
 
 class DBOSMaxStepRetriesExceeded(DBOSException):

--- a/dbos/roles.py
+++ b/dbos/roles.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type, TypeVar, 
 from dbos.error import DBOSNotAuthorizedError
 
 if TYPE_CHECKING:
-    from dbos.dbos import DBOS, _DBOSRegistry
+    from dbos.dbos import _DBOSRegistry
 
 from dbos.context import DBOSAssumeRole, get_local_dbos_context
 from dbos.registrations import (

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -60,7 +60,7 @@ class WorkflowStatusInternal(TypedDict):
     recovery_attempts: Optional[int]
     authenticated_user: Optional[str]
     assumed_role: Optional[str]
-    authenticated_roles: Optional[str]  # Comma-delimited list of roles.
+    authenticated_roles: Optional[str]  # JSON list of roles.
 
 
 class RecordedResult(TypedDict):

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -4,18 +4,7 @@ import select
 import threading
 import time
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Set,
-    TypedDict,
-    cast,
-)
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, TypedDict, cast
 
 import psycopg2
 import sqlalchemy as sa

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -244,6 +244,9 @@ class SystemDatabase:
             application_version=status["app_version"],
             application_id=status["app_id"],
             request=status["request"],
+            authenticated_user=status["authenticated_user"],
+            authenticated_roles=status["authenticated_roles"],
+            assumed_role=status["assumed_role"],
         )
         if replace:
             cmd = cmd.on_conflict_do_update(

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -58,6 +58,9 @@ class WorkflowStatusInternal(TypedDict):
     app_id: Optional[str]
     request: Optional[str]  # JSON (jsonpickle)
     recovery_attempts: Optional[int]
+    authenticated_user: Optional[str]
+    assumed_role: Optional[str]
+    authenticated_roles: Optional[str]  # Comma-delimited list of roles.
 
 
 class RecordedResult(TypedDict):
@@ -125,7 +128,7 @@ class WorkflowInformation(TypedDict, total=False):
     authenticated_user: str  # The user who ran the workflow. Empty string if not set.
     assumed_role: str
     # The role used to run this workflow.  Empty string if authorization is not required.
-    authenticatedRoles: List[str]
+    authenticated_roles: List[str]
     # All roles the authenticated user has, if any.
     input: Optional[WorkflowInputs]
     output: Optional[str]
@@ -311,6 +314,9 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.recovery_attempts,
                     SystemSchema.workflow_status.c.config_name,
                     SystemSchema.workflow_status.c.class_name,
+                    SystemSchema.workflow_status.c.authenticated_user,
+                    SystemSchema.workflow_status.c.authenticated_roles,
+                    SystemSchema.workflow_status.c.assumed_role,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -328,6 +334,9 @@ class SystemDatabase:
                 "executor_id": None,
                 "request": row[2],
                 "recovery_attempts": row[3],
+                "authenticated_user": row[6],
+                "authenticated_roles": row[7],
+                "assumed_role": row[8],
             }
             return status
 
@@ -364,6 +373,9 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.error,
                     SystemSchema.workflow_status.c.config_name,
                     SystemSchema.workflow_status.c.class_name,
+                    SystemSchema.workflow_status.c.authenticated_user,
+                    SystemSchema.workflow_status.c.authenticated_roles,
+                    SystemSchema.workflow_status.c.assumed_role,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -381,6 +393,9 @@ class SystemDatabase:
                 "executor_id": None,
                 "request": row[2],
                 "recovery_attempts": None,
+                "authenticated_user": row[7],
+                "authenticated_roles": row[8],
+                "assumed_role": row[9],
             }
             return status
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5406291ddfe1bed4b55b468933833e06086192458def0fe542c358a012a5129e"
+content_hash = "sha256:e8efa5c58d0f11b67f9e4ecd96a268a3c5d1818b9b0fdd1ee18e43e50b63775a"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -1418,6 +1418,21 @@ dependencies = [
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
     {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.3.0"
+requires_python = ">=3.7"
+summary = "pytest plugin to run your tests in a specific order"
+groups = ["dev"]
+dependencies = [
+    "pytest>=5.0; python_version < \"3.10\"",
+    "pytest>=6.2.4; python_version >= \"3.10\"",
+]
+files = [
+    {file = "pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e"},
+    {file = "pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e8efa5c58d0f11b67f9e4ecd96a268a3c5d1818b9b0fdd1ee18e43e50b63775a"
+content_hash = "sha256:9070f6c3539dc964d8cb951c1e76a950f667c80913049b9dd78645758e087708"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -1374,6 +1374,17 @@ groups = ["default", "dev"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+requires_python = ">=3.8"
+summary = "JSON Web Token implementation in Python"
+groups = ["dev"]
+files = [
+    {file = "PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850"},
+    {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pdm>=2.18.0",
     "pdm-backend>=2.3.3",
     "GitPython>=3.1.43",
+    "pytest-order>=1.3.0",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "pdm-backend>=2.3.3",
     "GitPython>=3.1.43",
     "pytest-order>=1.3.0",
+    "pyjwt>=2.9.0",
 ]
 
 [tool.black]

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -84,6 +84,9 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
 

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -92,6 +92,9 @@ def test_admin_recovery(dbos: DBOS) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
     status = dbos.get_workflow_status(wfuuid)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,10 +1,6 @@
 import datetime
-import importlib
-import sys
 import time
 import uuid
-from importlib.abc import MetaPathFinder
-from importlib.machinery import ModuleSpec
 from typing import Any, Optional
 
 import pytest

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -651,7 +651,10 @@ def test_retrieve_workflow_in_workflow(dbos: DBOS) -> None:
     assert stat.recovery_attempts == 0
 
 
-def test_without_fastapi() -> None:
+# This makes other tests break if run in the middle of the suite
+# If run at the end of the suite, it fails because something imported fastapi.
+# @pytest.mark.order("last")
+def disabled_test_without_fastapi() -> None:
     """
     Since DBOS does not depend on FastAPI directly, verify DBOS works in an environment without FastAPI.
     """

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -353,6 +353,9 @@ def test_recovery_workflow(dbos: DBOS) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
 
@@ -412,6 +415,9 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
 
@@ -464,6 +470,9 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -127,6 +127,9 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "app_version": None,
             "request": None,
             "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
         }
     )
 

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -1,7 +1,9 @@
-from typing import Awaitable, Callable, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple
 
+import jwt
 import pytest
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.security import OAuth2PasswordBearer
 from fastapi.testclient import TestClient
 
 # For tracing test
@@ -181,12 +183,60 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 def test_jwt_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     dbos, app = dbos_fastapi
 
+    JWT_SECRET = "dbsecret"
+    JWT_ALG = "HS256"
+
+    class TokenData:
+        def __init__(self) -> None:
+            self.username: str = ""
+            self.roles: List[str] = []
+
+    def decode_jwt(token: str) -> TokenData:
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALG])
+            username: str = payload.get("sub")
+            roles: List[str] = payload.get("roles", [])
+            if username is None or not len(username):
+                raise HTTPException(
+                    status_code=401,
+                    detail="Could not validate credentials",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            td = TokenData()
+            td.username = username
+            td.roles = roles
+            return td
+        except jwt.PyJWTError:
+            raise HTTPException(
+                status_code=401,
+                detail="Could not validate credentials",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    def create_jwt_token(username: str, roles: List[str]) -> str:
+        to_encode = {"sub": username, "roles": roles}
+        encoded_jwt = jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALG)
+        return encoded_jwt
+
+    oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
     @app.middleware("http")
     async def jwtAuthMiddleware(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
+        user: Optional[str] = None
+        roles: Optional[List[str]] = None
+        try:
+            token = await oauth2_scheme(request)
+            if token is not None:
+                tdata = decode_jwt(token)
+                user = tdata.username
+                roles = tdata.roles
+        except Exception as e:
+            pass
+
         with DBOSContextEnsure() as ctx:
-            ctx.set_authentication("user1", ["user", "engineer"])
+            ctx.set_authentication(user, roles)
             try:
                 response = await call_next(request)
                 return response
@@ -230,19 +280,24 @@ def test_jwt_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 
     client = TestClient(app)
 
+    token = create_jwt_token(username="user1", roles=["user", "engineer"])
+
     response = client.get("/open/a")
     assert response.status_code == 200
     assert response.text == '"a"'
 
     response = client.get("/user/b")
+    assert response.status_code == 403
+
+    response = client.get("/user/b", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
     assert response.text == '"b"'
 
-    response = client.get("/engineer/c")
+    response = client.get("/engineer/c", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
     assert response.text == '"c"'
 
-    response = client.get("/admin/d")
+    response = client.get("/admin/d", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 403
     assert (
         response.text

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -1,0 +1,132 @@
+from typing import Awaitable, Callable, Tuple
+
+import pytest
+import sqlalchemy as sa
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Public API
+from dbos import DBOS
+
+# Private API because this is a unit test
+from dbos.context import DBOSContextEnsure, assert_current_dbos_context
+from dbos.error import DBOSException, DBOSNotAuthorizedError
+
+
+def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
+    dbos, app = dbos_fastapi
+
+    class SetRoleMiddleware(BaseHTTPMiddleware):
+        async def dispatch(
+            self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+        ) -> Response:
+            with DBOSContextEnsure() as ctx:
+                ctx.authenticated_user = "user1"
+                ctx.authenticated_roles = ["user", "engineer"]
+                try:
+                    response = await call_next(request)
+                    return response
+                finally:
+                    ctx.authenticated_user = None
+                    ctx.authenticated_roles = None
+
+    app.add_middleware(SetRoleMiddleware)
+
+    @app.exception_handler(DBOSNotAuthorizedError)
+    async def role_error_handler(
+        request: Request, exc: DBOSNotAuthorizedError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": str(exc)},
+        )
+
+    @app.get("/dboserror")
+    def test_dbos_error() -> None:
+        raise DBOSNotAuthorizedError("test")
+
+    @app.get("/open/{var1}")
+    @DBOS.required_roles([])
+    @DBOS.workflow()
+    def test_open_endpoint(var1: str) -> str:
+        result = var1
+        ctx = assert_current_dbos_context()
+        return result
+
+    @app.get("/user/{var1}")
+    @DBOS.required_roles(["user"])
+    @DBOS.workflow()
+    def test_user_endpoint(var1: str) -> str:
+        result = var1
+        ctx = assert_current_dbos_context()
+        assert ctx.assumed_role == "user"
+        return result
+
+    @app.get("/engineer/{var1}")
+    @DBOS.required_roles(["engineer"])
+    @DBOS.workflow()
+    def test_engineer_endpoint(var1: str) -> str:
+        result = var1
+        ctx = assert_current_dbos_context()
+        assert ctx.assumed_role == "engineer"
+        return result
+
+    @app.get("/admin/{var1}")
+    @DBOS.required_roles(["admin"])
+    @DBOS.workflow()
+    def test_admin_endpoint(var1: str) -> str:
+        result = var1
+        ctx = assert_current_dbos_context()
+        assert ctx.assumed_role == "admin"
+        return result
+
+    @DBOS.required_roles(["admin"])
+    @DBOS.workflow()
+    def test_admin_endpoint_nh(var1: str) -> str:
+        result = var1
+        ctx = assert_current_dbos_context()
+        assert ctx.assumed_role == "admin"
+        return result
+
+    @app.get("/adminalt/{var1}")
+    def test_admin_handler(var1: str) -> str:
+        return test_admin_endpoint_nh(var1)
+
+    @app.get("/error")
+    def test_error() -> None:
+        raise HTTPException(status_code=401)
+
+    client = TestClient(app)
+
+    response = client.get("/error")
+    assert response.status_code == 401
+
+    response = client.get("/dboserror")
+    assert response.status_code == 400
+
+    response = client.get("/open/a")
+    assert response.status_code == 200
+    assert response.text == '"a"'
+
+    response = client.get("/user/b")
+    assert response.status_code == 200
+    assert response.text == '"b"'
+
+    response = client.get("/engineer/c")
+    assert response.status_code == 200
+    assert response.text == '"c"'
+
+    # response = client.get("/adminalt/d")
+    # assert response.status_code == 400
+
+    with pytest.raises(Exception) as exc_info:
+        response = client.get("/admin/d")
+    assert exc_info.value.__class__.__qualname__ == DBOSNotAuthorizedError.__qualname__
+    assert exc_info.value.__class__.__module__ == DBOSNotAuthorizedError.__module__
+    assert id(exc_info.value.__class__) == id(DBOSNotAuthorizedError)
+
+    assert isinstance(exc_info.value, DBOSNotAuthorizedError)
+    assert exc_info.errisinstance(DBOSNotAuthorizedError)
+    assert str(exc_info.value) == "well no"

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -1,12 +1,10 @@
-import json
-from typing import Any, Awaitable, Callable, Dict, List, Protocol, Tuple, cast
+from typing import Awaitable, Callable, Tuple
 
 import pytest
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.testclient import TestClient
 
 # For tracing test
-from opentelemetry import trace
 from opentelemetry.sdk import trace as tracesdk
 
 # from opentelemetry.sdk.trace import TracerProvider

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -131,7 +131,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert span.attributes is not None
     assert span.attributes["authenticatedUser"] == "user1"
     assert span.attributes["authenticatedUserAssumedRole"] == "user"
-    assert span.attributes["authenticatedUserRoles"] == "user,engineer"
+    assert span.attributes["authenticatedUserRoles"] == '["user", "engineer"]'
 
     # Verify that there is one workflow for this user.
     gwi = GetWorkflowsInput()

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -144,6 +144,11 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert wfs.authenticated_user == "user1"
     assert wfs.authenticated_roles == ["user", "engineer"]
 
+    # Make sure predicate is actually applied
+    gwi.authenticated_user = "user2"
+    wfl = dbos.sys_db.get_workflows(gwi)
+    assert len(wfl.workflow_uuids) == 0
+
     response = client.get("/error")
     assert response.status_code == 401
 

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -39,12 +39,14 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
         with DBOSContextEnsure() as ctx:
+            prev_user = ctx.authenticated_user
+            prev_roles = ctx.authenticated_roles
             ctx.set_authentication("user1", ["user", "engineer"])
             try:
                 response = await call_next(request)
                 return response
             finally:
-                ctx.set_authentication(None, None)
+                ctx.set_authentication(prev_user, prev_roles)
 
     @app.get("/dboserror")
     def test_dbos_error() -> None:
@@ -236,12 +238,14 @@ def test_jwt_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             pass
 
         with DBOSContextEnsure() as ctx:
+            prev_user = ctx.authenticated_user
+            prev_roles = ctx.authenticated_roles
             ctx.set_authentication(user, roles)
             try:
                 response = await call_next(request)
                 return response
             finally:
-                ctx.set_authentication(None, None)
+                ctx.set_authentication(prev_user, prev_roles)
 
     @app.get("/open/{var1}")
     @DBOS.required_roles([])

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -39,14 +39,14 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
         with DBOSContextEnsure() as ctx:
-            prev_user = ctx.authenticated_user
-            prev_roles = ctx.authenticated_roles
-            ctx.set_authentication("user1", ["user", "engineer"])
+            prev_user = DBOS.authenticated_user
+            prev_roles = DBOS.authenticated_roles
+            DBOS.set_authentication("user1", ["user", "engineer"])
             try:
                 response = await call_next(request)
                 return response
             finally:
-                ctx.set_authentication(prev_user, prev_roles)
+                DBOS.set_authentication(prev_user, prev_roles)
 
     @app.get("/dboserror")
     def test_dbos_error() -> None:
@@ -238,14 +238,14 @@ def test_jwt_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             pass
 
         with DBOSContextEnsure() as ctx:
-            prev_user = ctx.authenticated_user
-            prev_roles = ctx.authenticated_roles
-            ctx.set_authentication(user, roles)
+            prev_user = DBOS.authenticated_user
+            prev_roles = DBOS.authenticated_roles
+            DBOS.set_authentication(user, roles)
             try:
                 response = await call_next(request)
                 return response
             finally:
-                ctx.set_authentication(prev_user, prev_roles)
+                DBOS.set_authentication(prev_user, prev_roles)
 
     @app.get("/open/{var1}")
     @DBOS.required_roles([])

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -38,7 +38,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     async def authMiddleware(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        with DBOSContextEnsure() as ctx:
+        with DBOSContextEnsure():
             prev_user = DBOS.authenticated_user
             prev_roles = DBOS.authenticated_roles
             DBOS.set_authentication("user1", ["user", "engineer"])
@@ -138,6 +138,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert span.attributes["authenticatedUserRoles"] == '["user", "engineer"]'
 
     # Verify that there is one workflow for this user.
+    dbos.sys_db.wait_for_buffer_flush()
     gwi = GetWorkflowsInput()
     gwi.authenticated_user = "user1"
     wfl = dbos.sys_db.get_workflows(gwi)
@@ -237,7 +238,7 @@ def test_jwt_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
         except Exception as e:
             pass
 
-        with DBOSContextEnsure() as ctx:
+        with DBOSContextEnsure():
             prev_user = DBOS.authenticated_user
             prev_roles = DBOS.authenticated_roles
             DBOS.set_authentication(user, roles)


### PR DESCRIPTION
Simple middleware for setting up roles.
  Relevant Export
Tests for same
Default error handler for DBOSException to return HTTP status codes.
Removing "no fastapi" test
Set security info into spans
  Make the trace provider replaceable in unit test, add unit tests for spans
Write the user / roles / etc., to system database.  Test retrieval, and get_workflows query.