### PR TITLE
Improved CLI Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ def step_two():
     print("Step two completed!")
 
 @DBOS.workflow()
-def my_first_workflow():
+def dbos_workflow():
     step_one()
     for _ in range(5):
         print("Press Control + \ to stop the app...")
@@ -77,7 +77,7 @@ def my_first_workflow():
 
 @app.get("/")
 def fastapi_endpoint():
-    my_first_workflow()
+    dbos_workflow()
 ```
 
 Save the program into `main.py`, edit `dbos-config.yaml` to configure your Postgres connection settings, and start it with `fastapi run`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ def step_two():
     print("Step two completed!")
 
 @DBOS.workflow()
-def workflow():
+def my_first_workflow():
     step_one()
     for _ in range(5):
         print("Press Control + \ to stop the app...")
@@ -76,8 +76,8 @@ def workflow():
     step_two()
 
 @app.get("/")
-def endpoint():
-    workflow()
+def fastapi_endpoint():
+    my_first_workflow()
 ```
 
 Save the program into `main.py`, edit `dbos-config.yaml` to configure your Postgres connection settings, and start it with `fastapi run`.

--- a/dbos/cli.py
+++ b/dbos/cli.py
@@ -129,9 +129,12 @@ def copy_template(src_dir: str, project_name: str, config_mode: bool) -> None:
         "project_name": project_name,
         "package_name": package_name,
         "db_name": db_name,
+        "migration_command": "alembic upgrade head",
     }
 
     if config_mode:
+        ctx["package_name"] = "."
+        ctx["migration_command"] = "echo 'No migrations specified'"
         copy_dbos_template(
             os.path.join(src_dir, "dbos-config.yaml.dbos"),
             os.path.join(dst_dir, "dbos-config.yaml"),

--- a/dbos/cli.py
+++ b/dbos/cli.py
@@ -12,7 +12,7 @@ from typing import Any
 import tomlkit
 import typer
 from rich import print
-from rich.prompt import Confirm, Prompt
+from rich.prompt import Prompt
 from typing_extensions import Annotated
 
 from dbos import load_config
@@ -30,6 +30,7 @@ def on_windows() -> bool:
 def start() -> None:
     config = load_config()
     start_commands = config["runtimeConfig"]["start"]
+    typer.echo("Executing start commands from 'dbos-config.yaml'")
     for command in start_commands:
         typer.echo(f"Executing: {command}")
 
@@ -247,6 +248,7 @@ def migrate() -> None:
             app_db.destroy()
 
     # Next, run any custom migration commands specified in the configuration
+    typer.echo("Executing migration commands from 'dbos-config.yaml'")
     try:
         migrate_commands = (
             config["database"]["migrate"]

--- a/dbos/templates/hello/dbos-config.yaml.dbos
+++ b/dbos/templates/hello/dbos-config.yaml.dbos
@@ -15,7 +15,7 @@ database:
   password: ${PGPASSWORD}
   app_db_name: ${db_name}
   migrate:
-    - alembic upgrade head
+    - ${migration_command}
 telemetry:
   logs:
     logLevel: INFO


### PR DESCRIPTION
- `dbos init --config` will not configure migration commands as it does not configure migrations.
- `dbos start` and `dbos migrate` now indicate where their commands come from