### PR TITLE
exit LifespanMiddleware after shutdown

### DIFF
--- a/dbos/fastapi.py
+++ b/dbos/fastapi.py
@@ -70,6 +70,7 @@ class LifespanMiddleware:
                 elif message["type"] == "lifespan.shutdown":
                     self.dbos._destroy()
                     await send({"type": "lifespan.shutdown.complete"})
+                    break
         else:
             await self.app(scope, receive, send)
 


### PR DESCRIPTION
W/o the added while break, fastapi issues a log message `INFO:     ASGI 'lifespan' protocol appears unsupported.`. Exiting `LifespanMiddleware.__call__` after sending the shutdown response eliminates the stray message