### PR TITLE
Fix q global concurrency

### DIFF
--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -76,7 +76,9 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                     execute_workflow_by_id(dbos, id)
             except OperationalError as e:
                 # Ignore serialization error
-                if not isinstance(e.orig, errors.SerializationFailure):
+                if not isinstance(
+                    e.orig, (errors.SerializationFailure, errors.LockNotAvailable)
+                ):
                     dbos.logger.warning(
                         f"Exception encountered in queue thread: {traceback.format_exc()}"
                     )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1341,7 +1341,7 @@ class SystemDatabase:
                     )
                 )
                 .order_by(SystemSchema.workflow_queue.c.created_at_epoch_ms.asc())
-                # Set a dequeue limit if necessary. worker_concurrency <= concurrency is already enforced, but still.
+                # Set a dequeue limit if necessary.
                 .limit(
                     sa.func.least(
                         queue.worker_concurrency,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1359,7 +1359,7 @@ class SystemDatabase:
             )
             # Apply limit only if max_tasks is finite
             if max_tasks != float("inf"):
-                query = query.limit(max_tasks)
+                query = query.limit(int(max_tasks))
 
             rows = c.execute(query).fetchall()
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -189,6 +189,7 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database="postgres",
+            query={"application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"}
         )
         engine = sa.create_engine(postgres_db_url)
         with engine.connect() as conn:
@@ -207,6 +208,7 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database=sysdb_name,
+            query={"application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"}
         )
 
         # Create a connection pool for the system database

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1354,12 +1354,9 @@ class SystemDatabase:
 
             # Now, get the workflow IDs of functions that have not yet been started
             dequeued_ids: List[str] = [row[0] for row in rows if row[1] is None]
-            already_started_ids: List[str] = [
-                row[0] for row in rows if row[1] is not None
-            ]
-            if len(already_started_ids) > 0:
+            if len(dequeued_ids) > 0:
                 dbos_logger.debug(
-                    f"[{queue.name}] already started {len(already_started_ids)} task(s)"
+                    f"[{queue.name}] dequeueing {len(dequeued_ids)} task(s)"
                 )
             ret_ids: list[str] = []
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1341,12 +1341,23 @@ class SystemDatabase:
 
             max_tasks = float("inf")
             if queue.worker_concurrency is not None:
+                # Worker local concurrency limit should always be >= running_tasks_for_this_worker
+                # This should never happen but a check + warning doesn't hurt
+                if queue.worker_concurrency > running_tasks_for_this_worker:
+                    dbos_logger.warning(
+                        f"Worker concurrency limit {queue.worker_concurrency} is less than the number of tasks running for this worker {running_tasks_for_this_worker}"
+                    )
                 max_tasks = max(
                     0, queue.worker_concurrency - running_tasks_for_this_worker
                 )
             if queue.concurrency is not None:
                 total_running_tasks = sum(running_tasks_result_dict.values())
-                # queue.concurrency should always be >= running_tasks_count
+                # Queue global concurrency limit should always be >= running_tasks_count
+                # This should never happen but a check + warning doesn't hurt
+                if queue.concurrency > total_running_tasks:
+                    dbos_logger.warning(
+                        f"Queue global concurrency limit {queue.concurrency} is less than the number of tasks running for this queue {total_running_tasks}"
+                    )
                 available_tasks = max(0, queue.concurrency - total_running_tasks)
                 max_tasks = min(max_tasks, available_tasks)
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1317,10 +1317,10 @@ class SystemDatabase:
             running_tasks_subquery = (
                 sa.select(sa.func.count()).where(
                     (SystemSchema.workflow_queue.c.queue_name == queue.name)
-                    & (
+                    and (
                         SystemSchema.workflow_queue.c.executor_id.isnot(None)
                     )  # Task is dequeued
-                    & (
+                    and (
                         SystemSchema.workflow_queue.c.completed_at_epoch_ms.is_(None)
                     )  # Task is not completed
                 )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1345,9 +1345,9 @@ class SystemDatabase:
             if queue.worker_concurrency is not None:
                 # Worker local concurrency limit should always be >= running_tasks_for_this_worker
                 # This should never happen but a check + warning doesn't hurt
-                if queue.worker_concurrency > running_tasks_for_this_worker:
+                if running_tasks_for_this_worker > queue.worker_concurrency:
                     dbos_logger.warning(
-                        f"Worker concurrency limit {queue.worker_concurrency} is less than the number of tasks running for this worker {running_tasks_for_this_worker}"
+                        f"Number of tasks on this worker ({running_tasks_for_this_worker}) exceeds the worker concurrency limit ({queue.worker_concurrency})"
                     )
                 max_tasks = max(
                     0, queue.worker_concurrency - running_tasks_for_this_worker
@@ -1356,9 +1356,9 @@ class SystemDatabase:
                 total_running_tasks = sum(running_tasks_result_dict.values())
                 # Queue global concurrency limit should always be >= running_tasks_count
                 # This should never happen but a check + warning doesn't hurt
-                if queue.concurrency > total_running_tasks:
+                if total_running_tasks > queue.concurrency:
                     dbos_logger.warning(
-                        f"Queue global concurrency limit {queue.concurrency} is less than the number of tasks running for this queue {total_running_tasks}"
+                        f"Total running tasks ({total_running_tasks}) exceeds the global concurrency limit ({queue.concurrency})"
                     )
                 available_tasks = max(0, queue.concurrency - total_running_tasks)
                 max_tasks = min(max_tasks, available_tasks)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -189,6 +189,7 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database="postgres",
+            # fills the "application_name" column in pg_stat_activity
             query={
                 "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
             },
@@ -210,6 +211,7 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database=sysdb_name,
+            # fills the "application_name" column in pg_stat_activity
             query={
                 "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
             },

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -189,7 +189,9 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database="postgres",
-            query={"application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"}
+            query={
+                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
+            },
         )
         engine = sa.create_engine(postgres_db_url)
         with engine.connect() as conn:
@@ -208,7 +210,9 @@ class SystemDatabase:
             host=config["database"]["hostname"],
             port=config["database"]["port"],
             database=sysdb_name,
-            query={"application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"}
+            query={
+                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
+            },
         )
 
         # Create a connection pool for the system database
@@ -1311,11 +1315,14 @@ class SystemDatabase:
             # functions, else select all of them.
 
             running_tasks_subquery = (
-                sa.select(sa.func.count())
-                .where(
+                sa.select(sa.func.count()).where(
                     (SystemSchema.workflow_queue.c.queue_name == queue.name)
-                    & (SystemSchema.workflow_queue.c.executor_id.isnot(None))  # Task is dequeued
-                    & (SystemSchema.workflow_queue.c.completed_at_epoch_ms.is_(None))  # Task is not completed
+                    & (
+                        SystemSchema.workflow_queue.c.executor_id.isnot(None)
+                    )  # Task is dequeued
+                    & (
+                        SystemSchema.workflow_queue.c.completed_at_epoch_ms.is_(None)
+                    )  # Task is not completed
                 )
             ).scalar_subquery()
             query = (
@@ -1336,23 +1343,27 @@ class SystemDatabase:
                 .order_by(SystemSchema.workflow_queue.c.created_at_epoch_ms.asc())
                 # Set a dequeue limit if necessary. worker_concurrency <= concurrency is already enforced, but still.
                 .limit(
-                    sa.func.least(queue.worker_concurrency, queue.concurrency - running_tasks_subquery)
+                    sa.func.least(
+                        queue.worker_concurrency,
+                        queue.concurrency - running_tasks_subquery,
+                    )
                 )
-                .with_for_update(nowait=True) # Error out early
+                .with_for_update(nowait=True)  # Error out early
             )
             rows = c.execute(query).fetchall()
 
             # Now, get the workflow IDs of functions that have not yet been started
             dequeued_ids: List[str] = [row[0] for row in rows if row[1] is None]
-            already_started_ids: List[str] = [row[0] for row in rows if row[1] is not None]
+            already_started_ids: List[str] = [
+                row[0] for row in rows if row[1] is not None
+            ]
             if len(already_started_ids) > 0:
                 dbos_logger.debug(
                     f"[{queue.name}] already started {len(already_started_ids)} task(s)"
                 )
             ret_ids: list[str] = []
-            dbos_logger.debug(f"[{queue.name}] dequeueing {len(dequeued_ids)} task(s)")
-            for id in dequeued_ids:
 
+            for id in dequeued_ids:
                 # If we have a limiter, stop starting functions when the number
                 # of functions started this period exceeds the limit.
                 if queue.limiter is not None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -458,6 +458,7 @@ def run_dbos_test_in_process(
         },
         "telemetry": {},
         "env": {},
+        "application": {},
     }
     dbos = DBOS(config=dbos_config)
     DBOS.launch()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -474,8 +474,6 @@ def run_dbos_test_in_process(
     # Now whatever is in the queue should be cleared up fast (start/end events are already set)
     queue_entries_are_cleaned_up(dbos)
 
-    DBOS.destroy()
-
 
 def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
     # Start N proccesses to dequeue

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -379,11 +379,6 @@ def test_queue_workflow_in_recovered_workflow(dbos: DBOS) -> None:
     return
 
 
-###########################
-# TEST WORKER CONCURRENCY #
-###########################
-
-
 def test_one_at_a_time_with_worker_concurrency(dbos: DBOS) -> None:
     wf_counter = 0
     flag = False
@@ -483,7 +478,9 @@ def run_dbos_test_in_process(
     queue_entries_are_cleaned_up(dbos)
 
 
-# Test global concurrency and worker utilization (dequeues up to exactly local limit tasks)
+# Test global concurrency and worker utilization by carefully filling the queue up to 1) the local limit 2) the global limit
+# For the global limit, we fill the queue in 2 steps, ensuring that the 2nd worker is able to cap its local utilization even
+# after having dequeued some tasks already
 def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
     # Ensure children processes do not share global variables (including DBOS instance) with the parent
     multiprocessing.set_start_method("spawn")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,7 +1,5 @@
 import logging
 import multiprocessing
-
-print(multiprocessing.get_start_method())
 import multiprocessing.synchronize
 import os
 import subprocess
@@ -478,6 +476,8 @@ def run_dbos_test_in_process(
 
 
 def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
+    # Ensure children processes do not share global variables (including DBOS instance) with the parent
+    multiprocessing.set_start_method("spawn")
     # Start N proccesses to dequeue
     processes = []
     start_signals = []

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,7 @@
 import logging
 import multiprocessing
+
+print(multiprocessing.get_start_method())
 import multiprocessing.synchronize
 import os
 import subprocess

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -556,7 +556,6 @@ def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
         status = handle.get_status()
         statuses.append(status.status)
         executors.append(status.executor_id)
-    assert len(set(executors)) == 2
     assert set(statuses) == {
         WorkflowStatusString.PENDING.value,
         WorkflowStatusString.ENQUEUED.value,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -588,6 +588,9 @@ def test_worker_concurrency_with_n_dbos_instances(dbos: DBOS) -> None:
     for process in processes:
         process.join()
 
+    # Verify all queue entries eventually get cleaned up.
+    assert queue_entries_are_cleaned_up(dbos)
+
 
 # Test error cases where we have duplicated workflows starting with the same workflow ID.
 def test_duplicate_workflow_id(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -18,7 +18,6 @@ from dbos import (
     SetWorkflowID,
     WorkflowHandle,
 )
-from dbos._error import DBOSDeadLetterQueueError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from tests.conftest import default_config


### PR DESCRIPTION
- Correctly retrieve the total number of tasks executed across all workers to compute the local limit
- When doing this query, do a `FOR UPDATE NO WAIT` to lock the rows -- and fail early when failing to do so.
- Adjusted the `test_worker_concurrency_with_n_dbos_instances` test to enforce global concurrency.

Note we now ignore `LockNotAvailable` errors.

Nit: this PR also adds a nifty information: an `application_name` which can be used for debugging.
![Screenshot 2025-02-13 at 15 46 57](https://github.com/user-attachments/assets/f9bf31ba-1f0f-45f8-a235-80204fd62696)

