### PR TITLE
Remove workflow buffers

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -485,14 +485,6 @@ class DBOS:
             notification_listener_thread.start()
             self._background_threads.append(notification_listener_thread)
 
-            # Start flush workflow buffers thread
-            flush_workflow_buffers_thread = threading.Thread(
-                target=self._sys_db.flush_workflow_buffers,
-                daemon=True,
-            )
-            flush_workflow_buffers_thread.start()
-            self._background_threads.append(flush_workflow_buffers_thread)
-
             # Start the queue thread
             evt = threading.Event()
             self.stop_events.append(evt)
@@ -549,7 +541,9 @@ class DBOS:
         if _dbos_global_instance is not None:
             _dbos_global_instance._reset_system_database()
         else:
-            dbos_logger.warning("reset_system_database has no effect because global DBOS object does not exist")
+            dbos_logger.warning(
+                "reset_system_database has no effect because global DBOS object does not exist"
+            )
 
     def _reset_system_database(self) -> None:
         assert (

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -166,8 +166,6 @@ class StepInfo(TypedDict):
 
 
 _dbos_null_topic = "__null__topic__"
-_buffer_flush_batch_size = 100
-_buffer_flush_interval_secs = 1.0
 
 
 class SystemDatabase:
@@ -264,31 +262,16 @@ class SystemDatabase:
         self.notifications_map: Dict[str, threading.Condition] = {}
         self.workflow_events_map: Dict[str, threading.Condition] = {}
 
-        # Initialize the workflow status and inputs buffers
-        self._workflow_status_buffer: Dict[str, WorkflowStatusInternal] = {}
-        self._workflow_inputs_buffer: Dict[str, str] = {}
-        # Two sets for tracking which single-transaction workflows have been exported to the status table
-        self._exported_temp_txn_wf_status: Set[str] = set()
-        self._temp_txn_wf_ids: Set[str] = set()
-        self._is_flushing_status_buffer = False
-
         # Now we can run background processes
         self._run_background_processes = True
         self._debug_mode = debug_mode
 
     # Destroy the pool when finished
     def destroy(self) -> None:
-        self.wait_for_buffer_flush()
         self._run_background_processes = False
         if self.notification_conn is not None:
             self.notification_conn.close()
         self.engine.dispose()
-
-    def wait_for_buffer_flush(self) -> None:
-        # Wait until the buffers are flushed.
-        while self._is_flushing_status_buffer or not self._is_buffers_empty:
-            dbos_logger.debug("Waiting for system buffers to be exported")
-            time.sleep(1)
 
     def insert_workflow_status(
         self,
@@ -439,10 +422,6 @@ class SystemDatabase:
         else:
             with self.engine.begin() as c:
                 c.execute(cmd)
-
-        # If this is a single-transaction workflow, record that its status has been exported
-        if status["workflow_uuid"] in self._temp_txn_wf_ids:
-            self._exported_temp_txn_wf_status.add(status["workflow_uuid"])
 
     def cancel_workflow(
         self,
@@ -621,10 +600,7 @@ class SystemDatabase:
                     f"Workflow {workflow_uuid} has been called multiple times with different inputs"
                 )
             # TODO: actually changing the input
-        if workflow_uuid in self._temp_txn_wf_ids:
-            # Clean up the single-transaction tracking sets
-            self._exported_temp_txn_wf_status.discard(workflow_uuid)
-            self._temp_txn_wf_ids.discard(workflow_uuid)
+
         return
 
     def get_workflow_inputs(
@@ -1274,106 +1250,6 @@ class SystemDatabase:
                 }
             )
         return value
-
-    def _flush_workflow_status_buffer(self) -> None:
-        if self._debug_mode:
-            raise Exception("called _flush_workflow_status_buffer in debug mode")
-
-        """Export the workflow status buffer to the database, up to the batch size."""
-        if len(self._workflow_status_buffer) == 0:
-            return
-
-        # Record the exported status so far, and add them back on errors.
-        exported_status: Dict[str, WorkflowStatusInternal] = {}
-        with self.engine.begin() as c:
-            exported = 0
-            status_iter = iter(list(self._workflow_status_buffer))
-            wf_id: Optional[str] = None
-            while (
-                exported < _buffer_flush_batch_size
-                and (wf_id := next(status_iter, None)) is not None
-            ):
-                # Pop the first key in the buffer (FIFO)
-                status = self._workflow_status_buffer.pop(wf_id, None)
-                if status is None:
-                    continue
-                exported_status[wf_id] = status
-                try:
-                    self.update_workflow_status(status, conn=c)
-                    exported += 1
-                except Exception as e:
-                    dbos_logger.error(f"Error while flushing status buffer: {e}")
-                    c.rollback()
-                    # Add the exported status back to the buffer, so they can be retried next time
-                    self._workflow_status_buffer.update(exported_status)
-                    break
-
-    def _flush_workflow_inputs_buffer(self) -> None:
-        if self._debug_mode:
-            raise Exception("called _flush_workflow_inputs_buffer in debug mode")
-
-        """Export the workflow inputs buffer to the database, up to the batch size."""
-        if len(self._workflow_inputs_buffer) == 0:
-            return
-
-        # Record exported inputs so far, and add them back on errors.
-        exported_inputs: Dict[str, str] = {}
-        with self.engine.begin() as c:
-            exported = 0
-            input_iter = iter(list(self._workflow_inputs_buffer))
-            wf_id: Optional[str] = None
-            while (
-                exported < _buffer_flush_batch_size
-                and (wf_id := next(input_iter, None)) is not None
-            ):
-                if wf_id not in self._exported_temp_txn_wf_status:
-                    # Skip exporting inputs if the status has not been exported yet
-                    continue
-                inputs = self._workflow_inputs_buffer.pop(wf_id, None)
-                if inputs is None:
-                    continue
-                exported_inputs[wf_id] = inputs
-                try:
-                    self.update_workflow_inputs(wf_id, inputs, conn=c)
-                    exported += 1
-                except Exception as e:
-                    dbos_logger.error(f"Error while flushing inputs buffer: {e}")
-                    c.rollback()
-                    # Add the exported inputs back to the buffer, so they can be retried next time
-                    self._workflow_inputs_buffer.update(exported_inputs)
-                    break
-
-    def flush_workflow_buffers(self) -> None:
-        """Flush the workflow status and inputs buffers periodically, via a background thread."""
-        while self._run_background_processes:
-            try:
-                self._is_flushing_status_buffer = True
-                # Must flush the status buffer first, as the inputs table has a foreign key constraint on the status table.
-                self._flush_workflow_status_buffer()
-                self._flush_workflow_inputs_buffer()
-                self._is_flushing_status_buffer = False
-                if self._is_buffers_empty:
-                    # Only sleep if both buffers are empty
-                    time.sleep(_buffer_flush_interval_secs)
-            except Exception as e:
-                dbos_logger.error(f"Error while flushing buffers: {e}")
-                time.sleep(_buffer_flush_interval_secs)
-                # Will retry next time
-
-    def buffer_workflow_status(self, status: WorkflowStatusInternal) -> None:
-        self._workflow_status_buffer[status["workflow_uuid"]] = status
-
-    def buffer_workflow_inputs(self, workflow_id: str, inputs: str) -> None:
-        # inputs is a serialized WorkflowInputs string
-        self._workflow_inputs_buffer[workflow_id] = inputs
-        self._temp_txn_wf_ids.add(workflow_id)
-
-    @property
-    def _is_buffers_empty(self) -> bool:
-        return (
-            len(self._workflow_status_buffer) == 0
-            and len(self._workflow_inputs_buffer) == 0
-        )
 
     def enqueue(self, workflow_id: str, queue_name: str) -> None:
         if self._debug_mode:

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -97,8 +97,6 @@ def test_admin_recovery(config: ConfigFile) -> None:
     with SetWorkflowID(wfuuid):
         assert test_workflow("bob", "bob") == "bob1bob"
 
-    dbos._sys_db.wait_for_buffer_flush()
-
     # Manually update the database to pretend the workflow comes from another executor and is pending
     with dbos._sys_db.engine.begin() as c:
         query = (
@@ -257,7 +255,6 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
     # Run the workflow and flush its results
     simple_workflow()
     assert counter == 1
-    dbos._sys_db.wait_for_buffer_flush()
 
     # Verify the workflow has succeeded
     output = DBOS.list_workflows()
@@ -295,7 +292,6 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
     )
     assert response.status_code == 204
     assert event.wait(timeout=5)
-    dbos._sys_db.wait_for_buffer_flush()
     assert counter == 2
     info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
     assert info is not None
@@ -307,7 +303,6 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
         f"http://localhost:3001/workflows/{wfUuid}/resume", json=[], timeout=5
     )
     assert response.status_code == 204
-    dbos._sys_db.wait_for_buffer_flush()
     info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
     assert info is not None
     assert info.status == "SUCCESS", f"Expected status to be SUCCESS"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -47,7 +47,6 @@ async def test_async_workflow(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         result = await test_workflow("alice", "bob")
         assert result == "alicetxn11bobstep1"
-    dbos._sys_db.wait_for_buffer_flush()
 
     with SetWorkflowID(wfuuid):
         result = await test_workflow("alice", "bob")
@@ -93,7 +92,6 @@ async def test_async_step(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         result = await test_workflow("alice", "bob")
         assert result == "alicetxn11bobstep1"
-    dbos._sys_db.wait_for_buffer_flush()
 
     with SetWorkflowID(wfuuid):
         result = await test_workflow("alice", "bob")
@@ -323,7 +321,6 @@ async def test_async_step_temp(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         result = await test_step("alice")
         assert result == "alicestep1"
-    dbos._sys_db.wait_for_buffer_flush()
 
     with SetWorkflowID(wfuuid):
         result = await test_step("alice")

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -806,14 +806,12 @@ def test_inst_txn(dbos: DBOS) -> None:
 
     with SetWorkflowID(wfid):
         assert inst.transaction(input) == input * multiplier
-    dbos._sys_db.wait_for_buffer_flush()
     status = DBOS.retrieve_workflow(wfid).get_status()
     assert status.class_name == "TestClass"
     assert status.config_name == "test_class"
 
     handle = DBOS.start_workflow(inst.transaction, input)
     assert handle.get_result() == input * multiplier
-    dbos._sys_db.wait_for_buffer_flush()
     status = handle.get_status()
     assert status.class_name == "TestClass"
     assert status.config_name == "test_class"

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -146,43 +146,6 @@ def test_notification_errors(dbos: DBOS) -> None:
     assert duration < 3.0
 
 
-def test_buffer_flush_errors(dbos: DBOS) -> None:
-    @DBOS.transaction()
-    def test_transaction(var: str) -> str:
-        rows = DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
-        return var + str(rows[0][0])
-
-    cur_time: str = datetime.datetime.now().isoformat()
-    gwi: GetWorkflowsInput = GetWorkflowsInput()
-    gwi.start_time = cur_time
-
-    res = test_transaction("bob")
-    assert res == "bob1"
-
-    dbos._sys_db.wait_for_buffer_flush()
-    wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 1
-
-    # Crash the system database connection and make sure the buffer flush works on time.
-    backup_engine = dbos._sys_db.engine
-    dbos._sys_db.engine = sa.create_engine(
-        "postgresql+psycopg://fake:database@localhost/fake_db"
-    )
-
-    res = test_transaction("bob")
-    assert res == "bob1"
-
-    # Should see some errors in the logs
-    time.sleep(2)
-
-    # Switch back to the original good engine.
-    dbos._sys_db.engine = backup_engine
-
-    dbos._sys_db.wait_for_buffer_flush()
-    wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 2
-
-
 def test_dead_letter_queue(dbos: DBOS) -> None:
     event = threading.Event()
     max_recovery_attempts = 20
@@ -229,7 +192,6 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
     # Complete the blocked workflow
     event.set()
     assert handle.get_result() == resumed_handle.get_result() == None
-    dbos._sys_db.wait_for_buffer_flush()
     assert handle.get_status().status == WorkflowStatusString.SUCCESS.value
 
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -134,7 +134,6 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert response.json().get("id1") == wfuuid
     assert response.json().get("id2") != wfuuid
 
-    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
     dbos._sys_db.update_workflow_status(
         {

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -132,7 +132,6 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     assert span.attributes["authenticatedUserRoles"] == '["user", "engineer"]'
 
     # Verify that there is one workflow for this user.
-    dbos._sys_db.wait_for_buffer_flush()
     gwi = GetWorkflowsInput()
     gwi.authenticated_user = "user1"
     wfl = dbos._sys_db.get_workflows(gwi)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -95,7 +95,6 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
     assert response.json.get("id1") == wfuuid
     assert response.json.get("id2") != wfuuid
 
-    dbos._sys_db.wait_for_buffer_flush()
     # Change the workflow status to pending
     dbos._sys_db.update_workflow_status(
         {

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -19,7 +19,7 @@ from dbos import (
     WorkflowHandle,
 )
 from dbos._schemas.system_database import SystemSchema
-from dbos._sys_db import WorkflowStatusString, _buffer_flush_interval_secs
+from dbos._sys_db import WorkflowStatusString
 from tests.conftest import default_config, queue_entries_are_cleaned_up
 
 
@@ -232,7 +232,6 @@ def test_limiter(dbos: DBOS) -> None:
         assert times[limit * (wave + 1)] - times[limit * wave] < period + 0.2
 
     # Verify all workflows get the SUCCESS status eventually
-    dbos._sys_db.wait_for_buffer_flush()
     for h in handles:
         assert h.get_status().status == WorkflowStatusString.SUCCESS.value
 
@@ -300,7 +299,6 @@ def test_multiple_queues(dbos: DBOS) -> None:
         assert times[limit * (wave + 1)] - times[limit * wave] < period + 0.2
 
     # Verify all workflows get the SUCCESS status eventually
-    dbos._sys_db.wait_for_buffer_flush()
     for h in handles:
         assert h.get_status().status == WorkflowStatusString.SUCCESS.value
 
@@ -901,49 +899,6 @@ def test_resuming_queued_workflows(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
-# Test a race condition between removing a task from the queue and flushing the status buffer
-def test_resuming_already_completed_queue_workflow(dbos: DBOS) -> None:
-    dbos._sys_db._run_background_processes = False  # Disable buffer flush
-
-    start_event = threading.Event()
-    counter = 0
-
-    @DBOS.workflow()
-    def test_step() -> None:
-        start_event.set()
-        nonlocal counter
-        counter += 1
-
-    queue = Queue("test_queue")
-    handle = queue.enqueue(test_step)
-    start_event.wait()
-    start_event.clear()
-    time.sleep(_buffer_flush_interval_secs)
-    assert (
-        handle.get_status().status == WorkflowStatusString.PENDING.value
-    )  # Not flushed
-    assert counter == 1  # But, really, it's completed
-    dbos._sys_db._workflow_status_buffer = (
-        {}
-    )  # Clear buffer (simulates a process restart)
-
-    # Recovery picks up on the workflow and recovers it
-    recovered_ids = DBOS.recover_pending_workflows()
-    assert len(recovered_ids) == 1
-    assert recovered_ids[0].get_workflow_id() == handle.get_workflow_id()
-    start_event.wait()
-    assert counter == 2  # The workflow ran again
-    time.sleep(
-        _buffer_flush_interval_secs
-    )  # This is actually to wait that _get_wf_invoke_func buffers the status
-    dbos._sys_db._flush_workflow_status_buffer()  # Manually flush
-    assert (
-        handle.get_status().status == WorkflowStatusString.SUCCESS.value
-    )  # Is recovered
-    assert handle.get_status().executor_id == "local"
-    assert handle.get_status().recovery_attempts == 2
-
-
 def test_dlq_enqueued_workflows(dbos: DBOS) -> None:
     start_event = threading.Event()
     blocking_event = threading.Event()
@@ -1002,7 +957,6 @@ def test_dlq_enqueued_workflows(dbos: DBOS) -> None:
     # Complete the blocked workflow
     blocking_event.set()
     assert blocked_handle.get_result() == None
-    dbos._sys_db.wait_for_buffer_flush()
     assert blocked_handle.get_status().status == WorkflowStatusString.SUCCESS.value
     with dbos._sys_db.engine.begin() as c:
         query = sa.select(SystemSchema.workflow_status.c.recovery_attempts).where(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -205,7 +205,6 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
     for event in dbos.stop_events:
         event.set()
 
-    dbos._sys_db.wait_for_buffer_flush()
     dbos._sys_db.update_workflow_status(
         {
             "workflow_uuid": workflow_id,

--- a/tests/test_workflow_cmds.py
+++ b/tests/test_workflow_cmds.py
@@ -27,7 +27,6 @@ def test_list_workflow(dbos: DBOS) -> None:
     wfid = str(uuid.uuid4)
     with SetWorkflowID(wfid):
         assert simple_workflow(1) == 2
-    dbos._sys_db._flush_workflow_status_buffer()
 
     # List the workflow, then test every output
     outputs = DBOS.list_workflows()
@@ -765,8 +764,6 @@ async def test_callchild_first_asyncio(dbos: DBOS, sys_db: SystemDatabase) -> No
     with SetWorkflowID(wfid):
         handle = await dbos.start_workflow_async(parentWorkflow)
         child_id = await handle.get_result()
-
-    dbos._sys_db._flush_workflow_status_buffer()
 
     wfsteps = _workflow_commands.list_workflow_steps(sys_db, wfid)
     assert len(wfsteps) == 4


### PR DESCRIPTION
This PR removes pre-mature optimizations on workflow status/input buffering.
- No more input buffering for single-transaction workflows.
- No more output buffering for all workflows. When a workflow returns a result, it is guaranteed that the workflow status is updated to `SUCCESS` with its output.