### PR TITLE
Update Workflow Status

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -185,8 +185,8 @@ def _init_workflow(
         # Synchronously record the status and inputs for workflows and single-step workflows
         # We also have to do this for single-step workflows because of the foreign key constraint on the operation outputs table
         # TODO: Make this transactional (and with the queue step below)
-        wf_status = dbos._sys_db.update_workflow_status(
-            status, False, max_recovery_attempts=max_recovery_attempts
+        wf_status = dbos._sys_db.insert_workflow_status(
+            status, max_recovery_attempts=max_recovery_attempts
         )
         # TODO: Modify the inputs if they were changed by `update_workflow_inputs`
         dbos._sys_db.update_workflow_inputs(wfid, _serialization.serialize_args(inputs))

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -338,133 +338,57 @@ class SystemDatabase:
                     status["workflow_uuid"], max_recovery_attempts
                 )
 
-        # Record we have exported status for this single-transaction workflow
-        if status["workflow_uuid"] in self._temp_txn_wf_ids:
-            self._exported_temp_txn_wf_status.add(status["workflow_uuid"])
-
         return wf_status
 
     def update_workflow_status(
         self,
         status: WorkflowStatusInternal,
-        replace: bool = True,
         *,
         conn: Optional[sa.Connection] = None,
-        max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS,
-        is_status_flush: bool = False,
-    ) -> WorkflowStatuses:
+    ) -> None:
         wf_status: WorkflowStatuses = status["status"]
 
-        cmd = pg.insert(SystemSchema.workflow_status).values(
-            workflow_uuid=status["workflow_uuid"],
-            status=status["status"],
-            name=status["name"],
-            class_name=status["class_name"],
-            config_name=status["config_name"],
-            output=status["output"],
-            error=status["error"],
-            executor_id=status["executor_id"],
-            application_version=status["app_version"],
-            application_id=status["app_id"],
-            request=status["request"],
-            authenticated_user=status["authenticated_user"],
-            authenticated_roles=status["authenticated_roles"],
-            assumed_role=status["assumed_role"],
-            queue_name=status["queue_name"],
-            recovery_attempts=(
-                1 if wf_status != WorkflowStatusString.ENQUEUED.value else 0
-            ),
-        )
-        if replace:
-            cmd = cmd.on_conflict_do_update(
+        cmd = (
+            pg.insert(SystemSchema.workflow_status)
+            .values(
+                workflow_uuid=status["workflow_uuid"],
+                status=status["status"],
+                name=status["name"],
+                class_name=status["class_name"],
+                config_name=status["config_name"],
+                output=status["output"],
+                error=status["error"],
+                executor_id=status["executor_id"],
+                application_version=status["app_version"],
+                application_id=status["app_id"],
+                request=status["request"],
+                authenticated_user=status["authenticated_user"],
+                authenticated_roles=status["authenticated_roles"],
+                assumed_role=status["assumed_role"],
+                queue_name=status["queue_name"],
+                recovery_attempts=(
+                    1 if wf_status != WorkflowStatusString.ENQUEUED.value else 0
+                ),
+            )
+            .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
                 set_=dict(
                     status=status["status"],
                     output=status["output"],
                     error=status["error"],
-                    recovery_attempts=(
-                        SystemSchema.workflow_status.c.recovery_attempts + 1
-                        if not is_status_flush
-                        else SystemSchema.workflow_status.c.recovery_attempts
-                    ),
                 ),
             )
-        else:
-            cmd = cmd.on_conflict_do_update(
-                index_elements=["workflow_uuid"],
-                set_=dict(
-                    recovery_attempts=(
-                        SystemSchema.workflow_status.c.recovery_attempts + 1
-                        if not is_status_flush
-                        else SystemSchema.workflow_status.c.recovery_attempts
-                    ),
-                ),
-            )
-
-        cmd = cmd.returning(SystemSchema.workflow_status.c.recovery_attempts, SystemSchema.workflow_status.c.status, SystemSchema.workflow_status.c.name, SystemSchema.workflow_status.c.class_name, SystemSchema.workflow_status.c.config_name, SystemSchema.workflow_status.c.queue_name)  # type: ignore
+        )
 
         if conn is not None:
-            results = conn.execute(cmd)
+            conn.execute(cmd)
         else:
             with self.engine.begin() as c:
-                results = c.execute(cmd)
+                c.execute(cmd)
 
-        row = results.fetchone()
-        if row is not None:
-            # Check the started workflow matches the expected name, class_name, config_name, and queue_name
-            # A mismatch indicates a workflow starting with the same UUID but different functions, which would throw an exception.
-            recovery_attempts: int = row[0]
-            wf_status = row[1]
-            err_msg: Optional[str] = None
-            if row[2] != status["name"]:
-                err_msg = f"Workflow already exists with a different function name: {row[2]}, but the provided function name is: {status['name']}"
-            elif row[3] != status["class_name"]:
-                err_msg = f"Workflow already exists with a different class name: {row[3]}, but the provided class name is: {status['class_name']}"
-            elif row[4] != status["config_name"]:
-                err_msg = f"Workflow already exists with a different config name: {row[4]}, but the provided config name is: {status['config_name']}"
-            elif row[5] != status["queue_name"]:
-                # This is a warning because a different queue name is not necessarily an error.
-                dbos_logger.warning(
-                    f"Workflow already exists in queue: {row[5]}, but the provided queue name is: {status['queue_name']}. The queue is not updated."
-                )
-            if err_msg is not None:
-                raise DBOSConflictingWorkflowError(status["workflow_uuid"], err_msg)
-
-            # recovery_attempt means "attempts" (we kept the name for backward compatibility). It's default value is 1.
-            # Every time we init the status, we increment `recovery_attempts` by 1.
-            # Thus, when this number becomes equal to `maxRetries + 1`, we should mark the workflow as `RETRIES_EXCEEDED`.
-            if recovery_attempts > max_recovery_attempts + 1:
-                with self.engine.begin() as c:
-                    c.execute(
-                        sa.delete(SystemSchema.workflow_queue).where(
-                            SystemSchema.workflow_queue.c.workflow_uuid
-                            == status["workflow_uuid"]
-                        )
-                    )
-                    c.execute(
-                        sa.update(SystemSchema.workflow_status)
-                        .where(
-                            SystemSchema.workflow_status.c.workflow_uuid
-                            == status["workflow_uuid"]
-                        )
-                        .where(
-                            SystemSchema.workflow_status.c.status
-                            == WorkflowStatusString.PENDING.value
-                        )
-                        .values(
-                            status=WorkflowStatusString.RETRIES_EXCEEDED.value,
-                            queue_name=None,
-                        )
-                    )
-                raise DBOSDeadLetterQueueError(
-                    status["workflow_uuid"], max_recovery_attempts
-                )
-
-        # Record we have exported status for this single-transaction workflow
+        # If this is a single-transaction workflow, record that its status has been exported
         if status["workflow_uuid"] in self._temp_txn_wf_ids:
             self._exported_temp_txn_wf_status.add(status["workflow_uuid"])
-
-        return wf_status
 
     def set_workflow_status(
         self,
@@ -1158,7 +1082,7 @@ class SystemDatabase:
                     continue
                 exported_status[wf_id] = status
                 try:
-                    self.update_workflow_status(status, conn=c, is_status_flush=True)
+                    self.update_workflow_status(status, conn=c)
                     exported += 1
                 except Exception as e:
                     dbos_logger.error(f"Error while flushing status buffer: {e}")


### PR DESCRIPTION
Refactor `update_workflow_status`, eliminating its incomprehensible flags by splitting it into two separate functions.

- `insert_workflow_status` inserts a new workflow status, is called when starting a workflow, and contains code for tracking workflow attempts and for validating the workflow was called properly.
- `update_workflow_status` updates the status of an existing workflow, is called when terminating a workflow to record its final status and output, and contains no extraneous code.

This does not change behavior or semantics.