### PR TITLE
Fix workflow introspection

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1061,11 +1061,11 @@ class DBOS:
 
     @classproperty
     def step_id(cls) -> int:
-        """Return the step ID for the current context. This is a unique identifier of the current step within the workflow."""
+        """Return the step ID for the currently executing step. This is a unique identifier of the current step within the workflow."""
         ctx = assert_current_dbos_context()
         assert (
-            ctx.is_within_workflow()
-        ), "step_id is only available within a DBOS workflow."
+            ctx.is_step() or ctx.is_transaction()
+        ), "step_id is only available within a DBOS step."
         return ctx.function_id
 
     @classproperty

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1569,6 +1569,8 @@ class SystemDatabase:
 
     def call_function_as_step(self, fn: Callable[[], T], function_name: str) -> T:
         ctx = get_local_dbos_context()
+        if ctx and ctx.is_transaction():
+            raise Exception(f"Invalid call to `{function_name}` inside a transaction")
         if ctx and ctx.is_workflow():
             ctx.function_id += 1
             res = self.check_operation_execution(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1569,7 +1569,7 @@ class SystemDatabase:
 
     def call_function_as_step(self, fn: Callable[[], T], function_name: str) -> T:
         ctx = get_local_dbos_context()
-        if ctx and ctx.is_within_workflow():
+        if ctx and ctx.is_workflow():
             ctx.function_id += 1
             res = self.check_operation_execution(
                 ctx.workflow_id, ctx.function_id, function_name
@@ -1587,7 +1587,7 @@ class SystemDatabase:
                         f"Recorded output and error are both None for {function_name}"
                     )
         result = fn()
-        if ctx and ctx.is_within_workflow():
+        if ctx and ctx.is_workflow():
             self.record_operation_result(
                 {
                     "workflow_uuid": ctx.workflow_id,

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -1007,6 +1007,10 @@ def test_call_as_step_within_step(
     def getStatusWorkflow() -> str:
         return getStatus(DBOS.workflow_id)
 
+    @DBOS.transaction()
+    def transactionStatus() -> None:
+        DBOS.get_workflow_status(DBOS.workflow_id)
+
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         status = getStatusWorkflow()
@@ -1016,3 +1020,9 @@ def test_call_as_step_within_step(
 
     assert len(steps) == 1
     assert steps[0]["function_name"] == getStatus.__qualname__
+
+    with pytest.raises(Exception) as exc_info:
+        transactionStatus()
+    assert "Invalid call to `DBOS.getStatus` inside a transaction" in str(
+        exc_info.value
+    )


### PR DESCRIPTION
- `call_function_as_step` should use `ctx.is_workflow()` to make sure it's only checkpointing functions as steps within a workflow. If it's called within a normal step, then ignore the wrapper. Also don't allow it to be called from within a transaction.
- `DBOS.step_id` should only be available within a step or a transaction. It's invalid outside of a step/transaction.