### PR TITLE
Debug Mode

### DIFF
--- a/dbos/__main__.py
+++ b/dbos/__main__.py
@@ -1,0 +1,25 @@
+import re
+import sys
+
+from dbos.cli.cli import app
+
+
+def main():
+    # Modify sys.argv[0] to remove script or executable extensions
+    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+
+    retval = 1
+    try:
+        app()
+        retval = 0
+    except SystemExit as e:
+        retval = e.code
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        retval = 1
+    finally:
+        sys.exit(retval)
+
+
+if __name__ == "__main__":
+    main()

--- a/dbos/__main__.py
+++ b/dbos/__main__.py
@@ -1,17 +1,18 @@
 import re
 import sys
+from typing import NoReturn
 
 from dbos.cli.cli import app
 
 
-def main():
+def main() -> NoReturn:
     # Modify sys.argv[0] to remove script or executable extensions
     sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
 
-    retval = 1
+    retval: str | int | None = 1
     try:
         app()
-        retval = 0
+        retval = None
     except SystemExit as e:
         retval = e.code
     except Exception as e:

--- a/dbos/__main__.py
+++ b/dbos/__main__.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import NoReturn
+from typing import NoReturn, Optional, Union
 
 from dbos.cli.cli import app
 
@@ -9,7 +9,7 @@ def main() -> NoReturn:
     # Modify sys.argv[0] to remove script or executable extensions
     sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
 
-    retval: str | int | None = 1
+    retval: Optional[Union[str, int]] = 1
     try:
         app()
         retval = None

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -27,29 +27,30 @@ class RecordedResult(TypedDict):
 
 class ApplicationDatabase:
 
-    def __init__(self, config: ConfigFile):
+    def __init__(self, config: ConfigFile, debug_mode: bool = False):
         self.config = config
 
         app_db_name = config["database"]["app_db_name"]
 
         # If the application database does not already exist, create it
-        postgres_db_url = sa.URL.create(
-            "postgresql+psycopg",
-            username=config["database"]["username"],
-            password=config["database"]["password"],
-            host=config["database"]["hostname"],
-            port=config["database"]["port"],
-            database="postgres",
-        )
-        postgres_db_engine = sa.create_engine(postgres_db_url)
-        with postgres_db_engine.connect() as conn:
-            conn.execution_options(isolation_level="AUTOCOMMIT")
-            if not conn.execute(
-                sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
-                parameters={"db_name": app_db_name},
-            ).scalar():
-                conn.execute(sa.text(f"CREATE DATABASE {app_db_name}"))
-        postgres_db_engine.dispose()
+        if not debug_mode:
+            postgres_db_url = sa.URL.create(
+                "postgresql+psycopg",
+                username=config["database"]["username"],
+                password=config["database"]["password"],
+                host=config["database"]["hostname"],
+                port=config["database"]["port"],
+                database="postgres",
+            )
+            postgres_db_engine = sa.create_engine(postgres_db_url)
+            with postgres_db_engine.connect() as conn:
+                conn.execution_options(isolation_level="AUTOCOMMIT")
+                if not conn.execute(
+                    sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
+                    parameters={"db_name": app_db_name},
+                ).scalar():
+                    conn.execute(sa.text(f"CREATE DATABASE {app_db_name}"))
+            postgres_db_engine.dispose()
 
         # Create a connection pool for the application database
         app_db_url = sa.URL.create(
@@ -66,12 +67,13 @@ class ApplicationDatabase:
         self.sessionmaker = sessionmaker(bind=self.engine)
 
         # Create the dbos schema and transaction_outputs table in the application database
-        with self.engine.begin() as conn:
-            schema_creation_query = sa.text(
-                f"CREATE SCHEMA IF NOT EXISTS {ApplicationSchema.schema}"
-            )
-            conn.execute(schema_creation_query)
-        ApplicationSchema.metadata_obj.create_all(self.engine)
+        if not debug_mode:
+            with self.engine.begin() as conn:
+                schema_creation_query = sa.text(
+                    f"CREATE SCHEMA IF NOT EXISTS {ApplicationSchema.schema}"
+                )
+                conn.execute(schema_creation_query)
+            ApplicationSchema.metadata_obj.create_all(self.engine)
 
     def destroy(self) -> None:
         self.engine.dispose()

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -65,6 +65,7 @@ class ApplicationDatabase:
             app_db_url, pool_size=20, max_overflow=5, pool_timeout=30
         )
         self.sessionmaker = sessionmaker(bind=self.engine)
+        self.debug_mode = debug_mode
 
         # Create the dbos schema and transaction_outputs table in the application database
         if not debug_mode:
@@ -102,6 +103,8 @@ class ApplicationDatabase:
             raise
 
     def record_transaction_error(self, output: TransactionResultInternal) -> None:
+        if self.debug_mode:
+            raise Exception("called record_transaction_error in debug mode")
         try:
             with self.engine.begin() as conn:
                 conn.execute(

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -27,7 +27,7 @@ class RecordedResult(TypedDict):
 
 class ApplicationDatabase:
 
-    def __init__(self, config: ConfigFile, debug_mode: bool = False):
+    def __init__(self, config: ConfigFile, *, debug_mode: bool = False):
         self.config = config
 
         app_db_name = config["database"]["app_db_name"]

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -242,10 +242,11 @@ def _get_wf_invoke_func(
         except Exception as error:
             status["status"] = "ERROR"
             status["error"] = _serialization.serialize_exception(error)
-            if status["queue_name"] is not None:
-                queue = dbos._registry.queue_info_map[status["queue_name"]]
-                dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
-            dbos._sys_db.update_workflow_status(status)
+            if not dbos.debug_mode:
+                if status["queue_name"] is not None:
+                    queue = dbos._registry.queue_info_map[status["queue_name"]]
+                    dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
+                dbos._sys_db.update_workflow_status(status)
             raise
 
     return persist

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -221,10 +221,11 @@ def _get_wf_invoke_func(
             output = func()
             status["status"] = "SUCCESS"
             status["output"] = _serialization.serialize(output)
-            if status["queue_name"] is not None:
-                queue = dbos._registry.queue_info_map[status["queue_name"]]
-                dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
-            dbos._sys_db.buffer_workflow_status(status)
+            if not dbos._debug_mode:
+                if status["queue_name"] is not None:
+                    queue = dbos._registry.queue_info_map[status["queue_name"]]
+                    dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
+                dbos._sys_db.buffer_workflow_status(status)
             return output
         except DBOSWorkflowConflictIDError:
             # Retrieve the workflow handle and wait for the result.

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -590,6 +590,10 @@ def decorate_transaction(
                                         ctx.function_id,
                                     )
                                 )
+                                if dbos._debug_mode and recorded_output is None:
+                                    raise DBOSException(
+                                        "Transaction output not found in debug mode"
+                                    )
                                 if recorded_output:
                                     dbos.logger.debug(
                                         f"Replaying transaction, id: {ctx.function_id}, name: {attributes['name']}"
@@ -764,6 +768,8 @@ def decorate_step(
                 recorded_output = dbos._sys_db.check_operation_execution(
                     ctx.workflow_id, ctx.function_id
                 )
+                if dbos._debug_mode and recorded_output is None:
+                    raise DBOSException("Step output not found in debug mode")
                 if recorded_output:
                     dbos.logger.debug(
                         f"Replaying step, id: {ctx.function_id}, name: {attributes['name']}"

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -182,7 +182,7 @@ def _init_workflow(
         inputs = {"args": inputs["args"][1:], "kwargs": inputs["kwargs"]}
 
     wf_status = status["status"]
-    if dbos._debug_mode:
+    if dbos.debug_mode:
         get_status_result = dbos._sys_db.get_workflow_status(wfid)
         if get_status_result is None:
             raise DBOSNonExistentWorkflowError(wfid)
@@ -221,7 +221,7 @@ def _get_wf_invoke_func(
             output = func()
             status["status"] = "SUCCESS"
             status["output"] = _serialization.serialize(output)
-            if not dbos._debug_mode:
+            if not dbos.debug_mode:
                 if status["queue_name"] is not None:
                     queue = dbos._registry.queue_info_map[status["queue_name"]]
                     dbos._sys_db.remove_from_queue(status["workflow_uuid"], queue)
@@ -428,7 +428,7 @@ def start_workflow(
     wf_status = status["status"]
 
     if not execute_workflow or (
-        not dbos._debug_mode
+        not dbos.debug_mode
         and (
             wf_status == WorkflowStatusString.ERROR.value
             or wf_status == WorkflowStatusString.SUCCESS.value
@@ -591,7 +591,7 @@ def decorate_transaction(
                                         ctx.function_id,
                                     )
                                 )
-                                if dbos._debug_mode and recorded_output is None:
+                                if dbos.debug_mode and recorded_output is None:
                                     raise DBOSException(
                                         "Transaction output not found in debug mode"
                                     )
@@ -771,7 +771,7 @@ def decorate_step(
                 recorded_output = dbos._sys_db.check_operation_execution(
                     ctx.workflow_id, ctx.function_id
                 )
-                if dbos._debug_mode and recorded_output is None:
+                if dbos.debug_mode and recorded_output is None:
                     raise DBOSException("Step output not found in debug mode")
                 if recorded_output:
                     dbos.logger.debug(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -87,7 +87,6 @@ from ._context import (
 from ._dbos_config import ConfigFile, load_config, set_env_vars
 from ._error import (
     DBOSConflictingRegistrationError,
-    DBOSDebugModeCompleteError,
     DBOSException,
     DBOSNonExistentWorkflowError,
 )
@@ -458,8 +457,6 @@ class DBOS:
             for handler in dbos_logger.handlers:
                 handler.flush()
             add_otlp_to_all_loggers(self.app_version)
-        except DBOSDebugModeCompleteError:
-            raise
         except Exception:
             dbos_logger.error(f"DBOS failed to launch: {traceback.format_exc()}")
             raise

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -249,8 +249,9 @@ def load_config(
     )
 
     local_suffix = False
-    if db_connection.get("local_suffix") is not None:
-        local_suffix = db_connection["local_suffix"]
+    dbcon_local_suffix = db_connection.get("local_suffix")
+    if dbcon_local_suffix is not None:
+        local_suffix = dbcon_local_suffix
     if data["database"].get("local_suffix") is not None:
         local_suffix = data["database"].get("local_suffix")
     if dbos_dblocalsuffix is not None:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -252,7 +252,7 @@ def load_config(
     if db_connection.get("local_suffix") is not None:
         local_suffix = db_connection["local_suffix"]
     if data["database"].get("local_suffix") is not None:
-        local_suffix = data["database"]["local_suffix"]
+        local_suffix = data["database"].get("local_suffix")
     if dbos_dblocalsuffix is not None:
         local_suffix = dbos_dblocalsuffix
     data["database"]["local_suffix"] = local_suffix

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -220,7 +220,7 @@ def load_config(
     dblocalsuffix_env = os.getenv("DBOS_DBLOCALSUFFIX")
     if dblocalsuffix_env:
         try:
-            dbos_dblocalsuffix = bool(dblocalsuffix_env)
+            dbos_dblocalsuffix = dblocalsuffix_env.casefold() == "true".casefold()
         except ValueError:
             pass
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -247,12 +247,13 @@ def load_config(
         or os.environ.get("PGPASSWORD")
         or "dbos"
     )
-    data["database"]["local_suffix"] = (
-        dbos_dblocalsuffix
-        or data["database"].get("local_suffix")
-        or db_connection.get("local_suffix")
-        or False
-    )
+    data["database"]["local_suffix"] = False
+    if db_connection.get("local_suffix") is not None:
+        data["database"]["local_suffix"] = db_connection["local_suffix"]
+    if data["database"].get("local_suffix") is not None:
+        data["database"]["local_suffix"] = data["database"]["local_suffix"]
+    if dbos_dblocalsuffix is not None:
+        data["database"]["local_suffix"] = dbos_dblocalsuffix
 
     # Configure the DBOS logger
     config_logger(data)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -209,14 +209,14 @@ def load_config(
                 "[bold blue]Using default database connection parameters (localhost)[/bold blue]"
             )
 
-    dbos_dbport: int | None = None
+    dbos_dbport: Optional[int] = None
     dbport_env = os.getenv("DBOS_DBPORT")
     if dbport_env:
         try:
             dbos_dbport = int(dbport_env)
         except ValueError:
             pass
-    dbos_dblocalsuffix: bool | None = None
+    dbos_dblocalsuffix: Optional[bool] = None
     dblocalsuffix_env = os.getenv("DBOS_DBLOCALSUFFIX")
     if dblocalsuffix_env:
         try:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -192,7 +192,11 @@ def load_config(
     data = cast(ConfigFile, data)
     db_connection = load_db_connection()
     if not silent:
-        if data["database"].get("hostname"):
+        if os.getenv("DBOS_DBHOST"):
+            print(
+                "[bold blue]Loading database connection parameters from debug environment variables[/bold blue]"
+            )
+        elif data["database"].get("hostname"):
             print(
                 "[bold blue]Loading database connection parameters from dbos-config.yaml[/bold blue]"
             )
@@ -205,23 +209,47 @@ def load_config(
                 "[bold blue]Using default database connection parameters (localhost)[/bold blue]"
             )
 
+    dbos_dbport: int | None = None
+    dbport_env = os.getenv("DBOS_DBPORT")
+    if dbport_env:
+        try:
+            dbos_dbport = int(dbport_env)
+        except ValueError:
+            pass
+    dbos_dblocalsuffix: bool | None = None
+    dblocalsuffix_env = os.getenv("DBOS_DBLOCALSUFFIX")
+    if dblocalsuffix_env:
+        try:
+            dbos_dblocalsuffix = bool(dblocalsuffix_env)
+        except ValueError:
+            pass
+
     data["database"]["hostname"] = (
-        data["database"].get("hostname") or db_connection.get("hostname") or "localhost"
+        os.getenv("DBOS_DBHOST")
+        or data["database"].get("hostname")
+        or db_connection.get("hostname")
+        or "localhost"
     )
+
     data["database"]["port"] = (
-        data["database"].get("port") or db_connection.get("port") or 5432
+        dbos_dbport or data["database"].get("port") or db_connection.get("port") or 5432
     )
     data["database"]["username"] = (
-        data["database"].get("username") or db_connection.get("username") or "postgres"
+        os.getenv("DBOS_DBUSER")
+        or data["database"].get("username")
+        or db_connection.get("username")
+        or "postgres"
     )
     data["database"]["password"] = (
-        data["database"].get("password")
+        os.getenv("DBOS_DBPASSWORD")
+        or data["database"].get("password")
         or db_connection.get("password")
         or os.environ.get("PGPASSWORD")
         or "dbos"
     )
     data["database"]["local_suffix"] = (
-        data["database"].get("local_suffix")
+        dbos_dblocalsuffix
+        or data["database"].get("local_suffix")
         or db_connection.get("local_suffix")
         or False
     )
@@ -230,7 +258,9 @@ def load_config(
     config_logger(data)
 
     # Check the connectivity to the database and make sure it's properly configured
-    if use_db_wizard:
+    # Note, never use db wizard if the DBOS is running in debug mode (i.e. DBOS_DEBUG_WORKFLOW_ID env var is set)
+    debugWorkflowId = os.getenv("DBOS_DEBUG_WORKFLOW_ID")
+    if use_db_wizard and debugWorkflowId is None:
         data = db_wizard(data, config_file_path)
 
     if "local_suffix" in data["database"] and data["database"]["local_suffix"]:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -247,13 +247,15 @@ def load_config(
         or os.environ.get("PGPASSWORD")
         or "dbos"
     )
-    data["database"]["local_suffix"] = False
+
+    local_suffix = False
     if db_connection.get("local_suffix") is not None:
-        data["database"]["local_suffix"] = db_connection["local_suffix"]
+        local_suffix = db_connection["local_suffix"]
     if data["database"].get("local_suffix") is not None:
-        data["database"]["local_suffix"] = data["database"]["local_suffix"]
+        local_suffix = data["database"]["local_suffix"]
     if dbos_dblocalsuffix is not None:
-        data["database"]["local_suffix"] = dbos_dblocalsuffix
+        local_suffix = dbos_dblocalsuffix
+    data["database"]["local_suffix"] = local_suffix
 
     # Configure the DBOS logger
     config_logger(data)

--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -12,7 +12,7 @@ class PythonModule:
 
 def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> None:
     if isinstance(entrypoint, str):
-        runpy.run_path("app/main.py")
+        runpy.run_path(entrypoint)
     elif isinstance(entrypoint, PythonModule):
         runpy.run_module(entrypoint.module_name)
     else:

--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -1,5 +1,6 @@
 import re
 import runpy
+import sys
 from typing import Union
 
 from dbos import DBOS
@@ -11,6 +12,10 @@ class PythonModule:
 
 
 def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> None:
+    # include the current directory (represented by empty string) in the search path
+    # if it not already included
+    if "" not in sys.path:
+        sys.path.insert(0, "")
     if isinstance(entrypoint, str):
         runpy.run_path(entrypoint)
     elif isinstance(entrypoint, PythonModule):

--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -1,0 +1,40 @@
+import re
+import runpy
+from typing import Union
+
+from dbos import DBOS
+
+
+class PythonModule:
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+
+
+def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> None:
+    if isinstance(entrypoint, str):
+        runpy.run_path("app/main.py")
+    elif isinstance(entrypoint, PythonModule):
+        runpy.run_module(entrypoint.module_name)
+    else:
+        raise ValueError("Invalid entrypoint type. Must be a string or PythonModule.")
+
+    DBOS.logger.info(f"Debugging workflow {workflow_id}...")
+    DBOS.launch(debug_mode=True)
+    handle = DBOS.execute_workflow_id(workflow_id)
+    handle.get_result()
+    DBOS.logger.info("Workflow Debugging complete. Exiting process.")
+
+
+def parse_start_command(command: str) -> Union[str, PythonModule]:
+    match = re.match(r"fastapi\s+run\s+(\.?[\w/]+\.py)", command)
+    if match:
+        return match.group(1)
+    match = re.match(r"python3?\s+(\.?[\w/]+\.py)", command)
+    if match:
+        return match.group(1)
+    match = re.match(r"python3?\s+-m\s+([\w\.]+)", command)
+    if match:
+        return PythonModule(match.group(1))
+    raise ValueError(
+        "Invalid command format. Must be 'fastapi run <script>' or 'python <script>' or 'python -m <module>'"
+    )

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -37,6 +37,7 @@ class DBOSErrorCode(Enum):
     NotAuthorized = 8
     ConflictingWorkflowError = 9
     ConflictingRegistrationError = 25
+    DebugModeCompleteError = 10
 
 
 class DBOSWorkflowConflictIDError(DBOSException):
@@ -137,4 +138,14 @@ class DBOSConflictingRegistrationError(DBOSException):
         super().__init__(
             f"Operation (Name: {name}) is already registered with a conflicting function type",
             dbos_error_code=DBOSErrorCode.ConflictingRegistrationError.value,
+        )
+
+
+class DBOSDebugModeCompleteError(DBOSException):
+    """Exception raised when the debug mode execution is complete."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Debug mode execution is complete.",
+            dbos_error_code=DBOSErrorCode.DebugModeCompleteError.value,
         )

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -37,7 +37,6 @@ class DBOSErrorCode(Enum):
     NotAuthorized = 8
     ConflictingWorkflowError = 9
     ConflictingRegistrationError = 25
-    DebugModeCompleteError = 10
 
 
 class DBOSWorkflowConflictIDError(DBOSException):
@@ -138,14 +137,4 @@ class DBOSConflictingRegistrationError(DBOSException):
         super().__init__(
             f"Operation (Name: {name}) is already registered with a conflicting function type",
             dbos_error_code=DBOSErrorCode.ConflictingRegistrationError.value,
-        )
-
-
-class DBOSDebugModeCompleteError(DBOSException):
-    """Exception raised when the debug mode execution is complete."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Debug mode execution is complete.",
-            dbos_error_code=DBOSErrorCode.DebugModeCompleteError.value,
         )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -174,7 +174,7 @@ _buffer_flush_interval_secs = 1.0
 
 class SystemDatabase:
 
-    def __init__(self, config: ConfigFile, debug_mode: bool = False):
+    def __init__(self, config: ConfigFile, *, debug_mode: bool = False):
         self.config = config
 
         sysdb_name = (

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -243,7 +243,7 @@ def reset(
 def debug(
     workflow_id: Annotated[str, typer.Argument(help="Workflow ID to debug")],
 ) -> None:
-    config = load_config(silent=True)
+    config = load_config(silent=True, use_db_wizard=False)
     start = config["runtimeConfig"]["start"]
     if not start:
         typer.echo("No start commands found in 'dbos-config.yaml'")

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -243,7 +243,7 @@ def reset(
 def debug(
     workflow_id: Annotated[str, typer.Argument(help="Workflow ID to debug")],
 ) -> None:
-    config = load_config()
+    config = load_config(silent=True)
     start = config["runtimeConfig"]["start"]
     if not start:
         typer.echo("No start commands found in 'dbos-config.yaml'")

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -15,6 +15,8 @@ from rich import print
 from rich.prompt import IntPrompt
 from typing_extensions import Annotated
 
+from dbos._debug import debug_workflow, parse_start_command
+
 from .. import load_config
 from .._app_db import ApplicationDatabase
 from .._dbos_config import _is_valid_app_name
@@ -235,6 +237,22 @@ def reset(
     except sa.exc.SQLAlchemyError as e:
         typer.echo(f"Error resetting system database: {str(e)}")
         return
+
+
+@app.command(help="Replay Debug a DBOS workflow")
+def debug(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID to debug")],
+) -> None:
+    config = load_config()
+    start = config["runtimeConfig"]["start"]
+    if not start:
+        typer.echo("No start commands found in 'dbos-config.yaml'")
+        raise typer.Exit(code=1)
+    if len(start) > 1:
+        typer.echo("Multiple start commands found in 'dbos-config.yaml'")
+        raise typer.Exit(code=1)
+    entrypoint = parse_start_command(start[0])
+    debug_workflow(workflow_id, entrypoint)
 
 
 @workflow.command(help="List workflows for your application")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,4 +1,12 @@
+import uuid
+
+import pytest
+import sqlalchemy as sa
+
+from dbos import DBOS, ConfigFile, SetWorkflowID
+from dbos._dbos import _get_dbos_instance
 from dbos._debug import PythonModule, parse_start_command
+from dbos._schemas.system_database import SystemSchema
 
 
 def test_parse_fast_api_command() -> None:
@@ -34,3 +42,106 @@ def test_parse_python3_module_command() -> None:
     actual = parse_start_command(command)
     assert isinstance(actual, PythonModule)
     assert actual.module_name == "some_module"
+
+
+def get_recovery_attempts(wfuuid: str) -> int:
+    dbos = _get_dbos_instance()
+    with dbos._sys_db.engine.connect() as c:
+        stmt = sa.select(
+            SystemSchema.workflow_status.c.recovery_attempts,
+            SystemSchema.workflow_status.c.created_at,
+            SystemSchema.workflow_status.c.updated_at,
+        ).where(SystemSchema.workflow_status.c.workflow_uuid == wfuuid)
+        result = c.execute(stmt).fetchone()
+        assert result is not None
+        recovery_attempts, created_at, updated_at = result
+        return int(recovery_attempts)
+
+
+def test_wf_debug(dbos: DBOS, config: ConfigFile) -> None:
+    wf_counter: int = 0
+    step_counter: int = 0
+
+    @DBOS.workflow()
+    def test_workflow(var: str) -> str:
+        nonlocal wf_counter
+        wf_counter += 1
+        res = test_step(var)
+        DBOS.logger.info("I'm test_workflow")
+        return res
+
+    @DBOS.step()
+    def test_step(var: str) -> str:
+        nonlocal step_counter
+        step_counter += 1
+        DBOS.logger.info("I'm test_step")
+        return var
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowID(wfuuid):
+        handle = DBOS.start_workflow(test_workflow, "test")
+        result = handle.get_result()
+        assert result == "test"
+        assert wf_counter == 1
+        assert step_counter == 1
+
+    expected_retry_attempts = get_recovery_attempts(wfuuid)
+
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.launch(debug_mode=True)
+
+    handle = DBOS.execute_workflow_id(wfuuid)
+    result = handle.get_result()
+    assert result == "test"
+    assert wf_counter == 2
+    assert step_counter == 1
+
+    actual_retry_attempts = get_recovery_attempts(wfuuid)
+    assert actual_retry_attempts == expected_retry_attempts
+
+
+def test_wf_debug_exception(dbos: DBOS, config: ConfigFile) -> None:
+    wf_counter: int = 0
+    step_counter: int = 0
+
+    @DBOS.workflow()
+    def test_workflow(var: str) -> str:
+        nonlocal wf_counter
+        wf_counter += 1
+        res = test_step(var)
+        DBOS.logger.info("I'm test_workflow")
+        raise Exception("test_wf_debug_exception")
+
+    @DBOS.step()
+    def test_step(var: str) -> str:
+        nonlocal step_counter
+        step_counter += 1
+        DBOS.logger.info("I'm test_step")
+        return var
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowID(wfuuid):
+        handle = DBOS.start_workflow(test_workflow, "test")
+        with pytest.raises(Exception) as excinfo:
+            handle.get_result()
+        assert str(excinfo.value) == "test_wf_debug_exception"
+
+        assert wf_counter == 1
+        assert step_counter == 1
+
+    expected_retry_attempts = get_recovery_attempts(wfuuid)
+
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.launch(debug_mode=True)
+
+    handle = DBOS.execute_workflow_id(wfuuid)
+    with pytest.raises(Exception) as excinfo:
+        handle.get_result()
+    assert str(excinfo.value) == "test_wf_debug_exception"
+    assert wf_counter == 2
+    assert step_counter == 1
+
+    actual_retry_attempts = get_recovery_attempts(wfuuid)
+    assert actual_retry_attempts == expected_retry_attempts

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,35 +1,35 @@
 from dbos._debug import PythonModule, parse_start_command
 
 
-def test_parse_fast_api_command():
+def test_parse_fast_api_command() -> None:
     command = "fastapi run app/main.py"
     expected = "app/main.py"
     actual = parse_start_command(command)
     assert actual == expected
 
 
-def test_parse_python_command():
+def test_parse_python_command() -> None:
     command = "python app/main.py"
     expected = "app/main.py"
     actual = parse_start_command(command)
     assert actual == expected
 
 
-def test_parse_python3_command():
+def test_parse_python3_command() -> None:
     command = "python3 app/main.py"
     expected = "app/main.py"
     actual = parse_start_command(command)
     assert actual == expected
 
 
-def test_parse_python_module_command():
+def test_parse_python_module_command() -> None:
     command = "python -m some_module"
     actual = parse_start_command(command)
     assert isinstance(actual, PythonModule)
     assert actual.module_name == "some_module"
 
 
-def test_parse_python3_module_command():
+def test_parse_python3_module_command() -> None:
     command = "python3 -m some_module"
     actual = parse_start_command(command)
     assert isinstance(actual, PythonModule)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,36 @@
+from dbos._debug import PythonModule, parse_start_command
+
+
+def test_parse_fast_api_command():
+    command = "fastapi run app/main.py"
+    expected = "app/main.py"
+    actual = parse_start_command(command)
+    assert actual == expected
+
+
+def test_parse_python_command():
+    command = "python app/main.py"
+    expected = "app/main.py"
+    actual = parse_start_command(command)
+    assert actual == expected
+
+
+def test_parse_python3_command():
+    command = "python3 app/main.py"
+    expected = "app/main.py"
+    actual = parse_start_command(command)
+    assert actual == expected
+
+
+def test_parse_python_module_command():
+    command = "python -m some_module"
+    actual = parse_start_command(command)
+    assert isinstance(actual, PythonModule)
+    assert actual.module_name == "some_module"
+
+
+def test_parse_python3_module_command():
+    command = "python3 -m some_module"
+    actual = parse_start_command(command)
+    assert isinstance(actual, PythonModule)
+    assert actual.module_name == "some_module"


### PR DESCRIPTION
Adds debug mode to the python version of Transact.

* adds `debug_mode` kwarg to `DBOS.launch`. When debugging, `DBOS._launch` bails out after setting up the sys and app database connections. Stuff like the admin server, startup recovery thread, workflow buffer flush thread, etc are not created and started
* adds `debug_mode` kwarg to sys and app db classes. DB classes don't perform migrations and raise exceptions when attempting to write to a DB in debug mode
* updates _core.py to do these things in debug mode:
  * read existing workflow status in `_init_workflow` instead of calling `insert_workflow_status`
  * force workflow to run in `start_workflow` even though status is `SUCCESS` or `ERROR` 
  * raise exception in tx and step decorators if `recorded_output` returns None
* Adds `dbos debug` cli command that extracts the entrypoint from the runtime configuration start command and runs a specified wf via `execute_workflow_id`
* Adds `__main__.py` file so dbos can be run like a module (needed to support VSCode Python debugger)
* updates `load_config` to read DB connection info from `DBOS_DB*` env settings set by DBOS VSCode debugger extension