### PR TITLE
Dependency Versions

### DIFF
--- a/dbos/system_database.py
+++ b/dbos/system_database.py
@@ -793,7 +793,7 @@ class SystemDatabase:
                 self.notification_conn.execute("LISTEN dbos_workflow_events_channel")
 
                 while self._run_background_processes:
-                    gen = self.notification_conn.notifies(timeout=60)
+                    gen = self.notification_conn.notifies()
                     for notify in gen:
                         channel = notify.channel
                         dbos_logger.debug(

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6d385dffaab1ae5167d623bf53ba31a0cf4c37a17259d01ae95b5a6051c3906f"
+content_hash = "sha256:31dbe33b5f8abbc45ee552ee7be158cabbf4438e978f1e9fcb2a1f060c29ed87"
 
 [[metadata.targets]]
 requires_python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi[standard]>=0.115.2",
     "psutil>=6.0.0",
     "tomlkit>=0.13.2",
-    "psycopg>=3.2.3",
+    "psycopg>=3.1", # Keep compatibility with 3.1--older Python installations/machines can't always install 3.2
 ]
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
Add compatibility with older versions of psycopg as newer versions don't support all Python installations.