### PR TITLE
Expose OpenTelemetry TracerProvider

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -28,6 +28,7 @@ from typing import (
     overload,
 )
 
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import Span
 
 from ._classproperty import classproperty
@@ -863,6 +864,11 @@ class DBOS:
         """Return the tracing `Span` associated with the current context."""
         ctx = assert_current_dbos_context()
         return ctx.get_current_span()
+
+    @classproperty
+    def tracer_provider(cls) -> Optional["TracerProvider"]:
+        """Return the tracer provider associated with ..."""
+        return dbos_tracer.get_provider()
 
     @classproperty
     def request(cls) -> Optional["Request"]:

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -35,7 +35,11 @@ class DBOSTracer:
                     OTLPSpanExporter(endpoint=otlp_traces_endpoint)
                 )
                 provider.add_span_processor(processor)
+            self.set_provider(provider)
             trace.set_tracer_provider(provider)
+
+    def get_provider(self) -> Optional[TracerProvider]:
+        return self.provider
 
     def set_provider(self, provider: Optional[TracerProvider]) -> None:
         self.provider = provider


### PR DESCRIPTION
Enable additional OpenTelemtry tracing instrumentation by exposing the TracerProvider used by the DBOS singleton.


This is not ready to land, it may not even parse properly.
It is only to get feedback if this is a valid approach or what else is required.