### PR TITLE
Timeouts

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -127,7 +127,7 @@ class DBOSClient:
             "kwargs": kwargs,
         }
 
-        wf_status = self._sys_db.insert_workflow_status(status)
+        wf_status, _ = self._sys_db.insert_workflow_status(status)
         self._sys_db.update_workflow_inputs(
             workflow_id, _serialization.serialize_args(inputs)
         )

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -120,11 +120,10 @@ class DBOSClient:
             "executor_id": None,
             "recovery_attempts": None,
             "app_id": None,
-            "workflow_deadline_epoch_ms": (  # UNIX epoch timestamp of the timeout in ms
-                int((time.time() + workflow_timeout) * 1000)
-                if workflow_timeout is not None
-                else None
+            "workflow_timeout_ms": (
+                int(workflow_timeout * 1000) if workflow_timeout is not None else None
             ),
+            "workflow_deadline_epoch_ms": None,
         }
 
         inputs: WorkflowInputs = {
@@ -186,6 +185,7 @@ class DBOSClient:
             "recovery_attempts": None,
             "app_id": None,
             "app_version": None,
+            "workflow_timeout_ms": None,
             "workflow_deadline_epoch_ms": None,
         }
         with self._sys_db.engine.begin() as conn:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import time
 import uuid
 from typing import Any, Generic, List, Optional, TypedDict, TypeVar
 
@@ -119,7 +120,11 @@ class DBOSClient:
             "executor_id": None,
             "recovery_attempts": None,
             "app_id": None,
-            "workflow_timeout": workflow_timeout,
+            "workflow_timeout": (  # UNIX epoch timestamp of the timeout in ms
+                int((time.time() + workflow_timeout) * 1000)
+                if workflow_timeout is not None
+                else None
+            ),
         }
 
         inputs: WorkflowInputs = {

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -30,6 +30,7 @@ class EnqueueOptions(TypedDict):
     queue_name: str
     workflow_id: NotRequired[str]
     app_version: NotRequired[str]
+    workflow_timeout: NotRequired[int]
 
 
 class WorkflowHandleClientPolling(Generic[R]):
@@ -97,6 +98,7 @@ class DBOSClient:
         workflow_id = options.get("workflow_id")
         if workflow_id is None:
             workflow_id = str(uuid.uuid4())
+        workflow_timeout = options.get("workflow_timeout", None)
 
         status: WorkflowStatusInternal = {
             "workflow_uuid": workflow_id,
@@ -117,6 +119,7 @@ class DBOSClient:
             "executor_id": None,
             "recovery_attempts": None,
             "app_id": None,
+            "workflow_timeout": workflow_timeout,
         }
 
         inputs: WorkflowInputs = {
@@ -183,6 +186,7 @@ class DBOSClient:
             "recovery_attempts": None,
             "app_id": None,
             "app_version": None,
+            "workflow_timeout": None,
         }
         self._sys_db.insert_workflow_status(status)
         self._sys_db.send(status["workflow_uuid"], 0, destination_id, message, topic)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -120,7 +120,7 @@ class DBOSClient:
             "executor_id": None,
             "recovery_attempts": None,
             "app_id": None,
-            "workflow_timeout": (  # UNIX epoch timestamp of the timeout in ms
+            "workflow_deadline_epoch_ms": (  # UNIX epoch timestamp of the timeout in ms
                 int((time.time() + workflow_timeout) * 1000)
                 if workflow_timeout is not None
                 else None
@@ -186,7 +186,7 @@ class DBOSClient:
             "recovery_attempts": None,
             "app_id": None,
             "app_version": None,
-            "workflow_timeout": None,
+            "workflow_deadline_epoch_ms": None,
         }
         with self._sys_db.engine.begin() as conn:
             self._sys_db.insert_workflow_status(status, conn)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -31,7 +31,7 @@ class EnqueueOptions(TypedDict):
     queue_name: str
     workflow_id: NotRequired[str]
     app_version: NotRequired[str]
-    workflow_timeout: NotRequired[int]
+    workflow_timeout: NotRequired[float]
 
 
 class WorkflowHandleClientPolling(Generic[R]):

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -111,6 +111,7 @@ class DBOSContext:
         )
         rv.request = self.request
         rv.assumed_role = self.assumed_role
+        rv.workflow_timeout = self.workflow_timeout
         return rv
 
     def has_parent(self) -> bool:

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -380,6 +380,7 @@ class SetWorkflowTimeout:
             )
         self.created_ctx = False
         self.workflow_timeout = workflow_timeout
+        self.saved_workflow_timeout: Optional[float] = None
 
     def __enter__(self) -> SetWorkflowTimeout:
         # Code to create a basic context
@@ -388,6 +389,7 @@ class SetWorkflowTimeout:
             self.created_ctx = True
             _set_local_dbos_context(DBOSContext())
         ctx = assert_current_dbos_context()
+        self.saved_workflow_timeout = ctx.workflow_timeout
         ctx.workflow_timeout = self.workflow_timeout
         return self
 
@@ -397,7 +399,7 @@ class SetWorkflowTimeout:
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[False]:
-        assert_current_dbos_context().workflow_timeout = None
+        assert_current_dbos_context().workflow_timeout = self.saved_workflow_timeout
         # Code to clean up the basic context if we created it
         if self.created_ctx:
             _clear_local_dbos_context()

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -93,7 +93,7 @@ class DBOSContext:
         self.assumed_role: Optional[str] = None
         self.step_status: Optional[StepStatus] = None
 
-        self.workflow_timeout: Optional[int] = None
+        self.workflow_timeout: Optional[float] = None
 
     def create_child(self) -> DBOSContext:
         rv = DBOSContext()
@@ -373,7 +373,7 @@ class SetWorkflowTimeout:
         ```
     """
 
-    def __init__(self, workflow_timeout: int) -> None:
+    def __init__(self, workflow_timeout: float) -> None:
         self.created_ctx = False
         self.workflow_timeout = workflow_timeout
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -93,7 +93,7 @@ class DBOSContext:
         self.assumed_role: Optional[str] = None
         self.step_status: Optional[StepStatus] = None
 
-        self.workflow_timeout = None
+        self.workflow_timeout: Optional[int] = None
 
     def create_child(self) -> DBOSContext:
         rv = DBOSContext()

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -373,11 +373,11 @@ class SetWorkflowTimeout:
         ```
     """
 
-    def __init__(self, workflow_timeout: str) -> None:
+    def __init__(self, workflow_timeout: int) -> None:
         self.created_ctx = False
         self.workflow_timeout = workflow_timeout
 
-    def __enter__(self) -> SetWorkflowID:
+    def __enter__(self) -> SetWorkflowTimeout:
         # Code to create a basic context
         ctx = get_local_dbos_context()
         if ctx is None:
@@ -393,7 +393,7 @@ class SetWorkflowTimeout:
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[False]:
-        self.workflow_timeout = None
+        assert_current_dbos_context().workflow_timeout = None
         # Code to clean up the basic context if we created it
         if self.created_ctx:
             _clear_local_dbos_context()

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -374,6 +374,10 @@ class SetWorkflowTimeout:
     """
 
     def __init__(self, workflow_timeout: float) -> None:
+        if not workflow_timeout > 0:
+            raise Exception(
+                f"Invalid workflow timeout {workflow_timeout}. Timeouts must be positive."
+            )
         self.created_ctx = False
         self.workflow_timeout = workflow_timeout
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -428,7 +428,8 @@ class EnterDBOSWorkflow(AbstractContextManager[DBOSContext, Literal[False]]):
             ctx = DBOSContext()
             _set_local_dbos_context(ctx)
         assert not ctx.is_within_workflow()
-        # The workflow timeout should not be set within the workflow
+        # Unset the workflow_timeout_ms context var so it is not applied to this
+        # workflow's children (instead we propagate the deadline)
         self.saved_workflow_timeout = ctx.workflow_timeout_ms
         ctx.workflow_timeout_ms = None
         ctx.start_workflow(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -268,7 +268,7 @@ def _init_workflow(
         "created_at": None,
         "updated_at": None,
         "workflow_timeout": (  # UNIX epoch timestamp of the timeout in ms
-            (time.time() * 1000 + ctx.workflow_timeout)
+            int((time.time() + ctx.workflow_timeout) * 1000)
             if ctx.workflow_timeout is not None
             else None
         ),

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -287,7 +287,7 @@ def _init_workflow(
     else:
         # Synchronously record the status and inputs for workflows
         # TODO: Make this transactional (and with the queue step below)
-        wf_status = dbos._sys_db.insert_workflow_status(
+        wf_status, wf_timeout = dbos._sys_db.insert_workflow_status(
             status, max_recovery_attempts=max_recovery_attempts
         )
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -318,6 +318,8 @@ def _init_workflow(
         timeout_thread.start()
         dbos._background_threads.append(timeout_thread)
 
+    ctx.workflow_deadline_epoch_ms = workflow_deadline_epoch_ms
+    status["workflow_deadline_epoch_ms"] = workflow_deadline_epoch_ms
     status["status"] = wf_status
     return status
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -296,7 +296,6 @@ def _init_workflow(
 
     if queue is not None and wf_status == WorkflowStatusString.ENQUEUED.value:
         dbos._sys_db.enqueue(wfid, queue)
-
     if wf_timeout is not None:
         evt = threading.Event()
         dbos.stop_events.append(evt)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -275,7 +275,7 @@ def _init_workflow(
         "queue_name": queue,
         "created_at": None,
         "updated_at": None,
-        "workflow_timeout": (  # UNIX epoch timestamp of the timeout in ms
+        "workflow_deadline_epoch_ms": (  # UNIX epoch timestamp of the timeout in ms
             int((time.time() + workflow_timeout) * 1000)
             if workflow_timeout is not None
             else None

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -267,6 +267,11 @@ def _init_workflow(
         "queue_name": queue,
         "created_at": None,
         "updated_at": None,
+        "workflow_timeout": (  # UNIX epoch timestamp of the timeout in ms
+            (time.time() * 1000 + ctx.workflow_timeout)
+            if ctx.workflow_timeout is not None
+            else None
+        ),
     }
 
     # If we have a class name, the first arg is the instance and do not serialize

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -304,7 +304,7 @@ def _init_workflow(
         evt = threading.Event()
         dbos.stop_events.append(evt)
 
-        def timeout_func():
+        def timeout_func() -> None:
             time_to_wait_sec = (wf_timeout - (time.time() * 1000)) / 1000
             if time_to_wait_sec > 0:
                 was_stopped = evt.wait(time_to_wait_sec)

--- a/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
+++ b/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
@@ -1,0 +1,34 @@
+"""workflow_timeout
+
+Revision ID: 83f3732ae8e7
+Revises: f4b9b32ba814
+Create Date: 2025-04-16 17:05:36.642395
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "83f3732ae8e7"
+down_revision: Union[str, None] = "f4b9b32ba814"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflow_status",
+        sa.Column(
+            "timeout",
+            sa.BigInteger(),
+            nullable=True,
+        ),
+        schema="dbos",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workflow_status", "timeout", schema="dbos")

--- a/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
+++ b/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     op.add_column(
         "workflow_status",
         sa.Column(
-            "timeout",
+            "workflow_timeout",
             sa.BigInteger(),
             nullable=True,
         ),
@@ -31,4 +31,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("workflow_status", "timeout", schema="dbos")
+    op.drop_column("workflow_status", "workflow_timeout", schema="dbos")

--- a/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
+++ b/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
@@ -22,6 +22,15 @@ def upgrade() -> None:
     op.add_column(
         "workflow_status",
         sa.Column(
+            "workflow_timeout_ms",
+            sa.BigInteger(),
+            nullable=True,
+        ),
+        schema="dbos",
+    )
+    op.add_column(
+        "workflow_status",
+        sa.Column(
             "workflow_deadline_epoch_ms",
             sa.BigInteger(),
             nullable=True,
@@ -32,3 +41,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_column("workflow_status", "workflow_deadline_epoch_ms", schema="dbos")
+    op.drop_column("workflow_status", "workflow_timeout_ms", schema="dbos")

--- a/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
+++ b/dbos/_migrations/versions/83f3732ae8e7_workflow_timeout.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     op.add_column(
         "workflow_status",
         sa.Column(
-            "workflow_timeout",
+            "workflow_deadline_epoch_ms",
             sa.BigInteger(),
             nullable=True,
         ),
@@ -31,4 +31,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("workflow_status", "workflow_timeout", schema="dbos")
+    op.drop_column("workflow_status", "workflow_deadline_epoch_ms", schema="dbos")

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -54,7 +54,8 @@ class SystemSchema:
             nullable=True,
             server_default=text("'0'::bigint"),
         ),
-        Column("queue_name", Text),
+        Column("queue_name", Text, nullable=True),
+        Column("timeout", BigInteger, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
     )

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -55,7 +55,7 @@ class SystemSchema:
             server_default=text("'0'::bigint"),
         ),
         Column("queue_name", Text, nullable=True),
-        Column("timeout", BigInteger, nullable=True),
+        Column("workflow_timeout", BigInteger, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
     )

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -55,7 +55,7 @@ class SystemSchema:
             server_default=text("'0'::bigint"),
         ),
         Column("queue_name", Text, nullable=True),
-        Column("workflow_timeout", BigInteger, nullable=True),
+        Column("workflow_deadline_epoch_ms", BigInteger, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
     )

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -55,6 +55,7 @@ class SystemSchema:
             server_default=text("'0'::bigint"),
         ),
         Column("queue_name", Text, nullable=True),
+        Column("workflow_timeout_ms", BigInteger, nullable=True),
         Column("workflow_deadline_epoch_ms", BigInteger, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -440,8 +440,6 @@ class SystemDatabase:
         if self._debug_mode:
             raise Exception("called cancel_workflow in debug mode")
         with self.engine.begin() as c:
-            # Execute with snapshot isolation in case of concurrent calls on the same workflow
-            c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
             # Check the status of the workflow. If it is complete, do nothing.
             row = c.execute(
                 sa.select(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -83,7 +83,7 @@ class WorkflowStatusInternal(TypedDict):
     app_version: Optional[str]
     app_id: Optional[str]
     recovery_attempts: Optional[int]
-    workflow_timeout: Optional[int]  # Unix epoch timestamp in ms
+    workflow_deadline_epoch_ms: Optional[int]  # Unix epoch timestamp in ms
 
 
 class RecordedResult(TypedDict):
@@ -293,7 +293,7 @@ class SystemDatabase:
         if self._debug_mode:
             raise Exception("called insert_workflow_status in debug mode")
         wf_status: WorkflowStatuses = status["status"]
-        wf_timeout: Optional[int] = status["workflow_timeout"]
+        wf_timeout: Optional[int] = status["workflow_deadline_epoch_ms"]
 
         cmd = (
             pg.insert(SystemSchema.workflow_status)
@@ -316,7 +316,7 @@ class SystemDatabase:
                 recovery_attempts=(
                     1 if wf_status != WorkflowStatusString.ENQUEUED.value else 0
                 ),
-                workflow_deadline_epoch_ms=status["workflow_timeout"],
+                workflow_deadline_epoch_ms=status["workflow_deadline_epoch_ms"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
@@ -644,7 +644,7 @@ class SystemDatabase:
                 "updated_at": row[12],
                 "app_version": row[13],
                 "app_id": row[14],
-                "workflow_timeout": row[15],
+                "workflow_deadline_epoch_ms": row[15],
             }
             return status
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -83,6 +83,7 @@ class WorkflowStatusInternal(TypedDict):
     app_version: Optional[str]
     app_id: Optional[str]
     recovery_attempts: Optional[int]
+    workflow_timeout: Optional[int]  # Unix epoch timestamp in ms
 
 
 class RecordedResult(TypedDict):

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -83,12 +83,11 @@ class WorkflowStatusInternal(TypedDict):
     app_version: Optional[str]
     app_id: Optional[str]
     recovery_attempts: Optional[int]
-    workflow_timeout_ms: Optional[
-        int
-    ]  # The start-to-close timeout of the workflow in ms
-    workflow_deadline_epoch_ms: Optional[
-        int
-    ]  # The deadline of a workflow, computed by adding its timeout to its START time (which may be different from its creation time for queued workflows). Deadlines are propagated to children. At this deadline, the workflow is cancelled.
+    # The start-to-close timeout of the workflow in ms
+    workflow_timeout_ms: Optional[int]
+    # The deadline of a workflow, computed by adding its timeout to its start time.
+    # Deadlines propagate to children. When the deadline is reached, the workflow is cancelled.
+    workflow_deadline_epoch_ms: Optional[int]
 
 
 class RecordedResult(TypedDict):

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -509,11 +509,15 @@ class SystemDatabase:
                     queue_name=INTERNAL_QUEUE_NAME,
                 )
             )
-            # Set the workflow's status to ENQUEUED and clear its recovery attempts.
+            # Set the workflow's status to ENQUEUED and clear its recovery attempts and deadline.
             c.execute(
                 sa.update(SystemSchema.workflow_status)
                 .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
-                .values(status=WorkflowStatusString.ENQUEUED.value, recovery_attempts=0)
+                .values(
+                    status=WorkflowStatusString.ENQUEUED.value,
+                    recovery_attempts=0,
+                    workflow_deadline_epoch_ms=None,
+                )
             )
 
     def get_max_function_id(self, workflow_uuid: str) -> Optional[int]:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -556,6 +556,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.updated_at,
                     SystemSchema.workflow_status.c.application_version,
                     SystemSchema.workflow_status.c.application_id,
+                    SystemSchema.workflow_status.c.workflow_timeout,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -579,6 +580,7 @@ class SystemDatabase:
                 "updated_at": row[12],
                 "app_version": row[13],
                 "app_id": row[14],
+                "workflow_timeout": row[15],
             }
             return status
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -311,6 +311,7 @@ class SystemDatabase:
                 recovery_attempts=(
                     1 if wf_status != WorkflowStatusString.ENQUEUED.value else 0
                 ),
+                workflow_timeout=status["workflow_timeout"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1570,6 +1570,17 @@ class SystemDatabase:
                         status=WorkflowStatusString.PENDING.value,
                         application_version=app_version,
                         executor_id=executor_id,
+                        # If a timeout is set, set the deadline on dequeue
+                        workflow_deadline_epoch_ms=sa.case(
+                            (
+                                SystemSchema.workflow_status.c.workflow_timeout_ms.isnot(
+                                    None
+                                ),
+                                sa.func.extract("epoch", sa.func.now()) * 1000
+                                + SystemSchema.workflow_status.c.workflow_timeout_ms,
+                            ),
+                            else_=SystemSchema.workflow_status.c.workflow_deadline_epoch_ms,
+                        ),
                     )
                 )
                 if res.rowcount > 0:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -316,7 +316,7 @@ class SystemDatabase:
                 recovery_attempts=(
                     1 if wf_status != WorkflowStatusString.ENQUEUED.value else 0
                 ),
-                workflow_timeout=status["workflow_timeout"],
+                workflow_deadline_epoch_ms=status["workflow_timeout"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
@@ -330,7 +330,7 @@ class SystemDatabase:
             )
         )
 
-        cmd = cmd.returning(SystemSchema.workflow_status.c.recovery_attempts, SystemSchema.workflow_status.c.status, SystemSchema.workflow_status.c.workflow_timeout, SystemSchema.workflow_status.c.name, SystemSchema.workflow_status.c.class_name, SystemSchema.workflow_status.c.config_name, SystemSchema.workflow_status.c.queue_name)  # type: ignore
+        cmd = cmd.returning(SystemSchema.workflow_status.c.recovery_attempts, SystemSchema.workflow_status.c.status, SystemSchema.workflow_status.c.workflow_deadline_epoch_ms, SystemSchema.workflow_status.c.name, SystemSchema.workflow_status.c.class_name, SystemSchema.workflow_status.c.config_name, SystemSchema.workflow_status.c.queue_name)  # type: ignore
 
         results = conn.execute(cmd)
 
@@ -620,7 +620,7 @@ class SystemDatabase:
                     SystemSchema.workflow_status.c.updated_at,
                     SystemSchema.workflow_status.c.application_version,
                     SystemSchema.workflow_status.c.application_id,
-                    SystemSchema.workflow_status.c.workflow_timeout,
+                    SystemSchema.workflow_status.c.workflow_deadline_epoch_ms,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -36,3 +36,9 @@ def event_test(key: str, value: str, update: Optional[int] = None) -> str:
         DBOS.sleep(update)
         DBOS.set_event(key, f"updated-{value}")
     return f"{key}-{value}"
+
+
+@DBOS.workflow()
+def blocked_workflow() -> None:
+    while True:
+        DBOS.sleep(0.1)

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -245,7 +245,6 @@ def test_busy_admin_server_port_does_not_throw() -> None:
 
 
 def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
-    counter: int = 0
     event = threading.Event()
 
     @DBOS.workflow()

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -11,6 +11,7 @@ from requests.exceptions import ConnectionError
 
 # Public API
 from dbos import DBOS, ConfigFile, DBOSConfig, Queue, SetWorkflowID, _workflow_commands
+from dbos._error import DBOSWorkflowCancelledError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import SystemDatabase, WorkflowStatusString
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
@@ -248,32 +249,33 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
     event = threading.Event()
 
     @DBOS.workflow()
-    def simple_workflow() -> None:
-        event.set()
-        nonlocal counter
-        counter += 1
+    def blocking_workflow() -> None:
+        event.wait()
+        DBOS.sleep(0.1)
 
     # Run the workflow
-    simple_workflow()
-    assert counter == 1
+    handle = DBOS.start_workflow(blocking_workflow)
 
-    # Verify the workflow has succeeded
+    # Verify the workflow is pending
     output = DBOS.list_workflows()
-    assert len(output) == 1, f"Expected list length to be 1, but got {len(output)}"
-    assert output[0] != None, "Expected output to be not None"
-    wfUuid = output[0].workflow_id
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
-    assert info is not None, "Expected output to be not None"
-    assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
+    assert len(output) == 1
+    assert output[0] != None
+    wfid = output[0].workflow_id
+    info = _workflow_commands.get_workflow(sys_db, wfid, True)
+    assert info is not None
+    assert info.status == "PENDING"
 
     # Cancel the workflow. Verify it was cancelled
     response = requests.post(
-        f"http://localhost:3001/workflows/{wfUuid}/cancel", json=[], timeout=5
+        f"http://localhost:3001/workflows/{wfid}/cancel", json=[], timeout=5
     )
     assert response.status_code == 204
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
+    event.set()
+    with pytest.raises(DBOSWorkflowCancelledError):
+        handle.get_result()
+    info = _workflow_commands.get_workflow(sys_db, wfid, True)
     assert info is not None
-    assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
+    assert info.status == "CANCELLED"
 
     # Manually update the database to pretend the workflow comes from another executor and is pending
     with dbos._sys_db.engine.begin() as c:
@@ -282,35 +284,21 @@ def test_admin_workflow_resume(dbos: DBOS, sys_db: SystemDatabase) -> None:
             .values(
                 status=WorkflowStatusString.PENDING.value, executor_id="other-executor"
             )
-            .where(SystemSchema.workflow_status.c.workflow_uuid == wfUuid)
+            .where(SystemSchema.workflow_status.c.workflow_uuid == wfid)
         )
         c.execute(query)
 
     # Resume the workflow. Verify that it succeeds again.
-    event.clear()
     response = requests.post(
-        f"http://localhost:3001/workflows/{wfUuid}/resume", json=[], timeout=5
+        f"http://localhost:3001/workflows/{wfid}/resume", json=[], timeout=5
     )
     assert response.status_code == 204
-    assert event.wait(timeout=5)
     # Wait for the workflow to finish
-    DBOS.retrieve_workflow(wfUuid).get_result()
-    assert counter == 2
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
+    DBOS.retrieve_workflow(wfid).get_result()
+    info = _workflow_commands.get_workflow(sys_db, wfid, True)
     assert info is not None
-    assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
+    assert info.status == "SUCCESS"
     assert info.executor_id == GlobalParams.executor_id
-
-    # Resume the workflow. Verify it does not run and status remains SUCCESS
-    response = requests.post(
-        f"http://localhost:3001/workflows/{wfUuid}/resume", json=[], timeout=5
-    )
-    assert response.status_code == 204
-    DBOS.retrieve_workflow(wfUuid).get_result()
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
-    assert info is not None
-    assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
-    assert counter == 2
 
 
 def test_admin_workflow_restart(dbos: DBOS, sys_db: SystemDatabase) -> None:
@@ -338,28 +326,11 @@ def test_admin_workflow_restart(dbos: DBOS, sys_db: SystemDatabase) -> None:
     assert info.status == "SUCCESS", f"Expected status to be SUCCESS"
 
     response = requests.post(
-        f"http://localhost:3001/workflows/{wfUuid}/cancel", json=[], timeout=5
-    )
-    assert response.status_code == 204
-
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
-    if info is not None:
-        assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
-    else:
-        assert False, "Expected info to be not None"
-
-    response = requests.post(
         f"http://localhost:3001/workflows/{wfUuid}/restart", json=[], timeout=5
     )
     assert response.status_code == 204
 
     time.sleep(1)
-
-    info = _workflow_commands.get_workflow(sys_db, wfUuid, True)
-    if info is not None:
-        assert info.status == "CANCELLED", f"Expected status to be CANCELLED"
-    else:
-        assert False, "Expected info to be not None"
 
     output = DBOS.list_workflows()
     assert len(output) == 2, f"Expected list length to be 2, but got {len(output)}"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -486,12 +486,40 @@ async def test_workflow_timeout_async(dbos: DBOS) -> None:
             await handle.get_result()
 
     @DBOS.workflow()
-    async def parent_workflow() -> None:
+    async def parent_workflow_with_timeout() -> None:
+        assert assert_current_dbos_context().workflow_deadline_epoch_ms is None
         with SetWorkflowTimeout(0.1):
             with pytest.raises(DBOSWorkflowCancelledError):
                 await blocked_workflow()
             handle = await DBOS.start_workflow_async(blocked_workflow)
             with pytest.raises(DBOSWorkflowCancelledError):
                 await handle.get_result()
+        assert assert_current_dbos_context().workflow_deadline_epoch_ms is None
 
-    await parent_workflow()
+    # Verify if a parent calls a blocked workflow with a timeout, the child is cancelled
+    await parent_workflow_with_timeout()
+
+    start_child, direct_child = str(uuid.uuid4()), str(uuid.uuid4())
+
+    @DBOS.workflow()
+    async def parent_workflow() -> None:
+        assert assert_current_dbos_context().workflow_timeout_ms is None
+        assert assert_current_dbos_context().workflow_deadline_epoch_ms is not None
+        with SetWorkflowID(start_child):
+            await DBOS.start_workflow_async(blocked_workflow)
+        with SetWorkflowID(direct_child):
+            await blocked_workflow()
+
+    # Verify if a parent called with a timeout calls a blocked child
+    # the deadline propagates and the children are also cancelled.
+    with SetWorkflowTimeout(1.0):
+        with pytest.raises(DBOSWorkflowCancelledError):
+            await parent_workflow()
+
+    with pytest.raises(Exception) as exc_info:
+        await (await DBOS.retrieve_workflow_async(start_child)).get_result()
+    assert "was cancelled" in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        await (await DBOS.retrieve_workflow_async(direct_child)).get_result()
+    assert "was cancelled" in str(exc_info.value)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -474,7 +474,7 @@ async def test_workflow_timeout_async(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     async def blocked_workflow() -> None:
-        assert assert_current_dbos_context().workflow_timeout is None
+        assert assert_current_dbos_context().workflow_timeout_ms is None
         while True:
             DBOS.sleep(0.1)
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -20,7 +20,11 @@ from dbos._context import (
     assert_current_dbos_context,
     get_local_dbos_context,
 )
-from dbos._error import DBOSConflictingRegistrationError, DBOSMaxStepRetriesExceeded
+from dbos._error import (
+    DBOSConflictingRegistrationError,
+    DBOSMaxStepRetriesExceeded,
+    DBOSWorkflowCancelledError,
+)
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import GetWorkflowsInput
 from dbos._utils import GlobalParams
@@ -1457,8 +1461,9 @@ def test_workflow_timeout(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def blocked_workflow() -> None:
-        # threading.Event().wait()
-        pass
+        while True:
+            DBOS.sleep(0.1)
 
-    with SetWorkflowTimeout(0):
-        blocked_workflow()
+    with SetWorkflowTimeout(0.1):
+        with pytest.raises(DBOSWorkflowCancelledError):
+            blocked_workflow()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -599,6 +599,7 @@ def test_recovery_thread(config: ConfigFile) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout_ms": None,
             "workflow_deadline_epoch_ms": None,
         }
     )
@@ -1492,7 +1493,7 @@ def test_workflow_timeout(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def blocked_workflow() -> None:
-        assert assert_current_dbos_context().workflow_timeout is None
+        assert assert_current_dbos_context().workflow_timeout_ms is None
         while True:
             DBOS.sleep(0.1)
 
@@ -1515,8 +1516,8 @@ def test_workflow_timeout(dbos: DBOS) -> None:
     assert parent_workflow() == None
 
     with SetWorkflowTimeout(1.0):
-        assert assert_current_dbos_context().workflow_timeout == 1.0
+        assert assert_current_dbos_context().workflow_timeout_ms == 1000
         with SetWorkflowTimeout(2.0):
-            assert assert_current_dbos_context().workflow_timeout == 2.0
-        assert assert_current_dbos_context().workflow_timeout == 1.0
+            assert assert_current_dbos_context().workflow_timeout_ms == 2000
+        assert assert_current_dbos_context().workflow_timeout_ms == 1000
     assert get_local_dbos_context() is None

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -599,7 +599,7 @@ def test_recovery_thread(config: ConfigFile) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
-            "workflow_timeout": None,
+            "workflow_deadline_epoch_ms": None,
         }
     )
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -15,7 +15,11 @@ import sqlalchemy as sa
 from dbos import DBOS, ConfigFile, SetWorkflowID, WorkflowHandle, WorkflowStatusString
 
 # Private API because this is a test
-from dbos._context import assert_current_dbos_context, get_local_dbos_context
+from dbos._context import (
+    SetWorkflowTimeout,
+    assert_current_dbos_context,
+    get_local_dbos_context,
+)
 from dbos._error import DBOSConflictingRegistrationError, DBOSMaxStepRetriesExceeded
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import GetWorkflowsInput
@@ -1447,3 +1451,14 @@ def test_recovery_appversion(config: ConfigFile) -> None:
 
     # Clean up the environment variable
     del os.environ["DBOS__VMID"]
+
+
+def test_workflow_timeout(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def blocked_workflow() -> None:
+        # threading.Event().wait()
+        pass
+
+    with SetWorkflowTimeout(0):
+        blocked_workflow()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1461,6 +1461,7 @@ def test_workflow_timeout(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def blocked_workflow() -> None:
+        assert assert_current_dbos_context().workflow_timeout is None
         while True:
             DBOS.sleep(0.1)
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1467,3 +1467,6 @@ def test_workflow_timeout(dbos: DBOS) -> None:
     with SetWorkflowTimeout(0.1):
         with pytest.raises(DBOSWorkflowCancelledError):
             blocked_workflow()
+        handle = DBOS.start_workflow(blocked_workflow)
+        with pytest.raises(DBOSWorkflowCancelledError):
+            handle.get_result()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -591,6 +591,7 @@ def test_recovery_thread(config: ConfigFile) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout": None,
         }
     )
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -155,7 +155,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
-            "workflow_timeout": None,
+            "workflow_deadline_epoch_ms": None,
         }
     )
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -155,6 +155,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout_ms": None,
             "workflow_deadline_epoch_ms": None,
         }
     )

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -155,6 +155,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout": None,
         }
     )
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -116,6 +116,7 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout_ms": None,
             "workflow_deadline_epoch_ms": None,
         }
     )

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -116,6 +116,7 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout": None,
         }
     )
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -116,7 +116,7 @@ def test_endpoint_recovery(dbos_flask: Tuple[DBOS, Flask]) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
-            "workflow_timeout": None,
+            "workflow_deadline_epoch_ms": None,
         }
     )
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -18,7 +18,7 @@ from dbos import (
     SetWorkflowID,
     WorkflowHandle,
 )
-from dbos._context import SetWorkflowTimeout
+from dbos._context import SetWorkflowTimeout, assert_current_dbos_context
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from dbos._utils import GlobalParams
@@ -868,6 +868,7 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
 def test_timeout_queue(dbos: DBOS) -> None:
     @DBOS.workflow()
     def blocking_workflow() -> None:
+        assert assert_current_dbos_context().workflow_timeout is None
         while True:
             DBOS.sleep(0.1)
 
@@ -876,7 +877,7 @@ def test_timeout_queue(dbos: DBOS) -> None:
     num_workflows = 10
     handles: list[WorkflowHandle[None]] = []
     for _ in range(num_workflows):
-        with SetWorkflowTimeout(0.1):
+        with SetWorkflowTimeout(2.0):
             handle = queue.enqueue(blocking_workflow)
             handles.append(handle)
     for handle in handles:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -929,7 +929,7 @@ def test_timeout_queue(dbos: DBOS) -> None:
     queue = Queue("regular_queue")
 
     @DBOS.workflow()
-    def exiting_parent_workflow() -> None:
+    def exiting_parent_workflow() -> str:
         handle = queue.enqueue(blocking_workflow)
         return handle.get_workflow_id()
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -865,28 +865,28 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
-def test_timeout_queue(dbos: DBOS) -> None:
-    @DBOS.workflow()
-    def blocking_workflow() -> None:
-        assert assert_current_dbos_context().workflow_timeout is None
-        while True:
-            DBOS.sleep(0.1)
+# def test_timeout_queue(dbos: DBOS) -> None:
+#     @DBOS.workflow()
+#     def blocking_workflow() -> None:
+#         assert assert_current_dbos_context().workflow_timeout_ms is None
+#         while True:
+#             DBOS.sleep(0.1)
 
-    queue = Queue("test_queue", concurrency=1)
+#     queue = Queue("test_queue", concurrency=1)
 
-    num_workflows = 10
-    handles: list[WorkflowHandle[None]] = []
-    for _ in range(num_workflows):
-        with SetWorkflowTimeout(2.0):
-            handle = queue.enqueue(blocking_workflow)
-            handles.append(handle)
-    for handle in handles:
-        with pytest.raises(Exception) as exc_info:
-            handle.get_result()
-        assert "was cancelled" in str(exc_info.value)
+#     num_workflows = 10
+#     handles: list[WorkflowHandle[None]] = []
+#     for _ in range(num_workflows):
+#         with SetWorkflowTimeout(2.0):
+#             handle = queue.enqueue(blocking_workflow)
+#             handles.append(handle)
+#     for handle in handles:
+#         with pytest.raises(Exception) as exc_info:
+#             handle.get_result()
+#         assert "was cancelled" in str(exc_info.value)
 
-    # Verify all queue entries eventually get cleaned up.
-    assert queue_entries_are_cleaned_up(dbos)
+#     # Verify all queue entries eventually get cleaned up.
+#     assert queue_entries_are_cleaned_up(dbos)
 
 
 def test_resuming_queued_workflows(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -882,8 +882,8 @@ def test_timeout_queue(dbos: DBOS) -> None:
             handles.append(handle)
     for handle in handles:
         with pytest.raises(Exception) as exc_info:
-            assert "was cancelled" in str(exc_info.value)
             handle.get_result()
+        assert "was cancelled" in str(exc_info.value)
 
     # Verify all queue entries eventually get cleaned up.
     assert queue_entries_are_cleaned_up(dbos)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -902,6 +902,27 @@ def test_timeout_queue(dbos: DBOS) -> None:
     # Verify the normal workflow succeeds
     normal_handle.get_result()
 
+    # Verify if a parent called with a timeout enqueues a blocked child
+    # the deadline propagates and the child is also cancelled.
+    child_id = str(uuid.uuid4())
+    queue = Queue("regular_queue")
+
+    @DBOS.workflow()
+    def parent_workflow() -> None:
+        with SetWorkflowID(child_id):
+            handle = queue.enqueue(blocking_workflow)
+        handle.get_result()
+
+    with SetWorkflowTimeout(1.0):
+        handle = queue.enqueue(parent_workflow)
+    with pytest.raises(Exception) as exc_info:
+        handle.get_result()
+    assert "was cancelled" in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        DBOS.retrieve_workflow(child_id).get_result()
+    assert "was cancelled" in str(exc_info.value)
+
     # Verify all queue entries eventually get cleaned up.
     assert queue_entries_are_cleaned_up(dbos)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -869,12 +869,14 @@ def test_timeout_queue(dbos: DBOS) -> None:
     @DBOS.workflow()
     def blocking_workflow() -> None:
         assert assert_current_dbos_context().workflow_timeout_ms is None
+        assert assert_current_dbos_context().workflow_deadline_epoch_ms is not None
         while True:
             DBOS.sleep(0.1)
 
     @DBOS.workflow()
     def normal_workflow() -> None:
         assert assert_current_dbos_context().workflow_timeout_ms is None
+        assert assert_current_dbos_context().workflow_deadline_epoch_ms is not None
         return
 
     queue = Queue("test_queue", concurrency=1)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -224,6 +224,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout_ms": None,
             "workflow_deadline_epoch_ms": None,
         }
     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -224,7 +224,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
-            "workflow_timeout": None,
+            "workflow_deadline_epoch_ms": None,
         }
     )
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -224,6 +224,7 @@ def test_scheduler_oaoo(dbos: DBOS) -> None:
             "queue_name": None,
             "created_at": None,
             "updated_at": None,
+            "workflow_timeout": None,
         }
     )
 


### PR DESCRIPTION
You can now specify a timeout for a workflow (in seconds, as a float):

```python
with SetWorkflowTimeout(my_timeout):
  my_workflow()
```

This also works with queues:

```python
with SetWorkflowTimeout(my_timeout):
  queue.enqueue(my_workflow)
```

And from clients:
```python
options: EnqueueOptions = {
    "queue_name": "my_queue",
    "workflow_name": "my_workflow",
    "workflow_timeout": 0.1,
}
client.enqueue(options, args)
```

When the timeout expires, the workflow is cancelled. This immediately sets its status to CANCELLED, removes it from any queues it is in, and preempts it at the start of its next step.

Semantics:

- Timeouts are **start** to completion. If a workflow is enqueued with a timeout, the timeout does not start until the workflow is dequeued.
- Deadlines **propagate**. When a workflow starts, a deadline is computed from its start time and the timeout. This deadline propagates to all the workflow's children, so when the deadline is reached, they are all cancelled. To override the deadline start a child with `SetWorkflowTimeout()`  You can use `SetWorkflowTimeout(None)` for no timeout.