### PR TITLE
Fix Exceptions

### DIFF
--- a/dbos/_docker_pg_helper.py
+++ b/dbos/_docker_pg_helper.py
@@ -46,7 +46,7 @@ def start_docker_pg() -> None:
     if has_docker:
         start_docker_postgres(pool_config)
         logging.info(
-            f"Postgres available at postgres://postgres:{pool_config['password']}@{pool_config['host']}:{pool_config['port']}"
+            f"Postgres available at postgresql://postgres:{pool_config['password']}@{pool_config['host']}:{pool_config['port']}"
         )
     else:
         logging.warning("Docker not detected locally")

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -33,7 +33,11 @@ def test_cancel_resume(dbos: DBOS) -> None:
         step_one()
         main_thread_event.set()
         workflow_event.wait()
-        step_two()
+        # A handler like this should not catch DBOSWorkflowCancelledError
+        try:
+            step_two()
+        except Exception:
+            raise
         return x
 
     # Start the workflow and cancel it.


### PR DESCRIPTION
Certain exceptions thrown by DBOS should not be caught by generic exception handlers in user code. This PR guarantees that by making them inherit from `BaseException`.