### PR TITLE
Fix check recorded output for "None" output

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -734,11 +734,6 @@ def decorate_step(
                         )
                         raise deserialized_error
                     elif recorded_output["output"] is not None:
-                        print(
-                            recorded_output["output"],
-                            recorded_output["output"],
-                            _serialization.deserialize(recorded_output["output"]),
-                        )
                         return cast(
                             R, _serialization.deserialize(recorded_output["output"])
                         )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -719,7 +719,7 @@ def decorate_step(
                 finally:
                     dbos._sys_db.record_operation_result(step_output)
 
-            def check_existing_result() -> Optional[R]:
+            def check_existing_result() -> Optional[str]:
                 ctx = assert_current_dbos_context()
                 recorded_output = dbos._sys_db.check_operation_execution(
                     ctx.workflow_id, ctx.function_id
@@ -734,14 +734,7 @@ def decorate_step(
                         )
                         raise deserialized_error
                     elif recorded_output["output"] is not None:
-                        return cast(
-                            R,
-                            {
-                                "output": _serialization.deserialize(
-                                    recorded_output["output"]
-                                )
-                            },
-                        )
+                        return recorded_output["output"]
                     else:
                         raise Exception("Output and error are both None")
                 else:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -734,6 +734,11 @@ def decorate_step(
                         )
                         raise deserialized_error
                     elif recorded_output["output"] is not None:
+                        print(
+                            recorded_output["output"],
+                            recorded_output["output"],
+                            _serialization.deserialize(recorded_output["output"]),
+                        )
                         return cast(
                             R, _serialization.deserialize(recorded_output["output"])
                         )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -735,7 +735,12 @@ def decorate_step(
                         raise deserialized_error
                     elif recorded_output["output"] is not None:
                         return cast(
-                            R, _serialization.deserialize(recorded_output["output"])
+                            R,
+                            {
+                                "output": _serialization.deserialize(
+                                    recorded_output["output"]
+                                )
+                            },
                         )
                     else:
                         raise Exception("Output and error are both None")

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -60,7 +60,7 @@ class Immediate(Outcome[T]):
     @staticmethod
     def _intercept(func: Callable[[], T], interceptor: Callable[[], Optional[T]]) -> T:
         intercepted = interceptor()
-        return intercepted if intercepted else func()
+        return cast(T, intercepted["output"]) if intercepted else func()  # type: ignore
 
     def intercept(self, interceptor: Callable[[], Optional[T]]) -> "Immediate[T]":
         return Immediate[T](lambda: Immediate._intercept(self._func, interceptor))
@@ -154,7 +154,7 @@ class Pending(Outcome[T]):
         interceptor: Callable[[], Optional[T]],
     ) -> T:
         intercepted = await asyncio.to_thread(interceptor)
-        return intercepted if intercepted else await func()
+        return cast(T, intercepted["output"]) if intercepted else await func()  # type: ignore
 
     def intercept(self, interceptor: Callable[[], Optional[T]]) -> "Pending[T]":
         return Pending[T](lambda: Pending._intercept(self._func, interceptor))

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -4,6 +4,8 @@ import inspect
 import time
 from typing import Any, Callable, Coroutine, Optional, Protocol, TypeVar, Union, cast
 
+from . import _serialization
+
 T = TypeVar("T")
 R = TypeVar("R")
 
@@ -28,7 +30,7 @@ class Outcome(Protocol[T]):
         exceeded_retries: Callable[[int], BaseException],
     ) -> "Outcome[T]": ...
 
-    def intercept(self, interceptor: Callable[[], Optional[T]]) -> "Outcome[T]": ...
+    def intercept(self, interceptor: Callable[[], Optional[str]]) -> "Outcome[T]": ...
 
     def __call__(self) -> Union[T, Coroutine[Any, Any, T]]: ...
 
@@ -58,11 +60,15 @@ class Immediate(Outcome[T]):
         return Immediate(lambda: before()(self._func))
 
     @staticmethod
-    def _intercept(func: Callable[[], T], interceptor: Callable[[], Optional[T]]) -> T:
+    def _intercept(
+        func: Callable[[], T], interceptor: Callable[[], Optional[str]]
+    ) -> T:
         intercepted = interceptor()
-        return cast(T, intercepted["output"]) if intercepted else func()  # type: ignore
+        return (
+            cast(T, _serialization.deserialize(intercepted)) if intercepted else func()
+        )
 
-    def intercept(self, interceptor: Callable[[], Optional[T]]) -> "Immediate[T]":
+    def intercept(self, interceptor: Callable[[], Optional[str]]) -> "Immediate[T]":
         return Immediate[T](lambda: Immediate._intercept(self._func, interceptor))
 
     @staticmethod
@@ -151,12 +157,16 @@ class Pending(Outcome[T]):
     @staticmethod
     async def _intercept(
         func: Callable[[], Coroutine[Any, Any, T]],
-        interceptor: Callable[[], Optional[T]],
+        interceptor: Callable[[], Optional[str]],
     ) -> T:
         intercepted = await asyncio.to_thread(interceptor)
-        return cast(T, intercepted["output"]) if intercepted else await func()  # type: ignore
+        return (
+            cast(T, _serialization.deserialize(intercepted))
+            if intercepted
+            else await func()
+        )
 
-    def intercept(self, interceptor: Callable[[], Optional[T]]) -> "Pending[T]":
+    def intercept(self, interceptor: Callable[[], Optional[str]]) -> "Pending[T]":
         return Pending[T](lambda: Pending._intercept(self._func, interceptor))
 
     @staticmethod

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -390,7 +390,7 @@ def test_recovery_workflow_step(dbos: DBOS) -> None:
         nonlocal step_counter
         step_counter += 1
         print("I'm a test_step!")
-        return "step_result"
+        return
 
     wfuuid = str(uuid.uuid4())
     with SetWorkflowID(wfuuid):
@@ -504,18 +504,11 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
     wf_counter: int = 0
     test_var = "dbos"
 
-    @DBOS.step()
-    def test_step(var: int) -> None:
-        print(f"I'm test_step {var}")
-        return
-
     @DBOS.workflow()
     def test_workflow(var: str) -> str:
-        test_step(1)
         nonlocal wf_counter
         if var == test_var:
             wf_counter += 1
-        test_step(2)
         return var
 
     wfuuid = str(uuid.uuid4())
@@ -548,18 +541,11 @@ def test_recovery_thread(config: ConfigFile, dbos: DBOS) -> None:
     dbos._destroy()  # Unusual pattern - reusing the memory
     dbos.__init__(config=config)  # type: ignore
 
-    @DBOS.step()
-    def test_step(var: int) -> None:
-        print(f"I'm test_step {var}")
-        return
-
-    @DBOS.workflow()
+    @DBOS.workflow()  # type: ignore
     def test_workflow(var: str) -> str:
-        test_step(1)
         nonlocal wf_counter
         if var == test_var:
             wf_counter += 1
-        test_step(2)
         return var
 
     DBOS.launch()  # Usually the framework does this but we destroyed it above

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -386,10 +386,10 @@ def test_recovery_workflow_step(dbos: DBOS) -> None:
         return var
 
     @DBOS.step()
-    def test_step(var2: str) -> str:
+    def test_step(var2: str) -> None:
         nonlocal step_counter
         step_counter += 1
-        print("I'm a test_step!")
+        print(f"I'm a test_step {var2}!")
         return
 
     wfuuid = str(uuid.uuid4())


### PR DESCRIPTION
Handle the case where the recorded output itself is `None`. Previously, the bug was that it would rerun the step again.
Added a test.