### PR TITLE
Catch Exceptions During System Database Migration

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -227,7 +227,12 @@ class SystemDatabase:
             self.engine.url.render_as_string(hide_password=False),
         )
         alembic_cfg.set_main_option("sqlalchemy.url", escaped_conn_string)
-        command.upgrade(alembic_cfg, "head")
+        try:
+            command.upgrade(alembic_cfg, "head")
+        except Exception as e:
+            dbos_logger.warning(
+                f"Error during system database construction. This is most likely because the system database was configured using a later version of DBOS: {e}"
+            )
 
         self.notification_conn: Optional[psycopg.connection.Connection] = None
         self.notifications_map: Dict[str, threading.Condition] = {}

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -231,7 +231,7 @@ class SystemDatabase:
             command.upgrade(alembic_cfg, "head")
         except Exception as e:
             dbos_logger.warning(
-                f"Error during system database construction. This is most likely because the system database was configured using a later version of DBOS: {e}"
+                f"Exception during system database construction. This is most likely because the system database was configured using a later version of DBOS: {e}"
             )
 
         self.notification_conn: Optional[psycopg.connection.Connection] = None


### PR DESCRIPTION
This allows an older version of DBOS to start using a system database created by a later version, assuming all changes are backwards-compatible (as they should be).