### PR TITLE
Support priority in queues

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -433,12 +433,12 @@ class SetEnqueueOptions:
     """
 
     def __init__(
-        self, *, deduplication_id: Optional[str] = None, priority: Optional[int]
+        self, *, deduplication_id: Optional[str] = None, priority: Optional[int] = None
     ) -> None:
         self.created_ctx = False
         self.deduplication_id: Optional[str] = deduplication_id
         self.saved_deduplication_id: Optional[str] = None
-        if priority < MinPriority or priority > MaxPriority:
+        if priority is not None and (priority < MinPriority or priority > MaxPriority):
             raise Exception(
                 f"Invalid priority {priority}. Priority must be between {MinPriority}~{MaxPriority}."
             )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -544,6 +544,7 @@ def start_workflow(
     )
     enqueue_options = EnqueueOptionsInternal(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
+        priority=local_ctx.priority if local_ctx is not None else None,
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 
@@ -635,6 +636,7 @@ async def start_workflow_async(
     )
     enqueue_options = EnqueueOptionsInternal(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
+        priority=local_ctx.priority if local_ctx is not None else None,
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 

--- a/dbos/_migrations/versions/933e86bdac6a_add_queue_priority.py
+++ b/dbos/_migrations/versions/933e86bdac6a_add_queue_priority.py
@@ -1,0 +1,63 @@
+"""add queue priority
+
+Revision ID: 933e86bdac6a
+Revises: 27ac6900c6ad
+Create Date: 2025-04-25 18:17:40.462737
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "933e86bdac6a"
+down_revision: Union[str, None] = "27ac6900c6ad"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflow_queue",
+        sa.Column(
+            "priority",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("'0'::int"),
+        ),
+        schema="dbos",
+    )
+
+    # Create index on queue name
+    op.create_index(
+        "workflow_queue_name_index",
+        "workflow_queue",
+        ["queue_name"],
+        unique=False,
+        schema="dbos",
+    )
+
+    # Create index on created_at and priority
+    op.create_index(
+        "workflow_queue_created_at_priority_index",
+        "workflow_queue",
+        ["created_at_epoch_ms", "priority"],
+        unique=False,
+        schema="dbos",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "workflow_queue_created_at_priority_index",
+        table_name="workflow_queue",
+        schema="dbos",
+    )
+    op.drop_index(
+        "workflow_queue_name_index",
+        table_name="workflow_queue",
+        schema="dbos",
+    )
+    op.drop_column("workflow_queue", "priority", schema="dbos")

--- a/dbos/_migrations/versions/933e86bdac6a_add_queue_priority.py
+++ b/dbos/_migrations/versions/933e86bdac6a_add_queue_priority.py
@@ -30,34 +30,6 @@ def upgrade() -> None:
         schema="dbos",
     )
 
-    # Create index on queue name
-    op.create_index(
-        "workflow_queue_name_index",
-        "workflow_queue",
-        ["queue_name"],
-        unique=False,
-        schema="dbos",
-    )
-
-    # Create index on created_at and priority
-    op.create_index(
-        "workflow_queue_created_at_priority_index",
-        "workflow_queue",
-        ["created_at_epoch_ms", "priority"],
-        unique=False,
-        schema="dbos",
-    )
-
 
 def downgrade() -> None:
-    op.drop_index(
-        "workflow_queue_created_at_priority_index",
-        table_name="workflow_queue",
-        schema="dbos",
-    )
-    op.drop_index(
-        "workflow_queue_name_index",
-        table_name="workflow_queue",
-        schema="dbos",
-    )
     op.drop_column("workflow_queue", "priority", schema="dbos")

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -186,15 +186,6 @@ class SystemSchema:
             nullable=False,
             server_default=text("'0'::int"),
         ),
-        Index(
-            "workflow_queue_name_index",
-            "queue_name",
-        ),
-        Index(
-            "workflow_queue_created_at_priority_index",
-            "created_at_epoch_ms",
-            "priority",
-        ),
         UniqueConstraint(
             "queue_name", "deduplication_id", name="uq_workflow_queue_name_dedup_id"
         ),

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -180,6 +180,21 @@ class SystemSchema:
             Text,
             nullable=True,
         ),
+        Column(
+            "priority",
+            Integer,
+            nullable=False,
+            server_default=text("'0'::int"),
+        ),
+        Index(
+            "workflow_queue_name_index",
+            "queue_name",
+        ),
+        Index(
+            "workflow_queue_created_at_priority_index",
+            "created_at_epoch_ms",
+            "priority",
+        ),
         UniqueConstraint(
             "queue_name", "deduplication_id", name="uq_workflow_queue_name_dedup_id"
         ),

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -138,6 +138,9 @@ class WorkflowStatusInternal(TypedDict):
 
 class EnqueueOptionsInternal(TypedDict):
     deduplication_id: Optional[str]  # Unique ID for deduplication on a queue
+    priority: Optional[
+        int
+    ]  # Priority of the workflow on the queue, starting from 1 ~ 2,147,483,647. Default 0 (highest priority).
 
 
 class RecordedResult(TypedDict):
@@ -1629,12 +1632,19 @@ class SystemDatabase:
                 if enqueue_options is not None
                 else None
             )
+            priority = (
+                enqueue_options["priority"] if enqueue_options is not None else None
+            )
+            # Default to 0 (highest priority) if not provided
+            if priority is None:
+                priority = 0
             query = (
                 pg.insert(SystemSchema.workflow_queue)
                 .values(
                     workflow_uuid=workflow_id,
                     queue_name=queue_name,
                     deduplication_id=deduplication_id,
+                    priority=priority,
                 )
                 .on_conflict_do_nothing(
                     index_elements=SystemSchema.workflow_queue.primary_key.columns
@@ -1743,7 +1753,10 @@ class SystemDatabase:
                 .where(SystemSchema.workflow_queue.c.queue_name == queue.name)
                 .where(SystemSchema.workflow_queue.c.started_at_epoch_ms == None)
                 .where(SystemSchema.workflow_queue.c.completed_at_epoch_ms == None)
-                .order_by(SystemSchema.workflow_queue.c.created_at_epoch_ms.asc())
+                .order_by(
+                    SystemSchema.workflow_queue.c.priority.asc(),
+                    SystemSchema.workflow_queue.c.created_at_epoch_ms.asc(),
+                )
                 .with_for_update(nowait=True)  # Error out early
             )
             # Apply limit only if max_tasks is finite

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -11,6 +11,7 @@ class Person(TypedDict):
 
 
 queue = Queue("test_queue")
+inorder_queue = Queue("inorder_queue", 1)
 
 
 @DBOS.workflow()

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, TypedDict, cast
+from typing import List, Optional, TypedDict, cast
 
 from dbos import DBOS, Queue
 
@@ -12,6 +12,7 @@ class Person(TypedDict):
 
 queue = Queue("test_queue")
 inorder_queue = Queue("inorder_queue", 1)
+inorder_results: List[str] = []
 
 
 @DBOS.workflow()
@@ -27,6 +28,7 @@ def send_test(topic: Optional[str] = None) -> str:
 @DBOS.workflow()
 def retrieve_test(value: str) -> str:
     DBOS.sleep(5)
+    inorder_results.append(value)
     return value
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -532,16 +532,16 @@ def test_enqueue_with_priority(dbos: DBOS, client: DBOSClient) -> None:
     assert "Invalid priority" in str(exc_info.value)
 
     # Without priority should work
-    options["priority"] = None
+    del options["priority"]
     handle: WorkflowHandle[str] = client.enqueue(options, "abc")
 
     # Enqueue with a lower priority
     options["priority"] = 5
-    handle2 = client.enqueue(options, "def")
+    handle2: WorkflowHandle[str] = client.enqueue(options, "def")
 
     # Enqueue with a higher priority
     options["priority"] = 1
-    handle3 = client.enqueue(options, "ghi")
+    handle3: WorkflowHandle[str] = client.enqueue(options, "ghi")
 
     assert handle.get_result() == "abc"
 


### PR DESCRIPTION
Now support specifying priority during enqueue:
```
with SetEnqueueOptions(priority=<priority>):
            queue.enqueue(...)
```

Priority by default is 0 (highest), and users can specify priority between `1~2,147,483,647`,  a lower number is always a higher priority than higher numbers. The semantics is the same as BullMQ.

Within the same priority, tasks are dequeued in FIFO order.