### PR TITLE
Allow multiple logs and traces endpoints in the python DBOSConfig.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -53,7 +53,7 @@ jobs:
           --health-retries 5
       # Kafka service container
       kafka:
-        image: bitnami/kafka
+        image: bitnami/kafka:3.9.0
         ports:
           - 9092:9092
         options: >-

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -191,9 +191,11 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         ]
 
     # Telemetry config
-    telemetry = {
+    telemetry: TelemetryConfig = {
         "OTLPExporter": {"mergedTracesEndpoints": [], "mergedLogsEndpoints": []}
     }
+    assert telemetry["OTLPExporter"] is not None, "This is to make mypy happy"
+
     # Add OTLPExporter if traces endpoints exist
     otlp_trace_endpoints = config.get("otlp_traces_endpoints")
     if isinstance(otlp_trace_endpoints, list) and len(otlp_trace_endpoints) > 0:
@@ -208,7 +210,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     if log_level:
         telemetry["logs"] = {"logLevel": log_level}
     if telemetry:
-        translated_config["telemetry"] = cast(TelemetryConfig, telemetry)
+        translated_config["telemetry"] = telemetry
 
     return translated_config
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -192,7 +192,8 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     telemetry: TelemetryConfig = {
         "OTLPExporter": {"tracesEndpoint": [], "logsEndpoint": []}
     }
-    assert telemetry["OTLPExporter"] is not None, "This is to make mypy happy"
+    # For mypy
+    assert telemetry["OTLPExporter"] is not None
 
     # Add OTLPExporter if traces endpoints exist
     otlp_trace_endpoints = config.get("otlp_traces_endpoints")

--- a/dbos/_logger.py
+++ b/dbos/_logger.py
@@ -57,7 +57,7 @@ def config_logger(config: "ConfigFile") -> None:
 
     # Log to the OTLP endpoint if provided
     otlp_logs_endpoints = (
-        config.get("telemetry", {}).get("OTLPExporter", {}).get("mergedLogsEndpoints")  # type: ignore
+        config.get("telemetry", {}).get("OTLPExporter", {}).get("logsEndpoint")  # type: ignore
     )
     if otlp_logs_endpoints:
         log_provider = PatchedOTLPLoggerProvider(

--- a/dbos/_logger.py
+++ b/dbos/_logger.py
@@ -56,10 +56,10 @@ def config_logger(config: "ConfigFile") -> None:
         dbos_logger.setLevel(log_level)
 
     # Log to the OTLP endpoint if provided
-    otlp_logs_endpoint = (
-        config.get("telemetry", {}).get("OTLPExporter", {}).get("logsEndpoint")  # type: ignore
+    otlp_logs_endpoints = (
+        config.get("telemetry", {}).get("OTLPExporter", {}).get("mergedLogsEndpoints")  # type: ignore
     )
-    if otlp_logs_endpoint:
+    if otlp_logs_endpoints:
         log_provider = PatchedOTLPLoggerProvider(
             Resource.create(
                 attributes={
@@ -68,12 +68,13 @@ def config_logger(config: "ConfigFile") -> None:
             )
         )
         set_logger_provider(log_provider)
-        log_provider.add_log_record_processor(
-            BatchLogRecordProcessor(
-                OTLPLogExporter(endpoint=otlp_logs_endpoint),
-                export_timeout_millis=5000,
+        for e in otlp_logs_endpoints:
+            log_provider.add_log_record_processor(
+                BatchLogRecordProcessor(
+                    OTLPLogExporter(endpoint=e),
+                    export_timeout_millis=5000,
+                )
             )
-        )
         global _otlp_handler
         _otlp_handler = LoggingHandler(logger_provider=log_provider)
 

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -28,13 +28,11 @@ class DBOSTracer:
                 processor = BatchSpanProcessor(ConsoleSpanExporter())
                 provider.add_span_processor(processor)
             otlp_traces_endpoints = (
-                config.get("telemetry", {}).get("OTLPExporter", {}).get("mergedTracesEndpoints")  # type: ignore
+                config.get("telemetry", {}).get("OTLPExporter", {}).get("tracesEndpoint")  # type: ignore
             )
             if otlp_traces_endpoints:
                 for e in otlp_traces_endpoints:
-                    processor = BatchSpanProcessor(
-                        OTLPSpanExporter(endpoint = e)
-                    )
+                    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=e))
                     provider.add_span_processor(processor)
             trace.set_tracer_provider(provider)
 

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -27,14 +27,15 @@ class DBOSTracer:
             if os.environ.get("DBOS__CONSOLE_TRACES", None) is not None:
                 processor = BatchSpanProcessor(ConsoleSpanExporter())
                 provider.add_span_processor(processor)
-            otlp_traces_endpoint = (
-                config.get("telemetry", {}).get("OTLPExporter", {}).get("tracesEndpoint")  # type: ignore
+            otlp_traces_endpoints = (
+                config.get("telemetry", {}).get("OTLPExporter", {}).get("mergedTracesEndpoints")  # type: ignore
             )
-            if otlp_traces_endpoint:
-                processor = BatchSpanProcessor(
-                    OTLPSpanExporter(endpoint=otlp_traces_endpoint)
-                )
-                provider.add_span_processor(processor)
+            if otlp_traces_endpoints:
+                for e in otlp_traces_endpoints:
+                    processor = BatchSpanProcessor(
+                        OTLPSpanExporter(endpoint = e)
+                    )
+                    provider.add_span_processor(processor)
             trace.set_tracer_provider(provider)
 
     def set_provider(self, provider: Optional[TracerProvider]) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,6 +155,10 @@ def test_load_valid_config_file(mocker):
             bazbaz: BAZBAZ
             bob: ${BOBBOB}
             test_number: 123
+        telemetry:
+            OTLPExporter:
+                logsEndpoint: 'fooLogs'
+                tracesEndpoint: 'fooTraces'
     """
     os.environ["BARBAR"] = "FOOFOO"
     mocker.patch(
@@ -179,6 +183,9 @@ def test_load_valid_config_file(mocker):
     assert os.environ["foo"] == "FOOFOO"
     assert os.environ["test_number"] == "123"
     assert "bob" not in os.environ
+
+    assert configFile["telemetry"]["OTLPExporter"]["logsEndpoint"] == ["fooLogs"]
+    assert configFile["telemetry"]["OTLPExporter"]["tracesEndpoint"] == ["fooTraces"]
 
 
 def test_load_config_database_url(mocker):
@@ -335,8 +342,8 @@ def test_process_config_full():
                 "logLevel": "DEBUG",
             },
             "OTLPExporter": {
-                "logsEndpoint": "thelogsendpoint",
-                "tracesEndpoint": "thetracesendpoint",
+                "logsEndpoint": ["thelogsendpoint"],
+                "tracesEndpoint": ["thetracesendpoint"],
             },
         },
         "env": {
@@ -365,10 +372,12 @@ def test_process_config_full():
     assert configFile["runtimeConfig"]["run_admin_server"] == False
     assert configFile["runtimeConfig"]["setup"] == ["echo 'hello'"]
     assert configFile["telemetry"]["logs"]["logLevel"] == "DEBUG"
-    assert configFile["telemetry"]["OTLPExporter"]["logsEndpoint"] == "thelogsendpoint"
-    assert (
-        configFile["telemetry"]["OTLPExporter"]["tracesEndpoint"] == "thetracesendpoint"
-    )
+    assert configFile["telemetry"]["OTLPExporter"]["logsEndpoint"] == [
+        "thelogsendpoint"
+    ]
+    assert configFile["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
+        "thetracesendpoint"
+    ]
     assert configFile["env"]["FOO"] == "BAR"
 
 
@@ -806,11 +815,11 @@ def test_translate_dbosconfig_full_input():
     assert translated_config["database"]["sys_db_pool_size"] == 27
     assert "database_url" not in translated_config
     assert translated_config["telemetry"]["logs"]["logLevel"] == "DEBUG"
-    assert translated_config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"] == [
+    assert translated_config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
         "http://otel:7777",
         "notused",
     ]
-    assert "logsEndpoint" not in translated_config["telemetry"]["OTLPExporter"]
+    assert translated_config["telemetry"]["OTLPExporter"]["logsEndpoint"] == []
     assert translated_config["runtimeConfig"]["admin_port"] == 8001
     assert translated_config["runtimeConfig"]["run_admin_server"] == False
     assert "start" not in translated_config["runtimeConfig"]
@@ -908,13 +917,8 @@ def test_translate_empty_otlp_traces_endpoints():
         "otlp_traces_endpoints": [],
     }
     translated_config = translate_dbos_config_to_config_file(config)
-    assert (
-        len(translated_config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"]) == 0
-    )
-    assert (
-        len(translated_config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"])
-        == 0
-    )
+    assert len(translated_config["telemetry"]["OTLPExporter"]["logsEndpoint"]) == 0
+    assert len(translated_config["telemetry"]["OTLPExporter"]["tracesEndpoint"]) == 0
     assert translated_config["telemetry"]["logs"]["logLevel"] == "INFO"
 
 
@@ -926,13 +930,8 @@ def test_translate_ignores_otlp_traces_not_list():
     }
     translated_config = translate_dbos_config_to_config_file(config)
     assert translated_config["name"] == "test-app"
-    assert (
-        len(translated_config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"]) == 0
-    )
-    assert (
-        len(translated_config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"])
-        == 0
-    )
+    assert len(translated_config["telemetry"]["OTLPExporter"]["logsEndpoint"]) == 0
+    assert len(translated_config["telemetry"]["OTLPExporter"]["tracesEndpoint"]) == 0
 
 
 def test_translate_missing_name():
@@ -995,8 +994,8 @@ def test_overwrite_config(mocker):
         },
         "telemetry": {
             "OTLPExporter": {
-                "mergedTracesEndpoints": ["a"],
-                "mergedLogsEndpoints": ["b"],
+                "tracesEndpoint": ["a"],
+                "logsEndpoint": ["b"],
             },
             "logs": {
                 "logLevel": "DEBUG",
@@ -1025,11 +1024,11 @@ def test_overwrite_config(mocker):
     assert config["database"]["app_db_pool_size"] == 10
     assert "sys_db_pool_size" not in config["database"]
     assert config["telemetry"]["logs"]["logLevel"] == "DEBUG"
-    assert config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"] == [
+    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
         "a",
         "thetracesendpoint",
     ]
-    assert config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"] == [
+    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == [
         "b",
         "thelogsendpoint",
     ]
@@ -1081,12 +1080,10 @@ def test_overwrite_config_minimal(mocker):
     assert config["database"]["sys_db_name"] == "sysdbname"
     assert config["database"]["ssl"] == True
     assert config["database"]["ssl_ca"] == "cert.pem"
-    assert config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"] == [
+    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
         "thetracesendpoint"
     ]
-    assert config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"] == [
-        "thelogsendpoint"
-    ]
+    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == ["thelogsendpoint"]
     assert "runtimeConfig" not in config
     assert "env" not in config
 
@@ -1142,12 +1139,10 @@ def test_overwrite_config_has_telemetry(mocker):
     assert config["database"]["sys_db_name"] == "sysdbname"
     assert config["database"]["ssl"] == True
     assert config["database"]["ssl_ca"] == "cert.pem"
-    assert config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"] == [
+    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
         "thetracesendpoint"
     ]
-    assert config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"] == [
-        "thelogsendpoint"
-    ]
+    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == ["thelogsendpoint"]
     assert config["telemetry"]["logs"]["logLevel"] == "DEBUG"
     assert "runtimeConfig" not in config
     assert "env" not in config
@@ -1188,8 +1183,8 @@ def test_overwrite_config_no_telemetry_in_file(mocker):
     # Test that telemetry from provided_config is preserved
     assert config["telemetry"]["logs"]["logLevel"] == "DEBUG"
     assert config["telemetry"]["OTLPExporter"] == {
-        "mergedTracesEndpoints": [],
-        "mergedLogsEndpoints": [],
+        "tracesEndpoint": [],
+        "logsEndpoint": [],
     }
 
 
@@ -1226,16 +1221,16 @@ def test_overwrite_config_no_otlp_in_file(mocker):
         },
         "telemetry": {
             "OTLPExporter": {
-                "tracesEndpoint": "original-trace",
-                "logsEndpoint": "original-log",
+                "tracesEndpoint": ["original-trace"],
+                "logsEndpoint": ["original-log"],
             }
         },
     }
 
     config = overwrite_config(provided_config)
     # Test that OTLPExporter from provided_config is preserved
-    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == "original-trace"
-    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == "original-log"
+    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == ["original-trace"]
+    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == ["original-log"]
     assert "logs" not in config["telemetry"]
 
 
@@ -1284,12 +1279,10 @@ def test_overwrite_config_with_provided_database_url(mocker):
     assert config["database"]["sys_db_name"] == "sysdbname"
     assert config["database"]["ssl"] == True
     assert config["database"]["ssl_ca"] == "cert.pem"
-    assert config["telemetry"]["OTLPExporter"]["mergedTracesEndpoints"] == [
+    assert config["telemetry"]["OTLPExporter"]["tracesEndpoint"] == [
         "thetracesendpoint"
     ]
-    assert config["telemetry"]["OTLPExporter"]["mergedLogsEndpoints"] == [
-        "thelogsendpoint"
-    ]
+    assert config["telemetry"]["OTLPExporter"]["logsEndpoint"] == ["thelogsendpoint"]
     assert "runtimeConfig" not in config
     assert "env" not in config
 


### PR DESCRIPTION
The app can now export to a list of different logs and traces endpoints. When dbos-config.yaml also has otel endpoints, they are combined together. But the file may only have one set.

With this PR, Datadog instructions look like this:
https://docs.google.com/document/d/1p_hc2LSS3a_MLb51k4YcRKozPjqGap3MM5zmEpSc9Lk/edit?tab=t.0