### PR TITLE
Rate Limiting Queue

### DIFF
--- a/dbos/core.py
+++ b/dbos/core.py
@@ -218,7 +218,7 @@ def _execute_workflow_wthread(
         with EnterDBOSWorkflow(attributes):
             try:
                 return _execute_workflow(dbos, status, func, *args, **kwargs)
-            except Exception as e:
+            except Exception:
                 dbos.logger.error(
                     f"Exception encountered in asynchronous workflow: {traceback.format_exc()}"
                 )

--- a/dbos/core.py
+++ b/dbos/core.py
@@ -181,7 +181,8 @@ def _execute_workflow(
         status["status"] = "SUCCESS"
         status["output"] = utils.serialize(output)
         if status["queue_name"] is not None:
-            dbos._sys_db.remove_from_queue(status["workflow_uuid"])
+            queue = dbos._registry.queue_info_map[status["queue_name"]]
+            dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
         dbos._sys_db.buffer_workflow_status(status)
     except DBOSWorkflowConflictIDError:
         # Retrieve the workflow handle and wait for the result.
@@ -195,7 +196,8 @@ def _execute_workflow(
         status["status"] = "ERROR"
         status["error"] = utils.serialize_exception(error)
         if status["queue_name"] is not None:
-            dbos._sys_db.remove_from_queue(status["workflow_uuid"])
+            queue = dbos._registry.queue_info_map[status["queue_name"]]
+            dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
         dbos._sys_db.update_workflow_status(status)
         raise
 

--- a/dbos/migrations/versions/9d68c43d3e0b_job_queue_limiter.py
+++ b/dbos/migrations/versions/9d68c43d3e0b_job_queue_limiter.py
@@ -1,0 +1,33 @@
+"""job_queue_limiter
+
+Revision ID: 9d68c43d3e0b
+Revises: eab0cc1d9a14
+Create Date: 2024-09-25 13:28:19.683860
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9d68c43d3e0b"
+down_revision: Union[str, None] = "eab0cc1d9a14"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "job_queue",
+        sa.Column(
+            "started_at_epoch_ms",
+            sa.BigInteger(),
+        ),
+        schema="dbos",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("job_queue", "started_at_epoch_ms", schema="dbos")

--- a/dbos/migrations/versions/d76646551a6b_job_queue_limiter.py
+++ b/dbos/migrations/versions/d76646551a6b_job_queue_limiter.py
@@ -27,7 +27,16 @@ def upgrade() -> None:
         ),
         schema="dbos",
     )
+    op.add_column(
+        "job_queue",
+        sa.Column(
+            "completed_at_epoch_ms",
+            sa.BigInteger(),
+        ),
+        schema="dbos",
+    )
 
 
 def downgrade() -> None:
     op.drop_column("job_queue", "started_at_epoch_ms", schema="dbos")
+    op.drop_column("job_queue", "completed_at_epoch_ms", schema="dbos")

--- a/dbos/migrations/versions/d76646551a6b_job_queue_limiter.py
+++ b/dbos/migrations/versions/d76646551a6b_job_queue_limiter.py
@@ -1,8 +1,8 @@
 """job_queue_limiter
 
-Revision ID: 9d68c43d3e0b
-Revises: eab0cc1d9a14
-Create Date: 2024-09-25 13:28:19.683860
+Revision ID: d76646551a6b
+Revises: 50f3227f0b4b
+Create Date: 2024-09-25 14:48:10.218015
 
 """
 
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "9d68c43d3e0b"
-down_revision: Union[str, None] = "eab0cc1d9a14"
+revision: str = "d76646551a6b"
+down_revision: Union[str, None] = "50f3227f0b4b"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -45,9 +45,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
         time.sleep(1)
         for queue_name, queue in dbos._registry.queue_info_map.items():
             try:
-                wf_ids = dbos._sys_db.start_queued_workflows(
-                    queue_name, queue.concurrency
-                )
+                wf_ids = dbos._sys_db.start_queued_workflows(queue)
                 for id in wf_ids:
                     _execute_workflow_id(dbos, id)
             except Exception:

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,9 +1,6 @@
 import threading
-import time
 import traceback
 from typing import TYPE_CHECKING, Optional, TypedDict
-
-from pydantic import BaseModel
 
 from dbos.core import P, R, _execute_workflow_id, _start_workflow
 
@@ -11,13 +8,13 @@ if TYPE_CHECKING:
     from dbos.dbos import DBOS, Workflow, WorkflowHandle
 
 
-# Rate-limit the maximum number of functions from this queue
-# that can be started in a given duration. If the max is 5
-# and the duration is 10, no more than 5 functions can be
+# Limit the maximum number of functions from this queue
+# that can be started in a given period. If the limit is 5
+# and the period is 10, no more than 5 functions can be
 # started per 10 seconds.
 class Limiter(TypedDict):
-    max: int
-    duration: float
+    limit: int
+    period: float
 
 
 class Queue:

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -11,9 +11,13 @@ if TYPE_CHECKING:
     from dbos.dbos import DBOS, Workflow, WorkflowHandle
 
 
+# Rate-limit the maximum number of functions from this queue
+# that can be started in a given duration. If the max is 5
+# and the duration is 10, no more than 5 functions can be
+# started per 10 seconds.
 class Limiter(TypedDict):
     max: int
-    duration: int
+    duration: float
 
 
 class Queue:

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,9 +1,9 @@
 import threading
 import time
+import traceback
 from typing import TYPE_CHECKING, Optional
 
 from dbos.core import P, R, _execute_workflow_id, _start_workflow
-from dbos.error import DBOSInitializationError
 
 if TYPE_CHECKING:
     from dbos.dbos import DBOS, Workflow, WorkflowHandle
@@ -31,6 +31,13 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     while not stop_event.is_set():
         time.sleep(1)
         for queue_name, queue in dbos._registry.queue_info_map.items():
-            wf_ids = dbos._sys_db.start_queued_workflows(queue_name, queue.concurrency)
-            for id in wf_ids:
-                _execute_workflow_id(dbos, id)
+            try:
+                wf_ids = dbos._sys_db.start_queued_workflows(
+                    queue_name, queue.concurrency
+                )
+                for id in wf_ids:
+                    _execute_workflow_id(dbos, id)
+            except Exception:
+                dbos.logger.warning(
+                    f"Exception encountered in queue thread: {traceback.format_exc()}"
+                )

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -1,7 +1,9 @@
 import threading
 import time
 import traceback
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, TypedDict
+
+from pydantic import BaseModel
 
 from dbos.core import P, R, _execute_workflow_id, _start_workflow
 
@@ -9,10 +11,21 @@ if TYPE_CHECKING:
     from dbos.dbos import DBOS, Workflow, WorkflowHandle
 
 
+class Limiter(TypedDict):
+    max: int
+    duration: int
+
+
 class Queue:
-    def __init__(self, name: str, concurrency: Optional[int] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        concurrency: Optional[int] = None,
+        limiter: Optional[Limiter] = None,
+    ) -> None:
         self.name = name
         self.concurrency = concurrency
+        self.limiter = limiter
         from dbos.dbos import _get_or_create_dbos_registry
 
         registry = _get_or_create_dbos_registry()

--- a/dbos/queue.py
+++ b/dbos/queue.py
@@ -42,8 +42,9 @@ class Queue:
 
 def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     while not stop_event.is_set():
-        time.sleep(1)
-        for queue_name, queue in dbos._registry.queue_info_map.items():
+        if stop_event.wait(timeout=1):
+            return
+        for _, queue in dbos._registry.queue_info_map.items():
             try:
                 wf_ids = dbos._sys_db.start_queued_workflows(queue)
                 for id in wf_ids:

--- a/dbos/schemas/system_database.py
+++ b/dbos/schemas/system_database.py
@@ -161,4 +161,8 @@ class SystemSchema:
             nullable=False,
             server_default=text("(EXTRACT(epoch FROM now()) * 1000::numeric)::bigint"),
         ),
+        Column(
+            "started_at_epoch_ms",
+            BigInteger(),
+        ),
     )

--- a/dbos/schemas/system_database.py
+++ b/dbos/schemas/system_database.py
@@ -165,4 +165,8 @@ class SystemSchema:
             "started_at_epoch_ms",
             BigInteger(),
         ),
+        Column(
+            "completed_at_epoch_ms",
+            BigInteger(),
+        ),
     )

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1073,7 +1073,7 @@ class SystemDatabase:
             # that have not yet been started so we can start them.
             rows = c.execute(query).fetchall()
             dequeued_ids: List[str] = [row[0] for row in rows if row[1] is None]
-            ret_ids = []
+            ret_ids: list[str] = []
             for id in dequeued_ids:
 
                 # If we have a limiter, stop starting functions when the number

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1083,7 +1083,7 @@ class SystemDatabase:
     def remove_from_queue(self, workflow_id: str, queue: "Queue") -> None:
         with self.engine.begin() as c:
             if queue.limiter is None:
-                bob = c.execute(
+                c.execute(
                     sa.delete(SystemSchema.job_queue).where(
                         SystemSchema.job_queue.c.workflow_uuid == workflow_id
                     )

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1037,6 +1037,7 @@ class SystemDatabase:
     def start_queued_workflows(self, queue: "Queue") -> List[str]:
         start_time_ms = int(time.time() * 1000)
         with self.engine.begin() as c:
+            c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
             if queue.limiter is not None:
                 query = (
                     sa.select(sa.func.count())

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1047,7 +1047,7 @@ class SystemDatabase:
                         > start_time_ms - queue.limiter["duration"] * 1000
                     )
                 )
-                num_recent_queries = c.execute(query).fetchone()[0]
+                num_recent_queries = c.execute(query).fetchone()[0]  # type: ignore
                 num_executable_queries = queue.limiter["max"] - num_recent_queries
             query = (
                 sa.select(

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1056,11 +1056,10 @@ class SystemDatabase:
                 )
                 .where(SystemSchema.job_queue.c.queue_name == queue.name)
                 .where(SystemSchema.job_queue.c.completed_at_epoch_ms == None)
+                .order_by(SystemSchema.job_queue.c.created_at_epoch_ms.asc())
             )
             if queue.concurrency is not None:
-                query = query.order_by(
-                    SystemSchema.job_queue.c.created_at_epoch_ms.asc()
-                ).limit(queue.concurrency)
+                query = query.limit(queue.concurrency)
             rows = c.execute(query).fetchall()
             dequeued_ids: List[str] = [row[0] for row in rows if row[1] is None]
             ret_ids = []

--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -1054,6 +1054,8 @@ class SystemDatabase:
                     )
                 )
                 num_recent_queries = c.execute(query).fetchone()[0]  # type: ignore
+                if num_recent_queries >= queue.limiter["max"]:
+                    return []
 
             # Select not-yet-completed functions in the queue ordered by the
             # time at which they were enqueued.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -86,7 +86,7 @@ def test_one_at_a_time_with_limiter(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    queue = Queue("test_queue", concurrency=1, limiter={"max": 1, "duration": 1})
+    queue = Queue("test_queue", concurrency=1, limiter={"max": 10, "duration": 1})
     handle1 = queue.enqueue(workflow_one)
     handle2 = queue.enqueue(workflow_two)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -144,30 +144,19 @@ def test_queue_transaction(dbos: DBOS) -> None:
 
 def test_limiter(dbos: DBOS) -> None:
     wf_counter: int = 0
-    step_counter: int = 0
-
-    wfid = str(uuid.uuid4())
 
     @DBOS.workflow()
     def test_workflow(var1: str, var2: str) -> str:
-        assert DBOS.workflow_id == wfid
         nonlocal wf_counter
         wf_counter += 1
-        var1 = test_step(var1)
         return var1 + var2
 
-    @DBOS.step()
-    def test_step(var: str) -> str:
-        nonlocal step_counter
-        step_counter += 1
-        return var + "d"
+    queue = Queue("test_queue", limiter={"max": 1, "duration": 2})
 
-    queue = Queue("test_queue", limiter={"max": 1, "duration": 1})
+    h1 = queue.enqueue(test_workflow, "abc", "123")
+    h2 = queue.enqueue(test_workflow, "abc", "123")
 
-    with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_workflow, "abc", "123")
-    assert handle.get_result() == "abcd123"
-    with SetWorkflowID(wfid):
-        assert test_workflow("abc", "123") == "abcd123"
+    assert h1.get_result() == "abc123"
+    assert wf_counter == 1
+    assert h2.get_result() == "abc123"
     assert wf_counter == 2
-    assert step_counter == 1

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -196,7 +196,7 @@ def test_limiter(dbos: DBOS) -> None:
 
     # Verify that the gap between "waves" is ~equal to the duration
     for wave in range(num_waves - 1):
-        assert times[max * wave + 1] - times[max * wave] < 0.1
+        assert times[max * wave] - times[max * wave - 1] < duration + 0.1
 
     # Verify all workflows get the SUCCESS status eventually
     dbos._sys_db.wait_for_buffer_flush()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -178,9 +178,9 @@ def test_limiter(dbos: DBOS) -> None:
     handles: list[WorkflowHandle[float]] = []
     times: list[float] = []
 
-    # Launch a number of tasks equal to three times the max.
-    # This should lead to three "waves" of the max tasks being
-    # executed simultaneously, followed by a wait of the duration,
+    # Launch a number of tasks equal to three times the limit.
+    # This should lead to three "waves" of the limit tasks being
+    # executed simultaneously, followed by a wait of the period,
     # followed by the next wave.
     num_waves = 3
     for _ in range(limit * num_waves):
@@ -194,7 +194,7 @@ def test_limiter(dbos: DBOS) -> None:
         for i in range(wave * limit, (wave + 1) * limit - 1):
             assert times[i + 1] - times[i] < 0.1
 
-    # Verify that the gap between "waves" is ~equal to the duration
+    # Verify that the gap between "waves" is ~equal to the period
     for wave in range(num_waves - 1):
         assert times[limit * wave] - times[limit * wave - 1] < period + 0.1
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -10,7 +10,7 @@ from dbos.schemas.system_database import SystemSchema
 from dbos.system_database import WorkflowStatusString
 
 
-def queue_entries_are_cleaned_up(dbos: DBOS):
+def queue_entries_are_cleaned_up(dbos: DBOS) -> bool:
     max_tries = 10
     success = False
     for i in range(max_tries):
@@ -167,7 +167,7 @@ def test_queue_transaction(dbos: DBOS) -> None:
 def test_limiter(dbos: DBOS) -> None:
 
     @DBOS.workflow()
-    def test_workflow(var1: str, var2: str) -> str:
+    def test_workflow(var1: str, var2: str) -> float:
         assert var1 == "abc" and var2 == "123"
         return time.time()
 
@@ -175,7 +175,7 @@ def test_limiter(dbos: DBOS) -> None:
     duration = 2
     queue = Queue("test_queue", limiter={"max": max, "duration": duration})
 
-    handles: list[WorkflowHandle] = []
+    handles: list[WorkflowHandle[float]] = []
     times: list[float] = []
 
     # Launch a number of tasks equal to three times the max.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -108,3 +108,34 @@ def test_queue_transaction(dbos: DBOS) -> None:
     with SetWorkflowID(wfid):
         assert test_transaction("abc") == "abc1"
     assert step_counter == 1
+
+
+def test_limiter(dbos: DBOS) -> None:
+    wf_counter: int = 0
+    step_counter: int = 0
+
+    wfid = str(uuid.uuid4())
+
+    @DBOS.workflow()
+    def test_workflow(var1: str, var2: str) -> str:
+        assert DBOS.workflow_id == wfid
+        nonlocal wf_counter
+        wf_counter += 1
+        var1 = test_step(var1)
+        return var1 + var2
+
+    @DBOS.step()
+    def test_step(var: str) -> str:
+        nonlocal step_counter
+        step_counter += 1
+        return var + "d"
+
+    queue = Queue("test_queue", limiter={"max": 1, "duration": 1})
+
+    with SetWorkflowID(wfid):
+        handle = queue.enqueue(test_workflow, "abc", "123")
+    assert handle.get_result() == "abcd123"
+    with SetWorkflowID(wfid):
+        assert test_workflow("abc", "123") == "abcd123"
+    assert wf_counter == 2
+    assert step_counter == 1


### PR DESCRIPTION
You can now pass in a "limiter" to a queue, for example:

```python
queue = Queue("test_queue", limiter={"max": max, "duration": duration})
```

The queue will start at most `max` tasks in any given `duration` seconds.
This is useful when submitting jobs to rate-limited APIs.
For example, if your API only accepts 100 requests per minute, set a `max` of 100 and a `duration` of 60.