### PR TITLE
Step ID

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -982,6 +982,15 @@ class DBOS:
         return ctx.workflow_id
 
     @classproperty
+    def step_id(cls) -> str:
+        """Return the step ID for the current context. This is a unique identifier of the current step within the workflow."""
+        ctx = assert_current_dbos_context()
+        assert (
+            ctx.is_within_workflow()
+        ), "step_id is only available within a DBOS workflow."
+        return ctx.function_id
+
+    @classproperty
     def parent_workflow_id(cls) -> str:
         """
         Return the workflow ID for the parent workflow.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -982,7 +982,7 @@ class DBOS:
         return ctx.workflow_id
 
     @classproperty
-    def step_id(cls) -> str:
+    def step_id(cls) -> int:
         """Return the step ID for the current context. This is a unique identifier of the current step within the workflow."""
         ctx = assert_current_dbos_context()
         assert (

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -38,6 +38,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     @DBOS.transaction(isolation_level="REPEATABLE READ")
     def test_transaction(var2: str) -> str:
+        assert DBOS.step_id == 1
         rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
         nonlocal txn_counter
         txn_counter += 1
@@ -46,6 +47,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     @DBOS.step()
     def test_step(var: str) -> str:
+        assert DBOS.step_id == 2
         nonlocal step_counter
         step_counter += 1
         DBOS.logger.info("I'm test_step")


### PR DESCRIPTION
This PR adds a `DBOS.step_id` variable to the public API.  This variable is a unique identifier of the current step (or transaction) within a workflow.

For example:

```python
@DBOS.workflow()
def workflow():
  step_one()
  step_two()

@DBOS.step()
def step_one():
  print(DBOS.step_id) # Will be 1
  
@DBOS.step()
def step_two():
  print(DBOS.step_id) # Will be 2
```