### PR TITLE
Print a warning for duplicate workflow registration

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -172,6 +172,8 @@ class DBOSRegistry:
         if name in self.function_type_map:
             if self.function_type_map[name] != functype:
                 raise DBOSConflictingRegistrationError(name)
+            if name != TEMP_SEND_WF_NAME:
+                dbos_logger.warning(f"Duplicate registration for function '{name}'")
         self.function_type_map[name] = functype
         self.workflow_info_map[name] = wrapped_func
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1257,6 +1257,66 @@ def test_double_decoration(dbos: DBOS) -> None:
         my_function()
 
 
+def test_duplicate_registration(
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: ConfigFile
+) -> None:
+    original_propagate = logging.getLogger("dbos").propagate
+    caplog.set_level(logging.WARNING, "dbos")
+    logging.getLogger("dbos").propagate = True
+
+    @DBOS.transaction()
+    def my_transaction() -> None:
+        pass
+
+    @DBOS.transaction()
+    def my_transaction() -> None:
+        pass
+
+    assert (
+        "Duplicate registration for function '<temp>.test_duplicate_registration.<locals>.my_transaction'"
+        in caplog.text
+    )
+
+    @DBOS.step()
+    def my_step() -> None:
+        pass
+
+    @DBOS.step()
+    def my_step() -> None:
+        pass
+
+    assert (
+        "Duplicate registration for function '<temp>.test_duplicate_registration.<locals>.my_step'"
+        in caplog.text
+    )
+
+    @DBOS.workflow()
+    def my_workflow() -> None:
+        my_step()
+        my_transaction()
+
+    @DBOS.workflow()
+    def my_workflow() -> None:
+        my_step()
+        my_transaction()
+
+    assert (
+        "Duplicate registration for function 'test_duplicate_registration.<locals>.my_workflow'"
+        in caplog.text
+    )
+
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.launch()
+    assert (
+        "Duplicate registration for function '<temp>.temp_send_workflow'"
+        not in caplog.text
+    )
+
+    # Reset logging
+    logging.getLogger("dbos").propagate = original_propagate
+
+
 def test_app_version(config: ConfigFile) -> None:
     def is_hex(s: str) -> bool:
         return all(c in "0123456789abcdefABCDEF" for c in s)


### PR DESCRIPTION
- Generate a warning message if a workflow name is registered multiple times.
- Skip the warning if it's the temp send workflow: this is a false alert because we'll register it multiple times if we call `DBOS.destroy()` and initializer `DBOS()` in tests.