### PR TITLE
Database-Backed Preempting Cancel

### DIFF
--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -67,7 +67,7 @@ class ConductorWebsocket(threading.Thread):
                             recovery_message = p.RecoveryRequest.from_json(message)
                             success = True
                             try:
-                                self.dbos.recover_pending_workflows(
+                                self.dbos._recover_pending_workflows(
                                     recovery_message.executor_ids
                                 )
                             except Exception as e:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -983,13 +983,6 @@ def decorate_step(
                 "operationType": OperationType.STEP.value,
             }
 
-            # Check if the workflow is cancelled
-            ctx = assert_current_dbos_context()
-            if dbosreg.is_workflow_cancelled(ctx.workflow_id):
-                raise DBOSWorkflowCancelledError(
-                    f"Workflow {ctx.workflow_id} is cancelled. Aborting step {func.__name__}."
-                )
-
             attempts = max_attempts if retries_allowed else 1
             max_retry_interval_seconds: float = 3600  # 1 Hour
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -964,7 +964,7 @@ def decorate_step(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
 
-        stepName = func.__qualname__
+        step_name = func.__qualname__
 
         def invoke_step(*args: Any, **kwargs: Any) -> Any:
             if dbosreg.dbos is None:
@@ -1005,7 +1005,7 @@ def decorate_step(
                 step_output: OperationResultInternal = {
                     "workflow_uuid": ctx.workflow_id,
                     "function_id": ctx.function_id,
-                    "function_name": stepName,
+                    "function_name": step_name,
                     "output": None,
                     "error": None,
                 }
@@ -1023,7 +1023,7 @@ def decorate_step(
             def check_existing_result() -> Union[NoResult, R]:
                 ctx = assert_current_dbos_context()
                 recorded_output = dbos._sys_db.check_operation_execution(
-                    ctx.workflow_id, ctx.function_id
+                    ctx.workflow_id, ctx.function_id, step_name
                 )
                 if dbos.debug_mode and recorded_output is None:
                     raise DBOSException("Step output not found in debug mode")

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -924,20 +924,37 @@ class DBOS:
     @classmethod
     def cancel_workflow(cls, workflow_id: str) -> None:
         """Cancel a workflow by ID."""
-        dbos_logger.info(f"Cancelling workflow: {workflow_id}")
-        _get_dbos_instance()._sys_db.cancel_workflow(workflow_id)
+
+        def fn() -> None:
+            dbos_logger.info(f"Cancelling workflow: {workflow_id}")
+            _get_dbos_instance()._sys_db.cancel_workflow(workflow_id)
+
+        return _get_dbos_instance()._sys_db.call_function_as_step(
+            fn, "DBOS.cancelWorkflow"
+        )
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Resume a workflow by ID."""
-        dbos_logger.info(f"Resuming workflow: {workflow_id}")
-        _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
+
+        def fn() -> None:
+            dbos_logger.info(f"Resuming workflow: {workflow_id}")
+            _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
+
+        _get_dbos_instance()._sys_db.call_function_as_step(fn, "DBOS.resumeWorkflow")
         return cls.retrieve_workflow(workflow_id)
 
     @classmethod
     def restart_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Restart a workflow with a new workflow ID"""
-        forked_workflow_id = _get_dbos_instance()._sys_db.fork_workflow(workflow_id)
+
+        def fn() -> str:
+            dbos_logger.info(f"Restarting workflow: {workflow_id}")
+            return _get_dbos_instance()._sys_db.fork_workflow(workflow_id)
+
+        forked_workflow_id = _get_dbos_instance()._sys_db.call_function_as_step(
+            fn, "DBOS.restartWorkflow"
+        )
         return cls.retrieve_workflow(forked_workflow_id)
 
     @classmethod
@@ -955,18 +972,23 @@ class DBOS:
         offset: Optional[int] = None,
         sort_desc: bool = False,
     ) -> List[WorkflowStatus]:
-        return list_workflows(
-            _get_dbos_instance()._sys_db,
-            workflow_ids=workflow_ids,
-            status=status,
-            start_time=start_time,
-            end_time=end_time,
-            name=name,
-            app_version=app_version,
-            user=user,
-            limit=limit,
-            offset=offset,
-            sort_desc=sort_desc,
+        def fn() -> List[WorkflowStatus]:
+            return list_workflows(
+                _get_dbos_instance()._sys_db,
+                workflow_ids=workflow_ids,
+                status=status,
+                start_time=start_time,
+                end_time=end_time,
+                name=name,
+                app_version=app_version,
+                user=user,
+                limit=limit,
+                offset=offset,
+                sort_desc=sort_desc,
+            )
+
+        return _get_dbos_instance()._sys_db.call_function_as_step(
+            fn, "DBOS.listWorkflows"
         )
 
     @classmethod
@@ -982,16 +1004,21 @@ class DBOS:
         offset: Optional[int] = None,
         sort_desc: bool = False,
     ) -> List[WorkflowStatus]:
-        return list_queued_workflows(
-            _get_dbos_instance()._sys_db,
-            queue_name=queue_name,
-            status=status,
-            start_time=start_time,
-            end_time=end_time,
-            name=name,
-            limit=limit,
-            offset=offset,
-            sort_desc=sort_desc,
+        def fn() -> List[WorkflowStatus]:
+            return list_queued_workflows(
+                _get_dbos_instance()._sys_db,
+                queue_name=queue_name,
+                status=status,
+                start_time=start_time,
+                end_time=end_time,
+                name=name,
+                limit=limit,
+                offset=offset,
+                sort_desc=sort_desc,
+            )
+
+        return _get_dbos_instance()._sys_db.call_function_as_step(
+            fn, "DBOS.listQueuedWorkflows"
         )
 
     @classproperty

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -910,12 +910,12 @@ class DBOS:
         )
 
     @classmethod
-    def execute_workflow_id(cls, workflow_id: str) -> WorkflowHandle[Any]:
+    def _execute_workflow_id(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Execute a workflow by ID (for recovery)."""
         return execute_workflow_by_id(_get_dbos_instance(), workflow_id)
 
     @classmethod
-    def recover_pending_workflows(
+    def _recover_pending_workflows(
         cls, executor_ids: List[str] = ["local"]
     ) -> List[WorkflowHandle[Any]]:
         """Find all PENDING workflows and execute them."""

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -166,7 +166,6 @@ class DBOSRegistry:
         self.pollers: list[RegisteredJob] = []
         self.dbos: Optional[DBOS] = None
         self.config: Optional[ConfigFile] = None
-        self.workflow_cancelled_map: dict[str, bool] = {}
 
     def register_wf_function(self, name: str, wrapped_func: F, functype: str) -> None:
         if name in self.function_type_map:
@@ -208,15 +207,6 @@ class DBOSRegistry:
                 )
         else:
             self.instance_info_map[fn] = inst
-
-    def cancel_workflow(self, workflow_id: str) -> None:
-        self.workflow_cancelled_map[workflow_id] = True
-
-    def is_workflow_cancelled(self, workflow_id: str) -> bool:
-        return self.workflow_cancelled_map.get(workflow_id, False)
-
-    def clear_workflow_cancelled(self, workflow_id: str) -> None:
-        self.workflow_cancelled_map.pop(workflow_id, None)
 
     def compute_app_version(self) -> str:
         """
@@ -930,14 +920,12 @@ class DBOS:
         """Cancel a workflow by ID."""
         dbos_logger.info(f"Cancelling workflow: {workflow_id}")
         _get_dbos_instance()._sys_db.cancel_workflow(workflow_id)
-        _get_or_create_dbos_registry().cancel_workflow(workflow_id)
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Resume a workflow by ID."""
         dbos_logger.info(f"Resuming workflow: {workflow_id}")
         _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
-        _get_or_create_dbos_registry().clear_workflow_cancelled(workflow_id)
         return cls.retrieve_workflow(workflow_id)
 
     @classmethod

--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -28,7 +28,7 @@ def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> No
 
     DBOS.logger.info(f"Debugging workflow {workflow_id}...")
     DBOS.launch(debug_mode=True)
-    handle = DBOS.execute_workflow_id(workflow_id)
+    handle = DBOS._execute_workflow_id(workflow_id)
     handle.get_result()
     DBOS.logger.info("Workflow Debugging complete. Exiting process.")
 

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -37,6 +37,7 @@ class DBOSErrorCode(Enum):
     NotAuthorized = 8
     ConflictingWorkflowError = 9
     WorkflowCancelled = 10
+    UnexpectedStep = 11
     ConflictingRegistrationError = 25
 
 
@@ -154,4 +155,16 @@ class DBOSConflictingRegistrationError(DBOSException):
         super().__init__(
             f"Operation (Name: {name}) is already registered with a conflicting function type",
             dbos_error_code=DBOSErrorCode.ConflictingRegistrationError.value,
+        )
+
+
+class DBOSUnexpectedStepError(DBOSException):
+    """Exception raised when a step has an unexpected recorded name."""
+
+    def __init__(
+        self, workflow_id: str, step_id: int, expected_name: str, recorded_name: str
+    ) -> None:
+        super().__init__(
+            f"During execution of workflow {workflow_id} step {step_id}, function {recorded_name} was recorded when {expected_name} was expected. Check that your workflow is deterministic.",
+            dbos_error_code=DBOSErrorCode.UnexpectedStep.value,
         )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -599,6 +599,8 @@ class SystemDatabase:
                         error = row[2]
                         raise _serialization.deserialize_exception(error)
                     elif status == WorkflowStatusString.CANCELLED.value:
+                        # Return a normal exception here, not the cancellation exception
+                        # because the awaiting workflow is not being cancelled.
                         raise Exception(f"Awaited workflow {workflow_id} was cancelled")
                 else:
                     pass  # CB: I guess we're assuming the WF will show up eventually.

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -883,6 +883,8 @@ class SystemDatabase:
         *,
         conn: Optional[sa.Connection] = None,
     ) -> Optional[RecordedResult]:
+        # Retrieve the status of the workflow. Additionally, if this step
+        # has run before, retrieve its name, output, and error.
         sql = (
             sa.select(
                 SystemSchema.workflow_status.c.status,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -599,7 +599,7 @@ class SystemDatabase:
                         error = row[2]
                         raise _serialization.deserialize_exception(error)
                     elif status == WorkflowStatusString.CANCELLED.value:
-                        # Return a normal exception here, not the cancellation exception
+                        # Raise a normal exception here, not the cancellation exception
                         # because the awaiting workflow is not being cancelled.
                         raise Exception(f"Awaited workflow {workflow_id} was cancelled")
                 else:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -918,7 +918,6 @@ class SystemDatabase:
         )
         # If the workflow is cancelled, raise the exception
         if workflow_status == WorkflowStatusString.CANCELLED.value:
-            print("RAISE")
             raise DBOSWorkflowCancelledError(
                 f"Workflow {workflow_id} is cancelled. Aborting function."
             )

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -45,6 +45,9 @@ class WorkflowStatus:
     executor_id: Optional[str]
     # The application version on which this workflow was started
     app_version: Optional[str]
+
+    # INTERNAL FIELDS
+
     # The ID of the application executing this workflow
     app_id: Optional[str]
     # The number of times this workflow's execution has been attempted

--- a/tests/queuedworkflow.py
+++ b/tests/queuedworkflow.py
@@ -53,7 +53,7 @@ class WF:
 def main() -> None:
     DBOS(config=default_config())
     DBOS.launch()
-    DBOS.recover_pending_workflows()
+    DBOS._recover_pending_workflows()
 
     with SetWorkflowID("testqueuedwfcrash"):
         WF.enqueue_5_tasks()

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -411,7 +411,7 @@ def test_class_recovery(dbos: DBOS) -> None:
     assert exc_cnt == 1
 
     # Test we can execute the workflow by uuid as recovery would do
-    handle = DBOS.execute_workflow_id("run1")
+    handle = DBOS._execute_workflow_id("run1")
     assert handle.get_result() == "ran"
     assert exc_cnt == 1
 
@@ -444,7 +444,7 @@ def test_inst_recovery(dbos: DBOS) -> None:
 
     # Test we can execute the workflow by uuid as recovery would do
     last_inst = None
-    handle = DBOS.execute_workflow_id(wfid)
+    handle = DBOS._execute_workflow_id(wfid)
     assert handle.get_result() == "ran2"
     assert exc_cnt == 1
     # Workflow has finished so last_inst should be None
@@ -482,7 +482,7 @@ def test_inst_async_recovery(dbos: DBOS) -> None:
     assert status.class_name == "TestClass"
     assert status.config_name == "test_class"
 
-    recovery_handle = DBOS.execute_workflow_id(wfid)
+    recovery_handle = DBOS._execute_workflow_id(wfid)
 
     event.set()
     assert orig_handle.get_result() == input * multiplier
@@ -516,7 +516,7 @@ def test_inst_async_step_recovery(dbos: DBOS) -> None:
     assert status.class_name == "TestClass"
     assert status.config_name == "test_class"
 
-    recovery_handle = DBOS.execute_workflow_id(wfid)
+    recovery_handle = DBOS._execute_workflow_id(wfid)
 
     event.set()
     assert orig_handle.get_result() == input * multiplier
@@ -561,7 +561,7 @@ def test_step_recovery(dbos: DBOS) -> None:
     assert status.class_name == "TestClass"
     assert status.config_name == "test_class"
 
-    recovery_handle = DBOS.execute_workflow_id(wfid)
+    recovery_handle = DBOS._execute_workflow_id(wfid)
 
     blocking_event.set()
     thread.join()
@@ -614,7 +614,7 @@ def test_class_queue_recovery(dbos: DBOS) -> None:
     assert step_counter == 5
 
     # Recover the workflow, then resume it.
-    recovery_handles = DBOS.recover_pending_workflows()
+    recovery_handles = DBOS._recover_pending_workflows()
     # Wait until the 2nd invocation of the workflows are dequeued and executed
     for e in step_events:
         e.wait()
@@ -683,7 +683,7 @@ def test_class_static_queue_recovery(dbos: DBOS) -> None:
     assert step_counter == 5
 
     # Recover the workflow, then resume it.
-    recovery_handles = DBOS.recover_pending_workflows()
+    recovery_handles = DBOS._recover_pending_workflows()
     # Wait until the 2nd invocation of the workflows are dequeued and executed
     for e in step_events:
         e.wait()
@@ -757,7 +757,7 @@ def test_class_classmethod_queue_recovery(dbos: DBOS) -> None:
     assert step_counter == 5
 
     # Recover the workflow, then resume it.
-    recovery_handles = DBOS.recover_pending_workflows()
+    recovery_handles = DBOS._recover_pending_workflows()
     # Wait until the 2nd invocation of the workflows are dequeued and executed
     for e in step_events:
         e.wait()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -241,7 +241,7 @@ def test_client_send_idempotent(dbos: DBOS, client: DBOSClient) -> None:
         ).fetchall()
         assert len(sresult) == 1
 
-    DBOS.recover_pending_workflows()
+    DBOS._recover_pending_workflows()
     handle: WorkflowHandle[str] = DBOS.retrieve_workflow(wfid)
     result2 = handle.get_result()
     assert result2 == message
@@ -294,7 +294,7 @@ def test_client_send_failure(dbos: DBOS, client: DBOSClient) -> None:
         assert len(s2result) == 1
         assert s2result[0][0] == 2
 
-    DBOS.recover_pending_workflows()
+    DBOS._recover_pending_workflows()
     handle: WorkflowHandle[str] = DBOS.retrieve_workflow(wfid)
     result = handle.get_result()
     assert result == message

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -70,7 +70,7 @@ def test_simple_workflow(dbos: DBOS) -> None:
     assert wf_counter == 2  # Only increment once
 
     # Test we can execute the workflow by uuid
-    handle = DBOS.execute_workflow_id(wfuuid)
+    handle = DBOS._execute_workflow_id(wfuuid)
     assert handle.get_result() == "alice1alice"
     assert wf_counter == 2
 
@@ -257,7 +257,7 @@ def test_exception_workflow(dbos: DBOS) -> None:
     assert bad_txn_counter == 2  # Only increment once
 
     # Test we can execute the workflow by uuid, shouldn't throw errors
-    handle = DBOS.execute_workflow_id(wfuuid)
+    handle = DBOS._execute_workflow_id(wfuuid)
     with pytest.raises(Exception) as exc_info:
         handle.get_result()
     assert "test error" == str(exc_info.value)
@@ -399,7 +399,7 @@ def test_recovery_workflow(dbos: DBOS) -> None:
         )
 
     # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == "bob1bob"
     assert wf_counter == 2
@@ -444,7 +444,7 @@ def test_recovery_workflow_step(dbos: DBOS) -> None:
         )
 
     # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == "bob"
     assert wf_counter == 2
@@ -487,7 +487,7 @@ def test_workflow_returns_none(dbos: DBOS) -> None:
             .where(SystemSchema.workflow_status.c.workflow_uuid == wfuuid)
         )
 
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() is None
     assert wf_counter == 2
@@ -534,7 +534,7 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
         )
 
     # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == "bob1"
 
@@ -1418,7 +1418,7 @@ def test_recovery_appversion(config: ConfigFile) -> None:
     DBOS.launch()
 
     # The workflow should successfully recover
-    workflow_handles = DBOS.recover_pending_workflows(["testexecutor"])
+    workflow_handles = DBOS._recover_pending_workflows(["testexecutor"])
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == input
 
@@ -1441,7 +1441,7 @@ def test_recovery_appversion(config: ConfigFile) -> None:
     DBOS.launch()
 
     # The workflow should not recover
-    workflow_handles = DBOS.recover_pending_workflows(["testexecutor"])
+    workflow_handles = DBOS._recover_pending_workflows(["testexecutor"])
     assert len(workflow_handles) == 0
 
     # Clean up the environment variable

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -91,7 +91,7 @@ def test_wf_debug(dbos: DBOS, config: ConfigFile) -> None:
     DBOS(config=config)
     DBOS.launch(debug_mode=True)
 
-    handle = DBOS.execute_workflow_id(wfuuid)
+    handle = DBOS._execute_workflow_id(wfuuid)
     result = handle.get_result()
     assert result == "test"
     assert wf_counter == 2
@@ -136,7 +136,7 @@ def test_wf_debug_exception(dbos: DBOS, config: ConfigFile) -> None:
     DBOS(config=config)
     DBOS.launch(debug_mode=True)
 
-    handle = DBOS.execute_workflow_id(wfuuid)
+    handle = DBOS._execute_workflow_id(wfuuid)
     with pytest.raises(Exception) as excinfo:
         handle.get_result()
     assert str(excinfo.value) == "test_wf_debug_exception"

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -13,6 +13,7 @@ from dbos._error import (
     DBOSDeadLetterQueueError,
     DBOSException,
     DBOSMaxStepRetriesExceeded,
+    DBOSUnexpectedStepError,
 )
 from dbos._sys_db import WorkflowStatusString
 
@@ -221,9 +222,8 @@ def test_wfstatus_invalid(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         handle2 = dbos.start_workflow(non_deterministic_workflow)
 
-    with pytest.raises(DBOSException) as exc_info:
+    with pytest.raises(DBOSUnexpectedStepError) as exc_info:
         handle2.get_result()
-    assert "Hint: Check if your workflow is deterministic." in str(exc_info.value)
     event.set()
     assert handle1.get_result() == None
 

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1,4 +1,3 @@
-import datetime
 import threading
 import time
 import uuid
@@ -8,10 +7,9 @@ import sqlalchemy as sa
 from psycopg.errors import SerializationFailure
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
-from dbos import DBOS, GetWorkflowsInput, Queue, SetWorkflowID
+from dbos import DBOS, Queue, SetWorkflowID
 from dbos._error import (
     DBOSDeadLetterQueueError,
-    DBOSException,
     DBOSMaxStepRetriesExceeded,
     DBOSUnexpectedStepError,
 )

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -163,13 +163,13 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
 
     # Attempt to recover the blocked workflow the maximum number of times
     for i in range(max_recovery_attempts):
-        DBOS.recover_pending_workflows()
+        DBOS._recover_pending_workflows()
         assert recovery_count == i + 2
 
     # Verify an additional attempt (either through recovery or through a direct call) throws a DLQ error
     # and puts the workflow in the DLQ status.
     with pytest.raises(Exception) as exc_info:
-        DBOS.recover_pending_workflows()
+        DBOS._recover_pending_workflows()
     assert exc_info.errisinstance(DBOSDeadLetterQueueError)
     assert handle.get_status().status == WorkflowStatusString.RETRIES_EXCEEDED.value
     with pytest.raises(Exception) as exc_info:
@@ -179,7 +179,7 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
 
     # Resume the workflow. Verify it can recover again without error.
     resumed_handle = dbos.resume_workflow(wfid)
-    DBOS.recover_pending_workflows()
+    DBOS._recover_pending_workflows()
 
     # Complete the blocked workflow
     event.set()
@@ -379,7 +379,7 @@ def test_recovery_during_retries(dbos: DBOS) -> None:
 
     handle = DBOS.start_workflow(failing_workflow)
     start_event.wait()
-    recovery_handles = DBOS.recover_pending_workflows()
+    recovery_handles = DBOS._recover_pending_workflows()
     assert len(recovery_handles) == 1
     blocking_event.set()
     assert handle.get_result() is None
@@ -405,6 +405,6 @@ def test_keyboardinterrupt_during_retries(dbos: DBOS) -> None:
     with pytest.raises(KeyboardInterrupt):
         failing_workflow()
     raise_interrupt = False
-    recovery_handles = DBOS.recover_pending_workflows()
+    recovery_handles = DBOS._recover_pending_workflows()
     assert len(recovery_handles) == 1
     assert recovery_handles[0].get_result() == recovery_handles[0].workflow_id

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -159,7 +159,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     )
 
     # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == ("a", wfuuid)
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -120,6 +120,6 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
     )
 
     # Recovery should execute the workflow again but skip the transaction
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == ("a", wfuuid)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -856,7 +856,9 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
 
     # Complete the blocked workflow
     blocking_event.set()
-    assert blocked_handle.get_result() == None
+    with pytest.raises(Exception) as exc_info:
+        blocked_handle.get_result()
+    assert "was cancelled" in str(exc_info.value)
 
     # Verify all queue entries eventually get cleaned up.
     assert queue_entries_are_cleaned_up(dbos)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -227,7 +227,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
         }
     )
 
-    workflow_handles = DBOS.recover_pending_workflows()
+    workflow_handles = DBOS._recover_pending_workflows()
     assert len(workflow_handles) == 1
     assert workflow_handles[0].get_result() == None
     max_tries = 10

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -958,7 +958,7 @@ def test_list_transaction_error(
     assert wfsteps[3]["function_name"] == "DBOS.sleep"
 
 
-def test_list_workflows_as_step(dbos: DBOS):
+def test_list_workflows_as_step(dbos: DBOS) -> None:
     workflow_event = threading.Event()
     main_thread_event = threading.Event()
 
@@ -970,7 +970,7 @@ def test_list_workflows_as_step(dbos: DBOS):
         return length
 
     @DBOS.workflow()
-    def simple_workflow():
+    def simple_workflow() -> None:
         return
 
     # Start the workflow. It should find one workflow.

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -956,3 +956,37 @@ def test_list_transaction_error(
     assert wfsteps[2]["output"] == None
     assert isinstance(wfsteps[2]["error"], Exception)
     assert wfsteps[3]["function_name"] == "DBOS.sleep"
+
+
+def test_list_workflows_as_step(dbos: DBOS):
+    workflow_event = threading.Event()
+    main_thread_event = threading.Event()
+
+    @DBOS.workflow()
+    def listing_workflow() -> int:
+        length = len(DBOS.list_workflows())
+        main_thread_event.set()
+        workflow_event.wait()
+        return length
+
+    @DBOS.workflow()
+    def simple_workflow():
+        return
+
+    # Start the workflow. It should find one workflow.
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(listing_workflow)
+    main_thread_event.wait()
+
+    # Run another workflow
+    simple_workflow()
+
+    # Run the listing workflow again with the same ID.
+    with SetWorkflowID(wfid):
+        handle_two = DBOS.start_workflow(listing_workflow)
+
+    # Complete both executions. They should each find one workflow.
+    workflow_event.set()
+    assert handle.get_result() == 1
+    assert handle_two.get_result() == 1

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -140,6 +140,8 @@ def test_cancel_resume_queue(dbos: DBOS) -> None:
     main_thread_event.wait()
     DBOS.cancel_workflow(wfid)
     workflow_event.set()
+    with pytest.raises(Exception):
+        handle.get_result()
     assert steps_completed == 1
 
     # Resume the workflow. Verify it completes successfully.


### PR DESCRIPTION
- All steps check in the database if their workflow is cancelled before starting, aborting if it is.
- Better detection of nondeterminism: If a workflow encounters a step with an unexpected name during recovery, throw an error.
- Wrap all the introspection and management methods in steps so they can be safely called from workflows.