### PR TITLE
Destroy Registry Flag

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -238,13 +238,14 @@ class DBOS:
         return _dbos_global_instance
 
     @classmethod
-    def destroy(cls) -> None:
+    def destroy(cls, *, destroy_registry: bool = True) -> None:
         global _dbos_global_instance
-        global _dbos_global_registry
         if _dbos_global_instance is not None:
             _dbos_global_instance._destroy()
         _dbos_global_instance = None
-        _dbos_global_registry = None
+        if destroy_registry:
+            global _dbos_global_registry
+            _dbos_global_registry = None
 
     def __init__(
         self,


### PR DESCRIPTION
This provides a public interface to destroy the DBOS class with `DBOS.destroy()` without destroying the registry of decorated functions. Useful for re-launching after failures.

Addresses https://github.com/dbos-inc/dbos-transact-py/issues/160