### PR TITLE
Test + Improve Step Retries

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -824,7 +824,9 @@ def decorate_step(
             stepOutcome = Outcome[R].make(functools.partial(func, *args, **kwargs))
             if retries_allowed:
                 stepOutcome = stepOutcome.retry(
-                    max_attempts, on_exception, lambda i: DBOSMaxStepRetriesExceeded()
+                    max_attempts,
+                    on_exception,
+                    lambda i: DBOSMaxStepRetriesExceeded(func.__name__, i),
                 )
 
             outcome = (

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -130,6 +130,10 @@ class DBOSMaxStepRetriesExceeded(DBOSException):
             dbos_error_code=DBOSErrorCode.MaxStepRetriesExceeded.value,
         )
 
+    # Tell pickle to reconstruct the exception without calling its constructor
+    def __reduce__(self):
+        return (self.__class__, ())
+
 
 class DBOSWorkflowCancelledError(DBOSException):
     """Exception raised when the workflow has already been cancelled."""

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -1,7 +1,7 @@
 """Errors thrown by DBOS."""
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 
 class DBOSException(Exception):
@@ -124,7 +124,7 @@ class DBOSNotAuthorizedError(DBOSException):
 class DBOSMaxStepRetriesExceeded(DBOSException):
     """Exception raised when a step was retried the maximimum number of times without success."""
 
-    def __init__(self, step_name: str, max_retries: str) -> None:
+    def __init__(self, step_name: str, max_retries: int) -> None:
         self.step_name = step_name
         self.max_retries = max_retries
         super().__init__(
@@ -132,7 +132,7 @@ class DBOSMaxStepRetriesExceeded(DBOSException):
             dbos_error_code=DBOSErrorCode.MaxStepRetriesExceeded.value,
         )
 
-    def __reduce__(self):
+    def __reduce__(self) -> Any:
         # Tell jsonpickle how to reconstruct this object
         return (self.__class__, (self.step_name, self.max_retries))
 

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -124,15 +124,17 @@ class DBOSNotAuthorizedError(DBOSException):
 class DBOSMaxStepRetriesExceeded(DBOSException):
     """Exception raised when a step was retried the maximimum number of times without success."""
 
-    def __init__(self) -> None:
+    def __init__(self, step_name: str, max_retries: str) -> None:
+        self.step_name = step_name
+        self.max_retries = max_retries
         super().__init__(
-            "Step reached maximum retries.",
+            f"Step {step_name} has exceeded its maximum of {max_retries} retries",
             dbos_error_code=DBOSErrorCode.MaxStepRetriesExceeded.value,
         )
 
-    # Tell pickle to reconstruct the exception without calling its constructor
     def __reduce__(self):
-        return (self.__class__, ())
+        # Tell jsonpickle how to reconstruct this object
+        return (self.__class__, (self.step_name, self.max_retries))
 
 
 class DBOSWorkflowCancelledError(DBOSException):

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -8,10 +8,15 @@ import sqlalchemy as sa
 from psycopg.errors import SerializationFailure
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
-# Public API
-from dbos import DBOS, GetWorkflowsInput, SetWorkflowID
-from dbos._error import DBOSDeadLetterQueueError, DBOSException
+from dbos import DBOS, GetWorkflowsInput, Queue, SetWorkflowID
+from dbos._error import (
+    DBOSDeadLetterQueueError,
+    DBOSException,
+    DBOSMaxStepRetriesExceeded,
+)
 from dbos._sys_db import WorkflowStatusString
+
+from .conftest import queue_entries_are_cleaned_up
 
 
 def test_transaction_errors(dbos: DBOS) -> None:
@@ -258,3 +263,56 @@ def test_wfstatus_invalid(dbos: DBOS) -> None:
         with SetWorkflowID(wfuuid):
             non_deterministic_worklow()
     assert "Hint: Check if your workflow is deterministic." in str(exc_info.value)
+
+
+def test_step_retries(dbos: DBOS) -> None:
+    step_counter = 0
+
+    queue = Queue("test-queue")
+
+    @DBOS.step(retries_allowed=True, interval_seconds=0, max_attempts=2)
+    def failing_step():
+        nonlocal step_counter
+        step_counter += 1
+        raise Exception("fail")
+
+    @DBOS.workflow()
+    def failing_workflow():
+        failing_step()
+
+    @DBOS.workflow()
+    def enqueue_failing_step():
+        queue.enqueue(failing_step).get_result()
+
+    # Test calling the step directly
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
+        failing_step()
+    assert step_counter == 2
+
+    # Test calling the workflow
+    step_counter = 0
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
+        failing_workflow()
+    assert step_counter == 2
+
+    # Test enqueueing the step
+    step_counter = 0
+    handle = queue.enqueue(failing_step)
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
+        handle.get_result()
+    assert step_counter == 2
+
+    # Test enqueuing the workflow
+    step_counter = 0
+    handle = queue.enqueue(failing_workflow)
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
+        handle.get_result()
+    assert step_counter == 2
+
+    # Test enqueuing the step from a workflow
+    step_counter = 0
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
+        enqueue_failing_step()
+    assert step_counter == 2
+
+    assert queue_entries_are_cleaned_up(dbos)

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -272,17 +272,17 @@ def test_step_retries(dbos: DBOS) -> None:
     max_attempts = 2
 
     @DBOS.step(retries_allowed=True, interval_seconds=0, max_attempts=max_attempts)
-    def failing_step():
+    def failing_step() -> None:
         nonlocal step_counter
         step_counter += 1
         raise Exception("fail")
 
     @DBOS.workflow()
-    def failing_workflow():
+    def failing_workflow() -> None:
         failing_step()
 
     @DBOS.workflow()
-    def enqueue_failing_step():
+    def enqueue_failing_step() -> None:
         queue.enqueue(failing_step).get_result()
 
     error_message = f"Step {failing_step.__name__} has exceeded its maximum of {max_attempts} retries"


### PR DESCRIPTION
Improve the error message returned when a step exceeds maximum retries, test it rigorously, and fix an issue where the exception object did not properly deserialize (because of how jsonpickle/pickle special-cases exception serialization).