### PR TITLE
Docker secrets support

### DIFF
--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -215,9 +215,13 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
 
 
 def _substitute_env_vars(content: str, silent: bool = False) -> str:
-    regex = r"\$\{([^}]+)\}"  # Regex to match ${VAR_NAME} style placeholders
+    # Regex to match ${VAR_NAME} style placeholders for environment variables
+    env_regex = r"\$\{([^}]+)\}"
 
-    def replace_func(match: re.Match[str]) -> str:
+    # Regex to match ${SECRET:SECRET_NAME} style placeholders for Docker secrets
+    secret_regex = r"\$\{SECRET:([^}]+)\}"
+
+    def replace_env_func(match: re.Match[str]) -> str:
         var_name = match.group(1)
         value = os.environ.get(
             var_name, ""
@@ -228,7 +232,30 @@ def _substitute_env_vars(content: str, silent: bool = False) -> str:
             )
         return value
 
-    return re.sub(regex, replace_func, content)
+    def replace_secret_func(match: re.Match[str]) -> str:
+        secret_name = match.group(1)
+        try:
+            # Docker secrets are stored in /run/secrets/
+            secret_path = f"/run/secrets/{secret_name}"
+            if os.path.exists(secret_path):
+                with open(secret_path, "r") as f:
+                    return f.read().strip()
+            elif not silent:
+                dbos_logger.warning(
+                    f"Docker secret {secret_name} would be substituted from /run/secrets/{secret_name}, but the file does not exist"
+                )
+            return ""
+        except Exception as e:
+            if not silent:
+                dbos_logger.warning(
+                    f"Error reading Docker secret {secret_name}: {str(e)}"
+                )
+            return ""
+
+    # First replace Docker secrets
+    content = re.sub(secret_regex, replace_secret_func, content)
+    # Then replace environment variables
+    return re.sub(env_regex, replace_env_func, content)
 
 
 def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -216,10 +216,10 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
 
 def _substitute_env_vars(content: str, silent: bool = False) -> str:
 
-    # Regex to match ${SECRET:SECRET_NAME} style placeholders for Docker secrets
-    secret_regex = r"\$\{SECRET:([^}]+)\}"
+    # Regex to match ${DOCKER_SECRET:SECRET_NAME} style placeholders for Docker secrets
+    secret_regex = r"\$\{DOCKER_SECRET:([^}]+)\}"
     # Regex to match ${VAR_NAME} style placeholders for environment variables
-    env_regex = r"\$\{(?!SECRET:)([^}]+)\}"
+    env_regex = r"\$\{(?!DOCKER_SECRET:)([^}]+)\}"
 
     def replace_env_func(match: re.Match[str]) -> str:
         var_name = match.group(1)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -215,11 +215,11 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
 
 
 def _substitute_env_vars(content: str, silent: bool = False) -> str:
-    # Regex to match ${VAR_NAME} style placeholders for environment variables
-    env_regex = r"\$\{([^}]+)\}"
 
     # Regex to match ${SECRET:SECRET_NAME} style placeholders for Docker secrets
     secret_regex = r"\$\{SECRET:([^}]+)\}"
+    # Regex to match ${VAR_NAME} style placeholders for environment variables
+    env_regex = r"\$\{(?!SECRET:)([^}]+)\}"
 
     def replace_env_func(match: re.Match[str]) -> str:
         var_name = match.group(1)

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -40,7 +40,7 @@
           },
           "password": {
             "type": ["string", "null"],
-            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution to avoid storing secrets in source."
+            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution (${VAR_NAME}) or Docker secrets (${SECRET:SECRET_NAME}) to avoid storing secrets in source."
           },
           "connectionTimeoutMillis": {
             "type": "number",

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -40,7 +40,7 @@
           },
           "password": {
             "type": ["string", "null"],
-            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution (${VAR_NAME}) or Docker secrets (${SECRET:SECRET_NAME}) to avoid storing secrets in source."
+            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution (${VAR_NAME}) or Docker secrets (${DOCKER_SECRET:SECRET_NAME}) to avoid storing secrets in source."
           },
           "connectionTimeoutMillis": {
             "type": "number",

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,0 +1,470 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import mock_open, patch
+
+from dbos._dbos_config import DBOSConfig, _substitute_env_vars, load_config
+
+
+class TestDockerSecrets(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory to simulate /run/secrets/
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.secrets_dir = os.path.join(self.temp_dir.name, "secrets")
+        os.makedirs(self.secrets_dir)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_substitute_env_vars_with_env_vars(self):
+        # Test that environment variables are still substituted correctly
+        with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
+            content = "This is a ${TEST_VAR} test"
+            result = _substitute_env_vars(content)
+            self.assertEqual(result, "This is a test_value test")
+
+    def test_substitute_env_vars_with_docker_secrets(self):
+        # Create a mock Docker secret
+        secret_path = os.path.join(self.secrets_dir, "db_password")
+        with open(secret_path, "w") as f:
+            f.write("secret_password")
+
+        # Mock the /run/secrets/ path
+        with patch("os.path.exists") as mock_exists:
+            mock_exists.return_value = True
+            with patch(
+                "builtins.open", unittest.mock.mock_open(read_data="secret_password")
+            ):
+                content = "This is a ${SECRET:db_password} test"
+                result = _substitute_env_vars(content)
+                self.assertEqual(result, "This is a secret_password test")
+
+    def test_substitute_env_vars_with_missing_docker_secret(self):
+        # Test that a warning is logged when a Docker secret is missing
+        with patch("dbos._dbos_config.dbos_logger") as mock_logger:
+            content = "This is a ${SECRET:missing_secret} test"
+            result = _substitute_env_vars(content)
+            self.assertEqual(result, "This is a  test")
+            mock_logger.warning.assert_called_once()
+
+    def test_substitute_env_vars_with_both_env_vars_and_docker_secrets(self):
+        # Test that both environment variables and Docker secrets are substituted
+        with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
+            with patch("os.path.exists") as mock_exists:
+                mock_exists.return_value = True
+                with patch(
+                    "builtins.open",
+                    unittest.mock.mock_open(read_data="secret_password"),
+                ):
+                    content = "This is a ${TEST_VAR} and ${SECRET:db_password} test"
+                    result = _substitute_env_vars(content)
+                    self.assertEqual(
+                        result, "This is a test_value and secret_password test"
+                    )
+
+    def test_substitute_env_vars_with_silent_mode(self):
+        # Test that no warning is logged when silent mode is enabled
+        with patch("dbos._dbos_config.dbos_logger") as mock_logger:
+            content = "This is a ${SECRET:missing_secret} test"
+            result = _substitute_env_vars(content, silent=True)
+            self.assertEqual(result, "This is a  test")
+            mock_logger.warning.assert_not_called()
+
+    def test_load_config_with_docker_secrets(self):
+        # Create a mock configuration file with Docker secrets
+        config_content = """
+name: test-app
+database:
+  hostname: localhost
+  port: 5432
+  username: postgres
+  password: ${SECRET:db_password}
+  app_db_name: test_db
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "database": {
+                "hostname": "localhost",
+                "port": 5432,
+                "username": "postgres",
+                "password": "secret_password",
+                "app_db_name": "test_db",
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch(
+                "builtins.open", mock_open(read_data="secret_password"), create=True
+            ) as mock_secret_file,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks
+            mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that the Docker secret was correctly substituted
+            self.assertEqual(config["database"]["password"], "secret_password")
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+    def test_load_config_with_docker_secrets_in_database_url(self):
+        # Create a mock configuration file with Docker secrets in the database URL
+        config_content = """
+name: test-app
+database_url: postgresql://postgres:${SECRET:db_password}@localhost:5432/test_db
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "database_url": "postgresql://postgres:secret_password@localhost:5432/test_db",
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch(
+                "builtins.open", mock_open(read_data="secret_password"), create=True
+            ) as mock_secret_file,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks
+            mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that the Docker secret was correctly substituted in the database URL
+            self.assertEqual(
+                config["database_url"],
+                "postgresql://postgres:secret_password@localhost:5432/test_db",
+            )
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+    def test_load_config_with_docker_secrets_in_nested_config(self):
+        # Create a mock configuration file with Docker secrets in a nested configuration
+        config_content = """
+name: test-app
+telemetry:
+  OTLPExporter:
+    logsEndpoint: http://logs-collector:4317
+    tracesEndpoint: http://traces-collector:4317
+  logs:
+    logLevel: INFO
+application:
+  api_key: ${SECRET:api_key}
+  nested:
+    secret: ${SECRET:nested_secret}
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "telemetry": {
+                "OTLPExporter": {
+                    "logsEndpoint": "http://logs-collector:4317",
+                    "tracesEndpoint": "http://traces-collector:4317",
+                },
+                "logs": {"logLevel": "INFO"},
+            },
+            "application": {
+                "api_key": "secret_value",
+                "nested": {"secret": "secret_value"},
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch(
+                "builtins.open", mock_open(read_data="secret_value"), create=True
+            ) as mock_secret_file,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks
+            mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that the Docker secrets were correctly substituted in the nested configuration
+            self.assertEqual(config["application"]["api_key"], "secret_value")
+            self.assertEqual(config["application"]["nested"]["secret"], "secret_value")
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+    def test_load_config_with_docker_secrets_in_list(self):
+        # Create a mock configuration file with Docker secrets in a list
+        config_content = """
+name: test-app
+runtimeConfig:
+  setup:
+    - echo "Setting up environment"
+    - export API_KEY=${SECRET:api_key}
+    - export DB_PASSWORD=${SECRET:db_password}
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "runtimeConfig": {
+                "setup": [
+                    'echo "Setting up environment"',
+                    "export API_KEY=secret_value",
+                    "export DB_PASSWORD=secret_value",
+                ]
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch(
+                "builtins.open", mock_open(read_data="secret_value"), create=True
+            ) as mock_secret_file,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks
+            mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that the Docker secrets were correctly substituted in the list
+            self.assertEqual(
+                config["runtimeConfig"]["setup"][1], "export API_KEY=secret_value"
+            )
+            self.assertEqual(
+                config["runtimeConfig"]["setup"][2], "export DB_PASSWORD=secret_value"
+            )
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+    def test_load_config_with_multiple_docker_secrets_in_string(self):
+        # Create a mock configuration file with multiple Docker secrets in a string
+        config_content = """
+name: test-app
+application:
+  connection_string: "postgresql://${SECRET:username}:${SECRET:password}@${SECRET:host}:5432/${SECRET:database}"
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "application": {
+                "connection_string": "postgresql://dbuser:dbpass@dbhost:5432/dbname"
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks for different secrets
+            mock_exists.return_value = True
+
+            # Mock different secret values
+            def mock_secret_open(*args, **kwargs):
+                if "username" in args[0]:
+                    return mock_open(read_data="dbuser").return_value
+                elif "password" in args[0]:
+                    return mock_open(read_data="dbpass").return_value
+                elif "host" in args[0]:
+                    return mock_open(read_data="dbhost").return_value
+                elif "database" in args[0]:
+                    return mock_open(read_data="dbname").return_value
+                return mock_open(read_data="").return_value
+
+            with patch("builtins.open", side_effect=mock_secret_open, create=True):
+                mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                    "{}"
+                )
+                mock_yaml_load.return_value = mock_config_dict
+
+                # Call the load_config function
+                config = load_config(run_process_config=False)
+
+                # Verify that all Docker secrets were correctly substituted in the connection string
+                self.assertEqual(
+                    config["application"]["connection_string"],
+                    "postgresql://dbuser:dbpass@dbhost:5432/dbname",
+                )
+
+                # Verify that the schema validation was called
+                mock_validate.assert_called_once()
+
+    def test_load_config_without_docker_secrets(self):
+        """Test that configurations without Docker secrets still work correctly."""
+        # Create a mock configuration file without any Docker secrets
+        config_content = """
+name: test-app
+database:
+  hostname: localhost
+  port: 5432
+  username: postgres
+  password: plain_password
+  app_db_name: test_db
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "database": {
+                "hostname": "localhost",
+                "port": 5432,
+                "username": "postgres",
+                "password": "plain_password",
+                "app_db_name": "test_db",
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("yaml.safe_load") as mock_yaml_load,
+        ):
+
+            # Set up the mocks
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that the configuration was loaded correctly without any Docker secrets
+            self.assertEqual(config["database"]["password"], "plain_password")
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+    def test_load_config_with_mixed_env_vars_and_docker_secrets(self):
+        """Test that configurations with a mix of environment variables and Docker secrets work correctly."""
+        # Create a mock configuration file with both environment variables and Docker secrets
+        config_content = """
+name: test-app
+database:
+  hostname: ${DB_HOST}
+  port: 5432
+  username: postgres
+  password: ${SECRET:db_password}
+  app_db_name: test_db
+"""
+
+        # Mock the file open and read operations
+        mock_file = mock_open(read_data=config_content)
+
+        # Create a mock dictionary that would be returned by yaml.safe_load
+        mock_config_dict = {
+            "name": "test-app",
+            "database": {
+                "hostname": "db.example.com",
+                "port": 5432,
+                "username": "postgres",
+                "password": "secret_password",
+                "app_db_name": "test_db",
+            },
+        }
+
+        # Mock the schema validation to always pass
+        with (
+            patch("builtins.open", mock_file),
+            patch("dbos._dbos_config.validate") as mock_validate,
+            patch("dbos._dbos_config.resources.files") as mock_resources,
+            patch("os.path.exists") as mock_exists,
+            patch(
+                "builtins.open", mock_open(read_data="secret_password"), create=True
+            ) as mock_secret_file,
+            patch("yaml.safe_load") as mock_yaml_load,
+            patch.dict(os.environ, {"DB_HOST": "db.example.com"}),
+        ):
+
+            # Set up the mocks
+            mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
+
+            # Call the load_config function
+            config = load_config(run_process_config=False)
+
+            # Verify that both environment variables and Docker secrets were correctly substituted
+            self.assertEqual(config["database"]["hostname"], "db.example.com")
+            self.assertEqual(config["database"]["password"], "secret_password")
+
+            # Verify that the schema validation was called
+            mock_validate.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -53,14 +53,14 @@ class TestDockerSecrets(unittest.TestCase):
         with patch("os.path.exists") as mock_exists:
             mock_exists.return_value = True
             with patch("builtins.open", mock_open(read_data="secret_password")):
-                content = "This is a ${SECRET:db_password} test"
+                content = "This is a ${DOCKER_SECRET:db_password} test"
                 result = _substitute_env_vars(content)
                 self.assertEqual(result, "This is a secret_password test")
 
     def test_substitute_env_vars_with_missing_docker_secret(self) -> None:
         # Test that a warning is logged when a Docker secret is missing
         with patch("dbos._dbos_config.dbos_logger") as mock_logger:
-            content = "This is a ${SECRET:missing_secret} test"
+            content = "This is a ${DOCKER_SECRET:missing_secret} test"
             result = _substitute_env_vars(content)
             self.assertEqual(result, "This is a  test")
             mock_logger.warning.assert_called_once()
@@ -74,7 +74,9 @@ class TestDockerSecrets(unittest.TestCase):
                     "builtins.open",
                     mock_open(read_data="secret_password"),
                 ):
-                    content = "This is a ${TEST_VAR} and ${SECRET:db_password} test"
+                    content = (
+                        "This is a ${TEST_VAR} and ${DOCKER_SECRET:db_password} test"
+                    )
                     result = _substitute_env_vars(content)
                     self.assertEqual(
                         result, "This is a test_value and secret_password test"
@@ -83,7 +85,7 @@ class TestDockerSecrets(unittest.TestCase):
     def test_substitute_env_vars_with_silent_mode(self) -> None:
         # Test that no warning is logged when silent mode is enabled
         with patch("dbos._dbos_config.dbos_logger") as mock_logger:
-            content = "This is a ${SECRET:missing_secret} test"
+            content = "This is a ${DOCKER_SECRET:missing_secret} test"
             result = _substitute_env_vars(content, silent=True)
             self.assertEqual(result, "This is a  test")
             mock_logger.warning.assert_not_called()
@@ -96,7 +98,7 @@ database:
   hostname: localhost
   port: 5432
   username: postgres
-  password: ${SECRET:db_password}
+  password: ${DOCKER_SECRET:db_password}
   app_db_name: test_db
 """
 
@@ -147,7 +149,7 @@ database:
         # Create a mock configuration file with Docker secrets in the database URL
         config_content = """
 name: test-app
-database_url: postgresql://postgres:${SECRET:db_password}@localhost:5432/test_db
+database_url: postgresql://postgres:${DOCKER_SECRET:db_password}@localhost:5432/test_db
 """
 
         # Mock the file open and read operations
@@ -204,10 +206,10 @@ database:
   hostname: localhost
   port: 5432
   username: postgres
-  password: ${SECRET:db_password}
+  password: ${DOCKER_SECRET:db_password}
   app_db_name: test_db
   nested:
-    secret: ${SECRET:nested_secret}
+    secret: ${DOCKER_SECRET:nested_secret}
 """
 
         # Mock the file open and read operations
@@ -271,8 +273,8 @@ name: test-app
 runtimeConfig:
   setup:
     - echo "Setting up environment"
-    - export API_KEY=${SECRET:api_key}
-    - export DB_PASSWORD=${SECRET:db_password}
+    - export API_KEY=${DOCKER_SECRET:api_key}
+    - export DB_PASSWORD=${DOCKER_SECRET:db_password}
 """
 
         # Mock the file open and read operations
@@ -327,11 +329,11 @@ runtimeConfig:
         config_content = """
 name: test-app
 database:
-  hostname: ${SECRET:db_host}
-  port: ${SECRET:db_port}
-  username: ${SECRET:db_user}
-  password: ${SECRET:db_password}
-  app_db_name: ${SECRET:db_name}
+  hostname: ${DOCKER_SECRET:db_host}
+  port: ${DOCKER_SECRET:db_port}
+  username: ${DOCKER_SECRET:db_user}
+  password: ${DOCKER_SECRET:db_password}
+  app_db_name: ${DOCKER_SECRET:db_name}
 """
 
         # Mock the file open and read operations
@@ -454,7 +456,7 @@ database:
   hostname: ${DB_HOST}
   port: ${DB_PORT}
   username: ${DB_USER}
-  password: ${SECRET:db_password}
+  password: ${DOCKER_SECRET:db_password}
   app_db_name: ${DB_NAME}
 """
 

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -52,9 +52,7 @@ class TestDockerSecrets(unittest.TestCase):
         # Mock the /run/secrets/ path
         with patch("os.path.exists") as mock_exists:
             mock_exists.return_value = True
-            with patch(
-                "builtins.open", unittest.mock.mock_open(read_data="secret_password")
-            ):
+            with patch("builtins.open", mock_open(read_data="secret_password")):
                 content = "This is a ${SECRET:db_password} test"
                 result = _substitute_env_vars(content)
                 self.assertEqual(result, "This is a secret_password test")
@@ -74,7 +72,7 @@ class TestDockerSecrets(unittest.TestCase):
                 mock_exists.return_value = True
                 with patch(
                     "builtins.open",
-                    unittest.mock.mock_open(read_data="secret_password"),
+                    mock_open(read_data="secret_password"),
                 ):
                     content = "This is a ${TEST_VAR} and ${SECRET:db_password} test"
                     result = _substitute_env_vars(content)

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,29 +1,49 @@
 import os
 import tempfile
 import unittest
+from typing import Any, Dict, List, TypedDict, cast
 from unittest.mock import mock_open, patch
 
-from dbos._dbos_config import DBOSConfig, _substitute_env_vars, load_config
+from dbos._dbos_config import _substitute_env_vars, load_config
+
+
+class ConfigFile(TypedDict, total=False):
+    name: str
+    database: Dict[str, Any]
+    database_url: str
+    telemetry: Dict[str, Any]
+    runtimeConfig: Dict[str, List[str]]
+
+
+class DatabaseConfig(TypedDict, total=False):
+    hostname: str
+    port: int
+    username: str
+    password: str
+    app_db_name: str
+    url: str
+    nested: Dict[str, Any]
+    # Add other fields as needed
 
 
 class TestDockerSecrets(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # Create a temporary directory to simulate /run/secrets/
         self.temp_dir = tempfile.TemporaryDirectory()
         self.secrets_dir = os.path.join(self.temp_dir.name, "secrets")
         os.makedirs(self.secrets_dir)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
-    def test_substitute_env_vars_with_env_vars(self):
+    def test_substitute_env_vars_with_env_vars(self) -> None:
         # Test that environment variables are still substituted correctly
         with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
             content = "This is a ${TEST_VAR} test"
             result = _substitute_env_vars(content)
             self.assertEqual(result, "This is a test_value test")
 
-    def test_substitute_env_vars_with_docker_secrets(self):
+    def test_substitute_env_vars_with_docker_secrets(self) -> None:
         # Create a mock Docker secret
         secret_path = os.path.join(self.secrets_dir, "db_password")
         with open(secret_path, "w") as f:
@@ -39,7 +59,7 @@ class TestDockerSecrets(unittest.TestCase):
                 result = _substitute_env_vars(content)
                 self.assertEqual(result, "This is a secret_password test")
 
-    def test_substitute_env_vars_with_missing_docker_secret(self):
+    def test_substitute_env_vars_with_missing_docker_secret(self) -> None:
         # Test that a warning is logged when a Docker secret is missing
         with patch("dbos._dbos_config.dbos_logger") as mock_logger:
             content = "This is a ${SECRET:missing_secret} test"
@@ -47,7 +67,7 @@ class TestDockerSecrets(unittest.TestCase):
             self.assertEqual(result, "This is a  test")
             mock_logger.warning.assert_called_once()
 
-    def test_substitute_env_vars_with_both_env_vars_and_docker_secrets(self):
+    def test_substitute_env_vars_with_both_env_vars_and_docker_secrets(self) -> None:
         # Test that both environment variables and Docker secrets are substituted
         with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
             with patch("os.path.exists") as mock_exists:
@@ -62,7 +82,7 @@ class TestDockerSecrets(unittest.TestCase):
                         result, "This is a test_value and secret_password test"
                     )
 
-    def test_substitute_env_vars_with_silent_mode(self):
+    def test_substitute_env_vars_with_silent_mode(self) -> None:
         # Test that no warning is logged when silent mode is enabled
         with patch("dbos._dbos_config.dbos_logger") as mock_logger:
             content = "This is a ${SECRET:missing_secret} test"
@@ -70,7 +90,7 @@ class TestDockerSecrets(unittest.TestCase):
             self.assertEqual(result, "This is a  test")
             mock_logger.warning.assert_not_called()
 
-    def test_load_config_with_docker_secrets(self):
+    def test_load_config_with_docker_secrets(self) -> None:
         # Create a mock configuration file with Docker secrets
         config_content = """
 name: test-app
@@ -86,7 +106,7 @@ database:
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "database": {
                 "hostname": "localhost",
@@ -125,7 +145,7 @@ database:
             # Verify that the schema validation was called
             mock_validate.assert_called_once()
 
-    def test_load_config_with_docker_secrets_in_database_url(self):
+    def test_load_config_with_docker_secrets_in_database_url(self) -> None:
         # Create a mock configuration file with Docker secrets in the database URL
         config_content = """
 name: test-app
@@ -136,7 +156,7 @@ database_url: postgresql://postgres:${SECRET:db_password}@localhost:5432/test_db
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "database_url": "postgresql://postgres:secret_password@localhost:5432/test_db",
         }
@@ -172,7 +192,7 @@ database_url: postgresql://postgres:${SECRET:db_password}@localhost:5432/test_db
             # Verify that the schema validation was called
             mock_validate.assert_called_once()
 
-    def test_load_config_with_docker_secrets_in_nested_config(self):
+    def test_load_config_with_docker_secrets_in_nested_config(self) -> None:
         # Create a mock configuration file with Docker secrets in a nested configuration
         config_content = """
 name: test-app
@@ -182,8 +202,12 @@ telemetry:
     tracesEndpoint: http://traces-collector:4317
   logs:
     logLevel: INFO
-application:
-  api_key: ${SECRET:api_key}
+database:
+  hostname: localhost
+  port: 5432
+  username: postgres
+  password: ${SECRET:db_password}
+  app_db_name: test_db
   nested:
     secret: ${SECRET:nested_secret}
 """
@@ -192,7 +216,7 @@ application:
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "telemetry": {
                 "OTLPExporter": {
@@ -201,8 +225,12 @@ application:
                 },
                 "logs": {"logLevel": "INFO"},
             },
-            "application": {
-                "api_key": "secret_value",
+            "database": {
+                "hostname": "localhost",
+                "port": 5432,
+                "username": "postgres",
+                "password": "secret_password",
+                "app_db_name": "test_db",
                 "nested": {"secret": "secret_value"},
             },
         }
@@ -230,13 +258,15 @@ application:
             config = load_config(run_process_config=False)
 
             # Verify that the Docker secrets were correctly substituted in the nested configuration
-            self.assertEqual(config["application"]["api_key"], "secret_value")
-            self.assertEqual(config["application"]["nested"]["secret"], "secret_value")
+            self.assertEqual(config["database"]["password"], "secret_password")
+            # Use cast to handle the nested field
+            database_config = cast(DatabaseConfig, config["database"])
+            self.assertEqual(database_config["nested"]["secret"], "secret_value")
 
             # Verify that the schema validation was called
             mock_validate.assert_called_once()
 
-    def test_load_config_with_docker_secrets_in_list(self):
+    def test_load_config_with_docker_secrets_in_list(self) -> None:
         # Create a mock configuration file with Docker secrets in a list
         config_content = """
 name: test-app
@@ -251,7 +281,7 @@ runtimeConfig:
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "runtimeConfig": {
                 "setup": [
@@ -285,32 +315,39 @@ runtimeConfig:
             config = load_config(run_process_config=False)
 
             # Verify that the Docker secrets were correctly substituted in the list
-            self.assertEqual(
-                config["runtimeConfig"]["setup"][1], "export API_KEY=secret_value"
-            )
-            self.assertEqual(
-                config["runtimeConfig"]["setup"][2], "export DB_PASSWORD=secret_value"
-            )
+            setup_commands = config["runtimeConfig"]["setup"]
+            if setup_commands is not None:
+                self.assertEqual(setup_commands[0], 'echo "Setting up environment"')
+                self.assertEqual(setup_commands[1], "export API_KEY=secret_value")
+                self.assertEqual(setup_commands[2], "export DB_PASSWORD=secret_value")
 
             # Verify that the schema validation was called
             mock_validate.assert_called_once()
 
-    def test_load_config_with_multiple_docker_secrets_in_string(self):
+    def test_load_config_with_multiple_docker_secrets_in_string(self) -> None:
         # Create a mock configuration file with multiple Docker secrets in a string
         config_content = """
 name: test-app
-application:
-  connection_string: "postgresql://${SECRET:username}:${SECRET:password}@${SECRET:host}:5432/${SECRET:database}"
+database:
+  hostname: ${SECRET:db_host}
+  port: ${SECRET:db_port}
+  username: ${SECRET:db_user}
+  password: ${SECRET:db_password}
+  app_db_name: ${SECRET:db_name}
 """
 
         # Mock the file open and read operations
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
-            "application": {
-                "connection_string": "postgresql://dbuser:dbpass@dbhost:5432/dbname"
+            "database": {
+                "hostname": "host",
+                "port": 5432,
+                "username": "user",
+                "password": "pass",
+                "app_db_name": "db",
             },
         }
 
@@ -323,42 +360,46 @@ application:
             patch("yaml.safe_load") as mock_yaml_load,
         ):
 
-            # Set up the mocks for different secrets
+            # Set up the mocks
             mock_exists.return_value = True
+            mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
+                "{}"
+            )
+            mock_yaml_load.return_value = mock_config_dict
 
-            # Mock different secret values
-            def mock_secret_open(*args, **kwargs):
-                if "username" in args[0]:
-                    return mock_open(read_data="dbuser").return_value
-                elif "password" in args[0]:
-                    return mock_open(read_data="dbpass").return_value
-                elif "host" in args[0]:
-                    return mock_open(read_data="dbhost").return_value
-                elif "database" in args[0]:
-                    return mock_open(read_data="dbname").return_value
-                return mock_open(read_data="").return_value
+            def mock_secret_open(*args: Any, **kwargs: Any) -> Any:
+                filepath = args[0]
+                if filepath == "dbos-config.yaml":
+                    return mock_open(read_data=config_content).return_value
 
-            with patch("builtins.open", side_effect=mock_secret_open, create=True):
-                mock_resources.return_value.joinpath.return_value.open.return_value.__enter__.return_value.read.return_value = (
-                    "{}"
-                )
-                mock_yaml_load.return_value = mock_config_dict
+                secret_name = filepath.split("/")[-1]
+                secret_values = {
+                    "db_user": "user",
+                    "db_password": "pass",
+                    "db_host": "host",
+                    "db_port": "5432",
+                    "db_name": "db",
+                }
+                if secret_name in secret_values:
+                    return mock_open(read_data=secret_values[secret_name]).return_value
+                raise FileNotFoundError(f"Mock file not found: {filepath}")
 
+            with patch("builtins.open", mock_secret_open, create=True):
                 # Call the load_config function
                 config = load_config(run_process_config=False)
 
-                # Verify that all Docker secrets were correctly substituted in the connection string
-                self.assertEqual(
-                    config["application"]["connection_string"],
-                    "postgresql://dbuser:dbpass@dbhost:5432/dbname",
-                )
+                # Verify that all Docker secrets were correctly substituted in the string
+                self.assertEqual(config["database"]["hostname"], "host")
+                self.assertEqual(config["database"]["port"], 5432)
+                self.assertEqual(config["database"]["username"], "user")
+                self.assertEqual(config["database"]["password"], "pass")
+                self.assertEqual(config["database"]["app_db_name"], "db")
 
                 # Verify that the schema validation was called
                 mock_validate.assert_called_once()
 
-    def test_load_config_without_docker_secrets(self):
-        """Test that configurations without Docker secrets still work correctly."""
-        # Create a mock configuration file without any Docker secrets
+    def test_load_config_without_docker_secrets(self) -> None:
+        # Create a mock configuration file without Docker secrets
         config_content = """
 name: test-app
 database:
@@ -373,7 +414,7 @@ database:
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "database": {
                 "hostname": "localhost",
@@ -401,33 +442,32 @@ database:
             # Call the load_config function
             config = load_config(run_process_config=False)
 
-            # Verify that the configuration was loaded correctly without any Docker secrets
+            # Verify that the configuration was loaded correctly without any substitutions
             self.assertEqual(config["database"]["password"], "plain_password")
 
             # Verify that the schema validation was called
             mock_validate.assert_called_once()
 
-    def test_load_config_with_mixed_env_vars_and_docker_secrets(self):
-        """Test that configurations with a mix of environment variables and Docker secrets work correctly."""
+    def test_load_config_with_mixed_env_vars_and_docker_secrets(self) -> None:
         # Create a mock configuration file with both environment variables and Docker secrets
         config_content = """
 name: test-app
 database:
   hostname: ${DB_HOST}
-  port: 5432
-  username: postgres
+  port: ${DB_PORT}
+  username: ${DB_USER}
   password: ${SECRET:db_password}
-  app_db_name: test_db
+  app_db_name: ${DB_NAME}
 """
 
         # Mock the file open and read operations
         mock_file = mock_open(read_data=config_content)
 
         # Create a mock dictionary that would be returned by yaml.safe_load
-        mock_config_dict = {
+        mock_config_dict: ConfigFile = {
             "name": "test-app",
             "database": {
-                "hostname": "db.example.com",
+                "hostname": "localhost",
                 "port": 5432,
                 "username": "postgres",
                 "password": "secret_password",
@@ -445,7 +485,15 @@ database:
                 "builtins.open", mock_open(read_data="secret_password"), create=True
             ) as mock_secret_file,
             patch("yaml.safe_load") as mock_yaml_load,
-            patch.dict(os.environ, {"DB_HOST": "db.example.com"}),
+            patch.dict(
+                os.environ,
+                {
+                    "DB_HOST": "localhost",
+                    "DB_PORT": "5432",
+                    "DB_USER": "postgres",
+                    "DB_NAME": "test_db",
+                },
+            ),
         ):
 
             # Set up the mocks
@@ -459,8 +507,11 @@ database:
             config = load_config(run_process_config=False)
 
             # Verify that both environment variables and Docker secrets were correctly substituted
-            self.assertEqual(config["database"]["hostname"], "db.example.com")
+            self.assertEqual(config["database"]["hostname"], "localhost")
+            self.assertEqual(config["database"]["port"], 5432)
+            self.assertEqual(config["database"]["username"], "postgres")
             self.assertEqual(config["database"]["password"], "secret_password")
+            self.assertEqual(config["database"]["app_db_name"], "test_db")
 
             # Verify that the schema validation was called
             mock_validate.assert_called_once()


### PR DESCRIPTION
# Add Docker Secrets Support to DBOS Configuration
## Overview
This PR adds support for Docker secrets in the DBOS configuration system, allowing users to securely manage sensitive information like database credentials without exposing them in environment variables or configuration files.
## Changes
Modified _substitute_env_vars() function to support Docker secrets using the ${SECRET:SECRET_NAME} syntax
Added negative lookahead to environment variable regex to prevent conflicts with Docker secrets.
Updated schema documentation to include Docker secrets syntax.
Added comprehensive test suite for Docker secrets functionality
## Implementation Details
The implementation was carried out with a change to one function(_substitute_env_vars()) in the _dbos_config.py file. The implementation prioritizes Docker secrets over environment variables when both are present, ensuring that sensitive information is always sourced from the secure Docker secrets mechanism. The function uses regex matching to first process Docker secrets and then handles environment variables, with a regex pattern that prevents the environment variable processor from matching Docker secret patterns. 

## Potential negatives to consider
This change would have the potential negative effect of making Env variables with the prefix SECRET: to not work correctly in the dbos-config.yaml file.
 
## Testing
Tests were created using a similar mocking pattern to the tests in the test_config.py file
Added test cases for:
Basic Docker secret substitution
Nested configuration with Docker secrets
Lists containing Docker secrets
Multiple Docker secrets in a single string
Backward compatibility with configurations not using Docker secrets
Missing Docker secrets handling

I have run these tests myself and they all pass, as well as building the project locally to manually test that it works with an existing dbos project. When running the full pytest suite for the entire project everything seemed to pass as well. 

### Example Usage
```
database:
  hostname: ${DBOS_DB_HOST}
  port: ${DBOS_DB_PORT}
  username: ${DBOS_DB_USER}
  password: ${SECRET:db_pass}
  app_db_name: ${DBOS_DB_DBNAME}
```
## Documentation
Updated dbos-config.schema.json documentation to include Docker secrets syntax.

Checklist
[x] Added tests for new functionality
[x] All tests pass
[x] No breaking changes to existing functionality
