### PR TITLE
Unpin FastAPI CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "fastapi[standard]>=0.115.2",
     "tomlkit>=0.13.2",
     "psycopg[binary]>=3.1", # Keep compatibility with 3.1--older Python installations/machines can't always install 3.2
-    "fastapi-cli>=0.0.5",
     "docker>=7.1.0",
     "cryptography>=43.0.3",
     "rich>=13.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi[standard]>=0.115.2",
     "tomlkit>=0.13.2",
     "psycopg[binary]>=3.1", # Keep compatibility with 3.1--older Python installations/machines can't always install 3.2
-    "fastapi-cli==0.0.5",
+    "fastapi-cli>=0.0.5",
     "docker>=7.1.0",
     "cryptography>=43.0.3",
     "rich>=13.9.4",


### PR DESCRIPTION
Unpin the FastAPI CLI as a logging bug in 0.0.6 was fixed in 0.0.7.