### PR TITLE
Handle KeyboardInterrupts During Retries

### DIFF
--- a/dbos/__main__.py
+++ b/dbos/__main__.py
@@ -4,6 +4,9 @@ from typing import NoReturn, Optional, Union
 
 from dbos.cli.cli import app
 
+# This is used by the debugger to execute DBOS as a module.
+# Never used otherwise.
+
 
 def main() -> NoReturn:
     # Modify sys.argv[0] to remove script or executable extensions

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -903,13 +903,13 @@ def decorate_step(
 
                 try:
                     output = func()
-                    step_output["output"] = _serialization.serialize(output)
-                    dbos._sys_db.record_operation_result(step_output)
-                    return output
                 except Exception as error:
                     step_output["error"] = _serialization.serialize_exception(error)
                     dbos._sys_db.record_operation_result(step_output)
                     raise
+                step_output["output"] = _serialization.serialize(output)
+                dbos._sys_db.record_operation_result(step_output)
+                return output
 
             def check_existing_result() -> Union[NoResult, R]:
                 ctx = assert_current_dbos_context()

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -904,12 +904,12 @@ def decorate_step(
                 try:
                     output = func()
                     step_output["output"] = _serialization.serialize(output)
+                    dbos._sys_db.record_operation_result(step_output)
                     return output
                 except Exception as error:
                     step_output["error"] = _serialization.serialize_exception(error)
-                    raise
-                finally:
                     dbos._sys_db.record_operation_result(step_output)
+                    raise
 
             def check_existing_result() -> Union[NoResult, R]:
                 ctx = assert_current_dbos_context()

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -982,6 +982,15 @@ class DBOS:
         return ctx.workflow_id
 
     @classproperty
+    def step_id(cls) -> str:
+        """Return the step ID for the current context. This is a unique identifier of the current step within the workflow."""
+        ctx = assert_current_dbos_context()
+        assert (
+            ctx.is_within_workflow()
+        ), "step_id is only available within a DBOS workflow."
+        return ctx.function_id
+
+    @classproperty
     def parent_workflow_id(cls) -> str:
         """
         Return the workflow ID for the parent workflow.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -982,7 +982,7 @@ class DBOS:
         return ctx.workflow_id
 
     @classproperty
-    def step_id(cls) -> str:
+    def step_id(cls) -> int:
         """Return the step ID for the current context. This is a unique identifier of the current step within the workflow."""
         ctx = assert_current_dbos_context()
         assert (

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -38,6 +38,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     @DBOS.transaction(isolation_level="REPEATABLE READ")
     def test_transaction(var2: str) -> str:
+        assert DBOS.step_id == 1
         rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
         nonlocal txn_counter
         txn_counter += 1
@@ -46,6 +47,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
 
     @DBOS.step()
     def test_step(var: str) -> str:
+        assert DBOS.step_id == 2
         nonlocal step_counter
         step_counter += 1
         DBOS.logger.info("I'm test_step")

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -370,10 +370,11 @@ def test_keyboardinterrupt_during_retries(dbos: DBOS) -> None:
     @DBOS.workflow()
     def failing_workflow() -> None:
         failing_step()
+        return DBOS.workflow_id
 
     with pytest.raises(KeyboardInterrupt):
         failing_workflow()
     raise_interrupt = False
     recovery_handles = DBOS.recover_pending_workflows()
     assert len(recovery_handles) == 1
-    assert recovery_handles[0].get_result() is None
+    assert recovery_handles[0].get_result() == recovery_handles[0].workflow_id


### PR DESCRIPTION
Properly handle `KeyboardInterrupt` while retrying a step and add tests for the exception. Fixes https://github.com/dbos-inc/dbos-transact-py/issues/260