### PR TITLE
Adding IntelliJ IDE to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 
 # IDE files
 .vscode/
+.idea/


### PR DESCRIPTION
For contributors using IntelliJ: adding IntelliJ directory to `.gitignore`.

Implicitly tested by `.idea/` no part of the pull request :-)