### PR TITLE
Dead Letter Queue

### DIFF
--- a/dbos/core.py
+++ b/dbos/core.py
@@ -38,6 +38,7 @@ from dbos.error import (
     DBOSWorkflowFunctionNotFoundError,
 )
 from dbos.registrations import (
+    DEFAULT_MAX_RECOVERY_ATTEMPTS,
     get_config_name,
     get_dbos_class_name,
     get_dbos_func_name,
@@ -49,7 +50,6 @@ from dbos.registrations import (
 )
 from dbos.roles import check_required_roles
 from dbos.system_database import (
-    DEFAULT_MAX_RECOVERY_ATTEMPTS,
     GetEventWorkflowContext,
     OperationResultInternal,
     WorkflowStatusInternal,
@@ -301,6 +301,7 @@ def _workflow_wrapper(
     func.__orig_func = func  # type: ignore
 
     fi = get_or_create_func_info(func)
+    fi.max_recovery_attempts = max_recovery_attempts
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -410,6 +411,7 @@ def _start_workflow(
         config_name=get_config_name(fi, func, gin_args),
         temp_wf_type=get_temp_workflow_type(func),
         queue=queue_name,
+        max_recovery_attempts=fi.max_recovery_attempts,
     )
 
     if not execute_workflow:

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -159,7 +159,9 @@ def _init_workflow(
         # Synchronously record the status and inputs for workflows and single-step workflows
         # We also have to do this for single-step workflows because of the foreign key constraint on the operation outputs table
         # TODO: Make this transactional (and with the queue step below)
-        dbos._sys_db.update_workflow_status(status, False, ctx.in_recovery)
+        dbos._sys_db.update_workflow_status(
+            status, False, ctx.in_recovery, max_recovery_attempts=max_recovery_attempts
+        )
         dbos._sys_db.update_workflow_inputs(wfid, utils.serialize_args(inputs))
     else:
         # Buffer the inputs for single-transaction workflows, but don't buffer the status

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -79,7 +79,7 @@ from dbos.error import DBOSException, DBOSNonExistentWorkflowError
 from .application_database import ApplicationDatabase
 from .dbos_config import ConfigFile, load_config, set_env_vars
 from .logger import add_otlp_to_all_loggers, config_logger, dbos_logger, init_logger
-from .system_database import SystemDatabase
+from .system_database import DEFAULT_MAX_RECOVERY_ATTEMPTS, SystemDatabase
 
 # Most DBOS functions are just any callable F, so decorators / wrappers work on F
 # There are cases where the parameters P and return value R should be separate
@@ -401,9 +401,11 @@ class DBOS:
 
     # Decorators for DBOS functionality
     @classmethod
-    def workflow(cls) -> Callable[[F], F]:
+    def workflow(
+        cls, max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS
+    ) -> Callable[[F], F]:
         """Decorate a function for use as a DBOS workflow."""
-        return _workflow(_get_or_create_dbos_registry())
+        return _workflow(_get_or_create_dbos_registry(), max_recovery_attempts)
 
     @classmethod
     def transaction(

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -42,6 +42,7 @@ from dbos.decorators import classproperty
 from dbos.queue import Queue, queue_thread
 from dbos.recovery import _recover_pending_workflows, _startup_recovery_thread
 from dbos.registrations import (
+    DEFAULT_MAX_RECOVERY_ATTEMPTS,
     DBOSClassInfo,
     get_or_create_class_info,
     set_dbos_func_name,
@@ -79,7 +80,7 @@ from dbos.error import DBOSException, DBOSNonExistentWorkflowError
 from .application_database import ApplicationDatabase
 from .dbos_config import ConfigFile, load_config, set_env_vars
 from .logger import add_otlp_to_all_loggers, config_logger, dbos_logger, init_logger
-from .system_database import DEFAULT_MAX_RECOVERY_ATTEMPTS, SystemDatabase
+from .system_database import SystemDatabase
 
 # Most DBOS functions are just any callable F, so decorators / wrappers work on F
 # There are cases where the parameters P and return value R should be separate

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -402,7 +402,7 @@ class DBOS:
     # Decorators for DBOS functionality
     @classmethod
     def workflow(
-        cls, max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS
+        cls, *, max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS
     ) -> Callable[[F], F]:
         """Decorate a function for use as a DBOS workflow."""
         return _workflow(_get_or_create_dbos_registry(), max_recovery_attempts)

--- a/dbos/error.py
+++ b/dbos/error.py
@@ -32,6 +32,7 @@ class DBOSErrorCode(Enum):
     InitializationError = 3
     WorkflowFunctionNotFound = 4
     NonExistentWorkflowError = 5
+    DeadLetterQueueError = 6
     MaxStepRetriesExceeded = 7
     NotAuthorized = 8
 
@@ -83,6 +84,16 @@ class DBOSNonExistentWorkflowError(DBOSException):
         super().__init__(
             f"Sent to non-existent destination workflow ID: {destination_id}",
             dbos_error_code=DBOSErrorCode.NonExistentWorkflowError.value,
+        )
+
+
+class DBOSDeadLetterQueueError(DBOSException):
+    """Exception raised when a workflow database record does not exist for a given ID."""
+
+    def __init__(self, wf_id: str, max_retries: int):
+        super().__init__(
+            f"Workflow {wf_id} has been moved to the dead-letter queue after exceeding the maximum of ${max_retries} retries",
+            dbos_error_code=DBOSErrorCode.DeadLetterQueueError.value,
         )
 
 

--- a/dbos/registrations.py
+++ b/dbos/registrations.py
@@ -3,6 +3,8 @@ from enum import Enum
 from types import FunctionType
 from typing import Any, Callable, List, Literal, Optional, Tuple, Type, cast
 
+DEFAULT_MAX_RECOVERY_ATTEMPTS = 50
+
 
 def get_dbos_func_name(f: Any) -> str:
     if hasattr(f, "dbos_function_name"):
@@ -47,6 +49,7 @@ class DBOSFuncInfo:
         self.class_info: Optional[DBOSClassInfo] = None
         self.func_type: DBOSFuncType = DBOSFuncType.Unknown
         self.required_roles: Optional[List[str]] = None
+        self.max_recovery_attempts = DEFAULT_MAX_RECOVERY_ATTEMPTS
 
 
 def get_or_create_class_info(cls: Type[Any]) -> DBOSClassInfo:

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -29,6 +29,7 @@ from dbos.error import (
     DBOSNonExistentWorkflowError,
     DBOSWorkflowConflictIDError,
 )
+from dbos.registrations import DEFAULT_MAX_RECOVERY_ATTEMPTS
 
 from .dbos_config import ConfigFile
 from .logger import dbos_logger
@@ -49,8 +50,6 @@ class WorkflowStatusString(Enum):
 WorkflowStatuses = Literal[
     "PENDING", "SUCCESS", "ERROR", "RETRIES_EXCEEDED", "CANCELLED", "ENQUEUED"
 ]
-
-DEFAULT_MAX_RECOVERY_ATTEMPTS = 50
 
 
 class WorkflowStatusInternal(TypedDict):
@@ -286,7 +285,6 @@ class SystemDatabase:
         else:
             with self.engine.begin() as c:
                 results = c.execute(cmd)
-
         if in_recovery:
             row = results.fetchone()
             if row is not None:

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -239,6 +239,7 @@ class SystemDatabase:
         status: WorkflowStatusInternal,
         replace: bool = True,
         in_recovery: bool = False,
+        *,
         conn: Optional[sa.Connection] = None,
         max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS,
     ) -> None:
@@ -290,7 +291,7 @@ class SystemDatabase:
             row = results.fetchone()
             if row is not None:
                 recovery_attempts: int = row[0]
-                if recovery_attempts >= max_recovery_attempts:
+                if recovery_attempts > max_recovery_attempts:
                     sa.update(SystemSchema.workflow_status).where(
                         SystemSchema.workflow_status.c.workflow_uuid
                         == status["workflow_uuid"]

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -271,12 +271,18 @@ class SystemDatabase:
             )
         else:
             cmd = cmd.on_conflict_do_nothing()
+        cmd = cmd.returning(SystemSchema.workflow_status.c.recovery_attempts)  # type: ignore
 
         if conn is not None:
-            conn.execute(cmd)
+            results = conn.execute(cmd)
         else:
             with self.engine.begin() as c:
-                c.execute(cmd)
+                results = c.execute(cmd)
+
+        if in_recovery:
+            row = results.fetchone()
+            if row is not None:
+                recovery_attempts: int = row[0]
 
         # Record we have exported status for this single-transaction workflow
         if status["workflow_uuid"] in self._temp_txn_wf_ids:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -122,11 +122,11 @@ def test_buffer_flush_errors(dbos: DBOS) -> None:
 
 def test_dead_letter_queue(dbos: DBOS) -> None:
     event = threading.Event()
-    max_recovery_attempts = 50
+    max_recovery_attempts = 20
     recovery_count = 0
 
     @DBOS.workflow(max_recovery_attempts=max_recovery_attempts)
-    def dead_letter_workflow():
+    def dead_letter_workflow() -> None:
         nonlocal recovery_count
         recovery_count += 1
         event.wait()


### PR DESCRIPTION
This PR implements a [dead letter queue](https://en.wikipedia.org/wiki/Dead_letter_queue) for workflows. If a workflow execution is recovered more than N times (50 by default, configurable as an argument to `@DBOS.Workflow`), it is placed in the dead letter queue and no further attempts will be made to recover it.

The goal of this change is to reduce the damage caused by buggy workflows that crash the execution environment. Without a dead letter queue, these will be retried indefinitely, wasting resources and disrupting other works. With this change, they are retried a maximum number of times then placed in the DLQ for manual investigation and restart.