### PR TITLE
Fix race conditions with clear_queue_assignment

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -442,7 +442,7 @@ def start_workflow(
         )
     ):
         dbos.logger.debug(
-            f"Workflow {new_wf_id} being enqueued or already completed with status {wf_status}. Directly returning a workflow handle."
+            f"Workflow {new_wf_id} already completed with status {wf_status}. Directly returning a workflow handle."
         )
         return WorkflowHandlePolling(new_wf_id, dbos)
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -442,7 +442,7 @@ def start_workflow(
         )
     ):
         dbos.logger.debug(
-            f"Workflow {new_wf_id} already completed with status {wf_status}. Directly returning a workflow handle."
+            f"Workflow {new_wf_id} being enqueued or already completed with status {wf_status}. Directly returning a workflow handle."
         )
         return WorkflowHandlePolling(new_wf_id, dbos)
 

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -27,7 +27,7 @@ def startup_recovery_thread(
                     pending_workflow.queue_name
                     and pending_workflow.queue_name != "_dbos_internal_queue"
                 ):
-                    cleared: bool = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
+                    cleared = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
                     if cleared:
                         continue
                 execute_workflow_by_id(dbos, pending_workflow.workflow_uuid)
@@ -57,7 +57,7 @@ def recover_pending_workflows(
                 and pending_workflow.queue_name != "_dbos_internal_queue"
             ):
                 try:
-                    cleared: bool = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
+                    cleared = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
                     if cleared:
                         workflow_handles.append(
                             dbos.retrieve_workflow(pending_workflow.workflow_uuid)

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -27,8 +27,9 @@ def startup_recovery_thread(
                     pending_workflow.queue_name
                     and pending_workflow.queue_name != "_dbos_internal_queue"
                 ):
-                    dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
-                    continue
+                    cleared: bool = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
+                    if cleared:
+                        continue
                 execute_workflow_by_id(dbos, pending_workflow.workflow_uuid)
                 pending_workflows.remove(pending_workflow)
         except DBOSWorkflowFunctionNotFoundError:
@@ -56,10 +57,15 @@ def recover_pending_workflows(
                 and pending_workflow.queue_name != "_dbos_internal_queue"
             ):
                 try:
-                    dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
-                    workflow_handles.append(
-                        dbos.retrieve_workflow(pending_workflow.workflow_uuid)
-                    )
+                    cleared: bool = dbos._sys_db.clear_queue_assignment(pending_workflow.workflow_uuid)
+                    if cleared:
+                        workflow_handles.append(
+                            dbos.retrieve_workflow(pending_workflow.workflow_uuid)
+                        )
+                    else:
+                        workflow_handles.append(
+                            execute_workflow_by_id(dbos, pending_workflow.workflow_uuid)
+                        )
                 except Exception as e:
                     dbos.logger.error(e)
             else:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1467,8 +1467,6 @@ class SystemDatabase:
 
         with self.engine.connect() as conn:
             with conn.begin() as transaction:
-                conn.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
-
                 res = conn.execute(
                     sa.update(SystemSchema.workflow_queue)
                     .where(SystemSchema.workflow_queue.c.workflow_uuid == workflow_id)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1460,21 +1460,29 @@ class SystemDatabase:
                     .values(completed_at_epoch_ms=int(time.time() * 1000))
                 )
 
+
     def clear_queue_assignment(self, workflow_id: str) -> None:
         if self._debug_mode:
             raise Exception("called clear_queue_assignment in debug mode")
-        with self.engine.begin() as c:
-            c.execute(
-                sa.update(SystemSchema.workflow_queue)
-                .where(SystemSchema.workflow_queue.c.workflow_uuid == workflow_id)
-                .values(executor_id=None, started_at_epoch_ms=None)
-            )
-            c.execute(
-                sa.update(SystemSchema.workflow_status)
-                .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
-                .values(executor_id=None, status=WorkflowStatusString.ENQUEUED.value)
-            )
 
+        with self.engine.connect() as conn:
+            with conn.begin() as transaction:
+                res = conn.execute(
+                    sa.update(SystemSchema.workflow_queue)
+                    .where(SystemSchema.workflow_queue.c.workflow_uuid == workflow_id)
+                    .values(executor_id=None, started_at_epoch_ms=None)
+                )
+
+                # If no rows were affected, the workflow is not anymore in the queue
+                if res.rowcount == 0:
+                    transaction.rollback()
+                    return
+
+                conn.execute(
+                    sa.update(SystemSchema.workflow_status)
+                    .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
+                    .values(executor_id=None, status=WorkflowStatusString.ENQUEUED.value)
+                )
 
 def reset_system_database(config: ConfigFile) -> None:
     sysdb_name = (

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -906,7 +906,7 @@ def test_resuming_already_completed_queue_workflow(dbos: DBOS) -> None:
 
     start_event = threading.Event()
     counter = 0
-    @DBOS.step()
+    @DBOS.workflow()
     def test_step() -> None:
         start_event.set()
         nonlocal counter
@@ -927,6 +927,7 @@ def test_resuming_already_completed_queue_workflow(dbos: DBOS) -> None:
     assert recovered_ids[0].get_workflow_id() == handle.get_workflow_id()
     start_event.wait()
     assert counter == 2 # The workflow ran again
+    time.sleep(_buffer_flush_interval_secs) # This is actually to wait that _get_wf_invoke_func buffers the status
     dbos._sys_db._flush_workflow_status_buffer() # Manually flush
     assert handle.get_status().status == WorkflowStatusString.SUCCESS.value # Is recovered
     assert handle.get_status().executor_id == "local"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -19,7 +19,7 @@ from dbos import (
     WorkflowHandle,
 )
 from dbos._schemas.system_database import SystemSchema
-from dbos._sys_db import WorkflowStatusString
+from dbos._sys_db import WorkflowStatusString, _buffer_flush_interval_secs
 from tests.conftest import default_config, queue_entries_are_cleaned_up
 
 
@@ -902,7 +902,7 @@ def test_resuming_queued_workflows(dbos: DBOS) -> None:
 
 # Test a race condition between removing a task from the queue and flushing the status buffer
 def test_resuming_already_completed_queue_workflow(dbos: DBOS) -> None:
-    dbos._sys_db._buffer_flush_interval_secs = 999999 # Disable buffer flush
+    _buffer_flush_interval_secs = 999999 # Disable buffer flush
 
     start_event = threading.Event()
     counter = 0

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -19,7 +19,7 @@ from dbos import (
     WorkflowHandle,
 )
 from dbos._schemas.system_database import SystemSchema
-from dbos._sys_db import WorkflowStatusString, _buffer_flush_interval_secs
+from dbos._sys_db import WorkflowStatusString
 from tests.conftest import default_config, queue_entries_are_cleaned_up
 
 
@@ -902,7 +902,7 @@ def test_resuming_queued_workflows(dbos: DBOS) -> None:
 
 # Test a race condition between removing a task from the queue and flushing the status buffer
 def test_resuming_already_completed_queue_workflow(dbos: DBOS) -> None:
-    _buffer_flush_interval_secs = 999999 # Disable buffer flush
+    dbos._sys_db._buffer_flush_interval_secs = 999999 # Disable buffer flush
 
     start_event = threading.Event()
     counter = 0


### PR DESCRIPTION
It is possible for a task to be sent back to the `QUEUED` state if Transact crashes between removing the task from the queue, after completion, and flushing the workflow output buffer.

At restart, the queue will not pickup on the workflow (because it has been dequeued), and we skip the workflow during recovery -- so the status is never set to `SUCCESS`.

This PR:
- Has `clear_queue_assignment` check whether the workflow is still in the queue (checking the affected `rowcount` from the workflow queue clear)
- Has `clear_queue_assignment` return whether it did find a workflow to clear in the queue. If not, the recovery logic considers the workflow is not a queue task anymore and needs to be re-executed immediately