### PR TITLE
Application Versioning

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -49,7 +49,6 @@ class TracedAttributes(TypedDict, total=False):
 class DBOSContext:
     def __init__(self) -> None:
         self.executor_id = os.environ.get("DBOS__VMID", "local")
-        self.app_version = os.environ.get("DBOS__APPVERSION", "")
         self.app_id = os.environ.get("DBOS__APPID", "")
 
         self.logger = dbos_logger

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -163,7 +163,7 @@ def _init_workflow(
         "output": None,
         "error": None,
         "app_id": ctx.app_id,
-        "app_version": ctx.app_version,
+        "app_version": dbos.app_version,
         "executor_id": ctx.executor_id,
         "request": (
             _serialization.serialize(ctx.request) if ctx.request is not None else None

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -283,6 +283,7 @@ class DBOS:
         self._executor_field: Optional[ThreadPoolExecutor] = None
         self._background_threads: List[threading.Thread] = []
         self._executor_id: str = os.environ.get("DBOS__VMID", "local")
+        self.app_version = os.environ.get("DBOS__APPVERSION", "")
 
         # If using FastAPI, set up middleware and lifecycle events
         if self.fastapi is not None:
@@ -351,6 +352,8 @@ class DBOS:
                 dbos_logger.warning(f"DBOS was already launched")
                 return
             self._launched = True
+            if self.app_version == "":
+                self.app_version = self._compute_app_version()
             self._executor_field = ThreadPoolExecutor(max_workers=64)
             self._sys_db_field = SystemDatabase(self.config)
             self._app_db_field = ApplicationDatabase(self.config)
@@ -897,6 +900,9 @@ class DBOS:
         ctx = assert_current_dbos_context()
         ctx.authenticated_user = authenticated_user
         ctx.authenticated_roles = authenticated_roles
+
+    def _compute_app_version(self):
+        return "5"
 
 
 @dataclass

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -418,9 +418,8 @@ class DBOS:
                 self._background_threads.append(poller_thread)
             self._registry.pollers = []
 
-            dbos_logger.info(
-                f"DBOS launched! Application version hash: {self.app_version}"
-            )
+            dbos_logger.info("DBOS launched!")
+            dbos_logger.info(f"Application version: {self.app_version}")
 
             # Flush handlers and add OTLP to all loggers if enabled
             # to enable their export in DBOS Cloud

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -192,13 +192,15 @@ class DBOSRegistry:
         """
         An application's version is computed from a hash of the source of its workflows.
         This is guaranteed to be stable given identical source code because it uses an MD5 hash
-        and because it iterates through the workflows in insertion order (which Python dicts guarantee).
+        and because it iterates through the workflows in sorted order.
         This way, if the app's workflows are updated (which would break recovery), its version changes.
         App version can be manually set through the DBOS__APPVERSION environment variable.
         """
         hasher = hashlib.md5()
-        for wf in self.workflow_info_map.values():
-            source = inspect.getsource(wf)
+        sources = sorted(
+            [inspect.getsource(wf) for wf in self.workflow_info_map.values()]
+        )
+        for source in sources:
             hasher.update(source.encode("utf-8"))
         return hasher.hexdigest()
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -283,7 +283,7 @@ class DBOS:
         self._executor_field: Optional[ThreadPoolExecutor] = None
         self._background_threads: List[threading.Thread] = []
         self._executor_id: str = os.environ.get("DBOS__VMID", "local")
-        self.app_version = os.environ.get("DBOS__APPVERSION", "")
+        self.app_version: str = os.environ.get("DBOS__APPVERSION", "")
 
         # If using FastAPI, set up middleware and lifecycle events
         if self.fastapi is not None:
@@ -354,6 +354,7 @@ class DBOS:
             self._launched = True
             if self.app_version == "":
                 self.app_version = self._compute_app_version()
+            dbos_tracer.app_version = self.app_version
             self._executor_field = ThreadPoolExecutor(max_workers=64)
             self._sys_db_field = SystemDatabase(self.config)
             self._app_db_field = ApplicationDatabase(self.config)
@@ -407,7 +408,7 @@ class DBOS:
             # to enable their export in DBOS Cloud
             for handler in dbos_logger.handlers:
                 handler.flush()
-            add_otlp_to_all_loggers()
+            add_otlp_to_all_loggers(self.app_version)
         except Exception:
             dbos_logger.error(f"DBOS failed to launch: {traceback.format_exc()}")
             raise
@@ -901,7 +902,7 @@ class DBOS:
         ctx.authenticated_user = authenticated_user
         ctx.authenticated_roles = authenticated_roles
 
-    def _compute_app_version(self):
+    def _compute_app_version(self) -> str:
         return "5"
 
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -418,7 +418,9 @@ class DBOS:
                 self._background_threads.append(poller_thread)
             self._registry.pollers = []
 
-            dbos_logger.info("DBOS launched")
+            dbos_logger.info(
+                f"DBOS launched! Application version hash: {self.app_version}"
+            )
 
             # Flush handlers and add OTLP to all loggers if enabled
             # to enable their export in DBOS Cloud

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -386,7 +386,7 @@ class DBOS:
                 self.logger.info(f"Recovering {len(workflow_ids)} workflows")
             if num_wrong_version > 0:
                 self.logger.info(
-                    f"{num_wrong_version} workflows were not recovered because they belong to a different application version"
+                    f"{num_wrong_version} workflows with a different app version were not recovered"
                 )
 
             self._executor.submit(startup_recovery_thread, self, workflow_ids)

--- a/dbos/_logger.py
+++ b/dbos/_logger.py
@@ -86,8 +86,9 @@ def config_logger(config: "ConfigFile") -> None:
         dbos_logger.addFilter(_otlp_transformer)
 
 
-def add_otlp_to_all_loggers() -> None:
+def add_otlp_to_all_loggers(app_version: str) -> None:
     if _otlp_handler is not None and _otlp_transformer is not None:
+        _otlp_transformer.app_version = app_version
         root = logging.root
 
         root.addHandler(_otlp_handler)

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -70,6 +70,6 @@ def recover_pending_workflows(
         dbos.logger.info(f"Recovering {len(pending_workflows)} workflows")
         if num_wrong_version > 0:
             dbos.logger.info(
-                f"{num_wrong_version} workflows were not recovered because they belong to a different application version"
+                f"{num_wrong_version} workflows with a different app version were not recovered"
             )
     return workflow_handles

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -44,7 +44,7 @@ def recover_pending_workflows(
     workflow_handles: List["WorkflowHandle[Any]"] = []
     for executor_id in executor_ids:
         dbos.logger.debug(f"Recovering pending workflows for executor: {executor_id}")
-        num_wrong_version, pending_workflows = dbos._sys_db.get_pending_workflows(
+        pending_workflows = dbos._sys_db.get_pending_workflows(
             executor_id, dbos.app_version
         )
         for pending_workflow in pending_workflows:
@@ -63,9 +63,7 @@ def recover_pending_workflows(
                 workflow_handles.append(
                     execute_workflow_by_id(dbos, pending_workflow.workflow_uuid)
                 )
-        dbos.logger.info(f"Recovering {len(pending_workflows)} workflows")
-        if num_wrong_version > 0:
-            dbos.logger.info(
-                f"{num_wrong_version} workflows with a different app version were not recovered"
-            )
+        dbos.logger.info(
+            f"Recovering {len(pending_workflows)} workflows from version {dbos.app_version}"
+        )
     return workflow_handles

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -43,10 +43,6 @@ def recover_pending_workflows(
 ) -> List["WorkflowHandle[Any]"]:
     workflow_handles: List["WorkflowHandle[Any]"] = []
     for executor_id in executor_ids:
-        if executor_id == "local" and os.environ.get("DBOS__VMID"):
-            dbos.logger.debug(
-                f"Skip local recovery because it's running in a VM: {os.environ.get('DBOS__VMID')}"
-            )
         dbos.logger.debug(f"Recovering pending workflows for executor: {executor_id}")
         num_wrong_version, pending_workflows = dbos._sys_db.get_pending_workflows(
             executor_id, dbos.app_version

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -782,7 +782,20 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.application_version == app_version,
                 )
             ).fetchall()
-            return 0, [
+
+            num_wrong_version = (
+                c.execute(
+                    sa.select(sa.func.count()).where(
+                        SystemSchema.workflow_status.c.status
+                        == WorkflowStatusString.PENDING.value,
+                        SystemSchema.workflow_status.c.executor_id == executor_id,
+                        SystemSchema.workflow_status.c.application_version
+                        != app_version,
+                    )
+                ).scalar()
+                or 0
+            )
+            return num_wrong_version, [
                 GetPendingWorkflowsOutput(
                     workflow_uuid=row.workflow_uuid,
                     queue_name=row.queue_name,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -191,7 +191,7 @@ class SystemDatabase:
             database="postgres",
             # fills the "application_name" column in pg_stat_activity
             query={
-                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
+                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}"
             },
         )
         engine = sa.create_engine(postgres_db_url)
@@ -213,7 +213,7 @@ class SystemDatabase:
             database=sysdb_name,
             # fills the "application_name" column in pg_stat_activity
             query={
-                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}_{os.environ.get('DBOS__APPVERSION', '')}"
+                "application_name": f"dbos_transact_{os.environ.get('DBOS__VMID', 'local')}"
             },
         )
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     TypedDict,
     cast,
 )
@@ -767,8 +768,8 @@ class SystemDatabase:
         return GetWorkflowsOutput(workflow_uuids)
 
     def get_pending_workflows(
-        self, executor_id: str
-    ) -> list[GetPendingWorkflowsOutput]:
+        self, executor_id: str, app_version: str
+    ) -> Tuple[int, list[GetPendingWorkflowsOutput]]:
         with self.engine.begin() as c:
             rows = c.execute(
                 sa.select(
@@ -778,9 +779,10 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.status
                     == WorkflowStatusString.PENDING.value,
                     SystemSchema.workflow_status.c.executor_id == executor_id,
+                    SystemSchema.workflow_status.c.application_version == app_version,
                 )
             ).fetchall()
-            return [
+            return 0, [
                 GetPendingWorkflowsOutput(
                     workflow_uuid=row.workflow_uuid,
                     queue_name=row.queue_name,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 import re
 import threading
@@ -229,6 +230,7 @@ class SystemDatabase:
         )
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", migration_dir)
+        logging.getLogger("alembic").setLevel(logging.WARNING)
         # Alembic requires the % in URL-escaped parameters to itself be escaped to %%.
         escaped_conn_string = re.sub(
             r"%(?=[0-9A-Fa-f]{2})",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -769,7 +769,7 @@ class SystemDatabase:
 
     def get_pending_workflows(
         self, executor_id: str, app_version: str
-    ) -> Tuple[int, list[GetPendingWorkflowsOutput]]:
+    ) -> list[GetPendingWorkflowsOutput]:
         with self.engine.begin() as c:
             rows = c.execute(
                 sa.select(
@@ -783,19 +783,7 @@ class SystemDatabase:
                 )
             ).fetchall()
 
-            num_wrong_version = (
-                c.execute(
-                    sa.select(sa.func.count()).where(
-                        SystemSchema.workflow_status.c.status
-                        == WorkflowStatusString.PENDING.value,
-                        SystemSchema.workflow_status.c.executor_id == executor_id,
-                        SystemSchema.workflow_status.c.application_version
-                        != app_version,
-                    )
-                ).scalar()
-                or 0
-            )
-            return num_wrong_version, [
+            return [
                 GetPendingWorkflowsOutput(
                     workflow_uuid=row.workflow_uuid,
                     queue_name=row.queue_name,

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1255,3 +1255,5 @@ def test_app_version(config: ConfigFile):
 
     DBOS.launch()
     assert dbos.app_version == app_version
+
+    del os.environ["DBOS__APPVERSION"]

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="no-redef"
+
 import datetime
 import logging
 import os
@@ -554,7 +556,7 @@ def test_recovery_thread(config: ConfigFile) -> None:
     DBOS.destroy(destroy_registry=True)
     dbos = DBOS(config=config)
 
-    @DBOS.workflow()  # type: ignore
+    @DBOS.workflow()
     def test_workflow(var: str) -> str:
         nonlocal wf_counter
         if var == test_var:
@@ -591,9 +593,9 @@ def test_recovery_thread(config: ConfigFile) -> None:
     )
 
     DBOS.destroy(destroy_registry=True)
-    DBOS(config=config)  # type: ignore
+    DBOS(config=config)
 
-    @DBOS.workflow()  # type: ignore
+    @DBOS.workflow()
     def test_workflow(var: str) -> str:
         nonlocal wf_counter
         if var == test_var:
@@ -1198,19 +1200,19 @@ def test_destroy_semantics(dbos: DBOS, config: ConfigFile) -> None:
     assert test_workflow(var) == var
 
 
-def test_app_version(config: ConfigFile):
-    def is_hex(s):
+def test_app_version(config: ConfigFile) -> None:
+    def is_hex(s: str) -> bool:
         return all(c in "0123456789abcdefABCDEF" for c in s)
 
     DBOS.destroy(destroy_registry=True)
     dbos = DBOS(config=config)
 
     @DBOS.workflow()
-    def workflow_one(x: int):
+    def workflow_one(x: int) -> int:
         return x
 
     @DBOS.workflow()
-    def workflow_two(y: int):
+    def workflow_two(y: int) -> int:
         return y
 
     DBOS.launch()
@@ -1224,11 +1226,11 @@ def test_app_version(config: ConfigFile):
     dbos = DBOS(config=config)
 
     @DBOS.workflow()
-    def workflow_one(x: int):
+    def workflow_one(x: int) -> int:
         return x
 
     @DBOS.workflow()
-    def workflow_two(y: int):
+    def workflow_two(y: int) -> int:
         return y
 
     DBOS.launch()
@@ -1240,7 +1242,7 @@ def test_app_version(config: ConfigFile):
     dbos = DBOS(config=config)
 
     @DBOS.workflow()
-    def workflow_one(x: int):
+    def workflow_one(x: int) -> int:
         return x
 
     # Verify that changing the workflow source changes the workflow version
@@ -1255,7 +1257,7 @@ def test_app_version(config: ConfigFile):
     dbos = DBOS(config=config)
 
     @DBOS.workflow()
-    def workflow_one(x: int):
+    def workflow_one(x: int) -> int:
         return x
 
     DBOS.launch()

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -36,6 +36,7 @@ def test_spans(dbos: DBOS) -> None:
 
     for span in spans:
         assert span.attributes is not None
+        assert span.attributes["applicationVersion"] == dbos.app_version
         assert span.context is not None
 
     assert spans[0].name == test_step.__name__
@@ -73,6 +74,7 @@ async def test_spans_async(dbos: DBOS) -> None:
 
     for span in spans:
         assert span.attributes is not None
+        assert span.attributes["applicationVersion"] == dbos.app_version
         assert span.context is not None
 
     assert spans[0].name == test_step.__name__
@@ -85,7 +87,7 @@ async def test_spans_async(dbos: DBOS) -> None:
 
 
 def test_temp_wf_fastapi(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
-    _, app = dbos_fastapi
+    dbos, app = dbos_fastapi
 
     @app.get("/step")
     @DBOS.step()
@@ -109,6 +111,7 @@ def test_temp_wf_fastapi(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 
     for span in spans:
         assert span.attributes is not None
+        assert span.attributes["applicationVersion"] == dbos.app_version
         assert span.context is not None
 
     assert spans[0].name == test_step_endpoint.__name__


### PR DESCRIPTION
The PR expands the notion of application versions, which were previously only used in DBOS Cloud, to support more robust self-hosting of DBOS applications.

- When DBOS is launched, it constructs an application version by hashing the source of the application's workflows. This version is stable across restarts, but changes if the application's code is changed.
- The application version can be overridden through the `DBOS__APPVERSION` environment variable.
- When recovering workflows, DBOS does not recover workflows belonging to different application versions. This prevents code compatibility issues.
- Workflows belonging to different app versions can be manually recovered with `dbos workflow resume [workflow-ID]`.
