### PR TITLE
Wrap Existing FastAPI Lifespan Handlers

### DIFF
--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -80,7 +80,7 @@ def setup_fastapi_middleware(app: FastAPI, dbos: DBOS) -> None:
     app.add_middleware(LifespanMiddleware, dbos=dbos)
     app.add_exception_handler(DBOSException, _dbos_error_handler)
 
-    @app.middleware("http")
+    # @app.middleware("http")
     async def dbos_fastapi_middleware(
         request: FastAPIRequest, call_next: Callable[..., Any]
     ) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,15 +118,7 @@ def dbos_fastapi(
 ) -> Generator[Tuple[DBOS, FastAPI], Any, None]:
     DBOS.destroy()
     app = FastAPI()
-
-    # ignore the on_event deprecation warnings
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=DeprecationWarning,
-            message=r"\s*on_event is deprecated, use lifespan event handlers instead\.",
-        )
-        dbos = DBOS(fastapi=app, config=config)
+    dbos = DBOS(fastapi=app, config=config)
 
     # This is for test convenience.
     #    Usually fastapi itself does launch, but we are not completing the fastapi lifecycle

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -164,7 +164,9 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_custom_lifespan() -> None:
+async def test_custom_lifespan(
+    config: ConfigFile, cleanup_test_databases: None
+) -> None:
     resource = None
     port = 8000
 
@@ -176,6 +178,9 @@ async def test_custom_lifespan() -> None:
         resource = None
 
     app = FastAPI(lifespan=lifespan)
+
+    DBOS.destroy()
+    DBOS(fastapi=app, config=config)
 
     @app.get("/")
     async def get_resource() -> Any:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -183,7 +183,8 @@ async def test_custom_lifespan(
     DBOS(fastapi=app, config=config)
 
     @app.get("/")
-    async def get_resource() -> Any:
+    @DBOS.workflow()
+    def get_resource() -> Any:
         return {"resource": resource}
 
     config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="error")

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,14 +1,18 @@
+import asyncio
 import logging
 import uuid
-from typing import Tuple
+from contextlib import asynccontextmanager
+from typing import Any, Tuple
 
+import httpx
 import pytest
 import sqlalchemy as sa
+import uvicorn
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 # Public API
-from dbos import DBOS
+from dbos import DBOS, ConfigFile
 
 # Private API because this is a unit test
 from dbos._context import assert_current_dbos_context
@@ -157,3 +161,37 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     workflow_handles = DBOS.recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == ("a", wfuuid)
+
+
+@pytest.mark.asyncio
+async def test_custom_lifespan() -> None:
+    resource = None
+    port = 8000
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> Any:
+        nonlocal resource
+        resource = 1
+        yield
+        resource = None
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/")
+    async def get_resource() -> Any:
+        return {"resource": resource}
+
+    config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config=config)
+
+    # Run server in background task
+    server_task = asyncio.create_task(server.serve())
+    await asyncio.sleep(0.1)  # Give server time to start
+
+    async with httpx.AsyncClient() as client:
+        r = await client.get(f"http://127.0.0.1:{port}")
+        assert r.json()["resource"] == 1
+
+    server.should_exit = True
+    await server_task
+    assert resource is None

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -195,7 +195,7 @@ async def test_custom_lifespan(
 
     # Run server in background task
     server_task = asyncio.create_task(server.serve())
-    await asyncio.sleep(0.1)  # Give server time to start
+    await asyncio.sleep(0.2)  # Give server time to start
 
     async with httpx.AsyncClient() as client:
         r = await client.get(f"http://127.0.0.1:{port}")

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -183,8 +183,11 @@ async def test_custom_lifespan(
     DBOS(fastapi=app, config=config)
 
     @app.get("/")
+    async def get_resource():
+        return await resource_workflow()
+
     @DBOS.workflow()
-    def get_resource() -> Any:
+    async def resource_workflow():
         return {"resource": resource}
 
     config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="error")


### PR DESCRIPTION
Make the DBOS FastAPI lifespan handler wrap whatever handler already exists (if one does) instead of overriding it.