### PR TITLE
Config pool sizes

### DIFF
--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -66,6 +66,11 @@ class ApplicationDatabase:
             pool_size=config["database"]["app_db_pool_size"],
             max_overflow=0,
             pool_timeout=30,
+            connect_args={
+                "connect_timeout": int(
+                    config["database"]["connectionTimeoutMillis"] / 1000
+                )
+            },
         )
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.debug_mode = debug_mode

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -67,8 +67,7 @@ class ApplicationDatabase:
             t = cast(
                 int, config["database"]["connectionTimeoutMillis"]
             )  # mypy still thinks its an int | None
-            timeout = int(t / 1000)
-            connect_args["connect_timeout"] = timeout
+            connect_args["connect_timeout"] = int(t / 1000)
 
         self.engine = sa.create_engine(
             app_db_url,

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -1,11 +1,11 @@
-from typing import Optional, TypedDict, cast
+from typing import Optional, TypedDict
 
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
-from ._dbos_config import ConfigFile
+from ._dbos_config import ConfigFile, DatabaseConfig
 from ._error import DBOSWorkflowConflictIDError
 from ._schemas.application_database import ApplicationSchema
 
@@ -63,11 +63,13 @@ class ApplicationDatabase:
         )
 
         connect_args = {}
-        if config["database"].get("connectionTimeoutMillis") is not None:
-            t = cast(
-                int, config["database"]["connectionTimeoutMillis"]
-            )  # mypy still thinks its an int | None
-            connect_args["connect_timeout"] = int(t / 1000)
+        if (
+            "connectionTimeoutMillis" in config["database"]
+            and config["database"]["connectionTimeoutMillis"]
+        ):
+            connect_args["connect_timeout"] = int(
+                config["database"]["connectionTimeoutMillis"] / 1000
+            )
 
         self.engine = sa.create_engine(
             app_db_url,

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -62,7 +62,10 @@ class ApplicationDatabase:
             database=app_db_name,
         )
         self.engine = sa.create_engine(
-            app_db_url, pool_size=20, max_overflow=5, pool_timeout=30
+            app_db_url,
+            pool_size=config["database"]["app_db_pool_size"],
+            max_overflow=0,
+            pool_timeout=30,
         )
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.debug_mode = debug_mode

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -457,10 +457,10 @@ class DBOS:
             admin_port = self.config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001
-            disable_admin_server = self.config.get("runtimeConfig", {}).get(
-                "disable_admin_server"
+            run_admin_server = self.config.get("runtimeConfig", {}).get(
+                "run_admin_server"
             )
-            if not disable_admin_server:
+            if run_admin_server:
                 try:
                     self._admin_server_field = AdminServer(dbos=self, port=admin_port)
                 except Exception as e:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -457,7 +457,11 @@ class DBOS:
             admin_port = self.config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001
-            self._admin_server_field = AdminServer(dbos=self, port=admin_port)
+            disable_admin_server = self.config.get("runtimeConfig", {}).get(
+                "disable_admin_server"
+            )
+            if not disable_admin_server:
+                self._admin_server_field = AdminServer(dbos=self, port=admin_port)
 
             workflow_ids = self._sys_db.get_pending_workflows(
                 GlobalParams.executor_id, GlobalParams.app_version

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -461,7 +461,10 @@ class DBOS:
                 "disable_admin_server"
             )
             if not disable_admin_server:
-                self._admin_server_field = AdminServer(dbos=self, port=admin_port)
+                try:
+                    self._admin_server_field = AdminServer(dbos=self, port=admin_port)
+                except Exception as e:
+                    dbos_logger.error(f"Failed to start admin server: {e}")
 
             workflow_ids = self._sys_db.get_pending_workflows(
                 GlobalParams.executor_id, GlobalParams.app_version

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -464,7 +464,7 @@ class DBOS:
                 try:
                     self._admin_server_field = AdminServer(dbos=self, port=admin_port)
                 except Exception as e:
-                    dbos_logger.error(f"Failed to start admin server: {e}")
+                    dbos_logger.warning(f"Failed to start admin server: {e}")
 
             workflow_ids = self._sys_db.get_pending_workflows(
                 GlobalParams.executor_id, GlobalParams.app_version

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -400,6 +400,8 @@ def process_config(
         data["database"]["app_db_pool_size"] = 20
     if not data["database"].get("sys_db_pool_size"):
         data["database"]["sys_db_pool_size"] = 20
+    if not data["database"].get("connectionTimeoutMillis"):
+        data["database"]["connectionTimeoutMillis"] = 10000
 
     # Check the connectivity to the database and make sure it's properly configured
     # Note, never use db wizard if the DBOS is running in debug mode (i.e. DBOS_DEBUG_WORKFLOW_ID env var is set)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -29,9 +29,13 @@ class DBOSConfig(TypedDict):
     Attributes:
         name (str): Application name
         database_url (str): Database connection string
+        app_db_pool_size (int): Application database pool size
         sys_db_name (str): System database name
+        sys_db_pool_size (int): System database pool size
         log_level (str): Log level
         otlp_traces_endpoints: List[str]: OTLP traces endpoints
+        admin_port (int): Admin port
+        disable_admin_server (bool): Disable admin server
     """
 
     name: str

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -22,7 +22,7 @@ from ._logger import dbos_logger
 DBOS_CONFIG_PATH = "dbos-config.yaml"
 
 
-class DBOSConfig(TypedDict):
+class DBOSConfig(TypedDict, total=False):
     """
     Data structure containing the DBOS library configuration.
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -180,7 +180,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     # Runtime config
     runtimeConfig: RuntimeConfig = {}
     if "admin_port" in config:
-        runtimeConfig = {"admin_port": config["admin_port"]}
+        runtimeConfig["admin_port"] = config["admin_port"]
     if "disable_admin_server" in config:
         runtimeConfig["disable_admin_server"] = config["disable_admin_server"]
     if runtimeConfig:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -289,6 +289,13 @@ def process_config(
             f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters long and contain only lowercase letters, numbers, dashes, and underscores.'
         )
 
+    if not data.get("telemetry"):
+        data["telemetry"] = {}
+    if not data["telemetry"].get("logs"):
+        data["telemetry"]["logs"] = {}
+    if not data["telemetry"].get("logs"):
+        data["telemetry"]["logs"]["logLevel"] = "INFO"
+
     if "database" not in data:
         data["database"] = {}
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -36,7 +36,9 @@ class DBOSConfig(TypedDict):
 
     name: str
     database_url: Optional[str]
+    app_db_pool_size: Optional[int]
     sys_db_name: Optional[str]
+    sys_db_pool_size: Optional[int]
     log_level: Optional[str]
     otlp_traces_endpoints: Optional[List[str]]
     admin_port: Optional[int]
@@ -55,7 +57,9 @@ class DatabaseConfig(TypedDict, total=False):
     password: str
     connectionTimeoutMillis: Optional[int]
     app_db_name: str
+    app_db_pool_size: Optional[int]
     sys_db_name: Optional[str]
+    sys_db_pool_size: Optional[int]
     ssl: Optional[bool]
     ssl_ca: Optional[str]
     local_suffix: Optional[bool]
@@ -160,6 +164,10 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         db_config = parse_database_url_to_dbconfig(database_url)
     if "sys_db_name" in config:
         db_config["sys_db_name"] = config.get("sys_db_name")
+    if "app_db_pool_size" in config:
+        db_config["app_db_pool_size"] = config.get("app_db_pool_size")
+    if "sys_db_pool_size" in config:
+        db_config["sys_db_pool_size"] = config.get("sys_db_pool_size")
     if db_config:
         translated_config["database"] = db_config
 
@@ -385,6 +393,11 @@ def process_config(
     if dbos_dblocalsuffix is not None:
         local_suffix = dbos_dblocalsuffix
     data["database"]["local_suffix"] = local_suffix
+
+    if not data["database"].get("app_db_pool_size"):
+        data["database"]["app_db_pool_size"] = 20
+    if not data["database"].get("sys_db_pool_size"):
+        data["database"]["sys_db_pool_size"] = 20
 
     # Check the connectivity to the database and make sure it's properly configured
     # Note, never use db wizard if the DBOS is running in debug mode (i.e. DBOS_DEBUG_WORKFLOW_ID env var is set)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -297,12 +297,14 @@ def process_config(
             f'Invalid app name {data["name"]}.  App names must be between 3 and 30 characters long and contain only lowercase letters, numbers, dashes, and underscores.'
         )
 
-    if not data.get("telemetry"):
+    if data.get("telemetry") is None:
         data["telemetry"] = {}
-    if not data["telemetry"].get("logs"):
-        data["telemetry"]["logs"] = {}
-    if not data["telemetry"].get("logs"):
-        data["telemetry"]["logs"]["logLevel"] = "INFO"
+    telemetry = cast(TelemetryConfig, data["telemetry"])
+    if telemetry.get("logs") is None:
+        telemetry["logs"] = {}
+    logs = cast(LoggerConfig, telemetry["logs"])
+    if logs.get("logLevel") is None:
+        logs["logLevel"] = "INFO"
 
     if "database" not in data:
         data["database"] = {}

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -203,8 +203,8 @@ class SystemDatabase:
         # Create a connection pool for the system database
         self.engine = sa.create_engine(
             system_db_url,
-            pool_size=20,
-            max_overflow=5,
+            pool_size=config["database"]["sys_db_pool_size"],
+            max_overflow=0,
             pool_timeout=30,
             connect_args={"connect_timeout": 10},
         )

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -181,7 +181,7 @@ def test_disable_admin_server(cleanup_test_databases: None) -> None:
 
     config: DBOSConfig = {
         "name": "test-app",
-        "disable_admin_server": True,
+        "run_admin_server": False,
     }  # type: ignore
     try:
         DBOS(config=config)

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import threading
 import time
 import uuid
@@ -191,6 +192,56 @@ def test_disable_admin_server(cleanup_test_databases: None) -> None:
     finally:
         # Clean up after the test
         DBOS.destroy()
+
+
+def test_busy_admin_server_port_does_not_throw() -> None:
+    # Initialize singleton
+    DBOS.destroy()  # In case of other tests leaving it
+
+    config: DBOSConfig = {
+        "name": "test-app",
+    }  # type: ignore
+    server_thread = None
+    stop_event = threading.Event()
+    try:
+
+        def start_dummy_server(port: int, stop_event: threading.Event) -> None:
+            """Starts a simple TCP server on the given port."""
+            server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server_socket.bind(("0.0.0.0", port))
+            server_socket.listen(1)
+            # We need to call accept for the port to be considered busy by the OS...
+            while not stop_event.is_set():
+                try:
+                    server_socket.settimeout(
+                        1
+                    )  # Timeout for accept in case the thread is stopped.
+                    client_socket, _ = server_socket.accept()
+                    client_socket.close()
+                except socket.timeout:
+                    pass
+            server_socket.close()
+
+        port_to_block = 3001
+        server_thread = threading.Thread(
+            target=start_dummy_server, args=(port_to_block, stop_event)
+        )
+        server_thread.daemon = (
+            True  # Allows the thread to be terminated when the main thread exits
+        )
+        server_thread.start()
+
+        DBOS(config=config)
+        DBOS.launch()
+    finally:
+        # Clean up after the test
+        DBOS.destroy()
+        if server_thread and server_thread.is_alive():
+            stop_event.set()
+            server_thread.join(2)
+            if server_thread.is_alive():
+                print("Warning: Server thread did not terminate gracefully.")
 
 
 def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -182,7 +182,7 @@ def test_disable_admin_server(cleanup_test_databases: None) -> None:
     config: DBOSConfig = {
         "name": "test-app",
         "run_admin_server": False,
-    }  # type: ignore
+    }
     try:
         DBOS(config=config)
         DBOS.launch()
@@ -200,7 +200,7 @@ def test_busy_admin_server_port_does_not_throw() -> None:
 
     config: DBOSConfig = {
         "name": "test-app",
-    }  # type: ignore
+    }
     server_thread = None
     stop_event = threading.Event()
     try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 import os
 from unittest.mock import mock_open
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -432,6 +432,7 @@ def test_process_config_load_defaults():
     assert processed_config["database"]["password"] == os.environ.get(
         "PGPASSWORD", "dbos"
     )
+    assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
 
 
 def test_process_config_load_default_with_None_database_url():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import os
 from unittest.mock import mock_open
 


### PR DESCRIPTION
- allow app and system db pool size configuration, set defaults to `20` in process_config
- disable overflow connections in  db pools (app and system)
- ensure user-provided `connect_timeout` is used in app db pool. Set to 10s if none provided.
- allow disabling admin server
- do not crash if admin server cannot be started -- log an error and continue
- default logging level to `INFO`