### PR TITLE
Test & Improve Queue Semantics

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -368,6 +368,28 @@ def execute_workflow_by_id(
                     )
 
 
+@overload
+def start_workflow(
+    dbos: "DBOS",
+    func: "Workflow[P, Coroutine[Any, Any, R]]",
+    queue_name: Optional[str],
+    execute_workflow: bool,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> "WorkflowHandle[R]": ...
+
+
+@overload
+def start_workflow(
+    dbos: "DBOS",
+    func: "Workflow[P, R]",
+    queue_name: Optional[str],
+    execute_workflow: bool,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> "WorkflowHandle[R]": ...
+
+
 def start_workflow(
     dbos: "DBOS",
     func: "Workflow[P, Union[R, Coroutine[Any, Any, R]]]",

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -368,28 +368,6 @@ def execute_workflow_by_id(
                     )
 
 
-@overload
-def start_workflow(
-    dbos: "DBOS",
-    func: "Workflow[P, Coroutine[Any, Any, R]]",
-    queue_name: Optional[str],
-    execute_workflow: bool,
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> "WorkflowHandle[R]": ...
-
-
-@overload
-def start_workflow(
-    dbos: "DBOS",
-    func: "Workflow[P, R]",
-    queue_name: Optional[str],
-    execute_workflow: bool,
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> "WorkflowHandle[R]": ...
-
-
 def start_workflow(
     dbos: "DBOS",
     func: "Workflow[P, Union[R, Coroutine[Any, Any, R]]]",

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -805,6 +805,7 @@ class DBOS:
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> None:
         """Resume a workflow by ID."""
+        _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
         execute_workflow_by_id(_get_dbos_instance(), workflow_id, False)
 
     @classproperty

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -800,9 +800,7 @@ class DBOS:
     @classmethod
     def cancel_workflow(cls, workflow_id: str) -> None:
         """Cancel a workflow by ID."""
-        _get_dbos_instance()._sys_db.set_workflow_status(
-            workflow_id, WorkflowStatusString.CANCELLED
-        )
+        _get_dbos_instance()._sys_db.cancel_workflow(workflow_id)
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> None:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -803,10 +803,10 @@ class DBOS:
         _get_dbos_instance()._sys_db.cancel_workflow(workflow_id)
 
     @classmethod
-    def resume_workflow(cls, workflow_id: str) -> None:
+    def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Resume a workflow by ID."""
         _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
-        execute_workflow_by_id(_get_dbos_instance(), workflow_id, False)
+        return execute_workflow_by_id(_get_dbos_instance(), workflow_id, False)
 
     @classproperty
     def logger(cls) -> Logger:

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -9,7 +9,6 @@ from ._sys_db import (
     GetWorkflowsOutput,
     SystemDatabase,
     WorkflowStatuses,
-    WorkflowStatusString,
 )
 
 
@@ -101,9 +100,10 @@ def get_workflow(
 def cancel_workflow(config: ConfigFile, uuid: str) -> None:
     try:
         sys_db = SystemDatabase(config)
-        sys_db.set_workflow_status(uuid, WorkflowStatusString.CANCELLED)
+        sys_db.cancel_workflow(uuid)
     except Exception as e:
         typer.echo(f"Failed to connect to DBOS system database: {e}")
+        raise e
     finally:
         if sys_db:
             sys_db.destroy()

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -1,22 +1,14 @@
-import importlib
-import os
-import sys
-from typing import Any, List, Optional, cast
+from typing import List, Optional, cast
 
 import typer
-from rich import print
 
-from dbos import DBOS
-
-from . import _serialization, load_config
-from ._core import execute_workflow_by_id
-from ._dbos_config import ConfigFile, _is_valid_app_name
+from . import _serialization
+from ._dbos_config import ConfigFile
 from ._sys_db import (
     GetWorkflowsInput,
     GetWorkflowsOutput,
     SystemDatabase,
     WorkflowStatuses,
-    WorkflowStatusInternal,
     WorkflowStatusString,
 )
 
@@ -41,7 +33,7 @@ class WorkflowInformation:
     queue_name: Optional[str]
 
 
-def _list_workflows(
+def list_workflows(
     config: ConfigFile,
     li: int,
     user: Optional[str],
@@ -91,17 +83,13 @@ def _list_workflows(
             sys_db.destroy()
 
 
-def _get_workflow(
+def get_workflow(
     config: ConfigFile, uuid: str, request: bool
 ) -> Optional[WorkflowInformation]:
-    sys_db = None
-
     try:
         sys_db = SystemDatabase(config)
-
         info = _get_workflow_info(sys_db, uuid, request)
         return info
-
     except Exception as e:
         typer.echo(f"Error getting workflow: {e}")
         return None
@@ -110,18 +98,12 @@ def _get_workflow(
             sys_db.destroy()
 
 
-def _cancel_workflow(config: ConfigFile, uuid: str) -> None:
-    # config = load_config()
-    sys_db = None
-
+def cancel_workflow(config: ConfigFile, uuid: str) -> None:
     try:
         sys_db = SystemDatabase(config)
         sys_db.set_workflow_status(uuid, WorkflowStatusString.CANCELLED)
-        return
-
     except Exception as e:
         typer.echo(f"Failed to connect to DBOS system database: {e}")
-        return None
     finally:
         if sys_db:
             sys_db.destroy()

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -19,7 +19,7 @@ from .. import load_config
 from .._app_db import ApplicationDatabase
 from .._dbos_config import _is_valid_app_name
 from .._sys_db import SystemDatabase, reset_system_database
-from .._workflow_commands import _cancel_workflow, _get_workflow, _list_workflows
+from .._workflow_commands import cancel_workflow, get_workflow, list_workflows
 from ..cli._github_init import create_template_from_github
 from ._template_init import copy_template, get_project_name, get_templates_directory
 
@@ -282,7 +282,7 @@ def list(
     ] = None,
 ) -> None:
     config = load_config()
-    workflows = _list_workflows(
+    workflows = list_workflows(
         config, limit, user, starttime, endtime, status, request, appversion
     )
     print(jsonpickle.encode(workflows, unpicklable=False))
@@ -301,7 +301,7 @@ def get(
     ] = True,
 ) -> None:
     config = load_config()
-    print(jsonpickle.encode(_get_workflow(config, uuid, request), unpicklable=False))
+    print(jsonpickle.encode(get_workflow(config, uuid, request), unpicklable=False))
 
 
 @workflow.command(
@@ -315,7 +315,7 @@ def cancel(
     ] = None,
 ) -> None:
     config = load_config()
-    _cancel_workflow(config, uuid)
+    cancel_workflow(config, uuid)
     print(f"Workflow {uuid} has been cancelled")
 
 

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -162,7 +162,7 @@ def test_admin_workflow_resume(dbos: DBOS, config: ConfigFile) -> None:
     time.sleep(1)
 
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -171,7 +171,7 @@ def test_admin_workflow_resume(dbos: DBOS, config: ConfigFile) -> None:
 
     wfUuid = output[0].workflowUUID
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     assert info is not None, "Expected output to be not None"
 
     assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
@@ -181,7 +181,7 @@ def test_admin_workflow_resume(dbos: DBOS, config: ConfigFile) -> None:
     )
     assert response.status_code == 204
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     if info is not None:
         assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
     else:
@@ -194,7 +194,7 @@ def test_admin_workflow_resume(dbos: DBOS, config: ConfigFile) -> None:
 
     time.sleep(1)
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     if info is not None:
         assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
     else:
@@ -213,7 +213,7 @@ def test_admin_workflow_restart(dbos: DBOS, config: ConfigFile) -> None:
     time.sleep(1)
 
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -222,7 +222,7 @@ def test_admin_workflow_restart(dbos: DBOS, config: ConfigFile) -> None:
 
     wfUuid = output[0].workflowUUID
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     assert info is not None, "Expected output to be not None"
 
     assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
@@ -232,7 +232,7 @@ def test_admin_workflow_restart(dbos: DBOS, config: ConfigFile) -> None:
     )
     assert response.status_code == 204
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     if info is not None:
         assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
     else:
@@ -245,13 +245,13 @@ def test_admin_workflow_restart(dbos: DBOS, config: ConfigFile) -> None:
 
     time.sleep(1)
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     if info is not None:
         assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
     else:
         assert False, "Expected info to be not None"
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     assert len(output) == 2, f"Expected list length to be 2, but got {len(output)}"
@@ -261,7 +261,7 @@ def test_admin_workflow_restart(dbos: DBOS, config: ConfigFile) -> None:
     else:
         new_wfUuid = output[0].workflowUUID
 
-    info = _workflow_commands._get_workflow(config, new_wfUuid, True)
+    info = _workflow_commands.get_workflow(config, new_wfUuid, True)
     if info is not None:
         assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
     else:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -189,19 +189,41 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
         recovery_count += 1
         event.wait()
 
-    handle = DBOS.start_workflow(dead_letter_workflow)
+    # Start a workflow that blocks forever
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(dead_letter_workflow)
 
+    # Attempt to recover the blocked workflow the maximum number of times
     for i in range(max_recovery_attempts):
         DBOS.recover_pending_workflows()
         assert recovery_count == i + 2
 
+    # Verify an additional attempt (either through recovery or through a direct call) throws a DLQ error
+    # and puts the workflow in the DLQ status.
     with pytest.raises(Exception) as exc_info:
         DBOS.recover_pending_workflows()
     assert exc_info.errisinstance(DBOSDeadLetterQueueError)
     assert handle.get_status().status == WorkflowStatusString.RETRIES_EXCEEDED.value
+    with pytest.raises(Exception) as exc_info:
+        with SetWorkflowID(wfid):
+            dead_letter_workflow()
+    assert exc_info.errisinstance(DBOSDeadLetterQueueError)
 
+    # Resume the workflow. Verify it returns to PENDING status without error.
+    resumed_handle = dbos.resume_workflow(wfid)
+    assert (
+        handle.get_status().status
+        == resumed_handle.get_status().status
+        == WorkflowStatusString.PENDING.value
+    )
+
+    # Verify the workflow can recover again without error.
+    DBOS.recover_pending_workflows()
+
+    # Complete the blocked workflow
     event.set()
-    assert handle.get_result() == None
+    assert handle.get_result() == resumed_handle.get_result() == None
     dbos._sys_db.wait_for_buffer_flush()
     assert handle.get_status().status == WorkflowStatusString.SUCCESS.value
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -677,6 +677,46 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_resuming_queued_workflows(dbos: DBOS) -> None:
+    start_event = threading.Event()
+    blocking_event = threading.Event()
+
+    @DBOS.workflow()
+    def stuck_workflow() -> None:
+        start_event.set()
+        blocking_event.wait()
+
+    @DBOS.workflow()
+    def regular_workflow() -> None:
+        return
+
+    # Enqueue a blocked workflow and two regular workflows on a queue with concurrency 1
+    queue = Queue("test_queue", concurrency=1)
+    wfid = str(uuid.uuid4())
+    blocked_handle = queue.enqueue(stuck_workflow)
+    with SetWorkflowID(wfid):
+        regular_handle_1 = queue.enqueue(regular_workflow)
+    regular_handle_2 = queue.enqueue(regular_workflow)
+
+    # Verify that the blocked workflow starts and is PENDING while the regular workflows remain ENQUEUED.
+    start_event.wait()
+    assert blocked_handle.get_status().status == WorkflowStatusString.PENDING.value
+    assert regular_handle_1.get_status().status == WorkflowStatusString.ENQUEUED.value
+    assert regular_handle_2.get_status().status == WorkflowStatusString.ENQUEUED.value
+
+    # Resume a regular workflow. Verify it completes.
+    dbos.resume_workflow(wfid)
+    assert regular_handle_1.get_result() == None
+
+    # Complete the blocked workflow. Verify the second regular workflow also completes.
+    blocking_event.set()
+    assert blocked_handle.get_result() == None
+    assert regular_handle_2.get_result() == None
+
+    # Verify all queue entries eventually get cleaned up.
+    assert queue_entries_are_cleaned_up(dbos)
+
+
 def test_dlq_enqueued_workflows(dbos: DBOS) -> None:
     start_event = threading.Event()
     blocking_event = threading.Event()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -639,7 +639,7 @@ def test_queue_recovery(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
-def test_cancelling_queued_workflows(dbos: DBOS):
+def test_cancelling_queued_workflows(dbos: DBOS) -> None:
     start_event = threading.Event()
     blocking_event = threading.Event()
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -709,7 +709,7 @@ def test_dlq_enqueued_workflows(dbos: DBOS) -> None:
         DBOS.recover_pending_workflows()
         assert recovery_count == i + 2
 
-    # Verify that recovering one more than the maximum throws a DLQ error and puts the workflow in the DLQ status.
+    # Verify an additional recovery throws a DLQ error and puts the workflow in the DLQ status.
     with pytest.raises(Exception) as exc_info:
         DBOS.recover_pending_workflows()
     assert exc_info.errisinstance(DBOSDeadLetterQueueError)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -593,7 +593,7 @@ def test_queue_recovery(dbos: DBOS) -> None:
     event = threading.Event()
 
     @DBOS.workflow()
-    def test_workflow() -> str:
+    def test_workflow() -> list[int]:
         assert DBOS.workflow_id == wfid
         handles = []
         for i in range(queued_steps):
@@ -602,7 +602,7 @@ def test_queue_recovery(dbos: DBOS) -> None:
         return [h.get_result() for h in handles]
 
     @DBOS.step()
-    def test_step(i: int) -> str:
+    def test_step(i: int) -> int:
         nonlocal step_counter
         step_counter += 1
         step_events[i].set()

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -31,7 +31,7 @@ def test_list_workflow(dbos: DBOS, config: ConfigFile) -> None:
     simple_workflow()
     time.sleep(1)  # wait for the workflow to complete
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -54,7 +54,7 @@ def test_list_workflow_limit(dbos: DBOS, config: ConfigFile) -> None:
     simple_workflow()
     time.sleep(1)  # wait for the workflow to complete
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 2, None, None, None, None, False, None
     )
     assert len(output) == 2, f"Expected list length to be 1, but got {len(output)}"
@@ -72,12 +72,12 @@ def test_list_workflow_status(dbos: DBOS, config: ConfigFile) -> None:
     simple_workflow()
     time.sleep(1)  # wait for the workflow to complete
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, "PENDING", False, None
     )
     assert len(output) == 0, f"Expected list length to be 0, but got {len(output)}"
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, "SUCCESS", False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -102,7 +102,7 @@ def test_list_workflow_start_end_times(dbos: DBOS, config: ConfigFile) -> None:
     endtime = datetime.now().isoformat()
     print(endtime)
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, starttime, endtime, None, False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -110,7 +110,7 @@ def test_list_workflow_start_end_times(dbos: DBOS, config: ConfigFile) -> None:
     newstarttime = (now - timedelta(seconds=30)).isoformat()
     newendtime = starttime
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, newstarttime, newendtime, None, False, None
     )
     assert len(output) == 0, f"Expected list length to be 0, but got {len(output)}"
@@ -141,19 +141,19 @@ def test_list_workflow_end_times_positive(dbos: DBOS, config: ConfigFile) -> Non
     # get the workflow list
     time_3 = datetime.now().isoformat()
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, time_0, time_1, None, False, None
     )
 
     assert len(output) == 0, f"Expected list length to be 0, but got {len(output)}"
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, time_1, time_2, None, False, None
     )
 
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
 
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, time_1, time_3, None, False, None
     )
     assert len(output) == 2, f"Expected list length to be 2, but got {len(output)}"
@@ -171,7 +171,7 @@ def test_get_workflow(dbos: DBOS, config: ConfigFile) -> None:
     simple_workflow()
     time.sleep(1)  # wait for the workflow to complete
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -180,7 +180,7 @@ def test_get_workflow(dbos: DBOS, config: ConfigFile) -> None:
 
     wfUuid = output[0].workflowUUID
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     assert info is not None, "Expected output to be not None"
 
     if info is not None:
@@ -199,7 +199,7 @@ def test_cancel_workflow(dbos: DBOS, config: ConfigFile) -> None:
     # run the workflow
     simple_workflow()
     # get the workflow list
-    output = _workflow_commands._list_workflows(
+    output = _workflow_commands.list_workflows(
         config, 10, None, None, None, None, False, None
     )
     # assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
@@ -208,9 +208,9 @@ def test_cancel_workflow(dbos: DBOS, config: ConfigFile) -> None:
     assert output[0] != None, "Expected output to be not None"
     wfUuid = output[0].workflowUUID
 
-    _workflow_commands._cancel_workflow(config, wfUuid)
+    _workflow_commands.cancel_workflow(config, wfUuid)
 
-    info = _workflow_commands._get_workflow(config, wfUuid, True)
+    info = _workflow_commands.get_workflow(config, wfUuid, True)
     assert info is not None, "Expected info to be not None"
     if info is not None:
         assert info.status == "CANCELLED", f"Expected status to be CANCELLED"


### PR DESCRIPTION
- Cancelling a workflow removes it from any queue it is in. This way, cancelled workflows don't block queues.
- Resume sets status to `PENDING` and resets recovery attempts. It also removes the workflow from any queue it is in. This way, resume can safely start DLQ'ed, `CANCELLED`, and `ENQUEUED` workflows.
- Lots and lots of tests.