### PR TITLE
Reset System Database

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -56,7 +56,7 @@ from ._registrations import (
 )
 from ._roles import default_required_roles, required_roles
 from ._scheduler import ScheduledWorkflow, scheduled
-from ._sys_db import WorkflowStatusString
+from ._sys_db import WorkflowStatusString, reset_system_database
 from ._tracer import dbos_tracer
 
 if TYPE_CHECKING:
@@ -408,6 +408,23 @@ class DBOS:
         except Exception:
             dbos_logger.error(f"DBOS failed to launch: {traceback.format_exc()}")
             raise
+
+    @classmethod
+    def reset_system_database(cls) -> None:
+        """
+        Reset the DBOS system database. Useful for resetting the state of DBOS between tests.
+        This is a destructive operation and should only be used in a test environment.
+        """
+        if _dbos_global_instance is not None:
+            _dbos_global_instance._reset_system_database()
+
+    def _reset_system_database(self) -> None:
+        if self._launched:
+            dbos_logger.error(
+                "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
+            )
+            return
+        reset_system_database(self.config)
 
     def _destroy(self) -> None:
         self._initialized = False

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -412,7 +412,7 @@ class DBOS:
     @classmethod
     def reset_system_database(cls) -> None:
         """
-        Reset the DBOS system database. Useful for resetting the state of DBOS between tests.
+        Destroy the DBOS system database. Useful for resetting the state of DBOS between tests.
         This is a destructive operation and should only be used in a test environment.
         """
         if _dbos_global_instance is not None:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -414,6 +414,7 @@ class DBOS:
         """
         Destroy the DBOS system database. Useful for resetting the state of DBOS between tests.
         This is a destructive operation and should only be used in a test environment.
+        More information on testing DBOS apps: https://docs.dbos.dev/python/tutorials/testing
         """
         if _dbos_global_instance is not None:
             _dbos_global_instance._reset_system_database()

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -419,11 +419,9 @@ class DBOS:
             _dbos_global_instance._reset_system_database()
 
     def _reset_system_database(self) -> None:
-        if self._launched:
-            dbos_logger.error(
-                "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
-            )
-            return
+        assert (
+            not self._launched
+        ), "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
         reset_system_database(self.config)
 
     def _destroy(self) -> None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1267,7 +1267,7 @@ class SystemDatabase:
                 )
 
 
-def reset_system_database(config: ConfigFile):
+def reset_system_database(config: ConfigFile) -> None:
     sysdb_name = (
         config["database"]["sys_db_name"]
         if "sys_db_name" in config["database"] and config["database"]["sys_db_name"]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -115,3 +115,35 @@ def test_init_config() -> None:
             actual_yaml = yaml.safe_load(f)
 
         assert actual_yaml == expected_yaml
+
+
+def test_reset(postgres_db_engine: sa.Engine) -> None:
+    app_name = "reset-app"
+    sysdb_name = "reset_app_dbos_sys"
+    with tempfile.TemporaryDirectory() as temp_path:
+        subprocess.check_call(
+            ["dbos", "init", app_name, "--template", "dbos-db-starter"],
+            cwd=temp_path,
+        )
+
+        # Create a system database and verify it exists
+        subprocess.check_call(["dbos", "migrate"], cwd=temp_path)
+        with postgres_db_engine.connect() as c:
+            c.execution_options(isolation_level="AUTOCOMMIT")
+            result = c.execute(
+                sa.text(
+                    f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'"
+                )
+            ).scalar()
+            assert result == 1
+
+        # Call reset and verify it's destroyed
+        subprocess.check_call(["dbos", "reset", "-y"], cwd=temp_path)
+        with postgres_db_engine.connect() as c:
+            c.execution_options(isolation_level="AUTOCOMMIT")
+            result = c.execute(
+                sa.text(
+                    f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'"
+                )
+            ).scalar()
+            assert result == 0

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -50,7 +50,7 @@ def test_package(build_wheel: str, postgres_db_engine: sa.Engine) -> None:
 
             # initalize the app with dbos scaffolding
             subprocess.check_call(
-                ["dbos", "init", template_name, "--template", "dbos-db-starter"],
+                ["dbos", "init", template_name, "--template", template_name],
                 cwd=temp_path,
                 env=venv,
             )

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -129,7 +129,7 @@ def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine):
         result = c.execute(
             sa.text(f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'")
         ).scalar()
-        assert result == 0, f"Database {sysdb_name} should not exist"
+        assert result == 0
 
     DBOS.launch()
 
@@ -138,3 +138,7 @@ def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine):
         sql = SystemSchema.workflow_status.select()
         result = c.execute(sql)
         assert result.fetchall() == []
+
+    # Verify that resetting after launch throws
+    with pytest.raises(AssertionError):
+        DBOS.reset_system_database()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -104,7 +104,7 @@ def rollback_system_db(sysdb_url: str) -> None:
     command.downgrade(alembic_cfg, "base")  # Rollback all migrations
 
 
-def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine):
+def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine) -> None:
     DBOS.destroy()
     dbos = DBOS(config=config)
     DBOS.launch()
@@ -126,10 +126,10 @@ def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine):
     )
     with postgres_db_engine.connect() as c:
         c.execution_options(isolation_level="AUTOCOMMIT")
-        result = c.execute(
+        count: int = c.execute(
             sa.text(f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'")
-        ).scalar()
-        assert result == 0
+        ).scalar_one()
+        assert count == 0
 
     DBOS.launch()
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -102,3 +102,39 @@ def rollback_system_db(sysdb_url: str) -> None:
     )
     alembic_cfg.set_main_option("sqlalchemy.url", escaped_conn_string)
     command.downgrade(alembic_cfg, "base")  # Rollback all migrations
+
+
+def test_reset(config: ConfigFile, postgres_db_engine: sa.Engine):
+    DBOS.destroy()
+    dbos = DBOS(config=config)
+    DBOS.launch()
+
+    # Make sure the system database exists
+    with dbos._sys_db.engine.connect() as c:
+        sql = SystemSchema.workflow_status.select()
+        result = c.execute(sql)
+        assert result.fetchall() == []
+
+    DBOS.destroy()
+    dbos = DBOS(config=config)
+    DBOS.reset_system_database()
+
+    sysdb_name = (
+        config["database"]["sys_db_name"]
+        if "sys_db_name" in config["database"] and config["database"]["sys_db_name"]
+        else config["database"]["app_db_name"] + SystemSchema.sysdb_suffix
+    )
+    with postgres_db_engine.connect() as c:
+        c.execution_options(isolation_level="AUTOCOMMIT")
+        result = c.execute(
+            sa.text(f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'")
+        ).scalar()
+        assert result == 0, f"Database {sysdb_name} should not exist"
+
+    DBOS.launch()
+
+    # Make sure the system database is recreated
+    with dbos._sys_db.engine.connect() as c:
+        sql = SystemSchema.workflow_status.select()
+        result = c.execute(sql)
+        assert result.fetchall() == []

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -7,7 +7,7 @@ from os import path
 import pytest
 
 # Public API
-from dbos import DBOS, ConfigFile, SetWorkflowID, WorkflowHandle
+from dbos import DBOS, SetWorkflowID, WorkflowHandle
 
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -7,7 +7,7 @@ from os import path
 import pytest
 
 # Public API
-from dbos import DBOS, SetWorkflowID, WorkflowHandle
+from dbos import DBOS, ConfigFile, SetWorkflowID, WorkflowHandle
 
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context


### PR DESCRIPTION
A new command for programmatically resetting the DBOS system database.  This is primarily useful for testing a DBOS app, to reset the internal state of DBOS between tests.