### PR TITLE
Configify

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,7 +1,7 @@
 from . import _error as error
 from ._context import DBOSContextEnsure, DBOSContextSetAuth, SetWorkflowID
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
-from ._dbos_config import ConfigFile, get_dbos_database_url, load_config
+from ._dbos_config import ConfigFile, get_dbos_database_url, load_config, process_config
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatusString
@@ -20,6 +20,7 @@ __all__ = [
     "WorkflowStatus",
     "WorkflowStatusString",
     "load_config",
+    "process_config",
     "get_dbos_database_url",
     "error",
     "Queue",

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,7 +1,7 @@
 from . import _error as error
 from ._context import DBOSContextEnsure, DBOSContextSetAuth, SetWorkflowID
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
-from ._dbos_config import ConfigFile, get_dbos_database_url, load_config
+from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url, load_config
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatusString

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,7 +1,7 @@
 from . import _error as error
 from ._context import DBOSContextEnsure, DBOSContextSetAuth, SetWorkflowID
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
-from ._dbos_config import ConfigFile, get_dbos_database_url, load_config, process_config
+from ._dbos_config import ConfigFile, get_dbos_database_url, load_config
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatusString
@@ -20,7 +20,6 @@ __all__ = [
     "WorkflowStatus",
     "WorkflowStatusString",
     "load_config",
-    "process_config",
     "get_dbos_database_url",
     "error",
     "Queue",

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -29,8 +29,8 @@ class DatabaseConnection(TypedDict):
 
 
 # This function first checks connectivity to the database configured in Transact
-# If it fails, it first determines whether the error is due to incorrect credentials or if the database (likely) does not existing
-# If the error is due to the database not existing, it will help the user start a database
+# If it fails, it determines whether the error is due to incorrect credentials or if the database likely does not exist because connection information are the default ones
+# Else, the function will help the user start a database
 def db_wizard(config: "ConfigFile") -> "ConfigFile":
     # 1. Check the connectivity to the database. Return if successful. If cannot connect, continue to the following steps.
     db_connection_error = _check_db_connectivity(config)
@@ -58,8 +58,6 @@ def db_wizard(config: "ConfigFile") -> "ConfigFile":
         raise DBOSInitializationError(
             f"Could not connect to the database. Exception: {db_connection_error}"
         )
-
-    # At this point we are confident the connection error is due to the desired databased not existing / being unavailable
 
     print("[yellow]Postgres not detected locally[/yellow]")
 

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -48,31 +48,6 @@ def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
             f"Could not connect to Postgres: password authentication failed: {db_connection_error}"
         )
 
-    # Read the config file and check if the database hostname/port/username are set
-    # If so, assume the library has incorrect connection information in the input config, surface the error and exit
-    try:
-        with open(config_file_path, "r") as file:
-            content = file.read()
-            local_config = yaml.safe_load(content)
-            if "database" not in local_config:
-                local_config["database"] = {}
-            local_config = cast("ConfigFile", local_config)
-
-            if (
-                local_config["database"].get("hostname")
-                or local_config["database"].get("port")
-                or local_config["database"].get("username")
-            ):
-                raise DBOSInitializationError(
-                    f"Could not connect to the database. Exception: {db_connection_error}"
-                )
-    except FileNotFoundError:
-        # Ignore the error if the file doesn't exist
-        pass
-    except Exception as e:
-        # Raise other exceptions
-        raise e
-
     # Finally, check if the database config is the default one. If not, surface the error and exit.
     db_config = config["database"]  # FIXME: what if database is not in config?
     if (

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -47,7 +47,6 @@ def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
         raise DBOSInitializationError(
             f"Could not connect to Postgres: password authentication failed: {db_connection_error}"
         )
-    db_config = config["database"]
 
     # Read the config file and check if the database hostname/port/username are set
     # If so, assume the library has incorrect connection information in the input config, surface the error and exit
@@ -75,6 +74,7 @@ def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
         raise e
 
     # Finally, check if the database config is the default one. If not, surface the error and exit.
+    db_config = config["database"]  # FIXME: what if database is not in config?
     if (
         db_config["hostname"] != "localhost"
         or db_config["port"] != 5432

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -31,7 +31,7 @@ class DatabaseConnection(TypedDict):
 # This function first checks connectivity to the database configured in Transact
 # If it fails, it first determines whether the error is due to incorrect credentials or if the database (likely) does not existing
 # If the error is due to the database not existing, it will help the user start a database
-def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
+def db_wizard(config: "ConfigFile") -> "ConfigFile":
     # 1. Check the connectivity to the database. Return if successful. If cannot connect, continue to the following steps.
     db_connection_error = _check_db_connectivity(config)
     if db_connection_error is None:

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -48,7 +48,7 @@ def db_wizard(config: "ConfigFile") -> "ConfigFile":
             f"Could not connect to Postgres: password authentication failed: {db_connection_error}"
         )
 
-    # Finally, check if the database config is the default one. If not, surface the error and exit.
+    # If the database config is not the default one, surface the error and exit.
     db_config = config["database"]  # FIXME: what if database is not in config?
     if (
         db_config["hostname"] != "localhost"
@@ -59,7 +59,7 @@ def db_wizard(config: "ConfigFile") -> "ConfigFile":
             f"Could not connect to the database. Exception: {db_connection_error}"
         )
 
-    # At this point we are confident the connection error is due to the desired databased not existing / being available
+    # At this point we are confident the connection error is due to the desired databased not existing / being unavailable
 
     print("[yellow]Postgres not detected locally[/yellow]")
 

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -28,10 +28,20 @@ class DatabaseConnection(TypedDict):
     local_suffix: Optional[bool]
 
 
-# This function first checks connectivity to the database configured in Transact
-# If it fails, it determines whether the error is due to incorrect credentials or if the database likely does not exist because connection information are the default ones
-# Else, the function will help the user start a database
 def db_wizard(config: "ConfigFile") -> "ConfigFile":
+    """Checks database connectivity and helps the user start a database if needed
+
+    First, check connectivity to the database configured in the provided `config` object.
+    If it fails:
+     - Return an error if the connection failed due to incorrect credentials.
+     - Return an error if it detects a non-default configuration.
+     - Otherwise assume the configured database is not running and guide the user through setting it up.
+
+     The wizard will first attempt to start a local Postgres instance using Docker.
+     If Docker is not available, it will prompt the user to connect to a DBOS Cloud database.
+
+     Finally, if a database was configured, its connection details will be saved in the local `.dbos/db_connection` file.
+    """
     # 1. Check the connectivity to the database. Return if successful. If cannot connect, continue to the following steps.
     db_connection_error = _check_db_connectivity(config)
     if db_connection_error is None:

--- a/dbos/_db_wizard.py
+++ b/dbos/_db_wizard.py
@@ -29,7 +29,7 @@ class DatabaseConnection(TypedDict):
 
 
 # This function first checks connectivity to the database configured in Transact
-# If it fails, it first determines whether the error is due to incorrect configuration or the database not existing
+# If it fails, it first determines whether the error is due to incorrect credentials or if the database (likely) does not existing
 # If the error is due to the database not existing, it will help the user start a database
 def db_wizard(config: "ConfigFile", config_file_path: str) -> "ConfigFile":
     # 1. Check the connectivity to the database. Return if successful. If cannot connect, continue to the following steps.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -341,26 +341,26 @@ class DBOS:
 
         # If no config is provided, load it from dbos-config.yaml
         if config is None:
-            dbos_logger.debug("No config provided: loading dbos-config.yaml")
+            print("No config provided: loading dbos-config.yaml")
             config = load_config()
             self.config: ConfigFile = config
             set_env_vars(self.config)
         # If a ConfigFile structure is provided, take it as-is but validate it using process_config()
         elif is_config_file(config):
             init_logger()
-            dbos_logger.debug("Initializing DBOS from ConfigFile")
+            print("Initializing DBOS from ConfigFile")
             if os.environ.get("DBOS__CLOUD") == "true":
-                dbos_logger.debug("Overwriting config with dbos-config.yaml")
+                print("Overwriting config with dbos-config.yaml")
                 config = overwrite_config(config)
             self.config: ConfigFile = process_config(data=config)
             set_env_vars(self.config)
         # If a DBOSConfig struct is provided, convert it to ConfigFile and validate it using process_config()
         elif is_dbos_config(config):
             init_logger()
-            dbos_logger.debug("Initializing DBOS from DBOSConfig")
+            print("Initializing DBOS from DBOSConfig")
             unvalidated_config = translate_dbos_config_to_config_file(config)
             if os.environ.get("DBOS__CLOUD") == "true":
-                dbos_logger.debug("Overwriting config with dbos-config.yaml")
+                print("Overwriting config with dbos-config.yaml")
                 unvalidated_config = overwrite_config(unvalidated_config)
             self.config: ConfigFile = process_config(data=unvalidated_config)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -341,26 +341,21 @@ class DBOS:
 
         # If no config is provided, load it from dbos-config.yaml
         if config is None:
-            print("No config provided: loading dbos-config.yaml")
             config = load_config()
             self.config: ConfigFile = config
             set_env_vars(self.config)
         # If a ConfigFile structure is provided, take it as-is but validate it using process_config()
         elif is_config_file(config):
             init_logger()
-            print("Initializing DBOS from ConfigFile")
             if os.environ.get("DBOS__CLOUD") == "true":
-                print("Overwriting config with dbos-config.yaml")
                 config = overwrite_config(config)
             self.config: ConfigFile = process_config(data=config)
             set_env_vars(self.config)
         # If a DBOSConfig struct is provided, convert it to ConfigFile and validate it using process_config()
         elif is_dbos_config(config):
             init_logger()
-            print("Initializing DBOS from DBOSConfig")
             unvalidated_config = translate_dbos_config_to_config_file(config)
             if os.environ.get("DBOS__CLOUD") == "true":
-                print("Overwriting config with dbos-config.yaml")
                 unvalidated_config = overwrite_config(unvalidated_config)
             self.config: ConfigFile = process_config(data=unvalidated_config)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -361,7 +361,6 @@ class DBOS:
         else:
             raise ValueError("No valid configuration was loaded.")
 
-        self.config: ConfigFile = process_config(data=unvalidated_config)
         set_env_vars(self.config)
         config_logger(self.config)
         dbos_tracer.config(self.config)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -344,14 +344,14 @@ class DBOS:
 
         if config is None:
             # If no config is provided, load it from dbos-config.yaml
-            unvalidated_config: ConfigFile = load_config()
+            unvalidated_config = load_config()
         elif is_dbos_configfile(config):
-            unvalidated_config: ConfigFile = config
+            unvalidated_config = cast(ConfigFile, config)
             if os.environ.get("DBOS__CLOUD") == "true":
-                unvalidated_config = overwrite_config(config)
+                unvalidated_config = overwrite_config(unvalidated_config)
         else:
-            unvalidated_config: ConfigFile = translate_dbos_config_to_config_file(
-                config
+            unvalidated_config = translate_dbos_config_to_config_file(
+                cast(DBOSConfig, config)
             )
             if os.environ.get("DBOS__CLOUD") == "true":
                 unvalidated_config = overwrite_config(unvalidated_config)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -344,7 +344,7 @@ class DBOS:
 
         if config is None:
             # If no config is provided, load it from dbos-config.yaml
-            unvalidated_config = load_config(process_config=False)
+            unvalidated_config = load_config(run_process_config=False)
         elif is_dbos_configfile(config):
             unvalidated_config = cast(ConfigFile, config)
             if os.environ.get("DBOS__CLOUD") == "true":

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -451,7 +451,7 @@ class DBOS:
             if debug_mode:
                 return
 
-            admin_port = self.config["runtimeConfig"].get("admin_port")
+            admin_port = self.config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001
             self._admin_server_field = AdminServer(dbos=self, port=admin_port)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -361,7 +361,7 @@ class DBOS:
             unvalidated_config = translate_dbos_config_to_config_file(config)
             if os.environ.get("DBOS__CLOUD") == "true":
                 dbos_logger.debug("Overwriting config with dbos-config.yaml")
-                config = overwrite_config(unvalidated_config)
+                unvalidated_config = overwrite_config(unvalidated_config)
             self.config: ConfigFile = process_config(data=unvalidated_config)
 
         config_logger(self.config)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -91,6 +91,7 @@ from ._context import (
 from ._dbos_config import (
     ConfigFile,
     DBOSConfig,
+    check_config_consistency,
     is_dbos_configfile,
     load_config,
     overwrite_config,
@@ -349,12 +350,14 @@ class DBOS:
             unvalidated_config = cast(ConfigFile, config)
             if os.environ.get("DBOS__CLOUD") == "true":
                 unvalidated_config = overwrite_config(unvalidated_config)
+            check_config_consistency(name=unvalidated_config["name"])
         else:
             unvalidated_config = translate_dbos_config_to_config_file(
                 cast(DBOSConfig, config)
             )
             if os.environ.get("DBOS__CLOUD") == "true":
                 unvalidated_config = overwrite_config(unvalidated_config)
+            check_config_consistency(name=unvalidated_config["name"])
 
         if unvalidated_config is not None:
             self.config: ConfigFile = process_config(data=unvalidated_config)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -344,7 +344,7 @@ class DBOS:
 
         if config is None:
             # If no config is provided, load it from dbos-config.yaml
-            unvalidated_config = load_config()
+            unvalidated_config = load_config(process_config=False)
         elif is_dbos_configfile(config):
             unvalidated_config = cast(ConfigFile, config)
             if os.environ.get("DBOS__CLOUD") == "true":
@@ -955,7 +955,9 @@ class DBOS:
         reg = _get_or_create_dbos_registry()
         if reg.config is not None:
             return reg.config
-        config = load_config()
+        config = (
+            load_config()
+        )  # This will return the processed & validated config (with defaults)
         reg.config = config
         return config
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -342,20 +342,25 @@ class DBOS:
         # If no config is provided, load it from dbos-config.yaml
         if config is None:
             config = load_config()
+            dbos_logger.debug("No config provided: loading dbos-config.yaml")
             self.config: ConfigFile = config
             set_env_vars(self.config)
         # If a ConfigFile structure is provided, take it as-is but validate it using process_config()
         elif is_config_file(config):
             init_logger()
+            dbos_logger.debug("Initializing DBOS from ConfigFile")
             if os.environ.get("DBOS__CLOUD") == "true":
+                dbos_logger.debug("Overwriting config with dbos-config.yaml")
                 config = overwrite_config(config)
             self.config: ConfigFile = process_config(data=config)
             set_env_vars(self.config)
         # If a DBOSConfig struct is provided, convert it to ConfigFile and validate it using process_config()
         elif is_dbos_config(config):
             init_logger()
+            dbos_logger.debug("Initializing DBOS from DBOSConfig")
             unvalidated_config = translate_dbos_config_to_config_file(config)
             if os.environ.get("DBOS__CLOUD") == "true":
+                dbos_logger.debug("Overwriting config with dbos-config.yaml")
                 config = overwrite_config(unvalidated_config)
             self.config: ConfigFile = process_config(data=unvalidated_config)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -341,8 +341,8 @@ class DBOS:
 
         # If no config is provided, load it from dbos-config.yaml
         if config is None:
-            config = load_config()
             dbos_logger.debug("No config provided: loading dbos-config.yaml")
+            config = load_config()
             self.config: ConfigFile = config
             set_env_vars(self.config)
         # If a ConfigFile structure is provided, take it as-is but validate it using process_config()

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -270,7 +270,10 @@ def process_config(
             f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters long and contain only lowercase letters, numbers, dashes, and underscores.'
         )
 
-    if "app_db_name" not in data["database"]:
+    if "app_db_name" not in data["database"] or data["database"]["app_db_name"] in (
+        "",
+        None,
+    ):
         data["database"]["app_db_name"] = _app_name_to_db_name(data["name"])
 
     # Load the DB connection file. Use its values for missing fields from dbos-config.yaml. Use defaults otherwise.

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -192,7 +192,7 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
         str: Database URL for the application database
 
     """
-    dbos_config = process_config(load_config(data=config_file_path))
+    dbos_config = process_config(data=load_config(config_file_path))
     db_url = URL.create(
         "postgresql+psycopg",
         username=dbos_config["database"]["username"],

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -3,12 +3,7 @@ import os
 import re
 import sys
 from importlib import resources
-from typing import Any, Dict, List, Optional, TypedDict, cast
-
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
+from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 
 import yaml
 from jsonschema import ValidationError, validate
@@ -121,7 +116,7 @@ class ConfigFile(TypedDict, total=False):
     env: Dict[str, str]
 
 
-def is_dbos_configfile(data: ConfigFile | DBOSConfig) -> bool:
+def is_dbos_configfile(data: Union[ConfigFile, DBOSConfig]) -> bool:
     return "name" in data and (
         "runtimeConfig" in data
         or "database" in data

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -477,7 +477,7 @@ def check_config_consistency(
     *,
     name: str,
     config_file_path: str = DBOS_CONFIG_PATH,
-):
+) -> None:
     # First load the config file and check whether it is present
     try:
         config = load_config(config_file_path)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -395,6 +395,8 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     provided_config["name"] = config_from_file["name"]
 
     # Database config
+    if "database" not in provided_config:
+        provided_config["database"] = {}
     provided_config["database"]["hostname"] = config_from_file["database"]["hostname"]
     provided_config["database"]["port"] = config_from_file["database"]["port"]
     provided_config["database"]["username"] = config_from_file["database"]["username"]

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -278,12 +278,15 @@ def process_config(
     # database_url takes precedence over database config, but we need to preserve rollback and migrate if they exist
     migrate = data["database"].get("migrate", False)
     rollback = data["database"].get("rollback", False)
+    local_suffix = data["database"].get("local_suffix", False)
     if data.get("database_url"):
         dbconfig = parse_database_url_to_dbconfig(cast(str, data["database_url"]))
         if migrate:
             dbconfig["migrate"] = cast(List[str], migrate)
         if rollback:
             dbconfig["rollback"] = cast(List[str], rollback)
+        if local_suffix:
+            dbconfig["local_suffix"] = cast(bool, local_suffix)
         data["database"] = dbconfig
 
     if "app_db_name" not in data["database"] or not (data["database"]["app_db_name"]):

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -206,6 +206,7 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
 
 def load_config(
     config_file_path: str = DBOS_CONFIG_PATH,
+    *,
     run_process_config: bool = True,
     use_db_wizard: bool = True,
     silent: bool = False,

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -254,7 +254,6 @@ def load_config(
 def process_config(
     *,
     use_db_wizard: bool = True,
-    config_file_path: str = DBOS_CONFIG_PATH,
     data: ConfigFile,
     silent: bool = False,
 ) -> ConfigFile:
@@ -347,7 +346,7 @@ def process_config(
     # Note, never use db wizard if the DBOS is running in debug mode (i.e. DBOS_DEBUG_WORKFLOW_ID env var is set)
     debugWorkflowId = os.getenv("DBOS_DEBUG_WORKFLOW_ID")
     if use_db_wizard and debugWorkflowId is None:
-        data = db_wizard(data, config_file_path)
+        data = db_wizard(data)
 
     if "local_suffix" in data["database"] and data["database"]["local_suffix"]:
         data["database"]["app_db_name"] = f"{data['database']['app_db_name']}_local"

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -151,7 +151,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     otlp_trace_endpoints = config.get("otlp_traces_endpoints")
     if otlp_trace_endpoints:
         telemetry["OTLPExporter"] = {"tracesEndpoint": otlp_trace_endpoints[0]}
-    # Add logs section if log_level exists
+    # Default to INFO -- the logging seems to default to WARN otherwise.
     log_level = config.get("log_level", "INFO")
     if log_level:
         telemetry["logs"] = {"logLevel": log_level}
@@ -373,8 +373,7 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # Load the DBOS configuration file and force the use of:
     # 1. The database connection parameters (sub the file data to the provided config)
     # 2. OTLP traces endpoints (add the config data to the provided config)
-    # 3. Custom setup steps (sub the file data to the provided config)
-    # 4. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
+    # 3. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
 
     config_from_file = load_config()
     # Be defensive

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -212,7 +212,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     if otlp_trace_endpoints:
         telemetry["OTLPExporter"] = {"tracesEndpoint": otlp_trace_endpoints[0]}
     # Add logs section if log_level exists
-    log_level = config.get("log_level", "info")
+    log_level = config.get("log_level", "INFO")
     if log_level:
         telemetry["logs"] = {"logLevel": log_level}
     # Only add telemetry section if it has content

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -73,7 +73,7 @@ def parse_database_url_to_dbconfig(database_url: str) -> DatabaseConfig:
             db_config["connectionTimeoutMillis"] = int(str_value) * 1000
         elif key == "sslmode":
             db_config["ssl"] = str_value == "require"
-        elif key == "sslcert":
+        elif key == "sslrootcert":
             db_config["ssl_ca"] = str_value
     return cast(DatabaseConfig, db_config)
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -262,6 +262,14 @@ def process_config(
     silent: bool = False,
 ) -> ConfigFile:
 
+    if "name" not in data:
+        raise DBOSInitializationError(f"Configuration must specify an application name")
+
+    if not _is_valid_app_name(data["name"]):
+        raise DBOSInitializationError(
+            f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters long and contain only lowercase letters, numbers, dashes, and underscores.'
+        )
+
     if "database" not in data:
         data["database"] = {}
 
@@ -276,14 +284,6 @@ def process_config(
         if rollback:
             dbconfig["rollback"] = cast(List[str], rollback)
         data["database"] = dbconfig
-
-    if "name" not in data:
-        raise DBOSInitializationError(f"Configuration must specify an application name")
-
-    if not _is_valid_app_name(data["name"]):
-        raise DBOSInitializationError(
-            f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters long and contain only lowercase letters, numbers, dashes, and underscores.'
-        )
 
     if "app_db_name" not in data["database"] or not (data["database"]["app_db_name"]):
         data["database"]["app_db_name"] = _app_name_to_db_name(data["name"])

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -5,6 +5,11 @@ import sys
 from importlib import resources
 from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeGuard
+else:
+    from typing import TypeGuard
+
 import yaml
 from jsonschema import ValidationError, validate
 from rich import print
@@ -118,12 +123,25 @@ class ConfigFile(TypedDict, total=False):
     env: Dict[str, str]
 
 
-def is_dbos_configfile(data: Union[ConfigFile, DBOSConfig]) -> bool:
-    return "name" in data and (
-        "runtimeConfig" in data
-        or "database" in data
-        or "env" in data
-        or "telemetry" in data
+def is_dbos_configfile(data: Union[ConfigFile, DBOSConfig]) -> TypeGuard[DBOSConfig]:
+    """
+    Type guard to check if the provided data is a DBOSConfig.
+
+    Args:
+        data: The configuration object to check
+
+    Returns:
+        True if the data is a DBOSConfig, False otherwise
+    """
+    return (
+        isinstance(data, dict)
+        and "name" in data
+        and (
+            "runtimeConfig" in data
+            or "database" in data
+            or "env" in data
+            or "telemetry" in data
+        )
     )
 
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -152,7 +152,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     telemetry = {}
     # Add OTLPExporter if traces endpoints exist
     otlp_trace_endpoints = config.get("otlp_traces_endpoints")
-    if otlp_trace_endpoints:
+    if isinstance(otlp_trace_endpoints, list) and len(otlp_trace_endpoints) > 0:
         telemetry["OTLPExporter"] = {"tracesEndpoint": otlp_trace_endpoints[0]}
     # Default to INFO -- the logging seems to default to WARN otherwise.
     log_level = config.get("log_level", "INFO")

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -270,11 +270,11 @@ def process_config(
     migrate = data["database"].get("migrate", False)
     rollback = data["database"].get("rollback", False)
     if data.get("database_url"):
-        dbconfig = parse_database_url_to_dbconfig(data["database_url"])
+        dbconfig = parse_database_url_to_dbconfig(cast(str, data["database_url"]))
         if migrate:
-            dbconfig["migrate"] = migrate
+            dbconfig["migrate"] = cast(List[str], migrate)
         if rollback:
-            dbconfig["rollback"] = rollback
+            dbconfig["rollback"] = cast(List[str], rollback)
         data["database"] = dbconfig
 
     if "name" not in data:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -23,14 +23,14 @@ class DBOSConfig(TypedDict):
 
     Attributes:
         name (str): Application name
-        db_string (str): Database connection string
+        database_url (str): Database connection string
         sys_db_name (str): System database name
         log_level (str): Log level
         otlp_traces_endpoints: List[str]: OTLP traces endpoints
     """
 
     name: str
-    db_string: Optional[str]
+    database_url: Optional[str]
     sys_db_name: Optional[str]
     log_level: Optional[str]
     otlp_traces_endpoints: Optional[List[str]]
@@ -58,8 +58,8 @@ class DatabaseConfig(TypedDict, total=False):
     rollback: Optional[List[str]]
 
 
-def parse_db_string_to_dbconfig(db_string: str) -> DatabaseConfig:
-    db_url = make_url(db_string)
+def parse_database_url_to_dbconfig(database_url: str) -> DatabaseConfig:
+    db_url = make_url(database_url)
     db_config = {
         "hostname": db_url.host,
         "port": db_url.port or 5432,
@@ -133,9 +133,9 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
 
     # Database config
     db_config: DatabaseConfig = {}
-    db_string = config.get("db_string")
-    if db_string:
-        db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = config.get("database_url")
+    if database_url:
+        db_config = parse_database_url_to_dbconfig(database_url)
     if "sys_db_name" in config:
         db_config["sys_db_name"] = config.get("sys_db_name")
     if db_config:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -129,7 +129,9 @@ def is_dbos_configfile(data: Union[ConfigFile, DBOSConfig]) -> bool:
 
 
 def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
-    # Start with the mandatory fields
+    if "name" not in config:
+        raise DBOSInitializationError(f"Configuration must specify an application name")
+
     translated_config: ConfigFile = {
         "name": config["name"],
     }

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -206,6 +206,9 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
 
 def load_config(
     config_file_path: str = DBOS_CONFIG_PATH,
+    process_config: bool = True,
+    use_db_wizard: bool = True,
+    silent: bool = False,
 ) -> ConfigFile:
     """
     Load the DBOS `ConfigFile` from the specified path (typically `dbos-config.yaml`).
@@ -242,7 +245,10 @@ def load_config(
     except ValidationError as e:
         raise DBOSInitializationError(f"Validation error: {e}")
 
-    return cast(ConfigFile, data)
+    data = cast(ConfigFile, data)
+    if process_config:
+        return process_config(data=data, use_db_wizard=use_db_wizard, silent=silent)
+    return data
 
 
 def process_config(
@@ -375,7 +381,7 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # 2. OTLP traces endpoints (add the config data to the provided config)
     # 3. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
 
-    config_from_file = load_config()
+    config_from_file = load_config(process_config=False)
     # Be defensive
     if config_from_file is None:
         return provided_config

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -212,7 +212,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     if otlp_trace_endpoints:
         telemetry["OTLPExporter"] = {"tracesEndpoint": otlp_trace_endpoints[0]}
     # Add logs section if log_level exists
-    log_level = config.get("log_level", "")
+    log_level = config.get("log_level", "info")
     if log_level:
         telemetry["logs"] = {"logLevel": log_level}
     # Only add telemetry section if it has content

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -206,7 +206,7 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
 
 def load_config(
     config_file_path: str = DBOS_CONFIG_PATH,
-    process_config: bool = True,
+    run_process_config: bool = True,
     use_db_wizard: bool = True,
     silent: bool = False,
 ) -> ConfigFile:
@@ -246,7 +246,7 @@ def load_config(
         raise DBOSInitializationError(f"Validation error: {e}")
 
     data = cast(ConfigFile, data)
-    if process_config:
+    if run_process_config:
         return process_config(data=data, use_db_wizard=use_db_wizard, silent=silent)
     return data
 
@@ -380,7 +380,7 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # 2. OTLP traces endpoints (add the config data to the provided config)
     # 3. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
 
-    config_from_file = load_config(process_config=False)
+    config_from_file = load_config(run_process_config=False)
     # Be defensive
     if config_from_file is None:
         return provided_config

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -379,13 +379,15 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # 1. The database connection parameters (sub the file data to the provided config)
     # 2. OTLP traces endpoints (add the config data to the provided config)
     # 3. Custom setup steps (sub the file data to the provided config)
-    # ? Name: should we override it with the config file ?
-    # ? logs level: right now this code ignores log level from the config file.
+    # 4. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
 
     config_from_file = load_config()
     # Be defensive
     if config_from_file is None:
         return provided_config
+
+    # Name
+    provided_config["name"] = config_from_file["name"]
 
     # Database config
     provided_config["database"]["hostname"] = config_from_file["database"]["hostname"]

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -92,7 +92,6 @@ class TelemetryConfig(TypedDict, total=False):
     OTLPExporter: Optional[OTLPExporterConfig]
 
 
-# FIXME: we should remove total=False and make database & runtimeConfig optional.
 class ConfigFile(TypedDict, total=False):
     """
     Data structure containing the DBOS Configuration.

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -12,7 +12,7 @@ from sqlalchemy import URL, make_url
 
 from ._db_wizard import db_wizard, load_db_connection
 from ._error import DBOSInitializationError
-from ._logger import dbos_logger, init_logger
+from ._logger import dbos_logger
 
 DBOS_CONFIG_PATH = "dbos-config.yaml"
 
@@ -471,3 +471,26 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
         del provided_config["env"]
 
     return provided_config
+
+
+def check_config_consistency(
+    *,
+    name: str,
+    config_file_path: str = DBOS_CONFIG_PATH,
+):
+    # First load the config file and check whether it is present
+    try:
+        config = load_config(config_file_path)
+    except FileNotFoundError:
+        dbos_logger.debug(
+            f"No configuration file {config_file_path} found. Skipping consistency check with provided config."
+        )
+        return
+    except Exception as e:
+        raise e
+
+    # Check the name
+    if name != config["name"]:
+        raise DBOSInitializationError(
+            f"Provided app name '{name}' does not match the app name '{config['name']}' in {config_file_path}."
+        )

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -148,7 +148,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     # Telemetry config
     telemetry = {}
     # Add OTLPExporter if traces endpoints exist
-    otlp_trace_endpoints = config.get("otlp_traces_endpoints", [])
+    otlp_trace_endpoints = config.get("otlp_traces_endpoints")
     if otlp_trace_endpoints:
         telemetry["OTLPExporter"] = {"tracesEndpoint": otlp_trace_endpoints[0]}
     # Add logs section if log_level exists

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -274,7 +274,6 @@ def process_config(
         data["database"] = {}
 
     # database_url takes precedence over database config, but we need to preserve rollback and migrate if they exist
-    # FIXME: do we also need to preserve local_suffix?
     migrate = data["database"].get("migrate", False)
     rollback = data["database"].get("rollback", False)
     if data.get("database_url"):

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -380,6 +380,8 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # 1. The database connection parameters (sub the file data to the provided config)
     # 2. OTLP traces endpoints (add the config data to the provided config)
     # 3. Use the application name from the file. This is a defensive measure to ensure the application name is whatever it was registered with in the cloud
+    # 4. Remove admin_port is provided in code
+    # 5. Remove env vars if provided in code
 
     config_from_file = load_config(run_process_config=False)
     # Be defensive

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -192,7 +192,7 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
         str: Database URL for the application database
 
     """
-    dbos_config = process_config(load_config(config_file_path))
+    dbos_config = process_config(load_config(data=config_file_path))
     db_url = URL.create(
         "postgresql+psycopg",
         username=dbos_config["database"]["username"],

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -247,8 +247,8 @@ def load_config(
 
     data = cast(ConfigFile, data)
     if run_process_config:
-        return process_config(data=data, use_db_wizard=use_db_wizard, silent=silent)
-    return data
+        data = process_config(data=data, use_db_wizard=use_db_wizard, silent=silent)
+    return data  # type: ignore
 
 
 def process_config(

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -192,7 +192,7 @@ def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
         str: Database URL for the application database
 
     """
-    dbos_config = load_config(config_file_path)
+    dbos_config = process_config(load_config(config_file_path))
     db_url = URL.create(
         "postgresql+psycopg",
         username=dbos_config["database"]["username"],

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -450,7 +450,7 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
     # 1. The database connection parameters (sub the file data to the provided config)
     # 2. OTLP traces endpoints (add the config data to the provided config)
     # 3. Custom setup steps (sub the file data to the provided config)
-    # ? Name
+    # ? Name: should we override it with the config file ?
     # ? logs level: right now this code ignores log level from the config file.
 
     config_from_file = parse_config_file()

--- a/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
+++ b/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
@@ -8,6 +8,7 @@ language: python
 runtimeConfig:
   start:
     - "fastapi run ${package_name}/main.py"
+database_url: ${DBOS_DATABASE_URL}
 database:
   migrate:
     - ${migration_command}

--- a/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
+++ b/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
@@ -11,6 +11,3 @@ runtimeConfig:
 database:
   migrate:
     - ${migration_command}
-telemetry:
-  logs:
-    logLevel: INFO

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -17,7 +17,7 @@ from typing_extensions import Annotated
 
 from dbos._debug import debug_workflow, parse_start_command
 
-from .. import load_config
+from .. import load_config, process_config
 from .._app_db import ApplicationDatabase
 from .._dbos_config import _is_valid_app_name
 from .._sys_db import SystemDatabase, reset_system_database
@@ -41,7 +41,7 @@ def _on_windows() -> bool:
     help="Start your DBOS application using the start commands in 'dbos-config.yaml'"
 )
 def start() -> None:
-    config = load_config()
+    config = process_config(data=load_config())
     start_commands = config["runtimeConfig"]["start"]
     typer.echo("Executing start commands from 'dbos-config.yaml'")
     for command in start_commands:
@@ -170,7 +170,7 @@ def init(
     help="Run your database schema migrations using the migration commands in 'dbos-config.yaml'"
 )
 def migrate() -> None:
-    config = load_config()
+    config = process_config(data=load_config())
     if not config["database"]["password"]:
         typer.echo(
             "DBOS configuration does not contain database password, please check your config file and retry!"
@@ -229,7 +229,7 @@ def reset(
         if not confirm:
             typer.echo("Operation cancelled.")
             raise typer.Exit()
-    config = load_config()
+    config = process_config(data=load_config())
     try:
         reset_system_database(config)
     except sa.exc.SQLAlchemyError as e:
@@ -241,7 +241,7 @@ def reset(
 def debug(
     workflow_id: Annotated[str, typer.Argument(help="Workflow ID to debug")],
 ) -> None:
-    config = load_config(silent=True, use_db_wizard=False)
+    config = process_config(data=load_config(), silent=True, use_db_wizard=False)
     start = config["runtimeConfig"]["start"]
     if not start:
         typer.echo("No start commands found in 'dbos-config.yaml'")
@@ -308,7 +308,7 @@ def list(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = load_config(silent=True)
+    config = process_config(data=load_config(), silent=True)
     sys_db = SystemDatabase(config)
     workflows = list_workflows(
         sys_db,
@@ -332,7 +332,7 @@ def get(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = load_config(silent=True)
+    config = process_config(data=load_config(), silent=True)
     sys_db = SystemDatabase(config)
     print(
         jsonpickle.encode(get_workflow(sys_db, workflow_id, request), unpicklable=False)
@@ -458,7 +458,7 @@ def list_queue(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = load_config(silent=True)
+    config = process_config(data=load_config(), silent=True)
     sys_db = SystemDatabase(config)
     workflows = list_queued_workflows(
         sys_db=sys_db,

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -17,7 +17,7 @@ from typing_extensions import Annotated
 
 from dbos._debug import debug_workflow, parse_start_command
 
-from .. import load_config, process_config
+from .. import load_config
 from .._app_db import ApplicationDatabase
 from .._dbos_config import _is_valid_app_name
 from .._sys_db import SystemDatabase, reset_system_database
@@ -41,7 +41,7 @@ def _on_windows() -> bool:
     help="Start your DBOS application using the start commands in 'dbos-config.yaml'"
 )
 def start() -> None:
-    config = process_config(data=load_config())
+    config = load_config()
     start_commands = config["runtimeConfig"]["start"]
     typer.echo("Executing start commands from 'dbos-config.yaml'")
     for command in start_commands:
@@ -170,7 +170,7 @@ def init(
     help="Run your database schema migrations using the migration commands in 'dbos-config.yaml'"
 )
 def migrate() -> None:
-    config = process_config(data=load_config())
+    config = load_config()
     if not config["database"]["password"]:
         typer.echo(
             "DBOS configuration does not contain database password, please check your config file and retry!"
@@ -229,7 +229,7 @@ def reset(
         if not confirm:
             typer.echo("Operation cancelled.")
             raise typer.Exit()
-    config = process_config(data=load_config())
+    config = load_config()
     try:
         reset_system_database(config)
     except sa.exc.SQLAlchemyError as e:
@@ -241,7 +241,7 @@ def reset(
 def debug(
     workflow_id: Annotated[str, typer.Argument(help="Workflow ID to debug")],
 ) -> None:
-    config = process_config(data=load_config(), silent=True, use_db_wizard=False)
+    config = load_config(silent=True, use_db_wizard=False)
     start = config["runtimeConfig"]["start"]
     if not start:
         typer.echo("No start commands found in 'dbos-config.yaml'")
@@ -308,7 +308,7 @@ def list(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = process_config(data=load_config(), silent=True)
+    config = load_config(silent=True)
     sys_db = SystemDatabase(config)
     workflows = list_workflows(
         sys_db,
@@ -332,7 +332,7 @@ def get(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = process_config(data=load_config(), silent=True)
+    config = load_config(silent=True)
     sys_db = SystemDatabase(config)
     print(
         jsonpickle.encode(get_workflow(sys_db, workflow_id, request), unpicklable=False)
@@ -458,7 +458,7 @@ def list_queue(
         typer.Option("--request", help="Retrieve workflow request information"),
     ] = False,
 ) -> None:
-    config = process_config(data=load_config(), silent=True)
+    config = load_config(silent=True)
     sys_db = SystemDatabase(config)
     workflows = list_queued_workflows(
         sys_db=sys_db,

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -16,6 +16,10 @@
           "python"
         ]
       },
+      "database_url": {
+        "type": "string",
+        "description": "The URL of the application database"
+      },
       "database": {
         "type": "object",
         "additionalProperties": false,

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -12,12 +12,11 @@
         "type": "string",
         "description": "The language used in your application",
         "enum": [
-          "typescript",
           "python"
         ]
       },
       "database_url": {
-        "type": "string",
+        "type": ["string", "null"],
         "description": "The URL of the application database"
       },
       "database": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,11 +32,6 @@ def default_config() -> ConfigFile:
             "password": os.environ["PGPASSWORD"],
             "app_db_name": "dbostestpy",
         },
-        "runtimeConfig": {
-            "start": ["python3 main.py"],
-        },
-        "telemetry": {},
-        "env": {},
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -381,7 +381,7 @@ def test_process_config_with_db_url_taking_precendence_over_database():
             "sys_db_name": "sys_db",
             "ssl": True,
             "ssl_ca": "ca.pem",
-            "local_suffix": False,
+            "local_suffix": True,
             "migrate": ["alembic upgrade head"],
             "rollback": ["alembic downgrade base"],
         },
@@ -433,7 +433,7 @@ def test_process_config_load_default_with_None_database_url():
     )
 
 
-def test_process_config_with_not_non_but_None_app_db_name():
+def test_process_config_with_None_app_db_name():
     config: ConfigFile = {
         "name": "some-app",
         "database": {
@@ -452,7 +452,7 @@ def test_process_config_with_not_non_but_None_app_db_name():
     )
 
 
-def test_process_config_with_not_non_but_empty_app_db_name():
+def test_process_config_with_empty_app_db_name():
     config: ConfigFile = {
         "name": "some-app",
         "database": {
@@ -627,7 +627,7 @@ def test_basic_fields_mapping():
 
 
 def test_no_db_name():
-    """Test that an exception is raised when dbname is not provided."""
+    """None app_db_name when dbname is not provided."""
     database_url = "postgresql://user:password@localhost:5432"
     db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["hostname"] == "localhost"
@@ -689,7 +689,6 @@ def test_query_parameters():
     assert db_config["connectionTimeoutMillis"] == 10000
     assert db_config["ssl"] == True
     assert db_config["ssl_ca"] == "ca.pem"
-    assert "application_name" not in db_config
 
 
 def test_complex_password():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,7 +182,7 @@ def test_load_valid_config_file(mocker):
 def test_load_config_database_url(mocker):
     mock_config = """
         name: "some-app"
-        database_url: "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem"
+        database_url: "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem"
     """
     mocker.patch(
         "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
@@ -192,7 +192,7 @@ def test_load_config_database_url(mocker):
     assert configFile["name"] == "some-app"
     assert (
         configFile["database_url"]
-        == "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem"
+        == "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem"
     )
     assert "database" not in configFile
 
@@ -200,7 +200,7 @@ def test_load_config_database_url(mocker):
 def test_load_config_database_url_and_database(mocker):
     mock_config = """
         name: "some-app"
-        database_url: "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem"
+        database_url: "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem"
         database:
             hostname: 'localhost'
             port: 5432
@@ -217,7 +217,7 @@ def test_load_config_database_url_and_database(mocker):
     assert configFile["name"] == "some-app"
     assert (
         configFile["database_url"]
-        == "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem"
+        == "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem"
     )
     assert configFile["database"]["hostname"] == "localhost"
     assert configFile["database"]["port"] == 5432
@@ -353,7 +353,7 @@ def test_process_config_full():
 def test_process_config_with_db_url():
     config: ConfigFile = {
         "name": "some-app",
-        "database_url": "postgresql://user:password@localhost:7777/dbn?connect_timeout=1&sslmode=require&sslcert=ca.pem",
+        "database_url": "postgresql://user:password@localhost:7777/dbn?connect_timeout=1&sslmode=require&sslrootcert=ca.pem",
     }
     processed_config = process_config(data=config, use_db_wizard=False)
     assert processed_config["name"] == "some-app"
@@ -681,13 +681,13 @@ def test_query_parameters():
     db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl"] == False
 
-    # Test sslcert mapping to ssl_ca
-    database_url = "postgresql://user:password@localhost:5432/dbname?sslcert=ca.pem"
+    # Test sslrootcert mapping to ssl_ca
+    database_url = "postgresql://user:password@localhost:5432/dbname?sslrootcert=ca.pem"
     db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl_ca"] == "ca.pem"
 
     # Test multiple parameters together
-    database_url = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem&application_name=myapp"
+    database_url = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem&application_name=myapp"
     db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["connectionTimeoutMillis"] == 10000
     assert db_config["ssl"] == True
@@ -724,7 +724,7 @@ def test_translate_dbosconfig_full_input():
     # Give all fields
     config: DBOSConfig = {
         "name": "test-app",
-        "database_url": "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem",
+        "database_url": "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslrootcert=ca.pem",
         "sys_db_name": "sysdb",
         "log_level": "DEBUG",
         "otlp_traces_endpoints": ["http://otel:7777", "notused"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -498,8 +498,8 @@ def test_dbosconfig_minimal():
     assert dbos.config["database"]["username"] == "user"
     assert dbos.config["database"]["password"] == "password"
     assert dbos.config["database"]["app_db_name"] == "dbname"
+    assert dbos.config["telemetry"]["logs"]["logLevel"] == "INFO"
     assert "sys_db_name" not in dbos.config["database"]
-    assert "telemetry" not in dbos.config
     assert "env" not in dbos.config
     assert "admin_port" not in dbos.config["runtimeConfig"]
     assert dbos.config["runtimeConfig"]["start"] == []
@@ -515,7 +515,8 @@ def test_dbosconfig_empty_otlp_traces_endpoints():
         "otlp_traces_endpoints": [],
     }
     dbos = DBOS(config=config)
-    assert "telemetry" not in dbos.config
+    assert "OTLPExporter" not in dbos.config["telemetry"]
+    assert dbos.config["telemetry"]["logs"]["logLevel"] == "INFO"
     dbos.destroy()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,7 +239,6 @@ def test_load_config_with_unset_database_url_env_var(mocker):
 
     configFile = load_config(mock_filename, run_process_config=False)
     assert configFile["name"] == "some-app"
-    print(configFile)
 
 
 def test_load_config_file_open_error(mocker):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -316,6 +316,44 @@ def test_process_config_load_defaults():
     )
 
 
+def test_process_config_with_not_non_but_None_app_db_name():
+    config: ConfigFile = {
+        "name": "some-app",
+        "database": {
+            "app_db_name": None,
+        },
+    }
+    processed_config = process_config(data=config)
+    print(processed_config)
+    assert processed_config["name"] == "some-app"
+    assert processed_config["database"]["app_db_name"] == "some_app"
+    assert processed_config["database"]["hostname"] == "localhost"
+    assert processed_config["database"]["port"] == 5432
+    assert processed_config["database"]["username"] == "postgres"
+    assert processed_config["database"]["password"] == os.environ.get(
+        "PGPASSWORD", "dbos"
+    )
+
+
+def test_process_config_with_not_non_but_empty_app_db_name():
+    config: ConfigFile = {
+        "name": "some-app",
+        "database": {
+            "app_db_name": "",
+        },
+    }
+    processed_config = process_config(data=config)
+    print(processed_config)
+    assert processed_config["name"] == "some-app"
+    assert processed_config["database"]["app_db_name"] == "some_app"
+    assert processed_config["database"]["hostname"] == "localhost"
+    assert processed_config["database"]["port"] == 5432
+    assert processed_config["database"]["username"] == "postgres"
+    assert processed_config["database"]["password"] == os.environ.get(
+        "PGPASSWORD", "dbos"
+    )
+
+
 def test_config_missing_name():
     config = {
         "database": {
@@ -469,6 +507,28 @@ def test_basic_fields_mapping():
     assert db_config["username"] == "user"
     assert db_config["password"] == "password"
     assert db_config["app_db_name"] == "dbname"
+
+
+def test_no_db_name():
+    """Test that an exception is raised when dbname is not provided."""
+    database_url = "postgresql://user:password@localhost:5432"
+    db_config = parse_database_url_to_dbconfig(database_url)
+    assert db_config["hostname"] == "localhost"
+    assert db_config["port"] == 5432
+    assert db_config["username"] == "user"
+    assert db_config["password"] == "password"
+    assert db_config["app_db_name"] == None
+
+
+def test_no_db_name_end_with_slash():
+    """Test that an exception is raised when dbname is not provided."""
+    database_url = "postgresql://user:password@localhost:5432/"
+    db_config = parse_database_url_to_dbconfig(database_url)
+    assert db_config["hostname"] == "localhost"
+    assert db_config["port"] == 5432
+    assert db_config["username"] == "user"
+    assert db_config["password"] == "password"
+    assert db_config["app_db_name"] == ""
 
 
 def test_default_port():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,7 +158,7 @@ def test_load_valid_config_file(mocker):
         "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
     )
 
-    configFile = load_config(mock_filename, process_config=False)
+    configFile = load_config(mock_filename, run_process_config=False)
     assert configFile["name"] == "some-app"
     assert configFile["database"]["hostname"] == "localhost"
     assert configFile["database"]["port"] == 5432
@@ -228,7 +228,7 @@ def test_load_config_file_custom_path():
     from unittest.mock import mock_open, patch
 
     with patch("builtins.open", mock_open(read_data=mock_config)) as mock_file:
-        result = load_config(custom_path, process_config=False)
+        result = load_config(custom_path, run_process_config=False)
         mock_file.assert_called_with(custom_path, "r")
         assert result["name"] == "test-app"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -787,10 +787,20 @@ def test_translate_empty_otlp_traces_endpoints():
         "name": "test-app",
         "otlp_traces_endpoints": [],
     }
-    dbos = DBOS(config=config)
-    assert "OTLPExporter" not in dbos.config["telemetry"]
-    assert dbos.config["telemetry"]["logs"]["logLevel"] == "INFO"
-    dbos.destroy()
+    translated_config = translate_dbos_config_to_config_file(config)
+    assert "OTLPExporter" not in translated_config["telemetry"]
+    assert translated_config["telemetry"]["logs"]["logLevel"] == "INFO"
+
+
+def test_translate_ignores_otlp_traces_not_list():
+    # Give an empty OTLP traces endpoint list
+    config: DBOSConfig = {
+        "name": "test-app",
+        "otlp_traces_endpoints": "http://otel:7777",
+    }
+    translated_config = translate_dbos_config_to_config_file(config)
+    assert translated_config["name"] == "test-app"
+    assert "OTLPExporter" not in translated_config["telemetry"]
 
 
 def test_translate_missing_name():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -364,6 +364,7 @@ def test_process_config_with_db_url():
     assert processed_config["database"]["connectionTimeoutMillis"] == 1000
     assert processed_config["database"]["ssl"] == True
     assert processed_config["database"]["ssl_ca"] == "ca.pem"
+    assert processed_config["database"]["local_suffix"] == False
     assert "rollback" not in processed_config["database"]
     assert "migrate" not in processed_config["database"]
 
@@ -393,9 +394,10 @@ def test_process_config_with_db_url_taking_precedence_over_database():
     assert processed_config["database"]["port"] == 7777
     assert processed_config["database"]["username"] == "boo"
     assert processed_config["database"]["password"] == "whoisdiz"
-    assert processed_config["database"]["app_db_name"] == "takesprecedence"
+    assert processed_config["database"]["app_db_name"] == "takesprecedence_local"
     assert processed_config["database"]["migrate"] == ["alembic upgrade head"]
     assert processed_config["database"]["rollback"] == ["alembic downgrade base"]
+    assert processed_config["database"]["local_suffix"] == True
     assert "connectionTimeoutMillis" not in processed_config["database"]
     assert "ssl" not in processed_config["database"]
     assert "ssl_ca" not in processed_config["database"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,6 +266,19 @@ def test_load_config_file_schema_validation_error(mocker):
     )
 
 
+def test_load_config_file_not_dict(mocker):
+    """Test handling when YAML doesn't parse to a dictionary."""
+    mock_config = "just a string"
+    mocker.patch(
+        "builtins.open", side_effect=generate_mock_open("dbos-config.yaml", mock_config)
+    )
+
+    with pytest.raises(DBOSInitializationError) as exc_info:
+        load_config()
+
+    assert "dbos-config.yaml must contain a dictionary" in str(exc_info.value)
+
+
 def test_load_config_file_custom_path():
     """Test parsing a config file from a custom path."""
     mock_config = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,7 +158,7 @@ def test_load_valid_config_file(mocker):
         "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
     )
 
-    configFile = load_config(mock_filename)
+    configFile = load_config(mock_filename, process_config=False)
     assert configFile["name"] == "some-app"
     assert configFile["database"]["hostname"] == "localhost"
     assert configFile["database"]["port"] == 5432
@@ -228,7 +228,7 @@ def test_load_config_file_custom_path():
     from unittest.mock import mock_open, patch
 
     with patch("builtins.open", mock_open(read_data=mock_config)) as mock_file:
-        result = load_config(custom_path)
+        result = load_config(custom_path, process_config=False)
         mock_file.assert_called_with(custom_path, "r")
         assert result["name"] == "test-app"
 
@@ -342,30 +342,19 @@ def test_config_bad_name():
 
 
 def test_load_config_load_db_connection(mocker):
-    mock_config = """
-        name: "some-app"
-        language: "python"
-        runtimeConfig:
-            start:
-                - "python3 main.py"
-    """
     mock_db_connection = """
     {"hostname": "example.com", "port": 2345, "username": "example", "password": "password", "local_suffix": true}
     """
     mocker.patch(
         "builtins.open",
-        side_effect=generate_mock_open(
-            [mock_filename, ".dbos/db_connection"], [mock_config, mock_db_connection]
-        ),
+        side_effect=generate_mock_open([".dbos/db_connection"], [mock_db_connection]),
     )
 
     config = {
         "name": "some-app",
     }
 
-    configFile = process_config(
-        data=config, config_file_path=mock_filename, use_db_wizard=False
-    )
+    configFile = process_config(data=config, use_db_wizard=False)
     assert configFile["name"] == "some-app"
     assert configFile["database"]["hostname"] == "example.com"
     assert configFile["database"]["port"] == 2345

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -368,7 +368,7 @@ def test_process_config_with_db_url():
     assert "migrate" not in processed_config["database"]
 
 
-def test_process_config_with_db_url_taking_precendence_over_database():
+def test_process_config_with_db_url_taking_precedence_over_database():
     config: ConfigFile = {
         "name": "some-app",
         "database": {
@@ -803,9 +803,12 @@ def test_translate_ignores_otlp_traces_not_list():
 
 
 def test_translate_missing_name():
-    with pytest.raises(KeyError) as exc_info:
+    with pytest.raises(DBOSInitializationError) as exc_info:
         translate_dbos_config_to_config_file({})
-    assert str(exc_info.value) == "'name'"
+    assert (
+        "Error initializing DBOS Transact: Configuration must specify an application name"
+        in str(exc_info.value)
+    )
 
 
 ####################

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -698,7 +698,7 @@ def test_overwrite_config(mocker):
     }
     config = overwrite_config(provided_config)
 
-    assert config["name"] == "test-app"
+    assert config["name"] == "stock-prices"
     assert config["database"]["hostname"] == "hostname"
     assert config["database"]["port"] == 1234
     assert config["database"]["username"] == "dbosadmin"
@@ -756,7 +756,7 @@ def test_overwrite_config_minimal(mocker):
     }
     config = overwrite_config(provided_config)
 
-    assert config["name"] == "test-app"
+    assert config["name"] == "stock-prices"
     assert config["database"]["hostname"] == "hostname"
     assert config["database"]["port"] == 1234
     assert config["database"]["username"] == "dbosadmin"
@@ -813,7 +813,7 @@ def test_overwrite_config_has_telemetry(mocker):
     }
     config = overwrite_config(provided_config)
 
-    assert config["name"] == "test-app"
+    assert config["name"] == "stock-prices"
     assert config["database"]["hostname"] == "hostname"
     assert config["database"]["port"] == 1234
     assert config["database"]["username"] == "dbosadmin"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ from dbos._dbos_config import (
     ConfigFile,
     DBOSConfig,
     overwrite_config,
-    parse_db_string_to_dbconfig,
+    parse_database_url_to_dbconfig,
     process_config,
     set_env_vars,
     translate_dbos_config_to_config_file,
@@ -472,8 +472,8 @@ def test_local_config_without_name(mocker):
 
 def test_basic_fields_mapping():
     """Test that basic fields from db_url are correctly mapped to db_config."""
-    db_string = "postgresql://user:password@localhost:5432/dbname"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname"
+    db_config = parse_database_url_to_dbconfig(database_url)
 
     assert db_config["hostname"] == "localhost"
     assert db_config["port"] == 5432
@@ -484,8 +484,8 @@ def test_basic_fields_mapping():
 
 def test_default_port():
     """Test that default port (5432) is used when port is not specified."""
-    db_string = "postgresql://user:password@localhost/dbname"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost/dbname"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["port"] == 5432
 
 
@@ -493,33 +493,33 @@ def test_query_parameters():
     """Test processing of various query parameters."""
 
     # Test connect_timeout conversion
-    db_string = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["connectionTimeoutMillis"] == 10000
 
     # Test sslmode=require (should set ssl=True)
-    db_string = "postgresql://user:password@localhost:5432/dbname?sslmode=require"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?sslmode=require"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl"] == True
 
     # Test sslmode=disable (should set ssl=False)
-    db_string = "postgresql://user:password@localhost:5432/dbname?sslmode=disable"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?sslmode=disable"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl"] == False
 
     # Test sslmode=prefer (should set ssl=False as it's not 'require')
-    db_string = "postgresql://user:password@localhost:5432/dbname?sslmode=prefer"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?sslmode=prefer"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl"] == False
 
     # Test sslcert mapping to ssl_ca
-    db_string = "postgresql://user:password@localhost:5432/dbname?sslcert=ca.pem"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?sslcert=ca.pem"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["ssl_ca"] == "ca.pem"
 
     # Test multiple parameters together
-    db_string = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem&application_name=myapp"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem&application_name=myapp"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["connectionTimeoutMillis"] == 10000
     assert db_config["ssl"] == True
     assert db_config["ssl_ca"] == "ca.pem"
@@ -528,23 +528,23 @@ def test_query_parameters():
 
 def test_complex_password():
     """Test handling of complex passwords with special characters."""
-    db_string = "postgresql://user:complex%23password@localhost:5432/dbname"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:complex%23password@localhost:5432/dbname"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["password"] == "complex#password"
 
 
 def test_hostname_with_dots():
     """Test handling of hostnames with dots."""
-    db_string = "postgresql://user:password@hostname.with.dots:5432/dbname"
-    db_config = parse_db_string_to_dbconfig(db_string)
+    database_url = "postgresql://user:password@hostname.with.dots:5432/dbname"
+    db_config = parse_database_url_to_dbconfig(database_url)
     assert db_config["hostname"] == "hostname.with.dots"
 
 
 def test_invalid_string():
     """Test handling of invalid db strings."""
     with pytest.raises(Exception):
-        db_string = "invalid"
-        parse_db_string_to_dbconfig(db_string)
+        database_url = "invalid"
+        parse_database_url_to_dbconfig(database_url)
 
 
 ####################
@@ -556,7 +556,7 @@ def test_translate_dbosconfig_full_input():
     # Give all fields
     config: DBOSConfig = {
         "name": "test-app",
-        "db_string": "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem",
+        "database_url": "postgresql://user:password@localhost:5432/dbname?connect_timeout=10&sslmode=require&sslcert=ca.pem",
         "sys_db_name": "sysdb",
         "log_level": "DEBUG",
         "otlp_traces_endpoints": ["http://otel:7777", "notused"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,6 +227,21 @@ def test_load_config_database_url_and_database(mocker):
     assert configFile["database"]["connectionTimeoutMillis"] == 3000
 
 
+def test_load_config_with_unset_database_url_env_var(mocker):
+    mock_config = """
+    name: "some-app"
+    database_url: ${UNSET}
+    """
+
+    mocker.patch(
+        "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
+    )
+
+    configFile = load_config(mock_filename, run_process_config=False)
+    assert configFile["name"] == "some-app"
+    print(configFile)
+
+
 def test_load_config_file_open_error(mocker):
     """Test handling when the config file can't be opened."""
     mocker.patch("builtins.open", side_effect=FileNotFoundError("File not found"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,19 +266,6 @@ def test_load_config_file_schema_validation_error(mocker):
     )
 
 
-def test_load_config_file_not_dict(mocker):
-    """Test handling when YAML doesn't parse to a dictionary."""
-    mock_config = "just a string"
-    mocker.patch(
-        "builtins.open", side_effect=generate_mock_open("dbos-config.yaml", mock_config)
-    )
-
-    with pytest.raises(DBOSInitializationError) as exc_info:
-        load_config()
-
-    assert "dbos-config.yaml must contain a dictionary" in str(exc_info.value)
-
-
 def test_load_config_file_custom_path():
     """Test parsing a config file from a custom path."""
     mock_config = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,7 +109,7 @@ def test_configfile_type_provided():
     assert dbos.config["database"]["hostname"] == "localhost"
     assert dbos.config["database"]["port"] == 5432
     assert dbos.config["database"]["username"] == "postgres"
-    assert dbos.config["database"]["password"] == "dbos"
+    assert dbos.config["database"]["password"] == os.environ["PGPASSWORD"]
     assert dbos.config["database"]["app_db_name"] == "some_app"
     dbos.destroy()
 
@@ -123,7 +123,7 @@ def test_dbosconfig_type_provided(mocker):
     assert dbos.config["database"]["hostname"] == "localhost"
     assert dbos.config["database"]["port"] == 5432
     assert dbos.config["database"]["username"] == "postgres"
-    assert dbos.config["database"]["password"] == "dbos"
+    assert dbos.config["database"]["password"] == os.environ["PGPASSWORD"]
     assert dbos.config["database"]["app_db_name"] == "some_app"
     dbos.destroy()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -795,13 +795,6 @@ def test_overwrite_config_minimal(mocker):
 
     provided_config: ConfigFile = {
         "name": "test-app",
-        "database": {
-            "hostname": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": "dbos",
-            "app_db_name": "dbostestpy",
-        },
     }
     config = overwrite_config(provided_config)
 

--- a/tests/test_dbwizard.py
+++ b/tests/test_dbwizard.py
@@ -1,0 +1,116 @@
+import os
+from unittest.mock import mock_open, patch
+
+import pytest
+import yaml
+
+from dbos._dbos_config import ConfigFile, db_wizard
+from dbos._error import DBOSInitializationError
+
+
+class TestDbWizardIntegration:
+    """Integration test suite for the db_wizard function with a real PostgreSQL database."""
+
+    @pytest.fixture
+    def standard_config(self) -> ConfigFile:
+        """Standard configuration with default database settings."""
+        return {
+            "name": "test-app",
+            "database": {
+                "hostname": "localhost",
+                "port": 5432,
+                "username": "postgres",
+                "password": os.environ.get("PGPASSWORD", "dbos"),
+                "app_db_name": "postgres",
+            },
+        }
+
+    @pytest.fixture
+    def non_default_config(self) -> ConfigFile:
+        """Configuration with non-default database settings."""
+        return {
+            "name": "test-app",
+            "database": {
+                "hostname": "non-existent-host",
+                "port": 5433,
+                "username": "non-existent-user",
+                "password": "wrong-password",
+                "app_db_name": "postgres",
+            },
+        }
+
+    @pytest.fixture
+    def wrong_password_config(self) -> ConfigFile:
+        """Configuration with correct host/port but wrong password."""
+        return {
+            "name": "test-app",
+            "database": {
+                "hostname": "localhost",
+                "port": 5432,
+                "username": "postgres",
+                "password": "wrong",
+                "app_db_name": "postgres",
+            },
+        }
+
+    @pytest.fixture
+    def non_existent_db_config(self) -> ConfigFile:
+        """Configuration with correct credentials but non-existent database."""
+        return {
+            "name": "test-app",
+            "database": {
+                "hostname": "localhost",
+                "port": 5433,  # Wrong port
+                "username": "postgres",
+                "password": os.environ.get("PGPASSWORD", "dbos"),
+            },
+        }
+
+    def test_successful_connection_postgres_db(self, standard_config):
+        """Test when connection to postgres database is successful."""
+        result = db_wizard(standard_config, "config.yaml")
+        assert result == standard_config
+
+    '''
+    Unfortunately psycopg gets a timeout error, even w/ the wrong password...
+    def test_wrong_password(self, wrong_password_config):
+        """Test with wrong password."""
+        with pytest.raises(DBOSInitializationError) as exc_info:
+            db_wizard(wrong_password_config, "config.yaml")
+        assert "password authentication failed" in str(exc_info.value)
+    '''
+
+    def test_non_default_config_in_file(self, non_existent_db_config):
+        """Test when config file contains custom database settings."""
+        # Mock a config file with custom settings
+        mock_file_content = yaml.dump(
+            {
+                "name": "test-app",
+                "database": {
+                    "hostname": "custom-host-in-file",
+                    "port": 5433,
+                    "username": "custom-user-in-file",
+                },
+            }
+        )
+
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            # Should raise error because config file has custom database settings
+            with pytest.raises(DBOSInitializationError) as exc_info:
+                db_wizard(non_existent_db_config, "config.yaml")
+
+            # Verify error message
+            assert "Could not connect to the database" in str(exc_info.value)
+
+    def test_non_default_config_settings(self, non_default_config):
+        """Test with non-default database configuration."""
+        mock_file_content = yaml.dump(
+            {"name": "test-app"}
+        )  # no db config in config file
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            # Should raise error because config has non-default database settings
+            with pytest.raises(DBOSInitializationError) as exc_info:
+                db_wizard(non_default_config, "config.yaml")
+
+            # Verify error message
+            assert "Could not connect to the database" in str(exc_info.value)

--- a/tests/test_dbwizard.py
+++ b/tests/test_dbwizard.py
@@ -54,19 +54,6 @@ class TestDbWizardIntegration:
             },
         }
 
-    @pytest.fixture
-    def non_existent_db_config(self) -> ConfigFile:
-        """Configuration with correct credentials but non-existent database."""
-        return {
-            "name": "test-app",
-            "database": {
-                "hostname": "localhost",
-                "port": 5433,  # Wrong port
-                "username": "postgres",
-                "password": os.environ.get("PGPASSWORD", "dbos"),
-            },
-        }
-
     def test_successful_connection_postgres_db(
         self, standard_config: ConfigFile
     ) -> None:
@@ -82,30 +69,6 @@ class TestDbWizardIntegration:
             db_wizard(wrong_password_config, "config.yaml")
         assert "password authentication failed" in str(exc_info.value)
     '''
-
-    def test_non_default_config_in_file(
-        self, non_existent_db_config: ConfigFile
-    ) -> None:
-        """Test when config file contains custom database settings."""
-        # Mock a config file with custom settings
-        mock_file_content = yaml.dump(
-            {
-                "name": "test-app",
-                "database": {
-                    "hostname": "custom-host-in-file",
-                    "port": 5433,
-                    "username": "custom-user-in-file",
-                },
-            }
-        )
-
-        with patch("builtins.open", mock_open(read_data=mock_file_content)):
-            # Should raise error because config file has custom database settings
-            with pytest.raises(DBOSInitializationError) as exc_info:
-                db_wizard(non_existent_db_config, "config.yaml")
-
-            # Verify error message
-            assert "Could not connect to the database" in str(exc_info.value)
 
     def test_non_default_config_settings(self, non_default_config: ConfigFile) -> None:
         """Test with non-default database configuration."""

--- a/tests/test_dbwizard.py
+++ b/tests/test_dbwizard.py
@@ -58,7 +58,7 @@ class TestDbWizardIntegration:
         self, standard_config: ConfigFile
     ) -> None:
         """Test when connection to postgres database is successful."""
-        result = db_wizard(standard_config, "config.yaml")
+        result = db_wizard(standard_config)
         assert result == standard_config
 
     '''
@@ -78,7 +78,7 @@ class TestDbWizardIntegration:
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             # Should raise error because config has non-default database settings
             with pytest.raises(DBOSInitializationError) as exc_info:
-                db_wizard(non_default_config, "config.yaml")
+                db_wizard(non_default_config)
 
             # Verify error message
             assert "Could not connect to the database" in str(exc_info.value)

--- a/tests/test_dbwizard.py
+++ b/tests/test_dbwizard.py
@@ -4,7 +4,8 @@ from unittest.mock import mock_open, patch
 import pytest
 import yaml
 
-from dbos._dbos_config import ConfigFile, db_wizard
+from dbos._db_wizard import db_wizard
+from dbos._dbos_config import ConfigFile
 from dbos._error import DBOSInitializationError
 
 
@@ -66,7 +67,9 @@ class TestDbWizardIntegration:
             },
         }
 
-    def test_successful_connection_postgres_db(self, standard_config):
+    def test_successful_connection_postgres_db(
+        self, standard_config: ConfigFile
+    ) -> None:
         """Test when connection to postgres database is successful."""
         result = db_wizard(standard_config, "config.yaml")
         assert result == standard_config
@@ -80,7 +83,9 @@ class TestDbWizardIntegration:
         assert "password authentication failed" in str(exc_info.value)
     '''
 
-    def test_non_default_config_in_file(self, non_existent_db_config):
+    def test_non_default_config_in_file(
+        self, non_existent_db_config: ConfigFile
+    ) -> None:
         """Test when config file contains custom database settings."""
         # Mock a config file with custom settings
         mock_file_content = yaml.dump(
@@ -102,7 +107,7 @@ class TestDbWizardIntegration:
             # Verify error message
             assert "Could not connect to the database" in str(exc_info.value)
 
-    def test_non_default_config_settings(self, non_default_config):
+    def test_non_default_config_settings(self, non_default_config: ConfigFile) -> None:
         """Test with non-default database configuration."""
         mock_file_content = yaml.dump(
             {"name": "test-app"}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -101,7 +101,6 @@ def test_init_config() -> None:
         "language": "python",
         "runtimeConfig": {"start": ["fastapi run ./main.py"]},
         "database": {"migrate": ["echo 'No migrations specified'"]},
-        "telemetry": {"logs": {"logLevel": "INFO"}},
     }
     with tempfile.TemporaryDirectory() as temp_path:
         subprocess.check_call(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -101,8 +101,10 @@ def test_init_config() -> None:
         "language": "python",
         "runtimeConfig": {"start": ["fastapi run ./main.py"]},
         "database": {"migrate": ["echo 'No migrations specified'"]},
+        "database_url": "${DBOS_DATABASE_URL}",
     }
     with tempfile.TemporaryDirectory() as temp_path:
+
         subprocess.check_call(
             ["dbos", "init", app_name, "--config"],
             cwd=temp_path,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -436,7 +436,6 @@ def run_dbos_test_in_process(
         },
         "telemetry": {},
         "env": {},
-        "application": {},
     }
     dbos = DBOS(config=dbos_config)
     DBOS.launch()

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -168,10 +168,11 @@ def test_config_before_singleton(cleanup_test_databases: None) -> None:
         #    then imports more
         from tests.classdefs import DBOSTestClass
 
-        url = DBOS.config["application"]["service_url"]
-        assert url == "https://service.org"
-        port = DBOS.config["application"]["service_config"]["port"]
-        assert port == 80
+        port = DBOS.config["database"]["hostname"]
+        assert port == "localhost"
+
+        name = DBOS.config["name"]
+        assert name == "test-app"
 
         # This is OK, it meant load_config anyway
         dbos: DBOS = DBOS()


### PR DESCRIPTION
Introduce a new `DBOSConfig` struct with the minimum info needed by the library to run. This becomes the recommended & documented way to instantiate a DBOS object.

```python
class DBOSConfig(TypedDict):
    """
    Data structure containing the DBOS library configuration.
    Attributes:
        name (str): Application name
        database_url (str): Database connection string
        sys_db_name (str): System database name
        log_level (str): Log level
        otlp_traces_endpoints: List[str]: OTLP traces endpoints
    """

    name: str
    database_url: Optional[str]
    sys_db_name: Optional[str]
    log_level: Optional[str]
    otlp_traces_endpoints: Optional[List[str]]
    admin_port: Optional[int]
```

# How config used to work
- Either nothing was passed to the `DBOS` class, in which case `load_config()` was called
- Either a `ConfigFile` struct was passed, in which case `load_config()` was *not* called
- `set_env_vars()` was called on the config object

Load config does a few things:
- call `init_logger()`
- Load `dbos-config.yaml`
- Validate config schema, check on mandatory properties
- Generate an application DB name if not provided
- Set the final DB connection parameters, checking on multiple sources
- Configure the DBOS logger
- Potentially run the DB wizard

# What this PR does

## split `load_config()`
In two steps, a `dbos-config.yaml` loading step and a `process_config()` step. The loading step reads the file and validate it against the JSON schema. `process_config()` does everything `load_config()` used to do, except for running the DB wizard and handling the `local suffix`.

`process_config` is called within `load_config` by default - to preserve backward compatibility - but can be disabled using `run_process_config`.

## Config resolution

- DBOS.__new__ accepts a `Union[DBOSConfig, ConfigFile]`.
- DBOS.__init__ resolves the final configuration:
    - If nothing is provided `load_config` from `dbos-config.yaml`
    - If the existing `DBOSConfig` struct is provided, take it as is.
    - If the new `DBOSConfig` struct is provided, translate it to a `ConfigFile` with `translate_dbos_config_to_config_file`

## Config overwrite for DBOS Cloud deployments
In DBOS Cloud we want the config file -- manipulated by our hosting environment -- to take precedence over the provided object for a few settings. See `overwrite_config`

## Add `database_url` to `dbos-config.yaml `schema
If `database_url` is found during process_config, it will take precedence over connection information provided in the `database` field.

# How is this tested
- All existing tests pass, they:
    * Exercise case where nothing is given or a `ConfigFile` is given
    * Exercise new actions when `ConfigFile` is given (`init_logger()`, `process_config()`)
- New unit tests:
    - Internal methods `test_parse_db_string_to_dbconfig`, `parse_config`, `overwrite_config` are tested
    - Instantiation with new `DBOSConfig` is tested, with a variety of input situations
- Demo apps are being updated in a separate [PR](https://github.com/dbos-inc/dbos-demo-apps/pull/288)
- Cloud test: separate PR