### PR TITLE
Fix db_wizard behavior and add a test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dbos/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -45,8 +45,16 @@ def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
             f"Could not connect to Postgres: password authentication failed: {db_connection_error}"
         )
     db_config = config["database"]
+
+    # Read the config file and check if the database hostname/port/username are set. If so, skip the wizard.
+    with open(config_file_path, "r") as file:
+        content = file.read()
+        local_config = yaml.safe_load(content)
     if (
-        db_config["hostname"] != "localhost"
+        local_config["database"]["hostname"]
+        or local_config["database"]["port"]
+        or local_config["database"]["username"]
+        or db_config["hostname"] != "localhost"
         or db_config["port"] != 5432
         or db_config["username"] != "postgres"
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -399,3 +399,26 @@ def test_db_connect_failed(mocker):
         load_config(mock_filename)
 
     assert "Could not connect to the database" in str(exc_info.value)
+
+
+def test_no_db_wizard(mocker):
+    mock_config = """
+        name: "some-app"
+        language: "python"
+        runtimeConfig:
+            start:
+                - "python3 main.py"
+        database:
+          hostname: 'localhost'
+          port: 5432
+          username: 'postgres'
+          password: 'somerandom'
+
+    """
+    mocker.patch(
+        "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
+    )
+
+    with pytest.raises(DBOSInitializationError) as exc_info:
+        load_config(mock_filename)
+    assert "Could not connect" in str(exc_info.value)


### PR DESCRIPTION
Similar fix to https://github.com/dbos-inc/dbos-transact-ts/pull/763
- DB wizard should not proceed if the `database` hostname/username/port is set in `dbos-config.yaml`.
- Add a test for DB wizard, making sure it will not proceed if the database field is set.