### PR TITLE
add debug logs before each step runs/replays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# IDE files
+.vscode/

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,6 +25,13 @@ To run unit tests:
 pdm run pytest
 ```
 
+NOTE: The tests need a Postgres database running on localhost:5432. To start one, run:
+
+```bash
+export PGPASSWORD=dbos
+python3 dbos/templates/hello/start_postgres_docker.py
+```
+
 To check types:
 
 ```

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -327,6 +327,9 @@ def _workflow_wrapper(dbosreg: "_DBOSRegistry", func: F) -> F:
                 temp_wf_type=get_temp_workflow_type(func),
             )
 
+            dbos.logger.debug(
+                f"Running workflow, id: {ctx.workflow_id}, name: {get_dbos_func_name(func)}"
+            )
             return _execute_workflow(dbos, status, func, *args, **kwargs)
 
     wrapped_func = cast(F, wrapper)
@@ -477,6 +480,9 @@ def _transaction(
                                     )
                                 )
                                 if recorded_output:
+                                    dbos.logger.debug(
+                                        f"Replaying transaction, id: {ctx.function_id}, name: {attributes['name']}"
+                                    )
                                     if recorded_output["error"]:
                                         deserialized_error = (
                                             utils.deserialize_exception(
@@ -493,6 +499,11 @@ def _transaction(
                                         raise Exception(
                                             "Output and error are both None"
                                         )
+                                else:
+                                    dbos.logger.debug(
+                                        f"Running transaction, id: {ctx.function_id}, name: {attributes['name']}"
+                                    )
+
                                 output = func(*args, **kwargs)
                                 txn_output["output"] = utils.serialize(output)
                                 assert (
@@ -590,6 +601,9 @@ def _step(
                     ctx.workflow_id, ctx.function_id
                 )
                 if recorded_output:
+                    dbos.logger.debug(
+                        f"Replaying step, id: {ctx.function_id}, name: {attributes['name']}"
+                    )
                     if recorded_output["error"] is not None:
                         deserialized_error = utils.deserialize_exception(
                             recorded_output["error"]
@@ -599,6 +613,11 @@ def _step(
                         return utils.deserialize(recorded_output["output"])
                     else:
                         raise Exception("Output and error are both None")
+                else:
+                    dbos.logger.debug(
+                        f"Running step, id: {ctx.function_id}, name: {attributes['name']}"
+                    )
+
                 output = None
                 error = None
                 local_max_attempts = max_attempts if retries_allowed else 1

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -617,7 +617,14 @@ class SystemDatabase:
                 workflow_uuid, function_id, conn=c
             )
             if recorded_output is not None:
+                dbos_logger.debug(
+                    f"Replaying send, id: {function_id}, destination_uuid: {destination_uuid}, topic: {topic}"
+                )
                 return  # Already sent before
+            else:
+                dbos_logger.debug(
+                    f"Running send, id: {function_id}, destination_uuid: {destination_uuid}, topic: {topic}"
+                )
 
             try:
                 c.execute(
@@ -653,10 +660,13 @@ class SystemDatabase:
         # First, check for previous executions.
         recorded_output = self.check_operation_execution(workflow_uuid, function_id)
         if recorded_output is not None:
+            dbos_logger.debug(f"Replaying recv, id: {function_id}, topic: {topic}")
             if recorded_output["output"] is not None:
                 return utils.deserialize(recorded_output["output"])
             else:
                 raise Exception("No output recorded in the last recv")
+        else:
+            dbos_logger.debug(f"Running recv, id: {function_id}, topic: {topic}")
 
         # Insert a condition to the notifications map, so the listener can notify it when a message is received.
         payload = f"{workflow_uuid}::{topic}"
@@ -799,9 +809,11 @@ class SystemDatabase:
         recorded_output = self.check_operation_execution(workflow_uuid, function_id)
         end_time: float
         if recorded_output is not None:
+            dbos_logger.debug(f"Replaying sleep, id: {function_id}, seconds: {seconds}")
             assert recorded_output["output"] is not None, "no recorded end time"
             end_time = utils.deserialize(recorded_output["output"])
         else:
+            dbos_logger.debug(f"Running sleep, id: {function_id}, seconds: {seconds}")
             end_time = time.time() + seconds
             try:
                 self.record_operation_result(
@@ -831,7 +843,10 @@ class SystemDatabase:
                 workflow_uuid, function_id, conn=c
             )
             if recorded_output is not None:
+                dbos_logger.debug(f"Replaying set_event, id: {function_id}, key: {key}")
                 return  # Already sent before
+            else:
+                dbos_logger.debug(f"Running set_event, id: {function_id}, key: {key}")
 
             c.execute(
                 pg.insert(SystemSchema.workflow_events)
@@ -872,10 +887,17 @@ class SystemDatabase:
                 caller_ctx["workflow_uuid"], caller_ctx["function_id"]
             )
             if recorded_output is not None:
+                dbos_logger.debug(
+                    f"Replaying get_event, id: {caller_ctx['function_id']}, key: {key}"
+                )
                 if recorded_output["output"] is not None:
                     return utils.deserialize(recorded_output["output"])
                 else:
                     raise Exception("No output recorded in the last get_event")
+            else:
+                dbos_logger.debug(
+                    f"Running get_event, id: {caller_ctx['function_id']}, key: {key}"
+                )
 
         payload = f"{target_uuid}::{key}"
         condition = threading.Condition()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -995,15 +995,15 @@ def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
     dest_wfid = str(uuid.uuid4())
 
     @DBOS.step()
-    def step_function(message):
+    def step_function(message: str) -> str:
         return f"Step: {message}"
 
     @DBOS.transaction()
-    def transaction_function(message):
+    def transaction_function(message: str) -> str:
         return f"Transaction: {message}"
 
     @DBOS.workflow()
-    def test_workflow():
+    def test_workflow() -> str:
         dbos.set_event("test_event", "event_value")
         step_result = step_function("Hello")
         transaction_result = transaction_function("World")
@@ -1012,7 +1012,7 @@ def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
         return ", ".join([step_result, transaction_result])
 
     @DBOS.workflow()
-    def test_workflow_dest():
+    def test_workflow_dest() -> str:
         event_value = dbos.get_event(wfid, "test_event")
         msg_value = dbos.recv(topic="test_topic")
         return ", ".join([event_value, msg_value])

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import threading
 import time
 import uuid
@@ -987,3 +988,79 @@ def test_multi_set_event(dbos: DBOS) -> None:
     event.set()
     assert handle.get_result() == None
     assert DBOS.get_event(wfid, "key") == "value2"
+
+
+def test_dbos_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
+    wfid = str(uuid.uuid4())
+    dest_wfid = str(uuid.uuid4())
+
+    @DBOS.step()
+    def step_function(message):
+        return f"Step: {message}"
+
+    @DBOS.transaction()
+    def transaction_function(message):
+        return f"Transaction: {message}"
+
+    @DBOS.workflow()
+    def test_workflow():
+        dbos.set_event("test_event", "event_value")
+        step_result = step_function("Hello")
+        transaction_result = transaction_function("World")
+        dbos.send(dest_wfid, "test_message", topic="test_topic")
+        dbos.sleep(1)
+        return ", ".join([step_result, transaction_result])
+
+    @DBOS.workflow()
+    def test_workflow_dest():
+        event_value = dbos.get_event(wfid, "test_event")
+        msg_value = dbos.recv(topic="test_topic")
+        return ", ".join([event_value, msg_value])
+
+    caplog.set_level(logging.DEBUG, "dbos")
+    logging.getLogger("dbos").propagate = True
+
+    # First run
+    with SetWorkflowID(dest_wfid):
+        dest_handle = dbos.start_workflow(test_workflow_dest)
+
+    with SetWorkflowID(wfid):
+        result1 = test_workflow()
+
+    assert result1 == "Step: Hello, Transaction: World"
+    assert "Running step" in caplog.text and "name: step_function" in caplog.text
+    assert (
+        "Running transaction" in caplog.text
+        and "name: transaction_function" in caplog.text
+    )
+    assert "Running sleep" in caplog.text
+    assert "Running set_event" in caplog.text
+    assert "Running send" in caplog.text
+
+    result2 = dest_handle.get_result()
+    assert result2 == "event_value, test_message"
+    assert "Running get_event" in caplog.text
+    assert "Running recv" in caplog.text
+    caplog.clear()
+
+    # Second run
+    with SetWorkflowID(dest_wfid):
+        dest_handle_2 = dbos.start_workflow(test_workflow_dest)
+
+    with SetWorkflowID(wfid):
+        result3 = test_workflow()
+
+    assert result3 == result1
+    assert "Replaying step" in caplog.text and "name: step_function" in caplog.text
+    assert (
+        "Replaying transaction" in caplog.text
+        and "name: transaction_function" in caplog.text
+    )
+    assert "Replaying sleep" in caplog.text
+    assert "Replaying set_event" in caplog.text
+    assert "Replaying send" in caplog.text
+
+    result4 = dest_handle_2.get_result()
+    assert result4 == result2
+    assert "Replaying get_event" in caplog.text
+    assert "Replaying recv" in caplog.text

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -990,7 +990,7 @@ def test_multi_set_event(dbos: DBOS) -> None:
     assert DBOS.get_event(wfid, "key") == "value2"
 
 
-def test_dbos_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
+def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
     wfid = str(uuid.uuid4())
     dest_wfid = str(uuid.uuid4())
 
@@ -1017,6 +1017,7 @@ def test_dbos_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
         msg_value = dbos.recv(topic="test_topic")
         return ", ".join([event_value, msg_value])
 
+    original_propagate = logging.getLogger("dbos").propagate
     caplog.set_level(logging.DEBUG, "dbos")
     logging.getLogger("dbos").propagate = True
 
@@ -1064,3 +1065,6 @@ def test_dbos_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
     assert result4 == result2
     assert "Replaying get_event" in caplog.text
     assert "Replaying recv" in caplog.text
+
+    # Reset logging
+    logging.getLogger("dbos").propagate = original_propagate


### PR DESCRIPTION
This PR adds debug logs before each step/transaction/sleep and other constructs that are tracked in the history. It is helpful to distinguish which parts of the workflow code are being replayed from history, vs being run for the first time. 