### PR TITLE
Don't set workflow ID if the header is not set

### DIFF
--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -94,7 +94,11 @@ def setup_fastapi_middleware(app: FastAPI, dbos: DBOS) -> None:
         with EnterDBOSHandler(attributes):
             ctx = assert_current_dbos_context()
             ctx.request = _make_request(request)
-            workflow_id = request.headers.get("dbos-idempotency-key", "")
-            with SetWorkflowID(workflow_id):
+            workflow_id = request.headers.get("dbos-idempotency-key")
+            if workflow_id is not None:
+                # Set the workflow ID for the handler
+                with SetWorkflowID(workflow_id):
+                    response = await call_next(request)
+            else:
                 response = await call_next(request)
         return response

--- a/dbos/_flask.py
+++ b/dbos/_flask.py
@@ -34,8 +34,12 @@ class FlaskMiddleware:
         with EnterDBOSHandler(attributes):
             ctx = assert_current_dbos_context()
             ctx.request = _make_request(request)
-            workflow_id = request.headers.get("dbos-idempotency-key", "")
-            with SetWorkflowID(workflow_id):
+            workflow_id = request.headers.get("dbos-idempotency-key")
+            if workflow_id is not None:
+                # Set the workflow ID for the handler
+                with SetWorkflowID(workflow_id):
+                    response = self.app(environ, start_response)
+            else:
                 response = self.app(environ, start_response)
         return response
 


### PR DESCRIPTION
This PR fixes a minor issue where the FastAPI/Flask handler would falsely print `Multiple workflows started in the same SetWorkflowID block.`

The solution is to not enter the `with SetWorkflowID` block if the HTTP request doesn't contain the header to set the WF ID.

Added tests to make sure no warning logs for those tests.