### PR TITLE
deprecate DB fields in JSON schema and accept null values

### DIFF
--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -24,43 +24,51 @@
         "additionalProperties": false,
         "properties": {
           "hostname": {
-            "type": "string",
-            "description": "The hostname or IP address of the application database"
+            "type": ["string", "null"],
+            "description": "The hostname or IP address of the application database",
+            "deprecated": true
           },
           "port": {
-            "type": "number",
-            "description": "The port number of the application database"
+            "type": ["number", "null"],
+            "description": "The port number of the application database",
+            "deprecated": true
           },
           "username": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "The username to use when connecting to the application database",
             "not": {
               "enum": ["dbos"]
-            }
+            },
+            "deprecated": true
           },
           "password": {
             "type": ["string", "null"],
-            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution (${VAR_NAME}) or Docker secrets (${DOCKER_SECRET:SECRET_NAME}) to avoid storing secrets in source."
+            "description": "The password to use when connecting to the application database. Developers are strongly encouraged to use environment variable substitution (${VAR_NAME}) or Docker secrets (${DOCKER_SECRET:SECRET_NAME}) to avoid storing secrets in source.",
+            "deprecated": true
           },
           "connectionTimeoutMillis": {
-            "type": "number",
-            "description": "The number of milliseconds the system waits before timing out when connecting to the application database"
+            "type": ["number", "null"],
+            "description": "The number of milliseconds the system waits before timing out when connecting to the application database",
+            "deprecated": true
           },
           "app_db_name": {
-            "type": "string",
-            "description": "The name of the application database"
+            "type": ["string", "null"],
+            "description": "The name of the application database",
+            "deprecated": true
           },
           "sys_db_name": {
             "type": "string",
             "description": "The name of the system database"
           },
           "ssl": {
-            "type": "boolean",
-            "description": "Use SSL/TLS to securely connect to the database (default: true)"
+            "type": ["boolean", "null"],
+            "description": "Use SSL/TLS to securely connect to the database (default: true)",
+            "deprecated": true
           },
           "ssl_ca": {
-            "type": "string",
-            "description": "If using SSL/TLS to securely connect to a database, path to an SSL root certificate file"
+            "type": ["string", "null"],
+            "description": "If using SSL/TLS to securely connect to a database, path to an SSL root certificate file",
+            "deprecated": true
           },
           "app_db_client": {
             "type": "string",
@@ -78,7 +86,8 @@
           },
           "rollback": {
             "type": "array",
-            "description": "Specify a list of user DB rollback commands to run"
+            "description": "Specify a list of user DB rollback commands to run",
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
Testing with this config:

```yaml
name: dbos-app-starter
language: python
database:
    app_db_name: ${NOTHERE}
    port: ${DBOS_PORT}
    hostname: ${DBOS_HOST}
    username: ${DBOS_USER}
    password: ${DBOS_PASSWORD}
    ssl: ${DBOS_SSL}
    ssl_ca: ${DBOS_SSL_CA}
    connectionTimeoutMillis: ${DBOS_SSL_CA}
runtimeConfig:
  start:
    - "fastapi run app/main.py"
database_url: ${DBOS_DATABASE_URL}

```

https://github.com/user-attachments/assets/62028d43-efd4-436c-85be-1e9cd419af74

