### PR TITLE
Fix Logging

### DIFF
--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -286,6 +286,7 @@ class DBOS:
         if launch:
             self.launch()
 
+        dbos_logger.info("DBOS initialized")
         for handler in dbos_logger.handlers:
             handler.flush()
 

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -286,7 +286,6 @@ class DBOS:
         if launch:
             self.launch()
 
-        dbos_logger.info("DBOS initialized")
         for handler in dbos_logger.handlers:
             handler.flush()
 

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -734,7 +734,6 @@ class SystemDatabase:
                 )
                 notification_cursor = self.notification_conn.cursor()
 
-                dbos_logger.info("Listening to notifications")
                 notification_cursor.execute("LISTEN dbos_notifications_channel")
                 notification_cursor.execute("LISTEN dbos_workflow_events_channel")
                 while self._run_background_processes:


### PR DESCRIPTION
Due to https://github.com/open-telemetry/opentelemetry-python/issues/3193, the OTLP exporter does not flush logs that were buffered when another process reconfigured the logger.

To mitigate this:

- During initialization, flush all DBOS logs immediately
- Only export non-DBOS logs to OTLP during `launch` after startup completes.