### PR TITLE
Explicit DBOS Launch in Template

### DIFF
--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -68,6 +68,8 @@ class LifespanMiddleware:
                     and not self.dbos._launched
                 ):
                     self.dbos._launch()
+                elif message["type"] == "lifespan.shutdown.complete":
+                    self.dbos._destroy()
                 await send(message)
 
             # Call the original app with our wrapped functions

--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -63,10 +63,11 @@ class LifespanMiddleware:
         if scope["type"] == "lifespan":
 
             async def wrapped_send(message: MutableMapping[str, Any]) -> None:
-                if message["type"] == "lifespan.startup.complete":
+                if (
+                    message["type"] == "lifespan.startup.complete"
+                    and not self.dbos._launched
+                ):
                     self.dbos._launch()
-                elif message["type"] == "lifespan.shutdown.complete":
-                    self.dbos._destroy()
                 await send(message)
 
             # Call the original app with our wrapped functions

--- a/dbos/_templates/dbos-db-starter/__package/main.py
+++ b/dbos/_templates/dbos-db-starter/__package/main.py
@@ -6,6 +6,7 @@
 
 # First, let's do imports, create a FastAPI app, and initialize DBOS.
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 
@@ -37,7 +38,7 @@ def example_transaction(name: str) -> str:
     return greeting
 
 
-# Finally, let's use FastAPI to serve an HTML + CSS readme
+# Now, let's use FastAPI to serve an HTML + CSS readme
 # from the root path.
 
 
@@ -66,14 +67,8 @@ def readme() -> HTMLResponse:
     return HTMLResponse(readme)
 
 
-# To deploy this app to DBOS Cloud:
-# - "npm i -g @dbos-inc/dbos-cloud@latest" to install the Cloud CLI (requires Node)
-# - "dbos-cloud app deploy" to deploy your app
-# - Deploy outputs a URL--visit it to see your app!
+# Finally, we'll launch DBOS then start the FastAPI server.
 
-
-# To run this app locally:
-# - Make sure you have a Postgres database to connect to
-# - "dbos migrate" to set up your database tables
-# - "dbos start" to start the app
-# - Visit localhost:8000 to see your app!
+if __name__ == "__main__":
+    DBOS.launch()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
+++ b/dbos/_templates/dbos-db-starter/dbos-config.yaml.dbos
@@ -7,8 +7,6 @@ name: ${project_name}
 language: python
 runtimeConfig:
   start:
-    - "fastapi run ${package_name}/main.py"
+    - "${start_command}"
 database_url: ${DBOS_DATABASE_URL}
-database:
-  migrate:
-    - ${migration_command}
+${migration_section}

--- a/dbos/cli/_template_init.py
+++ b/dbos/cli/_template_init.py
@@ -58,15 +58,20 @@ def copy_template(src_dir: str, project_name: str, config_mode: bool) -> None:
     dst_dir = path.abspath(".")
 
     package_name = project_name.replace("-", "_")
+    default_migration_section = """database:
+  migrate:
+    - alembic upgrade head
+"""
     ctx = {
         "project_name": project_name,
         "package_name": package_name,
-        "migration_command": "alembic upgrade head",
+        "start_command": f"python3 -m {package_name}.main",
+        "migration_section": default_migration_section,
     }
 
     if config_mode:
-        ctx["package_name"] = "."
-        ctx["migration_command"] = "echo 'No migrations specified'"
+        ctx["start_command"] = "python3 main.py"
+        ctx["migration_section"] = ""
         _copy_dbos_template(
             os.path.join(src_dir, "dbos-config.yaml.dbos"),
             os.path.join(dst_dir, "dbos-config.yaml"),

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -99,8 +99,7 @@ def test_init_config() -> None:
     expected_yaml = {
         "name": app_name,
         "language": "python",
-        "runtimeConfig": {"start": ["fastapi run ./main.py"]},
-        "database": {"migrate": ["echo 'No migrations specified'"]},
+        "runtimeConfig": {"start": ["python3 main.py"]},
         "database_url": "${DBOS_DATABASE_URL}",
     }
     with tempfile.TemporaryDirectory() as temp_path:


### PR DESCRIPTION
- Change the template to explicitly launch DBOS then start the FastAPI (uvicorn) server. I think a pattern of always explicitly launching DBOS in the templates will make the mechanics of DBOS clearer to new users.
- The FastAPI lifecycle handler will now launch DBOS only if it isn't already launched. That way you don't get the multiple-launches warning.
- Simplify the files in the template, don't show a migration command if none is needed.