### PR TITLE
Make child workflows create OpenTelemetry child spans

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -117,6 +117,7 @@ class DBOSContext:
         )
         rv.request = self.request
         rv.assumed_role = self.assumed_role
+        rv.spans = list(self.spans)
         return rv
 
     def has_parent(self) -> bool:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -492,7 +492,7 @@ def _get_new_wf() -> tuple[str, DBOSContext]:
     #   Pass the new context to a worker thread that will run the wf function
     cur_ctx = get_local_dbos_context()
     if cur_ctx is not None and cur_ctx.is_within_workflow():
-        assert cur_ctx.is_workflow()  # Not in a step
+        assert cur_ctx.is_workflow(), "Not in a step"  # Not in a step
         cur_ctx.function_id += 1
         if len(cur_ctx.id_assigned_for_next_workflow) == 0:
             cur_ctx.id_assigned_for_next_workflow = (


### PR DESCRIPTION
Make child workflows create OpenTelemetry child spans so that you can track execution across sub-workflows.

Testing:

- tested running against a local workflow that creates child works

Issues to fix:

- `Queue("...").enqueue_async` workflows do not create child spans