### PR TITLE
Add connection timeout + fix scheduler not handling errors

### DIFF
--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -1,4 +1,5 @@
 import threading
+import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -26,19 +27,17 @@ def scheduler_loop(
             f'Cannot run scheduled function {func.__name__}. Invalid crontab "{cron}"'
         )
     while not stop_event.is_set():
-        dbos_logger.info("Scheduling workflow")
         nextExecTime = iter.get_next(datetime)
         sleepTime = nextExecTime - datetime.now(timezone.utc)
         if stop_event.wait(timeout=sleepTime.total_seconds()):
             return
-        dbos_logger.info("Scheduling workflow after sleep")
         with SetWorkflowID(f"sched-{func.__qualname__}-{nextExecTime.isoformat()}"):
             try:
                 scheduler_queue.enqueue(func, nextExecTime, datetime.now(timezone.utc))
-            except Exception as e:
-                dbos_logger.warning(f"Error scheduling workflow: ", e)
-        dbos_logger.info("Scheduling workflow done")
-    dbos_logger.info("Scheduling workflow exiting!!!!")
+            except Exception:
+                dbos_logger.warning(
+                    f"Exception encountered in scheduler thread: {traceback.format_exc()})"
+                )
 
 
 def scheduled(

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -26,15 +26,19 @@ def scheduler_loop(
             f'Cannot run scheduled function {func.__name__}. Invalid crontab "{cron}"'
         )
     while not stop_event.is_set():
+        dbos_logger.info("Scheduling workflow")
         nextExecTime = iter.get_next(datetime)
         sleepTime = nextExecTime - datetime.now(timezone.utc)
         if stop_event.wait(timeout=sleepTime.total_seconds()):
             return
+        dbos_logger.info("Scheduling workflow after sleep")
         with SetWorkflowID(f"sched-{func.__qualname__}-{nextExecTime.isoformat()}"):
             try:
                 scheduler_queue.enqueue(func, nextExecTime, datetime.now(timezone.utc))
             except Exception as e:
                 dbos_logger.warning(f"Error scheduling workflow: ", e)
+        dbos_logger.info("Scheduling workflow done")
+    dbos_logger.info("Scheduling workflow exiting!!!!")
 
 
 def scheduled(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -202,7 +202,11 @@ class SystemDatabase:
 
         # Create a connection pool for the system database
         self.engine = sa.create_engine(
-            system_db_url, pool_size=20, max_overflow=5, pool_timeout=30
+            system_db_url,
+            pool_size=20,
+            max_overflow=5,
+            pool_timeout=30,
+            connect_args={"connect_timeout": 10},
         )
 
         # Run a schema migration for the system database


### PR DESCRIPTION
This PR addresses the issues when the connection to the remote database becomes unstable (e.g., temporary disconnects, etc)
- Set connect timeout to 10 seconds, so the code is not waiting forever and will print error messages promptly
- Fix a logging statement that caused a `TypeError` that made the scheduler thread exit silently.