### PR TITLE
List workflows and queues in a single query

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -5,8 +5,7 @@ from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle
 from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url, load_config
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
-from ._sys_db import GetWorkflowsInput, WorkflowStatusString
-from ._workflow_commands import WorkflowStatus
+from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString
 
 __all__ = [
     "ConfigFile",

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -19,9 +19,9 @@ from dbos._serialization import WorkflowInputs
 from dbos._sys_db import (
     StepInfo,
     SystemDatabase,
+    WorkflowStatus,
     WorkflowStatusInternal,
     WorkflowStatusString,
-    WorkflowStatus,
 )
 from dbos._workflow_commands import (
     fork_workflow,
@@ -30,7 +30,6 @@ from dbos._workflow_commands import (
     list_workflow_steps,
     list_workflows,
 )
-from dbos._workflow_commands import get_workflow, list_queued_workflows, list_workflows
 
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -21,15 +21,16 @@ from dbos._sys_db import (
     SystemDatabase,
     WorkflowStatusInternal,
     WorkflowStatusString,
+    WorkflowStatus,
 )
 from dbos._workflow_commands import (
-    WorkflowStatus,
     fork_workflow,
     get_workflow,
     list_queued_workflows,
     list_workflow_steps,
     list_workflows,
 )
+from dbos._workflow_commands import get_workflow, list_queued_workflows, list_workflows
 
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
@@ -54,7 +55,7 @@ class WorkflowHandleClientPolling(Generic[R]):
         res: R = self._sys_db.await_workflow_result(self.workflow_id)
         return res
 
-    def get_status(self) -> "WorkflowStatus":
+    def get_status(self) -> WorkflowStatus:
         status = get_workflow(self._sys_db, self.workflow_id, True)
         if status is None:
             raise DBOSNonExistentWorkflowError(self.workflow_id)
@@ -76,7 +77,7 @@ class WorkflowHandleClientAsyncPolling(Generic[R]):
         )
         return res
 
-    async def get_status(self) -> "WorkflowStatus":
+    async def get_status(self) -> WorkflowStatus:
         status = await asyncio.to_thread(
             get_workflow, self._sys_db, self.workflow_id, True
         )

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -3,8 +3,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import List, Optional, Type, TypedDict, TypeVar
 
-from dbos._sys_db import StepInfo
-from dbos._workflow_commands import WorkflowStatus
+from dbos._sys_db import StepInfo, WorkflowStatus
 
 
 class MessageType(str, Enum):

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -75,6 +75,7 @@ from ._serialization import WorkflowInputs
 from ._sys_db import (
     GetEventWorkflowContext,
     OperationResultInternal,
+    WorkflowStatus,
     WorkflowStatusInternal,
     WorkflowStatusString,
 )
@@ -87,7 +88,6 @@ if TYPE_CHECKING:
         DBOSRegistry,
         IsolationLevel,
     )
-    from ._workflow_commands import WorkflowStatus
 
 from sqlalchemy.exc import DBAPIError, InvalidRequestError
 
@@ -119,7 +119,7 @@ class WorkflowHandleFuture(Generic[R]):
         self.dbos._sys_db.record_get_result(self.workflow_id, serialized_r, None)
         return r
 
-    def get_status(self) -> "WorkflowStatus":
+    def get_status(self) -> WorkflowStatus:
         stat = self.dbos.get_workflow_status(self.workflow_id)
         if stat is None:
             raise DBOSNonExistentWorkflowError(self.workflow_id)
@@ -146,7 +146,7 @@ class WorkflowHandlePolling(Generic[R]):
         self.dbos._sys_db.record_get_result(self.workflow_id, serialized_r, None)
         return r
 
-    def get_status(self) -> "WorkflowStatus":
+    def get_status(self) -> WorkflowStatus:
         stat = self.dbos.get_workflow_status(self.workflow_id)
         if stat is None:
             raise DBOSNonExistentWorkflowError(self.workflow_id)
@@ -181,7 +181,7 @@ class WorkflowHandleAsyncTask(Generic[R]):
         )
         return r
 
-    async def get_status(self) -> "WorkflowStatus":
+    async def get_status(self) -> WorkflowStatus:
         stat = await asyncio.to_thread(self.dbos.get_workflow_status, self.workflow_id)
         if stat is None:
             raise DBOSNonExistentWorkflowError(self.workflow_id)
@@ -217,7 +217,7 @@ class WorkflowHandleAsyncPolling(Generic[R]):
         )
         return r
 
-    async def get_status(self) -> "WorkflowStatus":
+    async def get_status(self) -> WorkflowStatus:
         stat = await asyncio.to_thread(self.dbos.get_workflow_status, self.workflow_id)
         if stat is None:
             raise DBOSNonExistentWorkflowError(self.workflow_id)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -31,9 +31,9 @@ from typing import (
 from opentelemetry.trace import Span
 
 from dbos._conductor.conductor import ConductorWebsocket
+from dbos._sys_db import WorkflowStatus
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import (
-    WorkflowStatus,
     fork_workflow,
     list_queued_workflows,
     list_workflows,
@@ -68,7 +68,7 @@ from ._registrations import (
 )
 from ._roles import default_required_roles, required_roles
 from ._scheduler import ScheduledWorkflow, scheduled
-from ._sys_db import StepInfo, reset_system_database
+from ._sys_db import StepInfo, WorkflowStatus, reset_system_database
 from ._tracer import dbos_tracer
 
 if TYPE_CHECKING:
@@ -114,7 +114,7 @@ from ._error import (
 from ._event_loop import BackgroundEventLoop
 from ._logger import add_otlp_to_all_loggers, config_logger, dbos_logger, init_logger
 from ._sys_db import SystemDatabase
-from ._workflow_commands import WorkflowStatus, get_workflow, list_workflow_steps
+from ._workflow_commands import get_workflow, list_workflow_steps
 
 # Most DBOS functions are just any callable F, so decorators / wrappers work on F
 # There are cases where the parameters P and return value R should be separate

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -1,6 +1,8 @@
+import uuid
 from typing import List, Optional
 
 from dbos._error import DBOSException
+
 from ._app_db import ApplicationDatabase
 from ._sys_db import (
     GetQueuedWorkflowsInput,

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -1,62 +1,14 @@
-import json
-import uuid
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from dbos._error import DBOSException
-
-from . import _serialization
 from ._app_db import ApplicationDatabase
 from ._sys_db import (
     GetQueuedWorkflowsInput,
     GetWorkflowsInput,
-    GetWorkflowsOutput,
     StepInfo,
     SystemDatabase,
+    WorkflowStatus,
 )
-
-
-class WorkflowStatus:
-    # The workflow ID
-    workflow_id: str
-    # The workflow status. Must be one of ENQUEUED, PENDING, SUCCESS, ERROR, CANCELLED, or RETRIES_EXCEEDED
-    status: str
-    # The name of the workflow function
-    name: str
-    # The name of the workflow's class, if any
-    class_name: Optional[str]
-    # The name with which the workflow's class instance was configured, if any
-    config_name: Optional[str]
-    # The user who ran the workflow, if specified
-    authenticated_user: Optional[str]
-    # The role with which the workflow ran, if specified
-    assumed_role: Optional[str]
-    # All roles which the authenticated user could assume
-    authenticated_roles: Optional[list[str]]
-    # The deserialized workflow input object
-    input: Optional[_serialization.WorkflowInputs]
-    # The workflow's output, if any
-    output: Optional[Any] = None
-    # The error the workflow threw, if any
-    error: Optional[Exception] = None
-    # Workflow start time, as a Unix epoch timestamp in ms
-    created_at: Optional[int]
-    # Last time the workflow status was updated, as a Unix epoch timestamp in ms
-    updated_at: Optional[int]
-    # If this workflow was enqueued, on which queue
-    queue_name: Optional[str]
-    # The executor to most recently executed this workflow
-    executor_id: Optional[str]
-    # The application version on which this workflow was started
-    app_version: Optional[str]
-
-    # INTERNAL FIELDS
-
-    # The ID of the application executing this workflow
-    app_id: Optional[str]
-    # The number of times this workflow's execution has been attempted
-    recovery_attempts: Optional[int]
-    # The HTTP request that triggered the workflow, if known
-    request: Optional[str]
 
 
 def list_workflows(
@@ -88,12 +40,8 @@ def list_workflows(
     input.sort_desc = sort_desc
     input.workflow_id_prefix = workflow_id_prefix
 
-    output: GetWorkflowsOutput = sys_db.get_workflows(input)
-    infos: List[WorkflowStatus] = []
-    for workflow_id in output.workflow_uuids:
-        info = get_workflow(sys_db, workflow_id, request)  # Call the method for each ID
-        if info is not None:
-            infos.append(info)
+    infos: List[WorkflowStatus] = sys_db.get_workflows(input, request)
+
     return infos
 
 
@@ -120,63 +68,22 @@ def list_queued_workflows(
         "offset": offset,
         "sort_desc": sort_desc,
     }
-    output: GetWorkflowsOutput = sys_db.get_queued_workflows(input)
-    infos: List[WorkflowStatus] = []
-    for workflow_id in output.workflow_uuids:
-        info = get_workflow(sys_db, workflow_id, request)  # Call the method for each ID
-        if info is not None:
-            infos.append(info)
+
+    infos: List[WorkflowStatus] = sys_db.get_queued_workflows(input, request)
     return infos
 
 
 def get_workflow(
     sys_db: SystemDatabase, workflow_id: str, get_request: bool
 ) -> Optional[WorkflowStatus]:
+    input = GetWorkflowsInput()
+    input.workflow_ids = [workflow_id]
 
-    internal_status = sys_db.get_workflow_status(workflow_id)
-    if internal_status is None:
+    infos: List[WorkflowStatus] = sys_db.get_workflows(input, get_request)
+    if not infos:
         return None
 
-    info = WorkflowStatus()
-
-    info.workflow_id = workflow_id
-    info.status = internal_status["status"]
-    info.name = internal_status["name"]
-    info.class_name = internal_status["class_name"]
-    info.config_name = internal_status["config_name"]
-    info.authenticated_user = internal_status["authenticated_user"]
-    info.assumed_role = internal_status["assumed_role"]
-    info.authenticated_roles = (
-        json.loads(internal_status["authenticated_roles"])
-        if internal_status["authenticated_roles"] is not None
-        else None
-    )
-    info.request = internal_status["request"]
-    info.created_at = internal_status["created_at"]
-    info.updated_at = internal_status["updated_at"]
-    info.queue_name = internal_status["queue_name"]
-    info.executor_id = internal_status["executor_id"]
-    info.app_version = internal_status["app_version"]
-    info.app_id = internal_status["app_id"]
-    info.recovery_attempts = internal_status["recovery_attempts"]
-
-    input_data = sys_db.get_workflow_inputs(workflow_id)
-    if input_data is not None:
-        info.input = input_data
-
-    if internal_status.get("status") == "SUCCESS":
-        result = sys_db.await_workflow_result(workflow_id)
-        info.output = result
-    elif internal_status.get("status") == "ERROR":
-        try:
-            sys_db.await_workflow_result(workflow_id)
-        except Exception as e:
-            info.error = e
-
-    if not get_request:
-        info.request = None
-
-    return info
+    return infos[0]
 
 
 def list_workflow_steps(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -297,13 +297,13 @@ def test_temp_workflow(dbos: DBOS) -> None:
     assert res == "var"
 
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 2
+    assert len(wfs) == 2
 
-    wfi1 = dbos._sys_db.get_workflow_status(wfs.workflow_uuids[0])
+    wfi1 = dbos._sys_db.get_workflow_status(wfs[0].workflow_id)
     assert wfi1
     assert wfi1["name"].startswith("<temp>")
 
-    wfi2 = dbos._sys_db.get_workflow_status(wfs.workflow_uuids[1])
+    wfi2 = dbos._sys_db.get_workflow_status(wfs[1].workflow_id)
     assert wfi2
     assert wfi2["name"].startswith("<temp>")
 
@@ -518,10 +518,10 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
         assert res == "bob1"
 
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 1
-    assert wfs.workflow_uuids[0] == wfuuid
+    assert len(wfs) == 1
+    assert wfs[0].workflow_id == wfuuid
 
-    wfi = dbos._sys_db.get_workflow_status(wfs.workflow_uuids[0])
+    wfi = dbos._sys_db.get_workflow_status(wfs[0].workflow_id)
     assert wfi
     assert wfi["name"].startswith("<temp>")
 
@@ -539,10 +539,10 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
     assert workflow_handles[0].get_result() == "bob1"
 
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 1
-    assert wfs.workflow_uuids[0] == wfuuid
+    assert len(wfs) == 1
+    assert wfs[0].workflow_id == wfuuid
 
-    wfi = dbos._sys_db.get_workflow_status(wfs.workflow_uuids[0])
+    wfi = dbos._sys_db.get_workflow_status(wfs[0].workflow_id)
     assert wfi
     assert wfi["name"].startswith("<temp>")
     assert wfi["status"] == "SUCCESS"
@@ -937,11 +937,11 @@ def test_send_recv_temp_wf(dbos: DBOS) -> None:
     assert handle.get_result() == "testsend1"
 
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs.workflow_uuids) == 2
-    assert wfs.workflow_uuids[0] == dest_uuid
-    assert wfs.workflow_uuids[1] != dest_uuid
+    assert len(wfs) == 2
+    assert wfs[0].workflow_id == dest_uuid
+    assert wfs[1].workflow_id != dest_uuid
 
-    wfi = dbos._sys_db.get_workflow_status(wfs.workflow_uuids[1])
+    wfi = dbos._sys_db.get_workflow_status(wfs[1].workflow_id)
     assert wfi
     assert wfi["name"] == "<temp>.temp_send_workflow"
 
@@ -951,16 +951,16 @@ def test_send_recv_temp_wf(dbos: DBOS) -> None:
     gwi.start_time = None
     gwi.workflow_id_prefix = dest_uuid
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert wfs.workflow_uuids[0] == dest_uuid
+    assert wfs[0].workflow_id == dest_uuid
 
     gwi.workflow_id_prefix = dest_uuid[0:10]
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert dest_uuid in wfs.workflow_uuids
+    assert dest_uuid in [w.workflow_id for w in wfs]
 
     gwi.start_time = cur_time
     gwi.workflow_id_prefix = dest_uuid[0:10]
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert dest_uuid in wfs.workflow_uuids
+    assert dest_uuid in [w.workflow_id for w in wfs]
 
     x = dbos.list_workflows(
         start_time=datetime.datetime.now().isoformat(),

--- a/tests/test_fastapi_roles.py
+++ b/tests/test_fastapi_roles.py
@@ -135,8 +135,8 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     gwi = GetWorkflowsInput()
     gwi.authenticated_user = "user1"
     wfl = dbos._sys_db.get_workflows(gwi)
-    assert len(wfl.workflow_uuids) == 1
-    wfs = DBOS.get_workflow_status(wfl.workflow_uuids[0])
+    assert len(wfl) == 1
+    wfs = DBOS.get_workflow_status(wfl[0].workflow_id)
     assert wfs
     assert wfs.assumed_role == "user"
     assert wfs.authenticated_user == "user1"
@@ -145,7 +145,7 @@ def test_simple_endpoint(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
     # Make sure predicate is actually applied
     gwi.authenticated_user = "user2"
     wfl = dbos._sys_db.get_workflows(gwi)
-    assert len(wfl.workflow_uuids) == 0
+    assert len(wfl) == 0
 
     response = client.get("/error")
     assert response.status_code == 401


### PR DESCRIPTION
Previously, we issue many queries to the database to first fetch a list of workflow IDs and their result and inputs individually. So each workflow would involve many DB roundtrips. This could lead to really slow performance when the list of workflows are long.

This PR modifies `get_workflows` and `get_queued_workflows` to use a single DB query to fetch everything. Also moved `WorkflowStatus` to `_sys_db.py` so those functions can directly return a list of external-facing workflow status.