### PR TITLE
Record get_result as a step

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -544,7 +544,7 @@ def start_workflow(
             ctx.parent_workflow_id,
             new_child_workflow_id,
             ctx.parent_workflow_fid,
-            func.__name__,
+            get_dbos_func_name(func),
         )
 
     if not execute_workflow or (
@@ -629,7 +629,7 @@ async def start_workflow_async(
             ctx.parent_workflow_id,
             new_child_workflow_id,
             ctx.parent_workflow_fid,
-            func.__name__,
+            get_dbos_func_name(func),
         )
 
     wf_status = status["status"]
@@ -670,8 +670,6 @@ def workflow_wrapper(
     max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS,
 ) -> Callable[P, R]:
     func.__orig_func = func  # type: ignore
-
-    funcName = func.__name__
 
     fi = get_or_create_func_info(func)
     fi.max_recovery_attempts = max_recovery_attempts
@@ -743,7 +741,7 @@ def workflow_wrapper(
                     ctx.parent_workflow_id,
                     ctx.workflow_id,
                     ctx.parent_workflow_fid,
-                    funcName,
+                    get_dbos_func_name(func),
                 )
 
             return _get_wf_invoke_func(dbos, status)
@@ -954,7 +952,7 @@ def decorate_step(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
 
-        stepName = func.__name__
+        stepName = func.__qualname__
 
         def invoke_step(*args: Any, **kwargs: Any) -> Any:
             if dbosreg.dbos is None:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -759,9 +759,11 @@ def workflow_wrapper(
                 r = func()
             except Exception as e:
                 serialized_e = _serialization.serialize_exception(e)
+                assert workflow_id is not None
                 dbos._sys_db.record_get_result(workflow_id, None, serialized_e)
                 raise
             serialized_r = _serialization.serialize(r)
+            assert workflow_id is not None
             dbos._sys_db.record_get_result(workflow_id, serialized_r, None)
             return r
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -154,10 +154,15 @@ class GetPendingWorkflowsOutput:
 
 
 class StepInfo(TypedDict):
+    # The unique ID of the step in the workflow
     function_id: int
+    # The (fully qualified) name of the step
     function_name: str
-    output: Optional[str]  # JSON (jsonpickle)
-    error: Optional[str]  # JSON (jsonpickle)
+    # The step's output, if any
+    output: Optional[Any]
+    # The error the step threw, if any
+    error: Optional[Exception]
+    # If the step starts or retrieves the result of a workflow, its ID
     child_workflow_id: Optional[str]
 
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -771,8 +771,16 @@ class SystemDatabase:
                 StepInfo(
                     function_id=row[0],
                     function_name=row[1],
-                    output=row[2],  # Preserve JSON data
-                    error=row[3],
+                    output=(
+                        _serialization.deserialize(row[2])
+                        if row[2] is not None
+                        else row[2]
+                    ),
+                    error=(
+                        _serialization.deserialize_exception(row[3])
+                        if row[3] is not None
+                        else row[3]
+                    ),
                     child_workflow_id=row[4],
                 )
                 for row in rows

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -33,7 +33,6 @@ from ._dbos_config import ConfigFile
 from ._error import (
     DBOSConflictingWorkflowError,
     DBOSDeadLetterQueueError,
-    DBOSException,
     DBOSNonExistentWorkflowError,
     DBOSWorkflowConflictIDError,
 )
@@ -818,7 +817,7 @@ class SystemDatabase:
             raise
 
     def record_get_result(
-        self, resultWorkflowID: str, output: Optional[str], error: Optional[str]
+        self, result_workflow_id: str, output: Optional[str], error: Optional[str]
     ) -> None:
         ctx = get_local_dbos_context()
         # Only record get_result called in workflow functions
@@ -835,7 +834,7 @@ class SystemDatabase:
                 function_name="DBOS.getResult",
                 output=output,
                 error=error,
-                child_workflow_id=resultWorkflowID,
+                child_workflow_id=result_workflow_id,
             )
             .on_conflict_do_nothing()
         )

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -241,27 +241,25 @@ def test_wfstatus_invalid(dbos: DBOS) -> None:
     has_executed = False
 
     @DBOS.workflow()
-    def non_deterministic_worklow() -> None:
+    def non_deterministic_workflow() -> None:
         nonlocal has_executed
         handle = dbos.start_workflow(regular_workflow)
         if not has_executed:
             # Mock a scenario where the workflow control flow is changed by an external process
             dbos.set_event("test_event", "value1")
             has_executed = True
-
+        handle.get_status()
         res = handle.get_result()
         assert res == "done"
-
-        handle.get_status()
         return
 
     wfuuid = str(uuid.uuid4())
     with SetWorkflowID(wfuuid):
-        non_deterministic_worklow()
+        non_deterministic_workflow()
 
     with pytest.raises(DBOSException) as exc_info:
         with SetWorkflowID(wfuuid):
-            non_deterministic_worklow()
+            non_deterministic_workflow()
     assert "Hint: Check if your workflow is deterministic." in str(exc_info.value)
 
 

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -297,7 +297,7 @@ def test_queued_workflows(dbos: DBOS, sys_db: SystemDatabase) -> None:
     for i in range(queued_steps):
         # Check the enqueues
         assert steps[i]["function_id"] == i + 1
-        assert steps[i]["function_name"] == "temp_wf"
+        assert steps[i]["function_name"] == f"<temp>.{blocking_step.__qualname__}"
         assert steps[i]["child_workflow_id"] is not None
         assert steps[i]["output"] is None
         assert steps[i]["error"] is None
@@ -314,7 +314,7 @@ def test_queued_workflows(dbos: DBOS, sys_db: SystemDatabase) -> None:
         steps = _workflow_commands.list_workflow_steps(sys_db, c.workflow_id)
         assert len(steps) == 1
         assert steps[0]["function_id"] == 1
-        assert steps[0]["function_name"] == "blocking_step"
+        assert steps[0]["function_name"] == blocking_step.__qualname__
         assert steps[0]["child_workflow_id"] is None
         assert steps[0]["output"] == i
         assert steps[0]["error"] is None
@@ -343,8 +343,8 @@ def test_list_2steps_sleep(dbos: DBOS, sys_db: SystemDatabase) -> None:
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 3
-    assert wfsteps[0]["function_name"] == "stepOne"
-    assert wfsteps[1]["function_name"] == "stepTwo"
+    assert wfsteps[0]["function_name"] == stepOne.__qualname__
+    assert wfsteps[1]["function_name"] == stepTwo.__qualname__
     assert wfsteps[2]["function_name"] == "DBOS.sleep"
 
 
@@ -398,7 +398,7 @@ def test_set_get_event(dbos: DBOS, sys_db: SystemDatabase) -> None:
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 5
     assert wfsteps[0]["function_name"] == "DBOS.setEvent"
-    assert wfsteps[1]["function_name"] == "stepOne"
+    assert wfsteps[1]["function_name"] == stepOne.__qualname__
     assert wfsteps[2]["function_name"] == "DBOS.sleep"
     assert wfsteps[3]["function_name"] == "DBOS.getEvent"
     assert wfsteps[3]["child_workflow_id"] == None
@@ -437,9 +437,9 @@ def test_callchild_first_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 3
-    assert wfsteps[0]["function_name"] == "child_workflow"
-    assert wfsteps[1]["function_name"] == "stepOne"
-    assert wfsteps[2]["function_name"] == "stepTwo"
+    assert wfsteps[0]["function_name"] == child_workflow.__qualname__
+    assert wfsteps[1]["function_name"] == stepOne.__qualname__
+    assert wfsteps[2]["function_name"] == stepTwo.__qualname__
 
 
 def test_callchild_last_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
@@ -469,9 +469,9 @@ def test_callchild_last_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 3
-    assert wfsteps[0]["function_name"] == "stepOne"
-    assert wfsteps[1]["function_name"] == "stepTwo"
-    assert wfsteps[2]["function_name"] == "child_workflow"
+    assert wfsteps[0]["function_name"] == stepOne.__qualname__
+    assert wfsteps[1]["function_name"] == stepTwo.__qualname__
+    assert wfsteps[2]["function_name"] == child_workflow.__qualname__
 
 
 def test_callchild_first_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> None:
@@ -502,10 +502,10 @@ def test_callchild_first_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> Non
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 4
-    assert wfsteps[0]["function_name"] == "child_workflow"
+    assert wfsteps[0]["function_name"] == child_workflow.__qualname__
     assert wfsteps[1]["function_name"] == "DBOS.getStatus"
-    assert wfsteps[2]["function_name"] == "stepOne"
-    assert wfsteps[3]["function_name"] == "stepTwo"
+    assert wfsteps[2]["function_name"] == stepOne.__qualname__
+    assert wfsteps[3]["function_name"] == stepTwo.__qualname__
 
 
 def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> None:
@@ -537,16 +537,16 @@ def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> No
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 5
-    assert wfsteps[0]["function_name"] == "stepOne"
+    assert wfsteps[0]["function_name"] == stepOne.__qualname__
     assert wfsteps[0]["child_workflow_id"] == None
     assert wfsteps[0]["output"] == wfid
     assert wfsteps[0]["error"] == None
-    assert wfsteps[1]["function_name"] == "child_workflow"
+    assert wfsteps[1]["function_name"] == child_workflow.__qualname__
     assert wfsteps[1]["child_workflow_id"] == child_id
     assert wfsteps[1]["output"] == None
     assert wfsteps[1]["error"] == None
     assert wfsteps[2]["function_name"] == "DBOS.getStatus"
-    assert wfsteps[3]["function_name"] == "stepTwo"
+    assert wfsteps[3]["function_name"] == stepTwo.__qualname__
     assert wfsteps[3]["child_workflow_id"] == None
     assert wfsteps[3]["output"] == None
     assert wfsteps[3]["error"] == None
@@ -588,7 +588,7 @@ async def test_callchild_first_asyncio(dbos: DBOS, sys_db: SystemDatabase) -> No
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 4
-    assert wfsteps[0]["function_name"] == "child_workflow"
+    assert wfsteps[0]["function_name"] == child_workflow.__qualname__
     assert wfsteps[0]["child_workflow_id"] == child_id
     assert wfsteps[0]["output"] == None
     assert wfsteps[0]["error"] == None
@@ -596,11 +596,11 @@ async def test_callchild_first_asyncio(dbos: DBOS, sys_db: SystemDatabase) -> No
     assert wfsteps[1]["child_workflow_id"] == child_id
     assert wfsteps[1]["output"] == child_id
     assert wfsteps[1]["error"] == None
-    assert wfsteps[2]["function_name"] == "stepOne"
+    assert wfsteps[2]["function_name"] == stepOne.__qualname__
     assert wfsteps[2]["child_workflow_id"] == None
     assert wfsteps[2]["output"] == wfid
     assert wfsteps[2]["error"] == None
-    assert wfsteps[3]["function_name"] == "stepTwo"
+    assert wfsteps[3]["function_name"] == stepTwo.__qualname__
     assert wfsteps[3]["child_workflow_id"] == None
     assert wfsteps[3]["output"] == None
     assert wfsteps[3]["error"] == None

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -308,6 +308,17 @@ def test_queued_workflows(dbos: DBOS, sys_db: SystemDatabase) -> None:
         assert steps[i + queued_steps]["output"] == i
         assert steps[i + queued_steps]["error"] is None
 
+    child_workflows = DBOS.list_workflows(name=f"<temp>.{blocking_step.__qualname__}")
+    assert (len(child_workflows)) == queued_steps
+    for i, c in enumerate(child_workflows):
+        steps = _workflow_commands.list_workflow_steps(sys_db, c.workflow_id)
+        assert len(steps) == 1
+        assert steps[0]["function_id"] == 1
+        assert steps[0]["function_name"] == "blocking_step"
+        assert steps[0]["child_workflow_id"] is None
+        assert steps[0]["output"] == i
+        assert steps[0]["error"] is None
+
 
 def test_list_2steps_sleep(dbos: DBOS, sys_db: SystemDatabase) -> None:
 

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -1,6 +1,7 @@
 import threading
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
 
@@ -381,7 +382,7 @@ def test_set_get_event(dbos: DBOS, sys_db: SystemDatabase) -> None:
     value = "Hello, World!"
 
     @DBOS.workflow()
-    def set_get_workflow() -> None:
+    def set_get_workflow() -> Any:
         DBOS.set_event("key", value)
         stepOne()
         DBOS.get_event("fake_id", "fake_value", 0)
@@ -520,7 +521,7 @@ def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> No
         return handle.workflow_id
 
     @DBOS.step()
-    def stepOne() -> None:
+    def stepOne() -> str:
         return DBOS.workflow_id
 
     @DBOS.step()
@@ -528,7 +529,7 @@ def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> No
         return
 
     @DBOS.workflow()
-    def child_workflow() -> None:
+    def child_workflow() -> str:
         return DBOS.workflow_id
 
     wfid = str(uuid.uuid4())
@@ -568,7 +569,7 @@ async def test_callchild_first_asyncio(dbos: DBOS, sys_db: SystemDatabase) -> No
         return child_id
 
     @DBOS.step()
-    def stepOne() -> None:
+    def stepOne() -> str:
         return DBOS.workflow_id
 
     @DBOS.step()

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -485,7 +485,7 @@ def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> No
 
     @DBOS.step()
     def stepOne() -> None:
-        return
+        return DBOS.workflow_id
 
     @DBOS.step()
     def stepTwo() -> None:
@@ -502,7 +502,13 @@ def test_callchild_middle_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> No
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 5
     assert wfsteps[0]["function_name"] == "stepOne"
+    assert wfsteps[0]["child_workflow_id"] == None
+    assert wfsteps[0]["output"] == wfid
+    assert wfsteps[0]["error"] == None
     assert wfsteps[1]["function_name"] == "child_workflow"
+    assert wfsteps[1]["child_workflow_id"] == child_id
+    assert wfsteps[1]["output"] == None
+    assert wfsteps[1]["error"] == None
     assert wfsteps[2]["function_name"] == "DBOS.getStatus"
     assert wfsteps[3]["function_name"] == "stepTwo"
     assert wfsteps[3]["child_workflow_id"] == None

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -536,10 +536,11 @@ async def test_callchild_first_asyncio(dbos: DBOS, sys_db: SystemDatabase) -> No
     dbos._sys_db._flush_workflow_status_buffer()
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
-    assert len(wfsteps) == 3
+    assert len(wfsteps) == 4
     assert wfsteps[0]["function_name"] == "child_workflow"
-    assert wfsteps[1]["function_name"] == "stepOne"
-    assert wfsteps[2]["function_name"] == "stepTwo"
+    assert wfsteps[1]["function_name"] == "DBOS.getResult"
+    assert wfsteps[2]["function_name"] == "stepOne"
+    assert wfsteps[3]["function_name"] == "stepTwo"
 
 
 def test_callchild_rerun_async_thread(dbos: DBOS) -> None:

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -437,10 +437,11 @@ def test_callchild_first_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
         parentWorkflow()
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
-    assert len(wfsteps) == 3
+    assert len(wfsteps) == 4
     assert wfsteps[0]["function_name"] == child_workflow.__qualname__
-    assert wfsteps[1]["function_name"] == stepOne.__qualname__
-    assert wfsteps[2]["function_name"] == stepTwo.__qualname__
+    assert wfsteps[1]["function_name"] == "DBOS.getResult"
+    assert wfsteps[2]["function_name"] == stepOne.__qualname__
+    assert wfsteps[3]["function_name"] == stepTwo.__qualname__
 
 
 def test_callchild_last_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
@@ -469,10 +470,11 @@ def test_callchild_last_sync(dbos: DBOS, sys_db: SystemDatabase) -> None:
         parentWorkflow()
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
-    assert len(wfsteps) == 3
+    assert len(wfsteps) == 4
     assert wfsteps[0]["function_name"] == stepOne.__qualname__
     assert wfsteps[1]["function_name"] == stepTwo.__qualname__
     assert wfsteps[2]["function_name"] == child_workflow.__qualname__
+    assert wfsteps[3]["function_name"] == "DBOS.getResult"
 
 
 def test_callchild_first_async_thread(dbos: DBOS, sys_db: SystemDatabase) -> None:


### PR DESCRIPTION
- Record `get_result` as a step (`DBOS.getResult`).
- Record steps with their fully qualified names, to be consistent with workflow names.
- `list_steps` should return deserialized results, to be consistent with the workflow introspection operations.