### PR TITLE
Make admin server port configurable

### DIFF
--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -140,6 +140,10 @@
           "start": {
             "type": "array",
             "description": "Specify commands to run to start your application (Python only)"
+          },
+          "admin_port": {
+            "type": "number",
+            "description": "The port number of the admin server (Default: 3001)"
           }
         }
       },

--- a/dbos/dbos.py
+++ b/dbos/dbos.py
@@ -348,7 +348,10 @@ class DBOS:
             self._executor_field = ThreadPoolExecutor(max_workers=64)
             self._sys_db_field = SystemDatabase(self.config)
             self._app_db_field = ApplicationDatabase(self.config)
-            self._admin_server_field = AdminServer(dbos=self)
+            admin_port = self.config["runtimeConfig"].get("admin_port")
+            if admin_port is None:
+                admin_port = 3001
+            self._admin_server_field = AdminServer(dbos=self, port=admin_port)
 
             if not os.environ.get("DBOS__VMID"):
                 workflow_ids = self._sys_db.get_pending_workflows("local")

--- a/dbos/dbos_config.py
+++ b/dbos/dbos_config.py
@@ -14,6 +14,7 @@ from dbos.logger import dbos_logger
 
 class RuntimeConfig(TypedDict, total=False):
     start: List[str]
+    admin_port: Optional[int]
 
 
 class DatabaseConfig(TypedDict, total=False):

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -123,3 +123,39 @@ def test_admin_recovery(dbos: DBOS) -> None:
             time.sleep(1)
             print(f"Attempt {attempt + 1} failed. Retrying in 1 second...")
     assert succeeded, "Workflow did not recover"
+
+
+def test_admin_diff_port(cleanup_test_databases: None) -> None:
+    # Initialize singleton
+    DBOS.destroy()  # In case of other tests leaving it
+
+    config_string = """name: test-app
+language: python
+database:
+  hostname: localhost
+  port: 5432
+  username: postgres
+  password: ${PGPASSWORD}
+  app_db_name: dbostestpy
+runtimeConfig:
+  start:
+    - python3 main.py
+  admin_port: 8001
+"""
+    # Write the config to a text file for the moment
+    with open("dbos-config.yaml", "w") as file:
+        file.write(config_string)
+
+    try:
+        # Initialize DBOS
+        DBOS()
+        DBOS.launch()
+
+        # Test GET /dbos-healthz
+        response = requests.get("http://localhost:8001/dbos-healthz", timeout=5)
+        assert response.status_code == 200
+        assert response.text == "healthy"
+    finally:
+        # Clean up after the test
+        DBOS.destroy()
+        os.remove("dbos-config.yaml")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ def test_valid_config(mocker):
         runtimeConfig:
             start:
                 - "python3 main.py"
+            admin_port: 8001
         database:
           hostname: 'some host'
           port: 1234


### PR DESCRIPTION
PR to solve https://github.com/dbos-inc/dbos-transact-py/issues/129

Now you can specify the `admin_port` field under `runtimeConfig` in the dbos-config.yaml file.

Added a test to make sure we can specify a different port.