### PR TITLE
Simplify Database Configuration

### DIFF
--- a/dbos/cli.py
+++ b/dbos/cli.py
@@ -125,11 +125,9 @@ def copy_template(src_dir: str, project_name: str, config_mode: bool) -> None:
     dst_dir = path.abspath(".")
 
     package_name = project_name.replace("-", "_")
-    db_name = package_name if not package_name[0].isdigit() else f"_{package_name}"
     ctx = {
         "project_name": project_name,
         "package_name": package_name,
-        "db_name": db_name,
         "migration_command": "alembic upgrade head",
     }
 

--- a/dbos/cli.py
+++ b/dbos/cli.py
@@ -17,6 +17,7 @@ from typing_extensions import Annotated
 
 from dbos import load_config
 from dbos.application_database import ApplicationDatabase
+from dbos.dbos_config import is_valid_app_name
 from dbos.system_database import SystemDatabase
 
 app = typer.Typer()
@@ -163,14 +164,6 @@ def get_project_name() -> typing.Union[str, None]:
             pass
 
     return name
-
-
-def is_valid_app_name(name: str) -> bool:
-    name_len = len(name)
-    if name_len < 3 or name_len > 30:
-        return False
-    match = re.match("^[a-z0-9-_]+$", name)
-    return True if match != None else False
 
 
 @app.command()

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -86,8 +86,7 @@
           "hostname",
           "port",
           "username",
-          "password",
-          "app_db_name"
+          "password"
         ]
       },
       "telemetry": {

--- a/dbos/dbos_config.py
+++ b/dbos/dbos_config.py
@@ -167,11 +167,19 @@ def load_config(config_file_path: str = "dbos-config.yaml") -> ConfigFile:
 
     data = cast(ConfigFile, data)
 
+    if "app_db_name" not in data["database"]:
+        data["database"]["app_db_name"] = app_name_to_db_name(data["name"])
+
     if "local_suffix" in data["database"] and data["database"]["local_suffix"]:
         data["database"]["app_db_name"] = f"{data['database']['app_db_name']}_local"
 
     # Return data as ConfigFile type
     return data  # type: ignore
+
+
+def app_name_to_db_name(app_name: str) -> str:
+    name = app_name.replace("-", "_")
+    return name if not name[0].isdigit() else f"_{name}"
 
 
 def set_env_vars(config: ConfigFile) -> None:

--- a/dbos/dbos_config.py
+++ b/dbos/dbos_config.py
@@ -167,6 +167,11 @@ def load_config(config_file_path: str = "dbos-config.yaml") -> ConfigFile:
 
     data = cast(ConfigFile, data)
 
+    if not is_valid_app_name(data["name"]):
+        raise DBOSInitializationError(
+            f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters and contain only alphanumeric characters, dashes, and underscores.'
+        )
+
     if "app_db_name" not in data["database"]:
         data["database"]["app_db_name"] = app_name_to_db_name(data["name"])
 
@@ -175,6 +180,14 @@ def load_config(config_file_path: str = "dbos-config.yaml") -> ConfigFile:
 
     # Return data as ConfigFile type
     return data  # type: ignore
+
+
+def is_valid_app_name(name: str) -> bool:
+    name_len = len(name)
+    if name_len < 3 or name_len > 30:
+        return False
+    match = re.match("^[a-z0-9-_]+$", name)
+    return True if match != None else False
 
 
 def app_name_to_db_name(app_name: str) -> str:

--- a/dbos/templates/hello/dbos-config.yaml.dbos
+++ b/dbos/templates/hello/dbos-config.yaml.dbos
@@ -13,7 +13,6 @@ database:
   port: 5432
   username: postgres
   password: ${PGPASSWORD}
-  app_db_name: ${db_name}
   migrate:
     - ${migration_command}
 telemetry:


### PR DESCRIPTION
Make `app_db_name` optional and remove it from the template. If it's not specified, use the app name as `app_db_name`.