### PR TITLE
Improve Fork Semantics

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -235,11 +235,19 @@ class DBOSClient:
     async def cancel_workflow_async(self, workflow_id: str) -> None:
         await asyncio.to_thread(self.cancel_workflow, workflow_id)
 
-    def resume_workflow(self, workflow_id: str) -> None:
-        self._sys_db.resume_workflow(workflow_id)
+    def resume_workflow(
+        self, workflow_id: str, *, application_version: Optional[str] = None
+    ) -> None:
+        self._sys_db.resume_workflow(
+            workflow_id, application_version=application_version
+        )
 
-    async def resume_workflow_async(self, workflow_id: str) -> None:
-        await asyncio.to_thread(self.resume_workflow, workflow_id)
+    async def resume_workflow_async(
+        self, workflow_id: str, *, application_version: Optional[str] = None
+    ) -> None:
+        await asyncio.to_thread(
+            self.resume_workflow, workflow_id, application_version=application_version
+        )
 
     def list_workflows(
         self,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -245,17 +245,19 @@ class DBOSClient:
 
     def resume_workflow(
         self, workflow_id: str, *, application_version: Optional[str] = None
-    ) -> None:
+    ) -> WorkflowHandle[Any]:
         self._sys_db.resume_workflow(
             workflow_id, application_version=application_version
         )
+        return self.retrieve_workflow(workflow_id)
 
     async def resume_workflow_async(
         self, workflow_id: str, *, application_version: Optional[str] = None
-    ) -> None:
+    ) -> WorkflowHandleAsync[Any]:
         await asyncio.to_thread(
             self.resume_workflow, workflow_id, application_version=application_version
         )
+        return await self.retrieve_workflow_async(workflow_id)
 
     def list_workflows(
         self,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -243,20 +243,12 @@ class DBOSClient:
     async def cancel_workflow_async(self, workflow_id: str) -> None:
         await asyncio.to_thread(self.cancel_workflow, workflow_id)
 
-    def resume_workflow(
-        self, workflow_id: str, *, application_version: Optional[str] = None
-    ) -> WorkflowHandle[Any]:
-        self._sys_db.resume_workflow(
-            workflow_id, application_version=application_version
-        )
+    def resume_workflow(self, workflow_id: str) -> WorkflowHandle[Any]:
+        self._sys_db.resume_workflow(workflow_id)
         return self.retrieve_workflow(workflow_id)
 
-    async def resume_workflow_async(
-        self, workflow_id: str, *, application_version: Optional[str] = None
-    ) -> WorkflowHandleAsync[Any]:
-        await asyncio.to_thread(
-            self.resume_workflow, workflow_id, application_version=application_version
-        )
+    async def resume_workflow_async(self, workflow_id: str) -> WorkflowHandleAsync[Any]:
+        await asyncio.to_thread(self.resume_workflow, workflow_id)
         return await self.retrieve_workflow_async(workflow_id)
 
     def list_workflows(

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -245,11 +245,11 @@ class DBOSClient:
 
     def resume_workflow(self, workflow_id: str) -> WorkflowHandle[Any]:
         self._sys_db.resume_workflow(workflow_id)
-        return self.retrieve_workflow(workflow_id)
+        return WorkflowHandleClientPolling[Any](workflow_id, self._sys_db)
 
     async def resume_workflow_async(self, workflow_id: str) -> WorkflowHandleAsync[Any]:
         await asyncio.to_thread(self.resume_workflow, workflow_id)
-        return await self.retrieve_workflow_async(workflow_id)
+        return WorkflowHandleClientAsyncPolling[Any](workflow_id, self._sys_db)
 
     def list_workflows(
         self,
@@ -369,7 +369,7 @@ class DBOSClient:
         start_step: int,
         *,
         application_version: Optional[str] = None,
-    ) -> WorkflowHandle[R]:
+    ) -> WorkflowHandle[Any]:
         forked_workflow_id = fork_workflow(
             self._sys_db,
             self._app_db,
@@ -377,7 +377,7 @@ class DBOSClient:
             start_step,
             application_version=application_version,
         )
-        return WorkflowHandleClientPolling[R](forked_workflow_id, self._sys_db)
+        return WorkflowHandleClientPolling[Any](forked_workflow_id, self._sys_db)
 
     async def fork_workflow_async(
         self,
@@ -385,7 +385,7 @@ class DBOSClient:
         start_step: int,
         *,
         application_version: Optional[str] = None,
-    ) -> WorkflowHandleAsync[R]:
+    ) -> WorkflowHandleAsync[Any]:
         forked_workflow_id = await asyncio.to_thread(
             fork_workflow,
             self._sys_db,
@@ -394,4 +394,4 @@ class DBOSClient:
             start_step,
             application_version=application_version,
         )
-        return WorkflowHandleClientAsyncPolling[R](forked_workflow_id, self._sys_db)
+        return WorkflowHandleClientAsyncPolling[Any](forked_workflow_id, self._sys_db)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -361,16 +361,35 @@ class DBOSClient:
     async def list_workflow_steps_async(self, workflow_id: str) -> List[StepInfo]:
         return await asyncio.to_thread(self.list_workflow_steps, workflow_id)
 
-    def fork_workflow(self, workflow_id: str, start_step: int) -> WorkflowHandle[R]:
+    def fork_workflow(
+        self,
+        workflow_id: str,
+        start_step: int,
+        *,
+        application_version: Optional[str] = None,
+    ) -> WorkflowHandle[R]:
         forked_workflow_id = fork_workflow(
-            self._sys_db, self._app_db, workflow_id, start_step
+            self._sys_db,
+            self._app_db,
+            workflow_id,
+            start_step,
+            application_version=application_version,
         )
         return WorkflowHandleClientPolling[R](forked_workflow_id, self._sys_db)
 
     async def fork_workflow_async(
-        self, workflow_id: str, start_step: int
+        self,
+        workflow_id: str,
+        start_step: int,
+        *,
+        application_version: Optional[str] = None,
     ) -> WorkflowHandleAsync[R]:
         forked_workflow_id = await asyncio.to_thread(
-            fork_workflow, self._sys_db, self._app_db, workflow_id, start_step
+            fork_workflow,
+            self._sys_db,
+            self._app_db,
+            workflow_id,
+            start_step,
+            application_version=application_version,
         )
         return WorkflowHandleClientAsyncPolling[R](forked_workflow_id, self._sys_db)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -982,7 +982,13 @@ class DBOS:
         return cls.fork_workflow(workflow_id, 1)
 
     @classmethod
-    def fork_workflow(cls, workflow_id: str, start_step: int) -> WorkflowHandle[Any]:
+    def fork_workflow(
+        cls,
+        workflow_id: str,
+        start_step: int,
+        *,
+        application_version: Optional[str] = None,
+    ) -> WorkflowHandle[Any]:
         """Restart a workflow with a new workflow ID from a specific step"""
 
         def fn() -> str:
@@ -992,6 +998,7 @@ class DBOS:
                 _get_dbos_instance()._app_db,
                 workflow_id,
                 start_step,
+                application_version=application_version,
             )
 
         new_id = _get_dbos_instance()._sys_db.call_function_as_step(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -962,12 +962,16 @@ class DBOS:
         )
 
     @classmethod
-    def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
+    def resume_workflow(
+        cls, workflow_id: str, *, application_version: Optional[str] = None
+    ) -> WorkflowHandle[Any]:
         """Resume a workflow by ID."""
 
         def fn() -> None:
             dbos_logger.info(f"Resuming workflow: {workflow_id}")
-            _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
+            _get_dbos_instance()._sys_db.resume_workflow(
+                workflow_id, application_version=application_version
+            )
 
         _get_dbos_instance()._sys_db.call_function_as_step(fn, "DBOS.resumeWorkflow")
         return cls.retrieve_workflow(workflow_id)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -962,16 +962,12 @@ class DBOS:
         )
 
     @classmethod
-    def resume_workflow(
-        cls, workflow_id: str, *, application_version: Optional[str] = None
-    ) -> WorkflowHandle[Any]:
+    def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:
         """Resume a workflow by ID."""
 
         def fn() -> None:
             dbos_logger.info(f"Resuming workflow: {workflow_id}")
-            _get_dbos_instance()._sys_db.resume_workflow(
-                workflow_id, application_version=application_version
-            )
+            _get_dbos_instance()._sys_db.resume_workflow(workflow_id)
 
         _get_dbos_instance()._sys_db.call_function_as_step(fn, "DBOS.resumeWorkflow")
         return cls.retrieve_workflow(workflow_id)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -597,7 +597,12 @@ class SystemDatabase:
             return max_function_id
 
     def fork_workflow(
-        self, original_workflow_id: str, forked_workflow_id: str, start_step: int = 1
+        self,
+        original_workflow_id: str,
+        forked_workflow_id: str,
+        start_step: int,
+        *,
+        application_version: Optional[str],
     ) -> str:
 
         status = self.get_workflow_status(original_workflow_id)
@@ -617,7 +622,11 @@ class SystemDatabase:
                     name=status["name"],
                     class_name=status["class_name"],
                     config_name=status["config_name"],
-                    application_version=status["app_version"],
+                    application_version=(
+                        application_version
+                        if application_version is not None
+                        else status["app_version"]
+                    ),
                     application_id=status["app_id"],
                     request=status["request"],
                     authenticated_user=status["authenticated_user"],

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -537,9 +537,7 @@ class SystemDatabase:
                 )
             )
 
-    def resume_workflow(
-        self, workflow_id: str, *, application_version: Optional[str]
-    ) -> None:
+    def resume_workflow(self, workflow_id: str) -> None:
         if self._debug_mode:
             raise Exception("called resume_workflow in debug mode")
         with self.engine.begin() as c:
@@ -549,12 +547,11 @@ class SystemDatabase:
             status_row = c.execute(
                 sa.select(
                     SystemSchema.workflow_status.c.status,
-                    SystemSchema.workflow_status.c.application_version,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
             ).fetchone()
             if status_row is None:
                 return
-            status, original_application_version = status_row[0], status_row[1]
+            status = status_row[0]
             if (
                 status == WorkflowStatusString.SUCCESS.value
                 or status == WorkflowStatusString.ERROR.value
@@ -581,11 +578,6 @@ class SystemDatabase:
                     status=WorkflowStatusString.ENQUEUED.value,
                     recovery_attempts=0,
                     workflow_deadline_epoch_ms=None,
-                    application_version=(
-                        application_version
-                        if application_version is not None
-                        else original_application_version
-                    ),
                 )
             )
 

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -104,6 +104,8 @@ def fork_workflow(
     app_db: ApplicationDatabase,
     workflow_id: str,
     start_step: int,
+    *,
+    application_version: Optional[str],
 ) -> str:
     def get_max_function_id(workflow_uuid: str) -> int:
         max_transactions = app_db.get_max_function_id(workflow_uuid) or 0
@@ -122,5 +124,10 @@ def fork_workflow(
     else:
         forked_workflow_id = str(uuid.uuid4())
     app_db.clone_workflow_transactions(workflow_id, forked_workflow_id, start_step)
-    sys_db.fork_workflow(workflow_id, forked_workflow_id, start_step)
+    sys_db.fork_workflow(
+        workflow_id,
+        forked_workflow_id,
+        start_step,
+        application_version=application_version,
+    )
     return forked_workflow_id

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -439,12 +439,17 @@ def test_client_fork(dbos: DBOS, client: DBOSClient) -> None:
     assert handle.get_result() == input * 2
     assert len(client.list_workflow_steps(handle.workflow_id)) == 2
 
-    forked_handle: WorkflowHandle[int] = client.fork_workflow(handle.workflow_id, 1)
-    assert forked_handle.workflow_id != handle.workflow_id
+    fork_id = str(uuid.uuid4())
+    with SetWorkflowID(fork_id):
+        forked_handle: WorkflowHandle[int] = client.fork_workflow(handle.workflow_id, 1)
+    assert forked_handle.workflow_id == fork_id
     assert forked_handle.get_result() == input * 2
 
     forked_handle = client.fork_workflow(handle.workflow_id, 2)
-    assert forked_handle.workflow_id != handle.workflow_id
+    assert (
+        forked_handle.workflow_id != handle.workflow_id
+        and forked_handle.workflow_id != fork_id
+    )
     assert forked_handle.get_result() == input * 2
 
     assert len(client.list_workflows()) == 3


### PR DESCRIPTION
- Fork now respects `SetWorkflowID`
- It is now possible to pass an application version to fork. The workflow will execute on a process running that version. This is useful for "patching" workflows if an old version contained a bug.