### PR TITLE
Improve Dead Letter Queue

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -134,7 +134,9 @@ class DBOSClient:
             "kwargs": kwargs,
         }
 
-        self._sys_db.init_workflow(status, _serialization.serialize_args(inputs))
+        self._sys_db.init_workflow(
+            status, _serialization.serialize_args(inputs), max_recovery_attempts=None
+        )
         return workflow_id
 
     def enqueue(
@@ -190,7 +192,9 @@ class DBOSClient:
             "app_version": None,
         }
         with self._sys_db.engine.begin() as conn:
-            self._sys_db.insert_workflow_status(status, conn)
+            self._sys_db.insert_workflow_status(
+                status, conn, max_recovery_attempts=None
+            )
         self._sys_db.send(status["workflow_uuid"], 0, destination_id, message, topic)
 
     async def send_async(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -232,8 +232,8 @@ def _init_workflow(
     class_name: Optional[str],
     config_name: Optional[str],
     temp_wf_type: Optional[str],
-    queue: Optional[str] = None,
-    max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS,
+    queue: Optional[str],
+    max_recovery_attempts: Optional[int],
 ) -> WorkflowStatusInternal:
     wfid = (
         ctx.workflow_id
@@ -653,7 +653,7 @@ else:
 def workflow_wrapper(
     dbosreg: "DBOSRegistry",
     func: Callable[P, R],
-    max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS,
+    max_recovery_attempts: Optional[int] = DEFAULT_MAX_RECOVERY_ATTEMPTS,
 ) -> Callable[P, R]:
     func.__orig_func = func  # type: ignore
 
@@ -718,6 +718,7 @@ def workflow_wrapper(
                 class_name=get_dbos_class_name(fi, func, args),
                 config_name=get_config_name(fi, func, args),
                 temp_wf_type=get_temp_workflow_type(func),
+                queue=None,
                 max_recovery_attempts=max_recovery_attempts,
             )
 
@@ -765,7 +766,7 @@ def workflow_wrapper(
 
 
 def decorate_workflow(
-    reg: "DBOSRegistry", max_recovery_attempts: int
+    reg: "DBOSRegistry", max_recovery_attempts: Optional[int]
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def _workflow_decorator(func: Callable[P, R]) -> Callable[P, R]:
         wrapped_func = workflow_wrapper(reg, func, max_recovery_attempts)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -600,7 +600,7 @@ class DBOS:
     # Decorators for DBOS functionality
     @classmethod
     def workflow(
-        cls, *, max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS
+        cls, *, max_recovery_attempts: Optional[int] = DEFAULT_MAX_RECOVERY_ATTEMPTS
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """Decorate a function for use as a DBOS workflow."""
         return decorate_workflow(_get_or_create_dbos_registry(), max_recovery_attempts)

--- a/dbos/_registrations.py
+++ b/dbos/_registrations.py
@@ -51,7 +51,7 @@ class DBOSFuncInfo:
     class_info: Optional[DBOSClassInfo] = None
     func_type: DBOSFuncType = DBOSFuncType.Unknown
     required_roles: Optional[List[str]] = None
-    max_recovery_attempts: int = DEFAULT_MAX_RECOVERY_ATTEMPTS
+    max_recovery_attempts: Optional[int] = DEFAULT_MAX_RECOVERY_ATTEMPTS
 
 
 def get_or_create_class_info(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -354,7 +354,9 @@ class SystemDatabase:
 
             # Every time we start executing a workflow (and thus attempt to insert its status), we increment `recovery_attempts` by 1.
             # When this number becomes equal to `maxRetries + 1`, we mark the workflow as `RETRIES_EXCEEDED`.
-            if recovery_attempts > max_recovery_attempts + 1:
+            if (
+                wf_status != "SUCCESS" and wf_status != "ERROR"
+            ) and recovery_attempts > max_recovery_attempts + 1:
                 delete_cmd = sa.delete(SystemSchema.workflow_queue).where(
                     SystemSchema.workflow_queue.c.workflow_uuid
                     == status["workflow_uuid"]

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -13,6 +13,7 @@ from dbos._error import (
     DBOSMaxStepRetriesExceeded,
     DBOSUnexpectedStepError,
 )
+from dbos._registrations import DEFAULT_MAX_RECOVERY_ATTEMPTS
 from dbos._sys_db import WorkflowStatusString
 
 from .conftest import queue_entries_are_cleaned_up
@@ -190,6 +191,26 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
     for _ in range(max_recovery_attempts * 2):
         with SetWorkflowID(wfid):
             dead_letter_workflow()
+
+    event.clear()
+
+    @DBOS.workflow(max_recovery_attempts=None)
+    def infinite_dead_letter_workflow() -> None:
+        event.wait()
+
+    # Verify that a workflow with max_recovery_attempts=None is retried infinitely.
+    wfid = str(uuid.uuid4())
+    handles = []
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(infinite_dead_letter_workflow)
+        handles.append(handle)
+
+    # Attempt to recover the blocked workflow the maximum number of times
+    for i in range(DEFAULT_MAX_RECOVERY_ATTEMPTS * 2):
+        handles.extend(DBOS._recover_pending_workflows())
+    event.set()
+    for handle in handles:
+        assert handle.get_result() == None
 
 
 def test_nondeterministic_workflow(dbos: DBOS) -> None:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -186,6 +186,11 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
     assert handle.get_result() == resumed_handle.get_result() == None
     assert handle.get_status().status == WorkflowStatusString.SUCCESS.value
 
+    # Verify that retries of a completed workflow do not raise the DLQ exception
+    for _ in range(max_recovery_attempts * 2):
+        with SetWorkflowID(wfid):
+            dead_letter_workflow()
+
 
 def test_nondeterministic_workflow(dbos: DBOS) -> None:
     flag = True


### PR DESCRIPTION
- Calling a workflow that has already completed will no longer throw the DLQ error.
- You can disable the DLQ for a workflow with `@DBOS.workflow(max_recovery_attempts=None)`.