### PR TITLE
prefix internal dbos properties with underscore

### DIFF
--- a/dbos/recovery.py
+++ b/dbos/recovery.py
@@ -41,7 +41,7 @@ def _recover_pending_workflows(
                 f"Skip local recovery because it's running in a VM: {os.environ.get('DBOS__VMID')}"
             )
         dbos.logger.debug(f"Recovering pending workflows for executor: {executor_id}")
-        workflow_ids = dbos.sys_db.get_pending_workflows(executor_id)
+        workflow_ids = dbos._sys_db.get_pending_workflows(executor_id)
         dbos.logger.debug(f"Pending workflows: {workflow_ids}")
 
         for workflowID in workflow_ids:

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -69,8 +69,8 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
     for event in dbos.stop_events:
         event.set()
 
-    dbos.sys_db.wait_for_buffer_flush()
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.wait_for_buffer_flush()
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": workflow_id,
             "status": "PENDING",

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -76,9 +76,9 @@ def test_admin_recovery(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         assert test_workflow("bob", "bob") == "bob1bob"
 
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -249,18 +249,18 @@ def test_temp_workflow(dbos: DBOS) -> None:
 
     # Flush workflow inputs buffer shouldn't fail due to foreign key violation.
     # It should properly skip the transaction inputs.
-    dbos.sys_db._flush_workflow_inputs_buffer()
+    dbos._sys_db._flush_workflow_inputs_buffer()
 
     # Wait for buffers to flush
-    dbos.sys_db.wait_for_buffer_flush()
-    wfs = dbos.sys_db.get_workflows(gwi)
+    dbos._sys_db.wait_for_buffer_flush()
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 2
 
-    wfi1 = dbos.sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
+    wfi1 = dbos._sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
     assert wfi1
     assert wfi1["name"].startswith("<temp>")
 
-    wfi2 = dbos.sys_db.get_workflow_info(wfs.workflow_uuids[1], False)
+    wfi2 = dbos._sys_db.get_workflow_info(wfs.workflow_uuids[1], False)
     assert wfi2
     assert wfi2["name"].startswith("<temp>")
 
@@ -337,9 +337,9 @@ def test_recovery_workflow(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         assert test_workflow("bob", "bob") == "bob1bob"
 
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",
@@ -391,17 +391,17 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
         res = test_transaction("bob")
         assert res == "bob1"
 
-    dbos.sys_db.wait_for_buffer_flush()
-    wfs = dbos.sys_db.get_workflows(gwi)
+    dbos._sys_db.wait_for_buffer_flush()
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 1
     assert wfs.workflow_uuids[0] == wfuuid
 
-    wfi = dbos.sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
+    wfi = dbos._sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
     assert wfi
     assert wfi["name"].startswith("<temp>")
 
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",
@@ -426,12 +426,12 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == "bob1"
 
-    wfs = dbos.sys_db.get_workflows(gwi)
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 1
     assert wfs.workflow_uuids[0] == wfuuid
 
-    dbos.sys_db.wait_for_buffer_flush()
-    wfi = dbos.sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
+    dbos._sys_db.wait_for_buffer_flush()
+    wfi = dbos._sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
     assert wfi
     assert wfi["name"].startswith("<temp>")
     assert wfi["status"] == "SUCCESS"
@@ -454,9 +454,9 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         assert test_workflow(test_var) == test_var
 
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",
@@ -626,7 +626,7 @@ def test_retrieve_workflow_in_workflow(dbos: DBOS) -> None:
         fstat1 = wfh.get_status()
         assert fstat1
         fres = wfh.get_result()
-        dbos.sys_db.wait_for_buffer_flush()  # Wait for status to export.
+        dbos._sys_db.wait_for_buffer_flush()  # Wait for status to export.
         fstat2 = wfh.get_status()
         assert fstat2
         return fstat1.status + fres + fstat2.status
@@ -795,12 +795,12 @@ def test_send_recv_temp_wf(dbos: DBOS) -> None:
     dbos.send(dest_uuid, "testsend1", "testtopic")
     assert handle.get_result() == "testsend1"
 
-    wfs = dbos.sys_db.get_workflows(gwi)
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 2
     assert wfs.workflow_uuids[1] == dest_uuid
     assert wfs.workflow_uuids[0] != dest_uuid
 
-    wfi = dbos.sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
+    wfi = dbos._sys_db.get_workflow_info(wfs.workflow_uuids[0], False)
     assert wfi
     assert wfi["name"] == "<temp>.temp_send_workflow"
 

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -56,13 +56,13 @@ def test_notification_errors(dbos: DBOS) -> None:
         return "-".join([str(msg1), str(msg2), str(msg3)])
 
     # Crash the notification connection and make sure send/recv works on time.
-    while dbos.sys_db.notification_conn is None:
+    while dbos._sys_db.notification_conn is None:
         time.sleep(1)
-    dbos.sys_db.notification_conn.close()
-    assert dbos.sys_db.notification_conn.closed == 1
+    dbos._sys_db.notification_conn.close()
+    assert dbos._sys_db.notification_conn.closed == 1
 
     # Wait for the connection to be re-established
-    while dbos.sys_db.notification_conn.closed != 0:
+    while dbos._sys_db.notification_conn.closed != 0:
         time.sleep(1)
 
     dest_uuid = str("sruuid1")
@@ -94,13 +94,13 @@ def test_buffer_flush_errors(dbos: DBOS) -> None:
     res = test_transaction("bob")
     assert res == "bob1"
 
-    dbos.sys_db.wait_for_buffer_flush()
-    wfs = dbos.sys_db.get_workflows(gwi)
+    dbos._sys_db.wait_for_buffer_flush()
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 1
 
     # Crash the system database connection and make sure the buffer flush works on time.
-    backup_engine = dbos.sys_db.engine
-    dbos.sys_db.engine = sa.create_engine(
+    backup_engine = dbos._sys_db.engine
+    dbos._sys_db.engine = sa.create_engine(
         "postgresql+psycopg://fake:database@localhost/fake_db"
     )
 
@@ -111,8 +111,8 @@ def test_buffer_flush_errors(dbos: DBOS) -> None:
     time.sleep(2)
 
     # Switch back to the original good engine.
-    dbos.sys_db.engine = backup_engine
+    dbos._sys_db.engine = backup_engine
 
-    dbos.sys_db.wait_for_buffer_flush()
-    wfs = dbos.sys_db.get_workflows(gwi)
+    dbos._sys_db.wait_for_buffer_flush()
+    wfs = dbos._sys_db.get_workflows(gwi)
     assert len(wfs.workflow_uuids) == 2

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -111,9 +111,9 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert response.json().get("id1") == wfuuid
     assert response.json().get("id2") != wfuuid
 
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -138,10 +138,10 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert span.attributes["authenticatedUserRoles"] == '["user", "engineer"]'
 
     # Verify that there is one workflow for this user.
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     gwi = GetWorkflowsInput()
     gwi.authenticated_user = "user1"
-    wfl = dbos.sys_db.get_workflows(gwi)
+    wfl = dbos._sys_db.get_workflows(gwi)
     assert len(wfl.workflow_uuids) == 1
     wfs = DBOS.get_workflow_status(wfl.workflow_uuids[0])
     assert wfs
@@ -151,7 +151,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 
     # Make sure predicate is actually applied
     gwi.authenticated_user = "user2"
-    wfl = dbos.sys_db.get_workflows(gwi)
+    wfl = dbos._sys_db.get_workflows(gwi)
     assert len(wfl.workflow_uuids) == 0
 
     response = client.get("/error")

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -76,9 +76,9 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
     assert response.json.get("id1") == wfuuid
     assert response.json.get("id2") != wfuuid
 
-    dbos.sys_db.wait_for_buffer_flush()
+    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
-    dbos.sys_db.update_workflow_status(
+    dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": wfuuid,
             "status": "PENDING",

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -14,7 +14,7 @@ from dbos.schemas.system_database import SystemSchema
 
 def test_systemdb_migration(dbos: DBOS) -> None:
     # Make sure all tables exist
-    with dbos.sys_db.engine.connect() as connection:
+    with dbos._sys_db.engine.connect() as connection:
         sql = SystemSchema.workflow_status.select()
         result = connection.execute(sql)
         assert result.fetchall() == []
@@ -41,10 +41,10 @@ def test_systemdb_migration(dbos: DBOS) -> None:
 
     # Test migrating down
     rollback_system_db(
-        sysdb_url=dbos.sys_db.engine.url.render_as_string(hide_password=False)
+        sysdb_url=dbos._sys_db.engine.url.render_as_string(hide_password=False)
     )
 
-    with dbos.sys_db.engine.connect() as connection:
+    with dbos._sys_db.engine.connect() as connection:
         with pytest.raises(sa.exc.ProgrammingError) as exc_info:
             sql = SystemSchema.workflow_status.select()
             result = connection.execute(sql)
@@ -68,17 +68,17 @@ def test_custom_sysdb_name_migration(
     DBOS.launch()
 
     # Make sure all tables exist
-    with dbos.sys_db.engine.connect() as connection:
+    with dbos._sys_db.engine.connect() as connection:
         sql = SystemSchema.workflow_status.select()
         result = connection.execute(sql)
         assert result.fetchall() == []
 
     # Test migrating down
     rollback_system_db(
-        sysdb_url=dbos.sys_db.engine.url.render_as_string(hide_password=False)
+        sysdb_url=dbos._sys_db.engine.url.render_as_string(hide_password=False)
     )
 
-    with dbos.sys_db.engine.connect() as connection:
+    with dbos._sys_db.engine.connect() as connection:
         with pytest.raises(sa.exc.ProgrammingError) as exc_info:
             sql = SystemSchema.workflow_status.select()
             result = connection.execute(sql)


### PR DESCRIPTION
This way, `executor`, `sys_db`, `app_db` and `admin_server` don't show up in intellisense 