### PR TITLE
Fix FastAPI Debugging

### DIFF
--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -1,7 +1,10 @@
 import re
 import runpy
 import sys
+from pathlib import Path
 from typing import Union
+
+from fastapi_cli.discover import get_module_data_from_path
 
 from dbos import DBOS
 
@@ -33,7 +36,9 @@ def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> No
 def parse_start_command(command: str) -> Union[str, PythonModule]:
     match = re.match(r"fastapi\s+run\s+(\.?[\w/]+\.py)", command)
     if match:
-        return match.group(1)
+        mod_data = get_module_data_from_path(Path(match.group(1)))
+        sys.path.insert(0, str(mod_data.extra_sys_path))
+        return PythonModule(mod_data.module_import_str)
     match = re.match(r"python3?\s+(\.?[\w/]+\.py)", command)
     if match:
         return match.group(1)

--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -36,6 +36,7 @@ def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> No
 def parse_start_command(command: str) -> Union[str, PythonModule]:
     match = re.match(r"fastapi\s+run\s+(\.?[\w/]+\.py)", command)
     if match:
+        # Mirror the logic in fastapi's run command by converting the path argument to a module
         mod_data = get_module_data_from_path(Path(match.group(1)))
         sys.path.insert(0, str(mod_data.extra_sys_path))
         return PythonModule(mod_data.module_import_str)


### PR DESCRIPTION
The FastAPI run command takes a file path, but internally converts that path into a module. 

This PR updates the `fastapi run` branch of `parse_start_command` to use `get_module_data_from_path` from FastAPI to convert the file path argument to a module that can be loaded with `runpy.run_module`