### PR TITLE
Fix the warning message under fastapi dev runs

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -997,6 +997,10 @@ def _dbos_exit_hook() -> None:
         )
         return
     if not _dbos_global_instance._launched:
+        if _dbos_global_instance.fastapi is not None:
+            # FastAPI lifespan middleware will call launch/destroy, so we can ignore this.
+            # This is likely to happen during fastapi dev runs, where the reloader loads the module multiple times.
+            return
         print("DBOS exiting; DBOS exists but launch() was not called")
         dbos_logger.warning("DBOS exiting; DBOS exists but launch() was not called")
         return


### PR DESCRIPTION
Previously, `fastapi dev` would print a warning message `DBOS exiting; DBOS exists but launch() was not called`. This is caused by the reloader loading the file but not running it. With this PR, the warning message won't show up if the DBOS is initialized with a FastAPI app.