### PR TITLE
Background Event Loop

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -368,7 +368,6 @@ def _execute_workflow_wthread(
                     return dbos._background_event_loop.submit_coroutine(
                         cast(Pending[R], result)()
                     )
-                    return asyncio.run(cast(Pending[R], result)())
             except Exception:
                 dbos.logger.error(
                     f"Exception encountered in asynchronous workflow: {traceback.format_exc()}"

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -365,6 +365,9 @@ def _execute_workflow_wthread(
                 if isinstance(result, Immediate):
                     return cast(Immediate[R], result)()
                 else:
+                    return dbos._background_event_loop.submit_coroutine(
+                        cast(Pending[R], result)()
+                    )
                     return asyncio.run(cast(Pending[R], result)())
             except Exception:
                 dbos.logger.error(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -4,7 +4,6 @@ import asyncio
 import atexit
 import hashlib
 import inspect
-import json
 import os
 import sys
 import threading
@@ -31,7 +30,6 @@ from typing import (
 
 from opentelemetry.trace import Span
 
-from dbos import _serialization
 from dbos._conductor.conductor import ConductorWebsocket
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import (
@@ -111,6 +109,7 @@ from ._error import (
     DBOSException,
     DBOSNonExistentWorkflowError,
 )
+from ._event_loop import BackgroundEventLoop
 from ._logger import add_otlp_to_all_loggers, config_logger, dbos_logger, init_logger
 from ._sys_db import SystemDatabase
 from ._workflow_commands import WorkflowStatus, get_workflow
@@ -338,6 +337,7 @@ class DBOS:
         self.conductor_url: Optional[str] = conductor_url
         self.conductor_key: Optional[str] = conductor_key
         self.conductor_websocket: Optional[ConductorWebsocket] = None
+        self._background_event_loop: BackgroundEventLoop = BackgroundEventLoop()
 
         init_logger()
 
@@ -448,6 +448,7 @@ class DBOS:
             dbos_logger.info(f"Executor ID: {GlobalParams.executor_id}")
             dbos_logger.info(f"Application version: {GlobalParams.app_version}")
             self._executor_field = ThreadPoolExecutor(max_workers=64)
+            self._background_event_loop.start()
             self._sys_db_field = SystemDatabase(
                 self.config["database"], debug_mode=debug_mode
             )
@@ -565,6 +566,7 @@ class DBOS:
         self._initialized = False
         for event in self.stop_events:
             event.set()
+        self._background_event_loop.stop()
         if self._sys_db_field is not None:
             self._sys_db_field.destroy()
             self._sys_db_field = None

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -1,0 +1,63 @@
+import asyncio
+import threading
+from typing import Any, Coroutine, Optional, TypeVar
+
+
+class BackgroundEventLoop:
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._ready = threading.Event()
+
+    def start(self) -> None:
+        if self._running:
+            return
+
+        self._thread = threading.Thread(target=self._run_event_loop, daemon=True)
+        self._thread.start()
+        self._ready.wait()  # Wait until the loop is running
+
+    def stop(self) -> None:
+        if not self._running or self._loop is None or self._thread is None:
+            return
+
+        asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
+        self._thread.join()
+        self._running = False
+
+    def _run_event_loop(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+
+        self._running = True
+        self._ready.set()  # Signal that the loop is ready
+
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.close()
+
+    async def _shutdown(self) -> None:
+        if self._loop is None:
+            raise RuntimeError("Event loop not started")
+        tasks = [
+            task
+            for task in asyncio.all_tasks(self._loop)
+            if task is not asyncio.current_task(self._loop)
+        ]
+
+        for task in tasks:
+            task.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._loop.stop()
+
+    T = TypeVar("T")
+
+    def submit_coroutine(self, coro: Coroutine[Any, Any, T]) -> T:
+        """Submit a coroutine to the background event loop"""
+        if self._loop is None:
+            raise RuntimeError("Event loop not started")
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+        return future

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -64,5 +64,4 @@ class BackgroundEventLoop:
         """Submit a coroutine to the background event loop"""
         if self._loop is None:
             raise RuntimeError("Event loop not started")
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop).result()
-        return future
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -4,6 +4,11 @@ from typing import Any, Coroutine, Optional, TypeVar
 
 
 class BackgroundEventLoop:
+    """
+    This is the event loop to which DBOS submits any coroutines that are not started from within an event loop.
+    In particular, coroutines submitted to queues (such as from scheduled workflows) run on this event loop.
+    """
+
     def __init__(self) -> None:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -56,6 +56,15 @@ async def test_async_workflow(dbos: DBOS) -> None:
     assert step_counter == 1
     assert txn_counter == 1
 
+    # Test DBOS.start_workflow_async
+    handle = await DBOS.start_workflow_async(test_workflow, "alice", "bob")
+    assert (await handle.get_result()) == "alicetxn21bobstep2"
+
+    # Test DBOS.start_workflow. Not recommended for async workflows,
+    # but needed for backwards compatibility.
+    sync_handle = DBOS.start_workflow(test_workflow, "alice", "bob")
+    assert sync_handle.get_result() == "alicetxn31bobstep3"  # type: ignore
+
 
 @pytest.mark.asyncio
 async def test_async_step(dbos: DBOS) -> None:


### PR DESCRIPTION
Create a single event loop to which DBOS submits any coroutines that are not started from within an event loop. In particular, coroutines submitted to queues (such as from scheduled workflows) run on this event loop. This fixes an issue where coroutines are submitted to event loops on threads which are later killed when the function that started the thread completes, preventing the coroutines from finishing.