### PR TITLE
Outcome.intercept NoResult

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -719,7 +719,7 @@ def decorate_step(
                 finally:
                     dbos._sys_db.record_operation_result(step_output)
 
-            def check_existing_result() -> Optional[str]:
+            def check_existing_result() -> Optional[R]:
                 ctx = assert_current_dbos_context()
                 recorded_output = dbos._sys_db.check_operation_execution(
                     ctx.workflow_id, ctx.function_id
@@ -734,7 +734,9 @@ def decorate_step(
                         )
                         raise deserialized_error
                     elif recorded_output["output"] is not None:
-                        return recorded_output["output"]
+                        return cast(
+                            R, _serialization.deserialize(recorded_output["output"])
+                        )
                     else:
                         raise Exception("Output and error are both None")
                 else:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -21,7 +21,7 @@ from typing import (
     overload,
 )
 
-from dbos._outcome import Immediate, Outcome, Pending
+from dbos._outcome import Immediate, NoResult, Outcome, Pending
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
 
@@ -719,7 +719,7 @@ def decorate_step(
                 finally:
                     dbos._sys_db.record_operation_result(step_output)
 
-            def check_existing_result() -> Optional[R]:
+            def check_existing_result() -> Union[NoResult, R]:
                 ctx = assert_current_dbos_context()
                 recorded_output = dbos._sys_db.check_operation_execution(
                     ctx.workflow_id, ctx.function_id
@@ -743,7 +743,7 @@ def decorate_step(
                     dbos.logger.debug(
                         f"Running step, id: {ctx.function_id}, name: {attributes['name']}"
                     )
-                    return None
+                    return NoResult()
 
             stepOutcome = Outcome[R].make(functools.partial(func, *args, **kwargs))
             if retries_allowed:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -374,64 +374,6 @@ def test_recovery_workflow(dbos: DBOS) -> None:
     assert stat.recovery_attempts == 1
 
 
-def test_recovery_workflow_step(dbos: DBOS) -> None:
-    step_counter: int = 0
-    wf_counter: int = 0
-
-    @DBOS.workflow()
-    def test_workflow(var: str, var2: str) -> str:
-        nonlocal wf_counter
-        wf_counter += 1
-        test_step(var2)
-        return var
-
-    @DBOS.step()
-    def test_step(var2: str) -> None:
-        nonlocal step_counter
-        step_counter += 1
-        print(f"I'm a test_step {var2}!")
-        return
-
-    wfuuid = str(uuid.uuid4())
-    with SetWorkflowID(wfuuid):
-        assert test_workflow("bob", "bob") == "bob"
-
-    dbos._sys_db.wait_for_buffer_flush()
-    # Change the workflow status to pending
-    dbos._sys_db.update_workflow_status(
-        {
-            "workflow_uuid": wfuuid,
-            "status": "PENDING",
-            "name": test_workflow.__qualname__,
-            "class_name": None,
-            "config_name": None,
-            "output": None,
-            "error": None,
-            "executor_id": None,
-            "app_id": None,
-            "app_version": None,
-            "request": None,
-            "recovery_attempts": None,
-            "authenticated_user": None,
-            "authenticated_roles": None,
-            "assumed_role": None,
-            "queue_name": None,
-        }
-    )
-
-    # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
-    assert len(workflow_handles) == 1
-    assert workflow_handles[0].get_result() == "bob"
-    assert wf_counter == 2
-    assert step_counter == 1
-
-    # Test that there was a recovery attempt of this
-    stat = workflow_handles[0].get_status()
-    assert stat
-    assert stat.recovery_attempts == 1
-
-
 def test_recovery_temp_workflow(dbos: DBOS) -> None:
     txn_counter: int = 0
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -374,6 +374,64 @@ def test_recovery_workflow(dbos: DBOS) -> None:
     assert stat.recovery_attempts == 1
 
 
+def test_recovery_workflow_step(dbos: DBOS) -> None:
+    step_counter: int = 0
+    wf_counter: int = 0
+
+    @DBOS.workflow()
+    def test_workflow(var: str, var2: str) -> str:
+        nonlocal wf_counter
+        wf_counter += 1
+        test_step(var2)
+        return var
+
+    @DBOS.step()
+    def test_step(var2: str) -> None:
+        nonlocal step_counter
+        step_counter += 1
+        print(f"I'm a test_step {var2}!")
+        return
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowID(wfuuid):
+        assert test_workflow("bob", "bob") == "bob"
+
+    dbos._sys_db.wait_for_buffer_flush()
+    # Change the workflow status to pending
+    dbos._sys_db.update_workflow_status(
+        {
+            "workflow_uuid": wfuuid,
+            "status": "PENDING",
+            "name": test_workflow.__qualname__,
+            "class_name": None,
+            "config_name": None,
+            "output": None,
+            "error": None,
+            "executor_id": None,
+            "app_id": None,
+            "app_version": None,
+            "request": None,
+            "recovery_attempts": None,
+            "authenticated_user": None,
+            "authenticated_roles": None,
+            "assumed_role": None,
+            "queue_name": None,
+        }
+    )
+
+    # Recovery should execute the workflow again but skip the transaction
+    workflow_handles = DBOS.recover_pending_workflows()
+    assert len(workflow_handles) == 1
+    assert workflow_handles[0].get_result() == "bob"
+    assert wf_counter == 2
+    assert step_counter == 1
+
+    # Test that there was a recovery attempt of this
+    stat = workflow_handles[0].get_status()
+    assert stat
+    assert stat.recovery_attempts == 1
+
+
 def test_recovery_temp_workflow(dbos: DBOS) -> None:
     txn_counter: int = 0
 


### PR DESCRIPTION
The original implementation of `Outcome.intercept` used `Optional[T]` and thus could not distingish between no cached results and a cached result of None.

This PR adds a singleton NoResult class to use instead of `None` in as the return value of the `interceptor` parameter of `Outcome.intercept`. 