### PR TITLE
Improved Introspection

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -1,10 +1,11 @@
 from . import _error as error
 from ._context import DBOSContextEnsure, DBOSContextSetAuth, SetWorkflowID
-from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowStatus
+from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle
 from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url, load_config
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatusString
+from ._workflow_commands import WorkflowStatus
 
 __all__ = [
     "ConfigFile",

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -203,7 +203,7 @@ class ConductorWebsocket(threading.Thread):
                                 info = get_workflow(
                                     self.dbos._sys_db,
                                     get_workflow_message.workflow_id,
-                                    getRequest=False,
+                                    get_request=False,
                                 )
                             except Exception as e:
                                 error_message = f"Exception encountered when getting workflow {get_workflow_message.workflow_id}: {traceback.format_exc()}"

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import List, Optional, Type, TypedDict, TypeVar
 
-from dbos._workflow_commands import WorkflowInformation
+from dbos._workflow_commands import WorkflowStatus
 
 
 class MessageType(str, Enum):
@@ -141,7 +141,7 @@ class WorkflowsOutput:
     ExecutorID: Optional[str]
 
     @classmethod
-    def from_workflow_information(cls, info: WorkflowInformation) -> "WorkflowsOutput":
+    def from_workflow_information(cls, info: WorkflowStatus) -> "WorkflowsOutput":
         # Convert fields to strings as needed
         created_at_str = str(info.created_at) if info.created_at is not None else None
         updated_at_str = str(info.updated_at) if info.updated_at is not None else None

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -149,6 +149,11 @@ class WorkflowsOutput:
         outputs_str = str(info.output) if info.output is not None else None
         error_str = str(info.error) if info.error is not None else None
         request_str = str(info.request) if info.request is not None else None
+        roles_str = (
+            str(info.authenticated_roles)
+            if info.authenticated_roles is not None
+            else None
+        )
 
         return cls(
             WorkflowUUID=info.workflow_id,
@@ -158,7 +163,7 @@ class WorkflowsOutput:
             WorkflowConfigName=info.config_name,
             AuthenticatedUser=info.authenticated_user,
             AssumedRole=info.assumed_role,
-            AuthenticatedRoles=str(info.authenticated_roles),
+            AuthenticatedRoles=roles_str,
             Input=inputs_str,
             Output=outputs_str,
             Request=request_str,

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -152,9 +152,9 @@ class WorkflowsOutput:
         return cls(
             WorkflowUUID=info.workflow_id,
             Status=info.status,
-            WorkflowName=info.workflow_name,
-            WorkflowClassName=info.workflow_class_name,
-            WorkflowConfigName=info.workflow_config_name,
+            WorkflowName=info.name,
+            WorkflowClassName=info.class_name,
+            WorkflowConfigName=info.config_name,
             AuthenticatedUser=info.authenticated_user,
             AssumedRole=info.assumed_role,
             AuthenticatedRoles=info.authenticated_roles,

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -157,7 +157,7 @@ class WorkflowsOutput:
             WorkflowConfigName=info.config_name,
             AuthenticatedUser=info.authenticated_user,
             AssumedRole=info.assumed_role,
-            AuthenticatedRoles=info.authenticated_roles,
+            AuthenticatedRoles=str(info.authenticated_roles),
             Input=inputs_str,
             Output=outputs_str,
             Request=request_str,

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -147,6 +147,7 @@ class WorkflowsOutput:
         updated_at_str = str(info.updated_at) if info.updated_at is not None else None
         inputs_str = str(info.input) if info.input is not None else None
         outputs_str = str(info.output) if info.output is not None else None
+        error_str = str(info.error) if info.error is not None else None
         request_str = str(info.request) if info.request is not None else None
 
         return cls(
@@ -161,7 +162,7 @@ class WorkflowsOutput:
             Input=inputs_str,
             Output=outputs_str,
             Request=request_str,
-            Error=info.error,
+            Error=error_str,
             CreatedAt=created_at_str,
             UpdatedAt=updated_at_str,
             QueueName=info.queue_name,

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -458,12 +458,11 @@ class EnterDBOSStepRetry:
         self.current_attempt = current_attempt
         self.max_attempts = max_attempts
 
-    def __enter__(self) -> DBOSContext:
+    def __enter__(self) -> None:
         ctx = get_local_dbos_context()
         if ctx is not None and ctx.step_status is not None:
             ctx.step_status.current_attempt = self.current_attempt
             ctx.step_status.max_attempts = self.max_attempts
-        return ctx
 
     def __exit__(
         self,

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -459,11 +459,10 @@ class EnterDBOSStepRetry:
         self.max_attempts = max_attempts
 
     def __enter__(self) -> DBOSContext:
-        ctx = assert_current_dbos_context()
-        assert ctx.is_step()
-        assert ctx.step_status is not None
-        ctx.step_status.current_attempt = self.current_attempt
-        ctx.step_status.max_attempts = self.max_attempts
+        ctx = get_local_dbos_context()
+        if ctx is not None and ctx.step_status is not None:
+            ctx.step_status.current_attempt = self.current_attempt
+            ctx.step_status.max_attempts = self.max_attempts
         return ctx
 
     def __exit__(
@@ -472,11 +471,10 @@ class EnterDBOSStepRetry:
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[False]:
-        ctx = assert_current_dbos_context()
-        assert ctx.is_step()
-        assert ctx.step_status is not None
-        ctx.step_status.current_attempt = None
-        ctx.step_status.max_attempts = None
+        ctx = get_local_dbos_context()
+        if ctx is not None and ctx.step_status is not None:
+            ctx.step_status.current_attempt = None
+            ctx.step_status.max_attempts = None
         return False  # Did not handle
 
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -56,8 +56,8 @@ class StepStatus:
 
     Attributes:
         step_id: The unique ID of this step in its workflow.
-        current_attempt: For steps with automatic retry configuration, indicates which attempt number (zero-indexed) is currently executing.
-        max_attempts: For steps with automatic retry configuration, the maximum number of attempts that will be made before the step fails.
+        current_attempt: For steps with automatic retries, which attempt number (zero-indexed) is currently executing.
+        max_attempts: For steps with automatic retries, the maximum number of attempts that will be made before the step fails.
 
     """
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -56,7 +56,7 @@ class StepStatus:
 
     Attributes:
         step_id: The unique ID of this step in its workflow.
-        current_attempt: For steps with automatic retry configuration, indicates which attempt number is currently executing.
+        current_attempt: For steps with automatic retry configuration, indicates which attempt number (zero-indexed) is currently executing.
         max_attempts: For steps with automatic retry configuration, the maximum number of attempts that will be made before the step fails.
 
     """

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -602,9 +602,6 @@ async def start_workflow_async(
             or wf_status == WorkflowStatusString.SUCCESS.value
         )
     ):
-        dbos.logger.debug(
-            f"Workflow {new_wf_id} already completed with status {wf_status}. Directly returning a workflow handle."
-        )
         return WorkflowHandleAsyncPolling(new_wf_id, dbos)
 
     coro = _execute_workflow_async(dbos, status, func, new_wf_ctx, *args, **kwargs)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -946,7 +946,7 @@ def decorate_step(
 
             def on_exception(attempt: int, error: BaseException) -> float:
                 dbos.logger.warning(
-                    f"Step being automatically retried. (attempt {attempt} of {attempts}). {traceback.format_exc()}"
+                    f"Step being automatically retried. (attempt {attempt + 1} of {attempts}). {traceback.format_exc()}"
                 )
                 ctx = assert_current_dbos_context()
                 ctx.get_current_span().add_event(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -515,9 +515,6 @@ def start_workflow(
             or wf_status == WorkflowStatusString.SUCCESS.value
         )
     ):
-        dbos.logger.debug(
-            f"Workflow {new_wf_id} already completed with status {wf_status}. Directly returning a workflow handle."
-        )
         return WorkflowHandlePolling(new_wf_id, dbos)
 
     future = dbos._executor.submit(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -84,10 +84,10 @@ if TYPE_CHECKING:
         Workflow,
         WorkflowHandle,
         WorkflowHandleAsync,
-        WorkflowStatus,
         DBOSRegistry,
         IsolationLevel,
     )
+    from ._workflow_commands import WorkflowStatus
 
 from sqlalchemy.exc import DBAPIError, InvalidRequestError
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -86,6 +86,7 @@ from ._admin_server import AdminServer
 from ._app_db import ApplicationDatabase
 from ._context import (
     EnterDBOSStep,
+    StepStatus,
     TracedAttributes,
     assert_current_dbos_context,
     get_local_dbos_context,
@@ -1042,6 +1043,14 @@ class DBOS:
         return ctx.function_id
 
     @classproperty
+    def step_status(cls) -> StepStatus:
+        """Return the status of the currently executing step."""
+        ctx = assert_current_dbos_context()
+        assert ctx.is_step(), "step_status is only available within a DBOS step."
+        assert ctx.step_status is not None
+        return ctx.step_status
+
+    @classproperty
     def parent_workflow_id(cls) -> str:
         """
         Return the workflow ID for the parent workflow.
@@ -1128,23 +1137,6 @@ class WorkflowStatus:
     assumed_role: Optional[str]
     authenticated_roles: Optional[List[str]]
     recovery_attempts: Optional[int]
-
-
-@dataclass
-class StepStatus:
-    """
-    Status of a step execution.
-
-    Attributes:
-        step_id: The unique ID of this step in its workflow.
-        current_attempt: For steps with automatic retry configuration, indicates which attempt number is currently executing.
-        max_attempts: For steps with automatic retry configuration, the maximum number of attempts that will be made before the step fails.
-
-    """
-
-    step_id: int
-    current_attempt: Optional[int]
-    max_attempts: Optional[int]
 
 
 class WorkflowHandle(Generic[R], Protocol):

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1130,6 +1130,23 @@ class WorkflowStatus:
     recovery_attempts: Optional[int]
 
 
+@dataclass
+class StepStatus:
+    """
+    Status of a step execution.
+
+    Attributes:
+        step_id: The unique ID of this step in its workflow.
+        current_attempt: For steps with automatic retry configuration, indicates which attempt number is currently executing.
+        max_attempts: For steps with automatic retry configuration, the maximum number of attempts that will be made before the step fails.
+
+    """
+
+    step_id: int
+    current_attempt: Optional[int]
+    max_attempts: Optional[int]
+
+
 class WorkflowHandle(Generic[R], Protocol):
     """
     Handle to a workflow function.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -11,7 +11,6 @@ import threading
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 from logging import Logger
 from typing import (
     TYPE_CHECKING,
@@ -28,15 +27,15 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload,
 )
 
 from opentelemetry.trace import Span
 
+from dbos import _serialization
 from dbos._conductor.conductor import ConductorWebsocket
 from dbos._utils import GlobalParams
 from dbos._workflow_commands import (
-    WorkflowInformation,
+    WorkflowStatus,
     list_queued_workflows,
     list_workflows,
 )
@@ -114,6 +113,7 @@ from ._error import (
 )
 from ._logger import add_otlp_to_all_loggers, config_logger, dbos_logger, init_logger
 from ._sys_db import SystemDatabase
+from ._workflow_commands import WorkflowStatus, get_workflow
 
 # Most DBOS functions are just any callable F, so decorators / wrappers work on F
 # There are cases where the parameters P and return value R should be separate
@@ -735,72 +735,39 @@ class DBOS:
     @classmethod
     def get_workflow_status(cls, workflow_id: str) -> Optional[WorkflowStatus]:
         """Return the status of a workflow execution."""
+        sys_db = _get_dbos_instance()._sys_db
         ctx = get_local_dbos_context()
         if ctx and ctx.is_within_workflow():
             ctx.function_id += 1
-            stat = _get_dbos_instance()._sys_db.get_workflow_status_within_wf(
-                workflow_id, ctx.workflow_id, ctx.function_id
-            )
-        else:
-            stat = _get_dbos_instance()._sys_db.get_workflow_status(workflow_id)
-        if stat is None:
-            return None
+            res = sys_db.check_operation_execution(ctx.workflow_id, ctx.function_id)
+            if res is not None:
+                if res["output"]:
+                    resstat: WorkflowStatus = _serialization.deserialize(res["output"])
+                    return resstat
+                else:
+                    raise DBOSException(
+                        "Workflow status record not found. This should not happen! \033[1m Hint: Check if your workflow is deterministic.\033[0m"
+                    )
+        stat = get_workflow(_get_dbos_instance()._sys_db, workflow_id, True)
 
-        return WorkflowStatus(
-            workflow_id=workflow_id,
-            status=stat["status"],
-            name=stat["name"],
-            executor_id=stat["executor_id"],
-            recovery_attempts=stat["recovery_attempts"],
-            class_name=stat["class_name"],
-            config_name=stat["config_name"],
-            queue_name=stat["queue_name"],
-            authenticated_user=stat["authenticated_user"],
-            assumed_role=stat["assumed_role"],
-            authenticated_roles=(
-                json.loads(stat["authenticated_roles"])
-                if stat["authenticated_roles"] is not None
-                else None
-            ),
-        )
+        if ctx and ctx.is_within_workflow():
+            sys_db.record_operation_result(
+                {
+                    "workflow_uuid": ctx.workflow_id,
+                    "function_id": ctx.function_id,
+                    "function_name": "DBOS.getStatus",
+                    "output": _serialization.serialize(stat),
+                    "error": None,
+                }
+            )
+        return stat
 
     @classmethod
     async def get_workflow_status_async(
         cls, workflow_id: str
     ) -> Optional[WorkflowStatus]:
         """Return the status of a workflow execution."""
-        ctx = get_local_dbos_context()
-        if ctx and ctx.is_within_workflow():
-            ctx.function_id += 1
-            stat = await asyncio.to_thread(
-                lambda: _get_dbos_instance()._sys_db.get_workflow_status_within_wf(
-                    workflow_id, ctx.workflow_id, ctx.function_id
-                )
-            )
-        else:
-            stat = await asyncio.to_thread(
-                lambda: _get_dbos_instance()._sys_db.get_workflow_status(workflow_id)
-            )
-        if stat is None:
-            return None
-
-        return WorkflowStatus(
-            workflow_id=workflow_id,
-            status=stat["status"],
-            name=stat["name"],
-            executor_id=stat["executor_id"],
-            recovery_attempts=stat["recovery_attempts"],
-            class_name=stat["class_name"],
-            config_name=stat["config_name"],
-            queue_name=stat["queue_name"],
-            authenticated_user=stat["authenticated_user"],
-            assumed_role=stat["assumed_role"],
-            authenticated_roles=(
-                json.loads(stat["authenticated_roles"])
-                if stat["authenticated_roles"] is not None
-                else None
-            ),
-        )
+        return await asyncio.to_thread(cls.get_workflow_status, workflow_id)
 
     @classmethod
     def retrieve_workflow(
@@ -1014,7 +981,7 @@ class DBOS:
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         sort_desc: bool = False,
-    ) -> List[WorkflowInformation]:
+    ) -> List[WorkflowStatus]:
         return list_workflows(
             _get_dbos_instance()._sys_db,
             workflow_ids=workflow_ids,
@@ -1041,7 +1008,7 @@ class DBOS:
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         sort_desc: bool = False,
-    ) -> List[WorkflowInformation]:
+    ) -> List[WorkflowStatus]:
         return list_queued_workflows(
             _get_dbos_instance()._sys_db,
             queue_name=queue_name,
@@ -1161,41 +1128,6 @@ class DBOS:
         ctx = assert_current_dbos_context()
         ctx.authenticated_user = authenticated_user
         ctx.authenticated_roles = authenticated_roles
-
-
-@dataclass
-class WorkflowStatus:
-    """
-    Status of workflow execution.
-
-    This captures the state of a workflow execution at a point in time.
-
-    Attributes:
-        workflow_id(str):  The ID of the workflow execution
-        status(str):  The status of the execution, from `WorkflowStatusString`
-        name(str): The workflow function name
-        executor_id(str): The ID of the executor running the workflow
-        class_name(str): For member functions, the name of the class containing the workflow function
-        config_name(str): For instance member functions, the name of the class instance for the execution
-        queue_name(str): For workflows that are or were queued, the queue name
-        authenticated_user(str): The user who invoked the workflow
-        assumed_role(str): The access role used by the user to allow access to the workflow function
-        authenticated_roles(List[str]): List of all access roles available to the authenticated user
-        recovery_attempts(int): Number of times the workflow has been restarted (usually by recovery)
-
-    """
-
-    workflow_id: str
-    status: str
-    name: str
-    executor_id: Optional[str]
-    class_name: Optional[str]
-    config_name: Optional[str]
-    queue_name: Optional[str]
-    authenticated_user: Optional[str]
-    assumed_role: Optional[str]
-    authenticated_roles: Optional[List[str]]
-    recovery_attempts: Optional[int]
 
 
 class WorkflowHandle(Generic[R], Protocol):

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -35,7 +35,11 @@ from opentelemetry.trace import Span
 
 from dbos._conductor.conductor import ConductorWebsocket
 from dbos._utils import GlobalParams
-from dbos._workflow_commands import WorkflowInformation, list_workflows
+from dbos._workflow_commands import (
+    WorkflowInformation,
+    list_queued_workflows,
+    list_workflows,
+)
 
 from ._classproperty import classproperty
 from ._core import (
@@ -1020,6 +1024,31 @@ class DBOS:
             name=name,
             app_version=app_version,
             user=user,
+            limit=limit,
+            offset=offset,
+            sort_desc=sort_desc,
+        )
+
+    @classmethod
+    def list_queued_workflows(
+        cls,
+        *,
+        queue_name: Optional[str] = None,
+        status: Optional[str] = None,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        name: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort_desc: bool = False,
+    ) -> List[WorkflowInformation]:
+        return list_queued_workflows(
+            _get_dbos_instance()._sys_db,
+            queue_name=queue_name,
+            status=status,
+            start_time=start_time,
+            end_time=end_time,
+            name=name,
             limit=limit,
             offset=offset,
             sort_desc=sort_desc,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -35,6 +35,7 @@ from opentelemetry.trace import Span
 
 from dbos._conductor.conductor import ConductorWebsocket
 from dbos._utils import GlobalParams
+from dbos._workflow_commands import WorkflowInformation, list_workflows
 
 from ._classproperty import classproperty
 from ._core import (
@@ -994,6 +995,34 @@ class DBOS:
         _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
         _get_or_create_dbos_registry().clear_workflow_cancelled(workflow_id)
         return execute_workflow_by_id(_get_dbos_instance(), workflow_id, False)
+
+    def list_workflows(
+        cls,
+        *,
+        workflow_ids: Optional[List[str]] = None,
+        status: Optional[str] = None,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        name: Optional[str] = None,
+        app_version: Optional[str] = None,
+        user: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort_desc: bool = False,
+    ) -> List[WorkflowInformation]:
+        return list_workflows(
+            _get_dbos_instance()._sys_db,
+            workflow_ids=workflow_ids,
+            status=status,
+            start_time=start_time,
+            end_time=end_time,
+            name=name,
+            app_version=app_version,
+            user=user,
+            limit=limit,
+            offset=offset,
+            sort_desc=sort_desc,
+        )
 
     @classproperty
     def logger(cls) -> Logger:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -996,6 +996,7 @@ class DBOS:
         _get_or_create_dbos_registry().clear_workflow_cancelled(workflow_id)
         return execute_workflow_by_id(_get_dbos_instance(), workflow_id, False)
 
+    @classmethod
     def list_workflows(
         cls,
         *,

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -4,6 +4,8 @@ import inspect
 import time
 from typing import Any, Callable, Coroutine, Optional, Protocol, TypeVar, Union, cast
 
+from dbos._context import EnterDBOSStepRetry
+
 T = TypeVar("T")
 R = TypeVar("R")
 
@@ -98,7 +100,8 @@ class Immediate(Outcome[T]):
     ) -> T:
         for i in range(attempts):
             try:
-                return func()
+                with EnterDBOSStepRetry(i, attempts):
+                    return func()
             except Exception as exp:
                 wait_time = on_exception(i, exp)
                 time.sleep(wait_time)
@@ -184,7 +187,8 @@ class Pending(Outcome[T]):
     ) -> T:
         for i in range(attempts):
             try:
-                return await func()
+                with EnterDBOSStepRetry(i, attempts):
+                    return await func()
             except Exception as exp:
                 wait_time = on_exception(i, exp)
                 await asyncio.sleep(wait_time)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -541,32 +541,6 @@ class SystemDatabase:
             }
             return status
 
-    def get_workflow_status_within_wf(
-        self, workflow_uuid: str, calling_wf: str, calling_wf_fn: int
-    ) -> Optional[WorkflowStatusInternal]:
-        res = self.check_operation_execution(calling_wf, calling_wf_fn)
-        if res is not None:
-            if res["output"]:
-                resstat: WorkflowStatusInternal = _serialization.deserialize(
-                    res["output"]
-                )
-                return resstat
-            else:
-                raise DBOSException(
-                    "Workflow status record not found. This should not happen! \033[1m Hint: Check if your workflow is deterministic.\033[0m"
-                )
-        stat = self.get_workflow_status(workflow_uuid)
-        self.record_operation_result(
-            {
-                "workflow_uuid": calling_wf,
-                "function_id": calling_wf_fn,
-                "function_name": "DBOS.getStatus",
-                "output": _serialization.serialize(stat),
-                "error": None,
-            }
-        )
-        return stat
-
     def await_workflow_result_internal(self, workflow_uuid: str) -> dict[str, Any]:
         polling_interval_secs: float = 1.000
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -116,7 +116,7 @@ class GetWorkflowsInput:
         self.authenticated_user: Optional[str] = None  # The user who ran the workflow.
         self.start_time: Optional[str] = None  # Timestamp in ISO 8601 format
         self.end_time: Optional[str] = None  # Timestamp in ISO 8601 format
-        self.status: Optional[WorkflowStatuses] = None
+        self.status: Optional[str] = None
         self.application_version: Optional[str] = (
             None  # The application version that ran this workflow. = None
         )

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -122,52 +122,51 @@ def list_queued_workflows(
 
 
 def get_workflow(
-    sys_db: SystemDatabase, workflowUUID: str, getRequest: bool
+    sys_db: SystemDatabase, workflow_id: str, get_request: bool
 ) -> Optional[WorkflowInformation]:
 
-    info = sys_db.get_workflow_status(workflowUUID)
-    if info is None:
+    internal_status = sys_db.get_workflow_status(workflow_id)
+    if internal_status is None:
         return None
 
-    winfo = WorkflowInformation()
+    info = WorkflowInformation()
 
-    winfo.workflow_id = workflowUUID
-    winfo.status = info["status"]
-    winfo.name = info["name"]
-    winfo.class_name = info["class_name"]
-    winfo.config_name = info["config_name"]
-    winfo.authenticated_user = info["authenticated_user"]
-    winfo.assumed_role = info["assumed_role"]
-    winfo.authenticated_roles = info["authenticated_roles"]
-    winfo.request = info["request"]
-    winfo.created_at = info["created_at"]
-    winfo.updated_at = info["updated_at"]
-    winfo.queue_name = info["queue_name"]
-    winfo.executor_id = info["executor_id"]
-    winfo.app_version = info["app_version"]
-    winfo.app_id = info["app_id"]
-    winfo.recovery_attempts = info["recovery_attempts"]
+    info.workflow_id = workflow_id
+    info.status = internal_status["status"]
+    info.name = internal_status["name"]
+    info.class_name = internal_status["class_name"]
+    info.config_name = internal_status["config_name"]
+    info.authenticated_user = internal_status["authenticated_user"]
+    info.assumed_role = internal_status["assumed_role"]
+    info.authenticated_roles = internal_status["authenticated_roles"]
+    info.request = internal_status["request"]
+    info.created_at = internal_status["created_at"]
+    info.updated_at = internal_status["updated_at"]
+    info.queue_name = internal_status["queue_name"]
+    info.executor_id = internal_status["executor_id"]
+    info.app_version = internal_status["app_version"]
+    info.app_id = internal_status["app_id"]
+    info.recovery_attempts = internal_status["recovery_attempts"]
 
-    # no input field
-    input_data = sys_db.get_workflow_inputs(workflowUUID)
+    input_data = sys_db.get_workflow_inputs(workflow_id)
     if input_data is not None:
-        winfo.input = input_data
+        info.input = input_data
 
-    if info.get("status") == "SUCCESS":
-        result = sys_db.await_workflow_result(workflowUUID)
-        winfo.output = result
-    elif info.get("status") == "ERROR":
+    if internal_status.get("status") == "SUCCESS":
+        result = sys_db.await_workflow_result(workflow_id)
+        info.output = result
+    elif internal_status.get("status") == "ERROR":
         try:
-            sys_db.await_workflow_result(workflowUUID)
+            sys_db.await_workflow_result(workflow_id)
         except Exception as e:
-            winfo.error = str(e)
+            info.error = str(e)
 
-    if not getRequest:
-        winfo.request = None
+    if not get_request:
+        info.request = None
 
-    return winfo
+    return info
 
 
-def list_workflow_steps(sys_db: SystemDatabase, workflow_uuid: str) -> List[StepInfo]:
-    output = sys_db.get_workflow_steps(workflow_uuid)
+def list_workflow_steps(sys_db: SystemDatabase, workflow_id: str) -> List[StepInfo]:
+    output = sys_db.get_workflow_steps(workflow_id)
     return output

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -92,15 +92,15 @@ def list_workflows(
 def list_queued_workflows(
     sys_db: SystemDatabase,
     *,
-    limit: Optional[int] = None,
-    start_time: Optional[str] = None,
-    end_time: Optional[str] = None,
     queue_name: Optional[str] = None,
     status: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
     name: Optional[str] = None,
-    request: bool = False,
+    limit: Optional[int] = None,
     offset: Optional[int] = None,
     sort_desc: bool = False,
+    request: bool = False,
 ) -> List[WorkflowInformation]:
     input: GetQueuedWorkflowsInput = {
         "queue_name": queue_name,

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, cast
 
 from . import _serialization
@@ -27,7 +28,7 @@ class WorkflowStatus:
     # The role with which the workflow ran, if specified
     assumed_role: Optional[str]
     # All roles which the authenticated user could assume
-    authenticated_roles: Optional[str]
+    authenticated_roles: Optional[list[str]]
     # The deserialized workflow input object
     input: Optional[_serialization.WorkflowInputs]
     # The workflow's output, if any, serialized to JSON
@@ -138,7 +139,11 @@ def get_workflow(
     info.config_name = internal_status["config_name"]
     info.authenticated_user = internal_status["authenticated_user"]
     info.assumed_role = internal_status["assumed_role"]
-    info.authenticated_roles = internal_status["authenticated_roles"]
+    info.authenticated_roles = (
+        json.loads(internal_status["authenticated_roles"])
+        if internal_status["authenticated_roles"] is not None
+        else None
+    )
     info.request = internal_status["request"]
     info.created_at = internal_status["created_at"]
     info.updated_at = internal_status["updated_at"]

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -8,7 +8,6 @@ from ._sys_db import (
     GetWorkflowsOutput,
     StepInfo,
     SystemDatabase,
-    WorkflowStatuses,
 )
 
 

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -56,16 +56,16 @@ def list_workflows(
     sys_db: SystemDatabase,
     *,
     workflow_ids: Optional[List[str]] = None,
-    user: Optional[str] = None,
+    status: Optional[str] = None,
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
-    status: Optional[str] = None,
-    request: bool = False,
-    app_version: Optional[str] = None,
     name: Optional[str] = None,
+    app_version: Optional[str] = None,
+    user: Optional[str] = None,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
     sort_desc: bool = False,
+    request: bool = False,
 ) -> List[WorkflowInformation]:
     input = GetWorkflowsInput()
     input.workflow_ids = workflow_ids

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -12,25 +12,44 @@ from ._sys_db import (
 
 
 class WorkflowInformation:
+    # The workflow ID
     workflow_id: str
-    status: WorkflowStatuses
+    # The workflow status. Must be one of ENQUEUED, PENDING, SUCCESS, ERROR, CANCELLED, or RETRIES_EXCEEDED
+    status: str
+    # The name of the workflow function
     workflow_name: str
+    # The name of the workflow's class, if any
     workflow_class_name: Optional[str]
+    # The name with which the workflow's class instance was configured, if any
     workflow_config_name: Optional[str]
+    # The user who ran the workflow, if specified
     authenticated_user: Optional[str]
+    # The role with which the workflow ran, if specified
     assumed_role: Optional[str]
-    authenticated_roles: Optional[str]  # JSON list of roles.
-    input: Optional[_serialization.WorkflowInputs]  # JSON (jsonpickle)
-    output: Optional[str] = None  # JSON (jsonpickle)
-    request: Optional[str]  # JSON (jsonpickle)
-    error: Optional[str] = None  # JSON (jsonpickle)
-    created_at: Optional[int]  # Unix epoch timestamp in ms
-    updated_at: Optional[int]  # Unix epoch timestamp in ms
+    # All roles which the authenticated user could assume
+    authenticated_roles: Optional[str]
+    # The deserialized workflow input object
+    input: Optional[_serialization.WorkflowInputs]
+    # The workflow's output, if any, serialized to JSON
+    output: Optional[str] = None
+    # The error the workflow threw, if any, serialized to JSON
+    error: Optional[str] = None
+    # Workflow start time, as a Unix epoch timestamp in ms
+    created_at: Optional[int]
+    # Last time the workflow status was updated, as a Unix epoch timestamp in ms
+    updated_at: Optional[int]
+    # If this workflow was enqueued, on which queue
     queue_name: Optional[str]
+    # The executor to most recently executed this workflow
     executor_id: Optional[str]
+    # The application version on which this workflow was started
     app_version: Optional[str]
+    # The ID of the application executing this workflow
     app_id: Optional[str]
+    # The number of times this workflow's execution has been attempted
     recovery_attempts: Optional[int]
+    # The HTTP request that triggered the workflow, if known
+    request: Optional[str]
 
 
 def list_workflows(

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -31,9 +31,9 @@ class WorkflowStatus:
     # The deserialized workflow input object
     input: Optional[_serialization.WorkflowInputs]
     # The workflow's output, if any
-    output: Optional[Any]
+    output: Optional[Any] = None
     # The error the workflow threw, if any
-    error: Optional[Exception]
+    error: Optional[Exception] = None
     # Workflow start time, as a Unix epoch timestamp in ms
     created_at: Optional[int]
     # Last time the workflow status was updated, as a Unix epoch timestamp in ms
@@ -158,12 +158,10 @@ def get_workflow(
     if internal_status.get("status") == "SUCCESS":
         result = sys_db.await_workflow_result(workflow_id)
         info.output = result
-        info.error = None
     elif internal_status.get("status") == "ERROR":
         try:
             sys_db.await_workflow_result(workflow_id)
         except Exception as e:
-            info.output = None
             info.error = e
 
     if not get_request:

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -11,7 +11,7 @@ from ._sys_db import (
 )
 
 
-class WorkflowInformation:
+class WorkflowStatus:
     # The workflow ID
     workflow_id: str
     # The workflow status. Must be one of ENQUEUED, PENDING, SUCCESS, ERROR, CANCELLED, or RETRIES_EXCEEDED
@@ -66,7 +66,7 @@ def list_workflows(
     offset: Optional[int] = None,
     sort_desc: bool = False,
     request: bool = False,
-) -> List[WorkflowInformation]:
+) -> List[WorkflowStatus]:
     input = GetWorkflowsInput()
     input.workflow_ids = workflow_ids
     input.authenticated_user = user
@@ -81,7 +81,7 @@ def list_workflows(
     input.sort_desc = sort_desc
 
     output: GetWorkflowsOutput = sys_db.get_workflows(input)
-    infos: List[WorkflowInformation] = []
+    infos: List[WorkflowStatus] = []
     for workflow_id in output.workflow_uuids:
         info = get_workflow(sys_db, workflow_id, request)  # Call the method for each ID
         if info is not None:
@@ -101,7 +101,7 @@ def list_queued_workflows(
     offset: Optional[int] = None,
     sort_desc: bool = False,
     request: bool = False,
-) -> List[WorkflowInformation]:
+) -> List[WorkflowStatus]:
     input: GetQueuedWorkflowsInput = {
         "queue_name": queue_name,
         "start_time": start_time,
@@ -113,7 +113,7 @@ def list_queued_workflows(
         "sort_desc": sort_desc,
     }
     output: GetWorkflowsOutput = sys_db.get_queued_workflows(input)
-    infos: List[WorkflowInformation] = []
+    infos: List[WorkflowStatus] = []
     for workflow_id in output.workflow_uuids:
         info = get_workflow(sys_db, workflow_id, request)  # Call the method for each ID
         if info is not None:
@@ -123,13 +123,13 @@ def list_queued_workflows(
 
 def get_workflow(
     sys_db: SystemDatabase, workflow_id: str, get_request: bool
-) -> Optional[WorkflowInformation]:
+) -> Optional[WorkflowStatus]:
 
     internal_status = sys_db.get_workflow_status(workflow_id)
     if internal_status is None:
         return None
 
-    info = WorkflowInformation()
+    info = WorkflowStatus()
 
     info.workflow_id = workflow_id
     info.status = internal_status["status"]

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -17,11 +17,11 @@ class WorkflowInformation:
     # The workflow status. Must be one of ENQUEUED, PENDING, SUCCESS, ERROR, CANCELLED, or RETRIES_EXCEEDED
     status: str
     # The name of the workflow function
-    workflow_name: str
+    name: str
     # The name of the workflow's class, if any
-    workflow_class_name: Optional[str]
+    class_name: Optional[str]
     # The name with which the workflow's class instance was configured, if any
-    workflow_config_name: Optional[str]
+    config_name: Optional[str]
     # The user who ran the workflow, if specified
     authenticated_user: Optional[str]
     # The role with which the workflow ran, if specified
@@ -133,9 +133,9 @@ def get_workflow(
 
     winfo.workflow_id = workflowUUID
     winfo.status = info["status"]
-    winfo.workflow_name = info["name"]
-    winfo.workflow_class_name = info["class_name"]
-    winfo.workflow_config_name = info["config_name"]
+    winfo.name = info["name"]
+    winfo.class_name = info["class_name"]
+    winfo.config_name = info["config_name"]
     winfo.authenticated_user = info["authenticated_user"]
     winfo.assumed_role = info["assumed_role"]
     winfo.authenticated_roles = info["authenticated_roles"]

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -260,7 +260,7 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
     dbos._sys_db.wait_for_buffer_flush()
 
     # Verify the workflow has succeeded
-    output = _workflow_commands.list_workflows(sys_db)
+    output = DBOS.list_workflows()
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
     assert output[0] != None, "Expected output to be not None"
     wfUuid = output[0].workflow_id
@@ -326,7 +326,7 @@ def test_admin_workflow_restart(dbos: DBOS, sys_db: SystemDatabase) -> None:
     time.sleep(1)
 
     # get the workflow list
-    output = _workflow_commands.list_workflows(sys_db)
+    output = DBOS.list_workflows()
     assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
 
     assert output[0] != None, "Expected output to be not None"
@@ -362,7 +362,7 @@ def test_admin_workflow_restart(dbos: DBOS, sys_db: SystemDatabase) -> None:
     else:
         assert False, "Expected info to be not None"
 
-    output = _workflow_commands.list_workflows(sys_db)
+    output = DBOS.list_workflows()
     assert len(output) == 2, f"Expected list length to be 2, but got {len(output)}"
 
     if output[0].workflow_id == wfUuid:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1217,8 +1217,6 @@ def test_debug_logging(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
 
     result4 = dest_handle_2.get_result()
     assert result4 == result2
-    # In start_workflow, we skip the replay of already finished workflows
-    assert f"Workflow {dest_wfid} already completed with status" in caplog.text
 
     # Reset logging
     logging.getLogger("dbos").propagate = original_propagate

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -48,6 +48,9 @@ def test_simple_workflow(dbos: DBOS) -> None:
     @DBOS.step()
     def test_step(var: str) -> str:
         assert DBOS.step_id == 2
+        assert DBOS.step_status.step_id == 2
+        assert DBOS.step_status.current_attempt is None
+        assert DBOS.step_status.max_attempts is None
         nonlocal step_counter
         step_counter += 1
         DBOS.logger.info("I'm test_step")

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -34,9 +34,9 @@ def test_list_workflow(dbos: DBOS) -> None:
     output = outputs[0]
     assert output.workflow_id == wfid
     assert output.status == "SUCCESS"
-    assert output.workflow_name == simple_workflow.__qualname__
-    assert output.workflow_class_name == None
-    assert output.workflow_config_name == None
+    assert output.name == simple_workflow.__qualname__
+    assert output.class_name == None
+    assert output.config_name == None
     assert output.authenticated_user == None
     assert output.assumed_role == None
     assert output.authenticated_roles == None
@@ -223,7 +223,7 @@ def test_queued_workflows(dbos: DBOS) -> None:
         assert workflow.input["args"][0] == i
         assert workflow.output is None
         assert workflow.error is None
-        assert "blocking_step" in workflow.workflow_name
+        assert "blocking_step" in workflow.name
         assert workflow.executor_id == GlobalParams.executor_id
         assert workflow.app_version == GlobalParams.app_version
         assert workflow.created_at is not None and workflow.created_at > 0
@@ -249,7 +249,7 @@ def test_queued_workflows(dbos: DBOS) -> None:
         assert workflow.input["args"][0] == i
         assert workflow.output is None
         assert workflow.error is None
-        assert "blocking_step" in workflow.workflow_name
+        assert "blocking_step" in workflow.name
         assert workflow.executor_id == GlobalParams.executor_id
         assert workflow.app_version == GlobalParams.app_version
         assert workflow.created_at is not None and workflow.created_at > 0


### PR DESCRIPTION
This PR improves introspection for DBOS applications.

First, you can look up the status of your current step with:

```python
DBOS.step_status
```

This returns a `StepStatus` object:

```python
class StepStatus:
    """
    Status of a step execution.

    Attributes:
        step_id: The unique ID of this step in its workflow.
        current_attempt: For steps with automatic retries, which attempt number (zero-indexed) is currently executing.
        max_attempts: For steps with automatic retries, the maximum number of attempts that will be made before the step fails.

    """

    step_id: int
    current_attempt: Optional[int]
    max_attempts: Optional[int]
```

Second, you can now query workflows programmatically with

```python
DBOS.list_workflows(
        cls,
        *,
        workflow_ids: Optional[List[str]] = None,
        status: Optional[str] = None,
        start_time: Optional[str] = None,
        end_time: Optional[str] = None,
        name: Optional[str] = None,
        app_version: Optional[str] = None,
        user: Optional[str] = None,
        limit: Optional[int] = None,
        offset: Optional[int] = None,
        sort_desc: bool = False,
    ) -> List[WorkflowStatus]:
```

Third, all methods that query workflow status (including `get_workflow_status`, `get_workflow_status_async`, `list_workflows`, and `WorkflowHandle.get_status`) now return the same `WorkflowStatus` object:

```python
class WorkflowStatus:
    # The workflow ID
    workflow_id: str
    # The workflow status. Must be one of ENQUEUED, PENDING, SUCCESS, ERROR, CANCELLED, or RETRIES_EXCEEDED
    status: str
    # The name of the workflow function
    name: str
    # The name of the workflow's class, if any
    class_name: Optional[str]
    # The name with which the workflow's class instance was configured, if any
    config_name: Optional[str]
    # The user who ran the workflow, if specified
    authenticated_user: Optional[str]
    # The role with which the workflow ran, if specified
    assumed_role: Optional[str]
    # All roles which the authenticated user could assume
    authenticated_roles: Optional[list[str]]
    # The deserialized workflow input object
    input: Optional[_serialization.WorkflowInputs]
    # The workflow's output, if any
    output: Optional[Any]
    # The error the workflow threw, if any
    error: Optional[Exception]
    # Workflow start time, as a Unix epoch timestamp in ms
    created_at: Optional[int]
    # Last time the workflow status was updated, as a Unix epoch timestamp in ms
    updated_at: Optional[int]
    # If this workflow was enqueued, on which queue
    queue_name: Optional[str]
    # The executor to most recently executed this workflow
    executor_id: Optional[str]
    # The application version on which this workflow was started
    app_version: Optional[str]
    # The ID of the application executing this workflow
    app_id: Optional[str]
    # The number of times this workflow's execution has been attempted
    recovery_attempts: Optional[int]
    # The HTTP request that triggered the workflow, if known
    request: Optional[str]
```