### PR TITLE
Job Queue

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -20,4 +20,5 @@ __all__ = [
     "load_config",
     "get_dbos_database_url",
     "error",
+    "Queue",
 ]

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -3,6 +3,7 @@ from .context import DBOSContextEnsure, SetWorkflowID
 from .dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
 from .dbos_config import ConfigFile, get_dbos_database_url, load_config
 from .kafka_message import KafkaMessage
+from .queue import Queue
 from .system_database import GetWorkflowsInput, WorkflowStatusString
 
 __all__ = [

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -188,6 +188,7 @@ def _execute_workflow(
         output = func(*args, **kwargs)
         status["status"] = "SUCCESS"
         status["output"] = utils.serialize(output)
+        dbos._sys_db.remove_from_queue(status["workflow_uuid"])
         dbos._sys_db.buffer_workflow_status(status)
     except DBOSWorkflowConflictIDError:
         # Retrieve the workflow handle and wait for the result.
@@ -200,6 +201,7 @@ def _execute_workflow(
     except Exception as error:
         status["status"] = "ERROR"
         status["error"] = utils.serialize(error)
+        dbos._sys_db.remove_from_queue(status["workflow_uuid"])
         dbos._sys_db.update_workflow_status(status)
         raise
 

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -570,7 +570,7 @@ def _transaction(
         set_dbos_func_name(temp_wf, "<temp>." + func.__qualname__)
         set_temp_workflow_type(temp_wf, "transaction")
         dbosreg.register_wf_function(get_dbos_func_name(temp_wf), wrapped_wf)
-        wrapper.__orig_func = temp_wf
+        wrapper.__orig_func = temp_wf  # type: ignore
 
         return cast(F, wrapper)
 
@@ -687,7 +687,7 @@ def _step(
         set_dbos_func_name(temp_wf, "<temp>." + func.__qualname__)
         set_temp_workflow_type(temp_wf, "step")
         dbosreg.register_wf_function(get_dbos_func_name(temp_wf), wrapped_wf)
-        wrapper.__orig_func = temp_wf
+        wrapper.__orig_func = temp_wf  # type: ignore
 
         return cast(F, wrapper)
 

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -156,7 +156,7 @@ def _init_workflow(
             json.dumps(ctx.authenticated_roles) if ctx.authenticated_roles else None
         ),
         "assumed_role": ctx.assumed_role,
-        "was_queued": queue is not None,
+        "queue_name": queue,
     }
 
     # If we have a class name, the first arg is the instance and do not serialize
@@ -189,7 +189,7 @@ def _execute_workflow(
         output = func(*args, **kwargs)
         status["status"] = "SUCCESS"
         status["output"] = utils.serialize(output)
-        if status["was_queued"]:
+        if status["queue_name"] is not None:
             dbos._sys_db.remove_from_queue(status["workflow_uuid"])
         dbos._sys_db.buffer_workflow_status(status)
     except DBOSWorkflowConflictIDError:
@@ -203,7 +203,7 @@ def _execute_workflow(
     except Exception as error:
         status["status"] = "ERROR"
         status["error"] = utils.serialize(error)
-        if status["was_queued"]:
+        if status["queue_name"] is not None:
             dbos._sys_db.remove_from_queue(status["workflow_uuid"])
         dbos._sys_db.update_workflow_status(status)
         raise

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -264,6 +264,7 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
                     dbos,
                     wf_func,
                     status["queue_name"],
+                    True,
                     dbos._registry.instance_info_map[iname],
                     *inputs["args"],
                     **inputs["kwargs"],
@@ -280,6 +281,7 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
                     dbos,
                     wf_func,
                     status["queue_name"],
+                    True,
                     dbos._registry.class_info_map[class_name],
                     *inputs["args"],
                     **inputs["kwargs"],
@@ -290,6 +292,7 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
                     dbos,
                     wf_func,
                     status["queue_name"],
+                    True,
                     *inputs["args"],
                     **inputs["kwargs"],
                 )
@@ -364,6 +367,7 @@ def _start_workflow(
     dbos: "DBOS",
     func: "Workflow[P, R]",
     queue_name: Optional[str],
+    submit_workflow: bool,
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> "WorkflowHandle[R]":
@@ -419,6 +423,9 @@ def _start_workflow(
         temp_wf_type=get_temp_workflow_type(func),
         queue=queue_name,
     )
+
+    if not submit_workflow:
+        return _WorkflowHandlePolling(new_wf_id, dbos)
 
     if fself is not None:
         future = dbos._executor.submit(

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -263,6 +263,7 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
                 return _start_workflow(
                     dbos,
                     wf_func,
+                    status["queue_name"],
                     dbos._registry.instance_info_map[iname],
                     *inputs["args"],
                     **inputs["kwargs"],
@@ -278,6 +279,7 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
                 return _start_workflow(
                     dbos,
                     wf_func,
+                    status["queue_name"],
                     dbos._registry.class_info_map[class_name],
                     *inputs["args"],
                     **inputs["kwargs"],
@@ -285,7 +287,11 @@ def _execute_workflow_id(dbos: "DBOS", workflow_id: str) -> "WorkflowHandle[Any]
         else:
             with SetWorkflowID(workflow_id):
                 return _start_workflow(
-                    dbos, wf_func, *inputs["args"], **inputs["kwargs"]
+                    dbos,
+                    wf_func,
+                    status["queue_name"],
+                    *inputs["args"],
+                    **inputs["kwargs"],
                 )
 
 
@@ -357,6 +363,7 @@ def _workflow(reg: "_DBOSRegistry") -> Callable[[F], F]:
 def _start_workflow(
     dbos: "DBOS",
     func: "Workflow[P, R]",
+    queue_name: Optional[str],
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> "WorkflowHandle[R]":
@@ -410,6 +417,7 @@ def _start_workflow(
         class_name=get_dbos_class_name(fi, func, gin_args),
         config_name=get_config_name(fi, func, gin_args),
         temp_wf_type=get_temp_workflow_type(func),
+        queue=queue_name,
     )
 
     if fself is not None:

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -163,7 +163,7 @@ def _init_workflow(
     if class_name is not None:
         inputs = {"args": inputs["args"][1:], "kwargs": inputs["kwargs"]}
 
-    if temp_wf_type != "transaction":
+    if temp_wf_type != "transaction" or queue is not None:
         # Synchronously record the status and inputs for workflows and single-step workflows
         # We also have to do this for single-step workflows because of the foreign key constraint on the operation outputs table
         dbos._sys_db.update_workflow_status(status, False, ctx.in_recovery)
@@ -570,6 +570,7 @@ def _transaction(
         set_dbos_func_name(temp_wf, "<temp>." + func.__qualname__)
         set_temp_workflow_type(temp_wf, "transaction")
         dbosreg.register_wf_function(get_dbos_func_name(temp_wf), wrapped_wf)
+        wrapper.__orig_func = temp_wf
 
         return cast(F, wrapper)
 
@@ -686,6 +687,7 @@ def _step(
         set_dbos_func_name(temp_wf, "<temp>." + func.__qualname__)
         set_temp_workflow_type(temp_wf, "step")
         dbosreg.register_wf_function(get_dbos_func_name(temp_wf), wrapped_wf)
+        wrapper.__orig_func = temp_wf
 
         return cast(F, wrapper)
 

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -166,6 +166,7 @@ def _init_workflow(
     if temp_wf_type != "transaction" or queue is not None:
         # Synchronously record the status and inputs for workflows and single-step workflows
         # We also have to do this for single-step workflows because of the foreign key constraint on the operation outputs table
+        # TODO: Make this transactional (and with the queue step below)
         dbos._sys_db.update_workflow_status(status, False, ctx.in_recovery)
         dbos._sys_db.update_workflow_inputs(wfid, utils.serialize(inputs))
     else:
@@ -367,7 +368,7 @@ def _start_workflow(
     dbos: "DBOS",
     func: "Workflow[P, R]",
     queue_name: Optional[str],
-    submit_workflow: bool,
+    execute_workflow: bool,
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> "WorkflowHandle[R]":
@@ -424,7 +425,7 @@ def _start_workflow(
         queue=queue_name,
     )
 
-    if not submit_workflow:
+    if not execute_workflow:
         return _WorkflowHandlePolling(new_wf_id, dbos)
 
     if fself is not None:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -514,7 +514,7 @@ class DBOS:
         **kwargs: P.kwargs,
     ) -> WorkflowHandle[R]:
         """Invoke a workflow function in the background, returning a handle to the ongoing execution."""
-        return _start_workflow(_get_dbos_instance(), func, None, *args, **kwargs)
+        return _start_workflow(_get_dbos_instance(), func, None, True, *args, **kwargs)
 
     @classmethod
     def get_workflow_status(cls, workflow_id: str) -> Optional[WorkflowStatus]:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -39,6 +39,7 @@ from dbos.core import (
     _WorkflowHandlePolling,
 )
 from dbos.decorators import classproperty
+from dbos.queue import Queue
 from dbos.recovery import _recover_pending_workflows, _startup_recovery_thread
 from dbos.registrations import (
     DBOSClassInfo,
@@ -137,6 +138,7 @@ class _DBOSRegistry:
         self.workflow_info_map: dict[str, Workflow[..., Any]] = {}
         self.class_info_map: dict[str, type] = {}
         self.instance_info_map: dict[str, object] = {}
+        self.queue_info_map: dict[str, Queue] = {}
         self.pollers: list[_RegisteredJob] = []
         self.dbos: Optional[DBOS] = None
         self.config: Optional[ConfigFile] = None

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -494,13 +494,18 @@ class DBOS:
 
     @classmethod
     def kafka_consumer(
-        cls, config: dict[str, Any], topics: list[str]
+        cls,
+        config: dict[str, Any],
+        topics: list[str],
+        in_order: bool = False,
     ) -> Callable[[KafkaConsumerWorkflow], KafkaConsumerWorkflow]:
         """Decorate a function to be used as a Kafka consumer."""
         try:
             from dbos.kafka import kafka_consumer
 
-            return kafka_consumer(_get_or_create_dbos_registry(), config, topics)
+            return kafka_consumer(
+                _get_or_create_dbos_registry(), config, topics, in_order
+            )
         except ModuleNotFoundError as e:
             raise DBOSException(
                 f"{e.name} dependency not found. Please install {e.name} via your package manager."

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -514,7 +514,7 @@ class DBOS:
         **kwargs: P.kwargs,
     ) -> WorkflowHandle[R]:
         """Invoke a workflow function in the background, returning a handle to the ongoing execution."""
-        return _start_workflow(_get_dbos_instance(), func, *args, **kwargs)
+        return _start_workflow(_get_dbos_instance(), func, None, *args, **kwargs)
 
     @classmethod
     def get_workflow_status(cls, workflow_id: str) -> Optional[WorkflowStatus]:

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -20,7 +20,6 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    cast,
 )
 
 from opentelemetry.trace import Span

--- a/dbos/kafka.py
+++ b/dbos/kafka.py
@@ -75,6 +75,7 @@ def _kafka_consumer_loop(
                     f"kafka-unique-id-{msg.topic}-{msg.partition}-{msg.offset}"
                 ):
                     if in_order:
+                        assert msg.topic is not None
                         queue = in_order_kafka_queues[msg.topic]
                         queue.enqueue(func, msg)
                     else:
@@ -94,7 +95,7 @@ def kafka_consumer(
                     raise DBOSInitializationError(
                         f"Error: in-order processing is not supported for regular expression topic selectors ({topic})"
                     )
-                queue = Queue(f"_dbos_kafka_queue_topic_{topic}")
+                queue = Queue(f"_dbos_kafka_queue_topic_{topic}", concurrency=1)
                 in_order_kafka_queues[topic] = queue
         else:
             global kafka_queue

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -40,6 +40,13 @@ def upgrade() -> None:
         ),
         schema="dbos",
     )
+    op.add_column(
+        "workflow_status",
+        sa.Column(
+            "was_queued", sa.Boolean(), server_default=sa.text("False"), nullable=False
+        ),
+        schema="dbos",
+    )
 
 
 def downgrade() -> None:

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
             onupdate="CASCADE",
             ondelete="CASCADE",
         ),
+        schema="dbos",
     )
 
 

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -43,7 +43,8 @@ def upgrade() -> None:
     op.add_column(
         "workflow_status",
         sa.Column(
-            "was_queued", sa.Boolean(), server_default=sa.text("False"), nullable=False
+            "queue_name",
+            sa.Text(),
         ),
         schema="dbos",
     )

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -43,4 +43,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("job_queue")
+    op.drop_table("job_queue", schema="dbos")

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -1,0 +1,45 @@
+"""job_queue
+
+Revision ID: eab0cc1d9a14
+Revises: a3b18ad34abe
+Create Date: 2024-09-13 14:50:00.531294
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "eab0cc1d9a14"
+down_revision: Union[str, None] = "a3b18ad34abe"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "job_queue",
+        sa.Column("workflow_uuid", sa.Text(), nullable=False),
+        sa.Column("queue_name", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at_epoch_ms",
+            sa.BigInteger(),
+            server_default=sa.text(
+                "(EXTRACT(epoch FROM now()) * 1000::numeric)::bigint"
+            ),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_uuid"],
+            ["dbos.workflow_status.workflow_uuid"],
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("job_queue")

--- a/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
+++ b/dbos/migrations/versions/eab0cc1d9a14_job_queue.py
@@ -52,3 +52,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("job_queue", schema="dbos")
+    op.drop_column("workflow_status", "queue_name", schema="dbos")

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -3,7 +3,14 @@ import time
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from dbos.context import DBOSContext, get_local_dbos_context
-from dbos.core import P, R, _execute_workflow_id, _init_workflow, _WorkflowHandlePolling
+from dbos.core import (
+    P,
+    R,
+    _execute_workflow_id,
+    _init_workflow,
+    _start_workflow,
+    _WorkflowHandlePolling,
+)
 from dbos.error import DBOSInitializationError, DBOSWorkflowFunctionNotFoundError
 from dbos.registrations import (
     get_config_name,
@@ -37,49 +44,7 @@ class Queue:
         from dbos.dbos import _get_dbos_instance
 
         dbos = _get_dbos_instance()
-        fself: Optional[object] = None
-        if hasattr(func, "__self__"):
-            fself = func.__self__
-
-        fi = get_func_info(func)
-        if fi is None:
-            raise DBOSWorkflowFunctionNotFoundError(
-                "<NONE>", f"start_workflow: function {func.__name__} is not registered"
-            )
-
-        inputs: WorkflowInputs = {
-            "args": args,
-            "kwargs": kwargs,
-        }
-
-        cur_ctx = get_local_dbos_context()
-        if cur_ctx is not None and cur_ctx.is_within_workflow():
-            assert cur_ctx.is_workflow()  # Not in a step
-            cur_ctx.function_id += 1
-            if len(cur_ctx.id_assigned_for_next_workflow) == 0:
-                cur_ctx.id_assigned_for_next_workflow = (
-                    cur_ctx.workflow_id + "-" + str(cur_ctx.function_id)
-                )
-
-        new_wf_ctx = DBOSContext() if cur_ctx is None else cur_ctx.create_child()
-        new_wf_ctx.id_assigned_for_next_workflow = new_wf_ctx.assign_workflow_id()
-        new_wf_id = new_wf_ctx.id_assigned_for_next_workflow
-
-        gin_args: Tuple[Any, ...] = args
-        if fself is not None:
-            gin_args = (fself,)
-
-        _init_workflow(
-            dbos,
-            new_wf_ctx,
-            inputs=inputs,
-            wf_name=get_dbos_func_name(func),
-            class_name=get_dbos_class_name(fi, func, gin_args),
-            config_name=get_config_name(fi, func, gin_args),
-            temp_wf_type=get_temp_workflow_type(func),
-            queue=self.name,
-        )
-        return _WorkflowHandlePolling(new_wf_id, dbos)
+        return _start_workflow(dbos, func, self.name, False, *args, **kwargs)
 
 
 def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -16,10 +16,6 @@ class Queue:
         from dbos.dbos import _get_or_create_dbos_registry
 
         registry = _get_or_create_dbos_registry()
-        if self.name in registry.queue_info_map:
-            raise DBOSInitializationError(
-                f"Failed to register queue {self.name}: a queue of this name already exists."
-            )
         registry.queue_info_map[self.name] = self
 
     def enqueue(

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,25 +1,9 @@
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
-from dbos.context import DBOSContext, get_local_dbos_context
-from dbos.core import (
-    P,
-    R,
-    _execute_workflow_id,
-    _init_workflow,
-    _start_workflow,
-    _WorkflowHandlePolling,
-)
-from dbos.error import DBOSInitializationError, DBOSWorkflowFunctionNotFoundError
-from dbos.registrations import (
-    get_config_name,
-    get_dbos_class_name,
-    get_dbos_func_name,
-    get_func_info,
-    get_temp_workflow_type,
-)
-from dbos.system_database import WorkflowInputs
+from dbos.core import P, R, _execute_workflow_id, _start_workflow
+from dbos.error import DBOSInitializationError
 
 if TYPE_CHECKING:
     from dbos.dbos import DBOS, Workflow, WorkflowHandle

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,13 +1,72 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-from dbos.system_database import SystemDatabase
+from dbos.context import DBOSContext, get_local_dbos_context
+from dbos.core import P, R, _init_workflow, _WorkflowHandlePolling
+from dbos.dbos import WorkflowHandle
+from dbos.error import DBOSWorkflowFunctionNotFoundError
+from dbos.registrations import (
+    get_config_name,
+    get_dbos_class_name,
+    get_dbos_func_name,
+    get_func_info,
+    get_temp_workflow_type,
+)
+from dbos.system_database import WorkflowInputs
+
+if TYPE_CHECKING:
+    from dbos.dbos import DBOS, Workflow, WorkflowHandle
 
 
 class Queue:
 
-    def __init__(
-        self, sys_db: SystemDatabase, name: str, concurrency: Optional[int]
-    ) -> None:
-        self.sys_db = sys_db
+    def __init__(self, dbos: "DBOS", name: str, concurrency: Optional[int]) -> None:
+        self.dbos = dbos
         self.name = name
         self.concurrency = concurrency
+
+    def enqueue(
+        self, func: "Workflow[P, R]", *args: P.args, **kwargs: P.kwargs
+    ) -> WorkflowHandle[R]:
+        fself: Optional[object] = None
+        if hasattr(func, "__self__"):
+            fself = func.__self__
+
+        fi = get_func_info(func)
+        if fi is None:
+            raise DBOSWorkflowFunctionNotFoundError(
+                "<NONE>", f"start_workflow: function {func.__name__} is not registered"
+            )
+
+        inputs: WorkflowInputs = {
+            "args": args,
+            "kwargs": kwargs,
+        }
+
+        cur_ctx = get_local_dbos_context()
+        if cur_ctx is not None and cur_ctx.is_within_workflow():
+            assert cur_ctx.is_workflow()  # Not in a step
+            cur_ctx.function_id += 1
+            if len(cur_ctx.id_assigned_for_next_workflow) == 0:
+                cur_ctx.id_assigned_for_next_workflow = (
+                    cur_ctx.workflow_id + "-" + str(cur_ctx.function_id)
+                )
+
+        new_wf_ctx = DBOSContext() if cur_ctx is None else cur_ctx.create_child()
+        new_wf_ctx.id_assigned_for_next_workflow = new_wf_ctx.assign_workflow_id()
+        new_wf_id = new_wf_ctx.id_assigned_for_next_workflow
+
+        gin_args: Tuple[Any, ...] = args
+        if fself is not None:
+            gin_args = (fself,)
+
+        _init_workflow(
+            self.dbos,
+            new_wf_ctx,
+            inputs=inputs,
+            wf_name=get_dbos_func_name(func),
+            class_name=get_dbos_class_name(fi, func, gin_args),
+            config_name=get_config_name(fi, func, gin_args),
+            temp_wf_type=get_temp_workflow_type(func),
+            queue=self.name,
+        )
+        return _WorkflowHandlePolling(new_wf_id, self.dbos)

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,8 +1,7 @@
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from dbos.context import DBOSContext, get_local_dbos_context
 from dbos.core import P, R, _init_workflow, _WorkflowHandlePolling
-from dbos.dbos import Workflow, WorkflowHandle, _get_dbos_instance
 from dbos.error import DBOSWorkflowFunctionNotFoundError
 from dbos.registrations import (
     get_config_name,
@@ -13,6 +12,9 @@ from dbos.registrations import (
 )
 from dbos.system_database import WorkflowInputs
 
+if TYPE_CHECKING:
+    from dbos.dbos import Workflow, WorkflowHandle
+
 
 class Queue:
     def __init__(self, name: str, concurrency: Optional[int] = None) -> None:
@@ -22,6 +24,8 @@ class Queue:
     def enqueue(
         self, func: "Workflow[P, R]", *args: P.args, **kwargs: P.kwargs
     ) -> "WorkflowHandle[R]":
+        from dbos.dbos import _get_dbos_instance
+
         dbos = _get_dbos_instance()
         fself: Optional[object] = None
         if hasattr(func, "__self__"):

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -31,6 +31,6 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     while not stop_event.is_set():
         time.sleep(1)
         for queue_name, queue in dbos._registry.queue_info_map.items():
-            wf_ids = dbos._sys_db.dequeue(queue_name, queue.concurrency)
+            wf_ids = dbos._sys_db.start_queued_workflows(queue_name, queue.concurrency)
             for id in wf_ids:
                 _execute_workflow_id(dbos, id)

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from dbos.system_database import SystemDatabase
+
+
+class Queue:
+
+    def __init__(
+        self, sys_db: SystemDatabase, name: str, concurrency: Optional[int]
+    ) -> None:
+        self.sys_db = sys_db
+        self.name = name
+        self.concurrency = concurrency

--- a/dbos/scheduler/scheduler.py
+++ b/dbos/scheduler/scheduler.py
@@ -1,5 +1,4 @@
 import threading
-import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -9,7 +8,6 @@ if TYPE_CHECKING:
     from dbos.dbos import _DBOSRegistry
 
 from ..context import SetWorkflowID
-from ..logger import dbos_logger
 from .croniter import croniter  # type: ignore
 
 ScheduledWorkflow = Callable[[datetime, datetime], None]
@@ -35,7 +33,7 @@ def scheduled(
 ) -> Callable[[ScheduledWorkflow], ScheduledWorkflow]:
     def decorator(func: ScheduledWorkflow) -> ScheduledWorkflow:
         global scheduler_queue
-        scheduler_queue = Queue("_scheduler_queue")
+        scheduler_queue = Queue("_dbos_internal_queue")
         stop_event = threading.Event()
         dbosreg.register_poller(stop_event, scheduler_loop, func, cron, stop_event)
         return func

--- a/dbos/schemas/system_database.py
+++ b/dbos/schemas/system_database.py
@@ -139,3 +139,24 @@ class SystemSchema:
         Column("workflow_fn_name", Text, primary_key=True, nullable=False),
         Column("last_run_time", BigInteger, nullable=False),
     )
+
+    job_queue = Table(
+        "job_queue",
+        metadata_obj,
+        Column(
+            "workflow_uuid",
+            Text,
+            ForeignKey(
+                "workflow_status.workflow_uuid", onupdate="CASCADE", ondelete="CASCADE"
+            ),
+            nullable=False,
+            primary_key=True,
+        ),
+        Column("queue_name", Text, nullable=False),
+        Column(
+            "created_at_epoch_ms",
+            BigInteger,
+            nullable=False,
+            server_default=text("(EXTRACT(epoch FROM now()) * 1000::numeric)::bigint"),
+        ),
+    )

--- a/dbos/schemas/system_database.py
+++ b/dbos/schemas/system_database.py
@@ -1,5 +1,6 @@
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     Column,
     ForeignKey,
     Index,
@@ -53,6 +54,7 @@ class SystemSchema:
             nullable=True,
             server_default=text("'0'::bigint"),
         ),
+        Column("was_queued", Boolean, nullable=False, server_default=text("False")),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
     )

--- a/dbos/schemas/system_database.py
+++ b/dbos/schemas/system_database.py
@@ -54,7 +54,7 @@ class SystemSchema:
             nullable=True,
             server_default=text("'0'::bigint"),
         ),
-        Column("was_queued", Boolean, nullable=False, server_default=text("False")),
+        Column("queue_name", Text),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
     )

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1012,12 +1012,12 @@ class SystemDatabase:
             and len(self._workflow_inputs_buffer) == 0
         )
 
-    def enqueue(self, workflow_uuid: str, queue_name: str) -> None:
+    def enqueue(self, workflow_id: str, queue_name: str) -> None:
         with self.engine.begin() as c:
             c.execute(
                 pg.insert(SystemSchema.job_queue)
                 .values(
-                    workflow_uuid=workflow_uuid,
+                    workflow_uuid=workflow_id,
                     queue_name=queue_name,
                 )
                 .on_conflict_do_nothing()
@@ -1048,3 +1048,11 @@ class SystemDatabase:
                 if result.rowcount > 0:
                     ret_ids.append(id)
             return ret_ids
+
+    def remove_from_queue(self, workflow_id: str):
+        with self.engine.begin() as c:
+            c.execute(
+                sa.delete(SystemSchema.job_queue).where(
+                    SystemSchema.job_queue.c.workflow_uuid == workflow_id
+                )
+            )

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -62,7 +62,7 @@ class WorkflowStatusInternal(TypedDict):
     authenticated_user: Optional[str]
     assumed_role: Optional[str]
     authenticated_roles: Optional[str]  # JSON list of roles.
-    was_queued: bool
+    queue_name: Optional[str]
 
 
 class RecordedResult(TypedDict):
@@ -249,7 +249,7 @@ class SystemDatabase:
             authenticated_user=status["authenticated_user"],
             authenticated_roles=status["authenticated_roles"],
             assumed_role=status["assumed_role"],
-            was_queued=status["was_queued"],
+            queue_name=status["queue_name"],
         )
         if replace:
             cmd = cmd.on_conflict_do_update(
@@ -323,7 +323,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.authenticated_user,
                     SystemSchema.workflow_status.c.authenticated_roles,
                     SystemSchema.workflow_status.c.assumed_role,
-                    SystemSchema.workflow_status.c.was_queued,
+                    SystemSchema.workflow_status.c.queue_name,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -344,7 +344,7 @@ class SystemDatabase:
                 "authenticated_user": row[6],
                 "authenticated_roles": row[7],
                 "assumed_role": row[8],
-                "was_queued": row[9],
+                "queue_name": row[9],
             }
             return status
 
@@ -384,7 +384,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.authenticated_user,
                     SystemSchema.workflow_status.c.authenticated_roles,
                     SystemSchema.workflow_status.c.assumed_role,
-                    SystemSchema.workflow_status.c.was_queued,
+                    SystemSchema.workflow_status.c.queue_name,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -405,7 +405,7 @@ class SystemDatabase:
                 "authenticated_user": row[7],
                 "authenticated_roles": row[8],
                 "assumed_role": row[9],
-                "was_queued": row[10],
+                "queue_name": row[10],
             }
             return status
 

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1012,7 +1012,7 @@ class SystemDatabase:
             and len(self._workflow_inputs_buffer) == 0
         )
 
-    def enqueue(self, workflow_uuid: str, queue_name: str):
+    def enqueue(self, workflow_uuid: str, queue_name: str) -> None:
         with self.engine.begin() as c:
             c.execute(
                 pg.insert(SystemSchema.job_queue)

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -62,6 +62,7 @@ class WorkflowStatusInternal(TypedDict):
     authenticated_user: Optional[str]
     assumed_role: Optional[str]
     authenticated_roles: Optional[str]  # JSON list of roles.
+    was_queued: bool
 
 
 class RecordedResult(TypedDict):
@@ -248,6 +249,7 @@ class SystemDatabase:
             authenticated_user=status["authenticated_user"],
             authenticated_roles=status["authenticated_roles"],
             assumed_role=status["assumed_role"],
+            was_queued=status["was_queued"],
         )
         if replace:
             cmd = cmd.on_conflict_do_update(
@@ -321,6 +323,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.authenticated_user,
                     SystemSchema.workflow_status.c.authenticated_roles,
                     SystemSchema.workflow_status.c.assumed_role,
+                    SystemSchema.workflow_status.c.was_queued,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -341,6 +344,7 @@ class SystemDatabase:
                 "authenticated_user": row[6],
                 "authenticated_roles": row[7],
                 "assumed_role": row[8],
+                "was_queued": row[9],
             }
             return status
 
@@ -380,6 +384,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.authenticated_user,
                     SystemSchema.workflow_status.c.authenticated_roles,
                     SystemSchema.workflow_status.c.assumed_role,
+                    SystemSchema.workflow_status.c.was_queued,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -400,6 +405,7 @@ class SystemDatabase:
                 "authenticated_user": row[7],
                 "authenticated_roles": row[8],
                 "assumed_role": row[9],
+                "was_queued": row[10],
             }
             return status
 

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1029,7 +1029,9 @@ class SystemDatabase:
                 .on_conflict_do_nothing()
             )
 
-    def dequeue(self, queue_name: str, concurrency: Optional[int]) -> List[str]:
+    def start_queued_workflows(
+        self, queue_name: str, concurrency: Optional[int]
+    ) -> List[str]:
         with self.engine.begin() as c:
             query = sa.select(SystemSchema.job_queue.c.workflow_uuid).where(
                 SystemSchema.job_queue.c.queue_name == queue_name

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1049,7 +1049,7 @@ class SystemDatabase:
                     ret_ids.append(id)
             return ret_ids
 
-    def remove_from_queue(self, workflow_id: str):
+    def remove_from_queue(self, workflow_id: str) -> None:
         with self.engine.begin() as c:
             c.execute(
                 sa.delete(SystemSchema.job_queue).where(

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1012,41 +1012,13 @@ class SystemDatabase:
             and len(self._workflow_inputs_buffer) == 0
         )
 
-    def enqueue(self, status: WorkflowStatusInternal, inputs: str, queue_name: str):
-        with self.engine.begin as c:
-            c.execute(
-                pg.insert(SystemSchema.workflow_status)
-                .values(
-                    workflow_uuid=status["workflow_uuid"],
-                    status=status["status"],
-                    name=status["name"],
-                    class_name=status["class_name"],
-                    config_name=status["config_name"],
-                    output=status["output"],
-                    error=status["error"],
-                    executor_id=status["executor_id"],
-                    application_version=status["app_version"],
-                    application_id=status["app_id"],
-                    request=status["request"],
-                    authenticated_user=status["authenticated_user"],
-                    authenticated_roles=status["authenticated_roles"],
-                    assumed_role=status["assumed_role"],
-                )
-                .on_conflict_do_nothing()
-            )
-            c.execute(
-                pg.insert(SystemSchema.workflow_inputs)
-                .values(
-                    workflow_uuid=status["workflow_uuid"],
-                    inputs=inputs,
-                )
-                .on_conflict_do_nothing()
-            )
+    def enqueue(self, workflow_uuid: str, queue_name: str):
+        with self.engine.begin() as c:
             c.execute(
                 pg.insert(SystemSchema.job_queue)
                 .values(
-                    workflow_uuid=status["workflow_uuid"],
+                    workflow_uuid=workflow_uuid,
                     queue_name=queue_name,
                 )
-                .on_conflict_do_nothing
+                .on_conflict_do_nothing()
             )

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -33,10 +33,11 @@ class WorkflowStatusString(Enum):
     ERROR = "ERROR"
     RETRIES_EXCEEDED = "RETRIES_EXCEEDED"
     CANCELLED = "CANCELLED"
+    ENQUEUED = "ENQUEUED"
 
 
 WorkflowStatuses = Literal[
-    "PENDING", "SUCCESS", "ERROR", "RETRIES_EXCEEDED", "CANCELLED"
+    "PENDING", "SUCCESS", "ERROR", "RETRIES_EXCEEDED", "CANCELLED", "ENQUEUED"
 ]
 
 
@@ -1010,3 +1011,42 @@ class SystemDatabase:
             len(self._workflow_status_buffer) == 0
             and len(self._workflow_inputs_buffer) == 0
         )
+
+    def enqueue(self, status: WorkflowStatusInternal, inputs: str, queue_name: str):
+        with self.engine.begin as c:
+            c.execute(
+                pg.insert(SystemSchema.workflow_status)
+                .values(
+                    workflow_uuid=status["workflow_uuid"],
+                    status=status["status"],
+                    name=status["name"],
+                    class_name=status["class_name"],
+                    config_name=status["config_name"],
+                    output=status["output"],
+                    error=status["error"],
+                    executor_id=status["executor_id"],
+                    application_version=status["app_version"],
+                    application_id=status["app_id"],
+                    request=status["request"],
+                    authenticated_user=status["authenticated_user"],
+                    authenticated_roles=status["authenticated_roles"],
+                    assumed_role=status["assumed_role"],
+                )
+                .on_conflict_do_nothing()
+            )
+            c.execute(
+                pg.insert(SystemSchema.workflow_inputs)
+                .values(
+                    workflow_uuid=status["workflow_uuid"],
+                    inputs=inputs,
+                )
+                .on_conflict_do_nothing()
+            )
+            c.execute(
+                pg.insert(SystemSchema.job_queue)
+                .values(
+                    workflow_uuid=status["workflow_uuid"],
+                    queue_name=queue_name,
+                )
+                .on_conflict_do_nothing
+            )

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -16,7 +16,7 @@ def test_scheduled_workflow(dbos: DBOS) -> None:
         wf_counter += 1
 
     time.sleep(4)
-    assert wf_counter > 1 and wf_counter <= 4
+    assert wf_counter > 2 and wf_counter <= 4
 
 
 def test_scheduled_transaction(dbos: DBOS) -> None:
@@ -29,7 +29,7 @@ def test_scheduled_transaction(dbos: DBOS) -> None:
         txn_counter += 1
 
     time.sleep(4)
-    assert txn_counter > 1 and txn_counter <= 4
+    assert txn_counter > 2 and txn_counter <= 4
 
 
 def test_scheduled_workflow_exception(dbos: DBOS) -> None:

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -87,6 +87,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -9,14 +9,27 @@ from dbos import DBOS
 def test_scheduled_workflow(dbos: DBOS) -> None:
     wf_counter: int = 0
 
-    @DBOS.scheduled("*/2 * * * * *")
+    @DBOS.scheduled("* * * * * *")
     @DBOS.workflow()
     def test_workflow(scheduled: datetime, actual: datetime) -> None:
         nonlocal wf_counter
         wf_counter += 1
 
     time.sleep(4)
-    assert wf_counter > 1 and wf_counter <= 3
+    assert wf_counter > 1 and wf_counter <= 4
+
+
+def test_scheduled_transaction(dbos: DBOS) -> None:
+    txn_counter: int = 0
+
+    @DBOS.scheduled("* * * * * *")
+    @DBOS.transaction()
+    def test_transaction(scheduled: datetime, actual: datetime) -> None:
+        nonlocal txn_counter
+        txn_counter += 1
+
+    time.sleep(4)
+    assert txn_counter > 1 and txn_counter <= 4
 
 
 def test_scheduled_workflow_exception(dbos: DBOS) -> None:

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -87,7 +87,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -29,7 +29,7 @@ def test_scheduled_workflow_exception(dbos: DBOS) -> None:
         wf_counter += 1
         raise Exception("error")
 
-    time.sleep(2)
+    time.sleep(3)
     assert wf_counter >= 1 and wf_counter <= 3
 
 
@@ -52,7 +52,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
         nonlocal txn_counter
         txn_counter += 1
 
-    time.sleep(2)
+    time.sleep(3)
     assert wf_counter >= 1 and wf_counter <= 3
     max_tries = 10
     for i in range(max_tries):

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -95,7 +95,7 @@ def test_admin_recovery(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
     status = dbos.get_workflow_status(wfuuid)

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -95,6 +95,7 @@ def test_admin_recovery(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
     status = dbos.get_workflow_status(wfuuid)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -356,6 +356,7 @@ def test_recovery_workflow(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 
@@ -418,6 +419,7 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 
@@ -473,6 +475,7 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -356,7 +356,7 @@ def test_recovery_workflow(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 
@@ -419,7 +419,7 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 
@@ -475,7 +475,7 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -130,6 +130,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -130,7 +130,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -95,6 +95,7 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
+            "was_queued": False,
         }
     )
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -95,7 +95,7 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
             "authenticated_user": None,
             "authenticated_roles": None,
             "assumed_role": None,
-            "was_queued": False,
+            "queue_name": None,
         }
     )
 

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -43,9 +43,9 @@ def send_test_messages(server: str, topic: str) -> bool:
 
         producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
 
-        for _ in range(NUM_EVENTS):
+        for i in range(NUM_EVENTS):
             producer.produce(
-                topic, key=f"test message key", value=f"test message value"
+                topic, key=f"test message key {i}", value=f"test message value {i}"
             )
 
         producer.poll(10)
@@ -78,8 +78,8 @@ def test_kafka(dbos: DBOS) -> None:
     def test_kafka_workflow(msg: KafkaMessage) -> None:
         nonlocal kafka_count
         kafka_count += 1
-        assert msg.key == b"test message key"
-        assert msg.value == b"test message value"
+        assert b"test message key" in msg.key
+        assert b"test message value" in msg.value
         print(msg)
         if kafka_count == 3:
             event.set()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3,25 +3,32 @@ import uuid
 from dbos import DBOS, Queue, SetWorkflowID
 
 
-def test_simple_workflow(dbos: DBOS) -> None:
+def test_simple_queue(dbos: DBOS) -> None:
     wf_counter: int = 0
-
-    @DBOS.workflow()
-    def test_workflow(var1: str, var2: str) -> str:
-        nonlocal wf_counter
-        wf_counter += 1
-        return var1 + var2
-
-    assert test_workflow("abc", "123") == "abc123"
-    assert wf_counter == 1
-
-    queue = Queue("test_queue")
+    step_counter: int = 0
 
     wfid = str(uuid.uuid4())
 
+    @DBOS.workflow()
+    def test_workflow(var1: str, var2: str) -> str:
+        assert DBOS.workflow_id == wfid
+        nonlocal wf_counter
+        wf_counter += 1
+        var1 = test_step(var1)
+        return var1 + var2
+
+    @DBOS.step()
+    def test_step(var: str) -> str:
+        nonlocal step_counter
+        step_counter += 1
+        return var + "d"
+
+    queue = Queue("test_queue")
+
     with SetWorkflowID(wfid):
-        queue.enqueue(test_workflow, "abc", "123")
-    dequeue = dbos._sys_db.dequeue("test_queue", None)
-    assert dequeue == [wfid]
-    handle = DBOS.execute_workflow_id(wfid)
-    assert handle.get_result() == "abc123"
+        handle = queue.enqueue(test_workflow, "abc", "123")
+    assert handle.get_result() == "abcd123"
+    with SetWorkflowID(wfid):
+        assert test_workflow("abc", "123") == "abcd123"
+    assert wf_counter == 2
+    assert step_counter == 1

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,3 @@
-import sqlalchemy as sa
-
 from dbos import DBOS, Queue
 
 
@@ -15,6 +13,6 @@ def test_simple_workflow(dbos: DBOS) -> None:
     assert test_workflow("abc", "123") == "abc123"
     assert wf_counter == 1
 
-    queue = Queue("test_queue", None)
+    queue = Queue("test_queue")
 
     queue.enqueue(test_workflow, "abc", "123")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -15,6 +15,6 @@ def test_simple_workflow(dbos: DBOS) -> None:
     assert test_workflow("abc", "123") == "abc123"
     assert wf_counter == 1
 
-    queue = Queue(dbos, "test_queue", None)
+    queue = Queue("test_queue", None)
 
     queue.enqueue(test_workflow, "abc", "123")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,20 @@
+import sqlalchemy as sa
+
+from dbos import DBOS, Queue
+
+
+def test_simple_workflow(dbos: DBOS) -> None:
+    wf_counter: int = 0
+
+    @DBOS.workflow()
+    def test_workflow(var1: str, var2: str) -> str:
+        nonlocal wf_counter
+        wf_counter += 1
+        return var1 + var2
+
+    assert test_workflow("abc", "123") == "abc123"
+    assert wf_counter == 1
+
+    queue = Queue(dbos, "test_queue", None)
+
+    queue.enqueue(test_workflow, "abc", "123")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -36,12 +36,15 @@ def test_simple_queue(dbos: DBOS) -> None:
 
 
 def test_one_at_a_time(dbos: DBOS) -> None:
+    wf_counter = 0
     flag = False
     workflow_event = threading.Event()
     main_thread_event = threading.Event()
 
     @DBOS.workflow()
     def workflow_one() -> None:
+        nonlocal wf_counter
+        wf_counter += 1
         main_thread_event.set()
         workflow_event.wait()
 
@@ -60,6 +63,7 @@ def test_one_at_a_time(dbos: DBOS) -> None:
     assert handle1.get_result() == None
     assert handle2.get_result() == None
     assert flag
+    assert wf_counter == 1
 
 
 def test_queue_step(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -21,6 +21,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     with SetWorkflowID(wfid):
         queue.enqueue(test_workflow, "abc", "123")
-
+    dequeue = dbos._sys_db.dequeue("test_queue", None)
+    assert dequeue == [wfid]
     handle = DBOS.execute_workflow_id(wfid)
     assert handle.get_result() == "abc123"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -35,28 +35,28 @@ def test_simple_queue(dbos: DBOS) -> None:
     assert step_counter == 1
 
 
-# def test_one_at_a_time(dbos: DBOS) -> None:
-#     flag = False
-#     workflow_event = threading.Event()
-#     main_thread_event = threading.Event()
+def test_one_at_a_time(dbos: DBOS) -> None:
+    flag = False
+    workflow_event = threading.Event()
+    main_thread_event = threading.Event()
 
-#     @DBOS.workflow()
-#     def workflow_one() -> None:
-#         main_thread_event.set()
-#         workflow_event.wait()
+    @DBOS.workflow()
+    def workflow_one() -> None:
+        main_thread_event.set()
+        workflow_event.wait()
 
-#     @DBOS.workflow()
-#     def workflow_two() -> None:
-#         nonlocal flag
-#         flag = True
+    @DBOS.workflow()
+    def workflow_two() -> None:
+        nonlocal flag
+        flag = True
 
-#     queue = Queue("test_queue", 1)
-#     handle1 = queue.enqueue(workflow_one)
-#     handle2 = queue.enqueue(workflow_two)
+    queue = Queue("test_queue", 1)
+    handle1 = queue.enqueue(workflow_one)
+    handle2 = queue.enqueue(workflow_two)
 
-#     main_thread_event.wait()
-#     assert flag == False
-#     workflow_event.set()
-#     assert handle1.get_result() == None
-#     assert handle2.get_result() == None
-#     assert flag == False
+    main_thread_event.wait()
+    assert not flag
+    workflow_event.set()
+    assert handle1.get_result() == None
+    assert handle2.get_result() == None
+    assert flag

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import uuid
 
 from dbos import DBOS, Queue, SetWorkflowID
@@ -58,6 +59,7 @@ def test_one_at_a_time(dbos: DBOS) -> None:
     handle2 = queue.enqueue(workflow_two)
 
     main_thread_event.wait()
+    time.sleep(2)  # Verify the other task isn't scheduled on subsequent poller ticks.
     assert not flag
     workflow_event.set()
     assert handle1.get_result() == None

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 
 from dbos import DBOS, Queue, SetWorkflowID
@@ -32,3 +33,30 @@ def test_simple_queue(dbos: DBOS) -> None:
         assert test_workflow("abc", "123") == "abcd123"
     assert wf_counter == 2
     assert step_counter == 1
+
+
+# def test_one_at_a_time(dbos: DBOS) -> None:
+#     flag = False
+#     workflow_event = threading.Event()
+#     main_thread_event = threading.Event()
+
+#     @DBOS.workflow()
+#     def workflow_one() -> None:
+#         main_thread_event.set()
+#         workflow_event.wait()
+
+#     @DBOS.workflow()
+#     def workflow_two() -> None:
+#         nonlocal flag
+#         flag = True
+
+#     queue = Queue("test_queue", 1)
+#     handle1 = queue.enqueue(workflow_one)
+#     handle2 = queue.enqueue(workflow_two)
+
+#     main_thread_event.wait()
+#     assert flag == False
+#     workflow_event.set()
+#     assert handle1.get_result() == None
+#     assert handle2.get_result() == None
+#     assert flag == False

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,4 +1,6 @@
-from dbos import DBOS, Queue
+import uuid
+
+from dbos import DBOS, Queue, SetWorkflowID
 
 
 def test_simple_workflow(dbos: DBOS) -> None:
@@ -15,4 +17,10 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     queue = Queue("test_queue")
 
-    queue.enqueue(test_workflow, "abc", "123")
+    wfid = str(uuid.uuid4())
+
+    with SetWorkflowID(wfid):
+        queue.enqueue(test_workflow, "abc", "123")
+
+    handle = DBOS.execute_workflow_id(wfid)
+    assert handle.get_result() == "abc123"


### PR DESCRIPTION
Add a queue abstraction for asynchronous processing.

Example usage:
```python
queue = Queue("example_queue")

@DBOS.step()
def process_job(job):
  ...

@DBOS.workflow()
def process_jobs(jobs):
  for job in jobs:
    queue.enqueue(process_job, job)
```

You can enqueue any DBOS-annotated function (workflows, transactions, or steps).

`enqueue` returns a [workflow handle](https://docs.dbos.dev/python/reference/workflow_handles) so you can track the status of enqueued tasks.

You can set a maximum concurrency level for a queue to cap the maximum number of tasks from that queue that can be processed at once.

Scheduled workflows and Kafka workflows now use queues, making them more robust in a distributed setting.