### PR TITLE
Seconds as the first field in cron format

### DIFF
--- a/dbos/scheduler/scheduler.py
+++ b/dbos/scheduler/scheduler.py
@@ -16,7 +16,7 @@ ScheduledWorkflow = Callable[[datetime, datetime], None]
 def scheduler_loop(
     func: ScheduledWorkflow, cron: str, stop_event: threading.Event
 ) -> None:
-    iter = croniter(cron, datetime.now(timezone.utc))
+    iter = croniter(cron, datetime.now(timezone.utc), second_at_beginning=True)
     while not stop_event.is_set():
         nextExecTime = iter.get_next(datetime)
         sleepTime = nextExecTime - datetime.now(timezone.utc)

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -9,14 +9,14 @@ from dbos import DBOS
 def test_scheduled_workflow(dbos: DBOS) -> None:
     wf_counter: int = 0
 
-    @DBOS.scheduled("* * * * * *")
+    @DBOS.scheduled("*/2 * * * * *")
     @DBOS.workflow()
     def test_workflow(scheduled: datetime, actual: datetime) -> None:
         nonlocal wf_counter
         wf_counter += 1
 
-    time.sleep(2)
-    assert wf_counter >= 1 and wf_counter <= 3
+    time.sleep(4)
+    assert wf_counter > 1 and wf_counter <= 3
 
 
 def test_scheduled_workflow_exception(dbos: DBOS) -> None:


### PR DESCRIPTION
It's more natural to put `seconds` as the first field, keeping it consistent with our TS version.