### PR TITLE
Prevent different workflows starting with the same ID

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -99,7 +99,7 @@ class DBOSContext:
         else:
             if self.is_within_set_workflow_id_block:
                 self.logger.warning(
-                    f"Multiple workflow started within the SetWorkflowID block. Only the first workflow will be assigned with the specified workflow ID; subsequent workflows will use a generated workflow ID."
+                    f"Multiple workflows started in the same SetWorkflowID block. Only the first workflow is assigned the specified workflow ID; subsequent workflows will use a generated workflow ID."
                 )
             wfid = str(uuid.uuid4())
         return wfid

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -57,6 +57,7 @@ class DBOSContext:
         self.request: Optional["Request"] = None
 
         self.id_assigned_for_next_workflow: str = ""
+        self.is_within_set_workflow_id_block: bool = False
 
         self.parent_workflow_id: str = ""
         self.parent_workflow_fid: int = -1
@@ -78,6 +79,7 @@ class DBOSContext:
         rv.logger = self.logger
         rv.id_assigned_for_next_workflow = self.id_assigned_for_next_workflow
         self.id_assigned_for_next_workflow = ""
+        rv.is_within_set_workflow_id_block = self.is_within_set_workflow_id_block
         rv.parent_workflow_id = self.workflow_id
         rv.parent_workflow_fid = self.function_id
         rv.in_recovery = self.in_recovery
@@ -95,6 +97,10 @@ class DBOSContext:
         if len(self.id_assigned_for_next_workflow) > 0:
             wfid = self.id_assigned_for_next_workflow
         else:
+            if self.is_within_set_workflow_id_block:
+                self.logger.warning(
+                    f"Multiple workflow started within the SetWorkflowID block. Only the first workflow will be assigned with the specified workflow ID; subsequent workflows will use a generated workflow ID."
+                )
             wfid = str(uuid.uuid4())
         return wfid
 
@@ -286,7 +292,7 @@ class DBOSContextSwap:
 
 class SetWorkflowID:
     """
-    Set the workflow ID to be used for the enclosed workflow invocation.
+    Set the workflow ID to be used for the enclosed workflow invocation. Note: Only the first workflow will be started with the specified workflow ID within a `with SetWorkflowID` block.
 
     Typical Usage
         ```
@@ -311,7 +317,9 @@ class SetWorkflowID:
         if ctx is None:
             self.created_ctx = True
             _set_local_dbos_context(DBOSContext())
-        assert_current_dbos_context().id_assigned_for_next_workflow = self.wfid
+        ctx = assert_current_dbos_context()
+        ctx.id_assigned_for_next_workflow = self.wfid
+        ctx.is_within_set_workflow_id_block = True
         return self
 
     def __exit__(
@@ -321,6 +329,7 @@ class SetWorkflowID:
         traceback: Optional[TracebackType],
     ) -> Literal[False]:
         # Code to clean up the basic context if we created it
+        assert_current_dbos_context().is_within_set_workflow_id_block = False
         if self.created_ctx:
             _clear_local_dbos_context()
         return False  # Did not handle

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -188,6 +188,7 @@ def _init_workflow(
         wf_status = dbos._sys_db.update_workflow_status(
             status, False, ctx.in_recovery, max_recovery_attempts=max_recovery_attempts
         )
+        # TODO: Modify the inputs if they were changed by `update_workflow_inputs`
         dbos._sys_db.update_workflow_inputs(wfid, _serialization.serialize_args(inputs))
     else:
         # Buffer the inputs for single-transaction workflows, but don't buffer the status
@@ -494,7 +495,7 @@ def workflow_wrapper(
                 temp_wf_type=get_temp_workflow_type(func),
                 max_recovery_attempts=max_recovery_attempts,
             )
-
+            # TODO: maybe modify the parameters if they've been changed by `_init_workflow`
             dbos.logger.debug(
                 f"Running workflow, id: {ctx.workflow_id}, name: {get_dbos_func_name(func)}"
             )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -423,6 +423,9 @@ def start_workflow(
         or wf_status == WorkflowStatusString.ERROR.value
         or wf_status == WorkflowStatusString.SUCCESS.value
     ):
+        dbos.logger.debug(
+            f"Workflow {new_wf_id} already completed with status {wf_status}. Directly returning a workflow handle."
+        )
         return WorkflowHandlePolling(new_wf_id, dbos)
 
     if fself is not None:

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -35,6 +35,7 @@ class DBOSErrorCode(Enum):
     DeadLetterQueueError = 6
     MaxStepRetriesExceeded = 7
     NotAuthorized = 8
+    ConflictingWorkflowError = 9
 
 
 class DBOSWorkflowConflictIDError(DBOSException):
@@ -44,6 +45,16 @@ class DBOSWorkflowConflictIDError(DBOSException):
         super().__init__(
             f"Conflicting workflow ID {workflow_id}",
             dbos_error_code=DBOSErrorCode.ConflictingIDError.value,
+        )
+
+
+class DBOSConflictingWorkflowError(DBOSException):
+    """Exception raised different workflows started with the same workflow ID."""
+
+    def __init__(self, workflow_id: str, message: Optional[str] = None):
+        super().__init__(
+            f"Conflicting workflow invocation with the same ID ({workflow_id}): {message}",
+            dbos_error_code=DBOSErrorCode.ConflictingWorkflowError.value,
         )
 
 

--- a/dbos/_kafka.py
+++ b/dbos/_kafka.py
@@ -1,3 +1,4 @@
+import re
 import threading
 from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
@@ -19,6 +20,14 @@ _kafka_queue: Queue
 _in_order_kafka_queues: dict[str, Queue] = {}
 
 
+def safe_group_name(method_name: str, topics: list[str]) -> str:
+    safe_group_id = "-".join(
+        re.sub(r"[^a-zA-Z0-9\-]", "", str(r)) for r in [method_name, *topics]
+    )
+
+    return f"dbos-kafka-group-{safe_group_id}"[:255]
+
+
 def _kafka_consumer_loop(
     func: _KafkaConsumerWorkflow,
     config: dict[str, Any],
@@ -33,6 +42,12 @@ def _kafka_consumer_loop(
     config["error_cb"] = on_error
     if "auto.offset.reset" not in config:
         config["auto.offset.reset"] = "earliest"
+
+    if config.get("group.id") is None:
+        config["group.id"] = safe_group_name(func.__qualname__, topics)
+        dbos_logger.debug(
+            f"Consumer group ID not found. Using generated group.id {config['group.id']}"
+        )
 
     consumer = Consumer(config)
     try:
@@ -71,8 +86,9 @@ def _kafka_consumer_loop(
                     topic=cmsg.topic(),
                     value=cmsg.value(),
                 )
+                groupID = config.get("group.id")
                 with SetWorkflowID(
-                    f"kafka-unique-id-{msg.topic}-{msg.partition}-{msg.offset}"
+                    f"kafka-unique-id-{msg.topic}-{msg.partition}-{groupID}-{msg.offset}"
                 ):
                     if in_order:
                         assert msg.topic is not None

--- a/dbos/_kafka.py
+++ b/dbos/_kafka.py
@@ -45,7 +45,7 @@ def _kafka_consumer_loop(
 
     if config.get("group.id") is None:
         config["group.id"] = safe_group_name(func.__qualname__, topics)
-        dbos_logger.debug(
+        dbos_logger.warning(
             f"Consumer group ID not found. Using generated group.id {config['group.id']}"
         )
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import threading
@@ -478,7 +479,7 @@ def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
 
 
 # Test error cases where we have duplicated workflows starting with the same workflow ID.
-def test_duplicate_workflow_id(dbos: DBOS) -> None:
+def test_duplicate_workflow_id(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
     wfid = str(uuid.uuid4())
 
     @DBOS.workflow()
@@ -510,10 +511,16 @@ def test_duplicate_workflow_id(dbos: DBOS) -> None:
             DBOS.sleep(0.1)
             return self.config_name + ":" + var1
 
+    original_propagate = logging.getLogger("dbos").propagate
+    caplog.set_level(logging.WARNING, "dbos")
+    logging.getLogger("dbos").propagate = True
+
     with SetWorkflowID(wfid):
         origHandle = DBOS.start_workflow(test_workflow, "abc")
         # The second one will generate a warning message but no error.
         test_dup_workflow()
+
+    assert "Multiple workflow started within the SetWorkflowID block." in caplog.text
 
     # It's okay to call the same workflow with the same ID again.
     with SetWorkflowID(wfid):
@@ -559,6 +566,7 @@ def test_duplicate_workflow_id(dbos: DBOS) -> None:
     with SetWorkflowID(wfid):
         handle = queue.enqueue(test_workflow, "abc")
     assert handle.get_result() == "abc"
+    assert "Workflow already exists in queue" in caplog.text
 
     # Call with a different input would generate a warning, but still use the recorded input.
     with SetWorkflowID(wfid):
@@ -566,6 +574,10 @@ def test_duplicate_workflow_id(dbos: DBOS) -> None:
         # We want to see the warning message, but the result is non-deterministic
         # TODO: in the future, we may want to always use the recorded inputs.
         assert res == "abc" or res == "def"
+    assert f"Workflow inputs for {wfid} changed since the first call" in caplog.text
 
     assert origHandle.get_result() == "abc"
     assert same_handle.get_result() == "abc"
+
+    # Reset logging
+    logging.getLogger("dbos").propagate = original_propagate

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -520,7 +520,7 @@ def test_duplicate_workflow_id(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> 
         # The second one will generate a warning message but no error.
         test_dup_workflow()
 
-    assert "Multiple workflow started within the SetWorkflowID block." in caplog.text
+    assert "Multiple workflows started in the same SetWorkflowID block." in caplog.text
 
     # It's okay to call the same workflow with the same ID again.
     with SetWorkflowID(wfid):


### PR DESCRIPTION
This fix is similar to the one in TypeScript: https://github.com/dbos-inc/dbos-transact-ts/pull/726

- This PR mainly addresses the issue where different workflows started with the same workflow ID breaks the OAOO guarantees. The solution is to check the recorded function name, class name, and config name (if any) before proceeding to start the workflow. If there's any difference, throw a `DBOSConflictingWorkflowError` with a clear error message. 
- Plus, if multiple workflow started within the SetWorkflowID block, only the first workflow will be assigned with the specified workflow ID; subsequent workflows will use a generated workflow ID. Make sure we have a clear warning message for users.
- This PR also checks the recorded input versus the provided input, and the provided queue name versus the original queue name, and print a warning message if they don't match.
- It also fixes the Kafka consumer workflow IDs and adds a way to generate a group ID based on the function name and topics. This should match the TS implementation.