### PR TITLE
Always set executor ID correctly when starting a workflow

### DIFF
--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -43,6 +43,7 @@ def startup_recovery_thread(
 def recover_pending_workflows(
     dbos: "DBOS", executor_ids: List[str] = ["local"]
 ) -> List["WorkflowHandle[Any]"]:
+    """Attempt to recover pending workflows for a list of specific executors and return workflow handles for them."""
     workflow_handles: List["WorkflowHandle[Any]"] = []
     for executor_id in executor_ids:
         dbos.logger.debug(f"Recovering pending workflows for executor: {executor_id}")

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -305,6 +305,7 @@ class SystemDatabase:
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
                 set_=dict(
+                    executor_id=status["executor_id"],
                     recovery_attempts=(
                         SystemSchema.workflow_status.c.recovery_attempts + 1
                     ),


### PR DESCRIPTION
This PR fixes an issue where the app doesn't correctly set the executor ID to itself when recovering pending workflows from other executors.

Now we always make sure that whoever started the workflow will always update the executor ID.