### PR TITLE
Better Destroy

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -245,7 +245,7 @@ class DBOS:
         return _dbos_global_instance
 
     @classmethod
-    def destroy(cls, *, destroy_registry: bool = True) -> None:
+    def destroy(cls, *, destroy_registry: bool = False) -> None:
         global _dbos_global_instance
         if _dbos_global_instance is not None:
             _dbos_global_instance._destroy()

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -367,7 +367,7 @@ class SystemDatabase:
         with self.engine.begin() as c:
             stmt = (
                 sa.update(SystemSchema.workflow_status)
-                .where(SystemSchema.workflow_inputs.c.workflow_uuid == workflow_uuid)
+                .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
                 .values(
                     status=status,
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def cleanup_test_databases(config: ConfigFile, postgres_db_engine: sa.Engine) ->
 def dbos(
     config: ConfigFile, cleanup_test_databases: None
 ) -> Generator[DBOS, Any, None]:
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
 
     # This launches for test convenience.
     #    Tests add to running DBOS and then call stuff without adding
@@ -109,14 +109,14 @@ def dbos(
     DBOS.launch()
 
     yield dbos
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
 
 
 @pytest.fixture()
 def dbos_fastapi(
     config: ConfigFile, cleanup_test_databases: None
 ) -> Generator[Tuple[DBOS, FastAPI], Any, None]:
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
     app = FastAPI()
     dbos = DBOS(fastapi=app, config=config)
 
@@ -125,14 +125,14 @@ def dbos_fastapi(
     DBOS.launch()
 
     yield dbos, app
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
 
 
 @pytest.fixture()
 def dbos_flask(
     config: ConfigFile, cleanup_test_databases: None
 ) -> Generator[Tuple[DBOS, Flask], Any, None]:
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
     app = Flask(__name__)
 
     dbos = DBOS(flask=app, config=config)
@@ -142,7 +142,7 @@ def dbos_flask(
     DBOS.launch()
 
     yield dbos, app
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
 
 
 # Pretty-print test names

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -303,7 +303,7 @@ def test_async_tx_raises(config: ConfigFile) -> None:
             pass
 
     # destroy call needed to avoid "functions were registered but DBOS() was not called" warning
-    DBOS.destroy()
+    DBOS.destroy(destroy_registry=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1214,7 +1214,7 @@ def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
     logging.getLogger("dbos").propagate = original_propagate
 
 
-def test_destroy_semantics(dbos: DBOS, config: ConfigFile):
+def test_destroy_semantics(dbos: DBOS, config: ConfigFile) -> None:
 
     @DBOS.workflow()
     def test_workflow(var: str) -> str:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1212,3 +1212,19 @@ def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
 
     # Reset logging
     logging.getLogger("dbos").propagate = original_propagate
+
+
+def test_destroy_semantics(dbos: DBOS, config: ConfigFile):
+
+    @DBOS.workflow()
+    def test_workflow(var: str) -> str:
+        return var
+
+    var = "test"
+    assert test_workflow(var) == var
+
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.launch()
+
+    assert test_workflow(var) == var


### PR DESCRIPTION
For `DBOS.destroy()` to destroy the global registry by default (essentially un-decorating all DBOS functions) is unintuitive and makes it harder to write tests for DBOS applications. This PR changes its behavior not not destroy the global registry by default.