### PR TITLE
Issue 273: app_name fix in dbos_init

### DIFF
--- a/dbos/cli/_github_init.py
+++ b/dbos/cli/_github_init.py
@@ -97,6 +97,9 @@ def create_template_from_github(app_name: str, template_name: str) -> None:
         # Create directory if it doesn't exist
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
+        # Replace the template name with the given app_name
+        raw_content = raw_content.replace(template_name, app_name)
+
         # Write file with proper permissions
         with open(target_path, "w", encoding="utf-8") as f:
             f.write(raw_content)

--- a/dbos/cli/_github_init.py
+++ b/dbos/cli/_github_init.py
@@ -97,8 +97,9 @@ def create_template_from_github(app_name: str, template_name: str) -> None:
         # Create directory if it doesn't exist
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
-        # Replace the template name with the given app_name
-        raw_content = raw_content.replace(template_name, app_name)
+        # Replace template name with app name in required files
+        if file_path in ["dbos-config.yaml", "main.py"]:
+            raw_content = raw_content.replace(template_name, app_name)
 
         # Write file with proper permissions
         with open(target_path, "w", encoding="utf-8") as f:

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -164,7 +164,8 @@ def init(
                     print("[red]Please enter a valid number.[/red]")
 
         if template in git_templates:
-            project_name = template
+            if project_name is None:
+                project_name = template
         else:
             if project_name is None:
                 project_name = typing.cast(

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import tempfile
+
+import yaml
+
+
+def test_init_with_app_name() -> None:
+    """Test that when an app name is provided, it is used as the project name."""
+    app_name = "my-test-app"
+
+    with tempfile.TemporaryDirectory() as temp_path:
+        # Run the init command with app name and template
+        subprocess.check_call(
+            ["dbos", "init", app_name, "-t", "dbos-toolbox"],
+            cwd=temp_path,
+        )
+
+        # Verify dbos-config.yaml
+        config_path = os.path.join(temp_path, "dbos-config.yaml")
+        assert os.path.exists(config_path)
+
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+            assert config["name"] == app_name
+
+        # Verify main.py
+        main_path = os.path.join(temp_path, "main.py")
+        assert os.path.exists(main_path)
+
+        with open(main_path) as f:
+            main_content = f.read()
+            # Check for the DBOSConfig dictionary with the correct name
+            assert f'"name": "{app_name}"' in main_content
+
+
+def test_init_without_app_name() -> None:
+    """Test that when no app name is provided, the template name is used as the project name."""
+    template = "dbos-toolbox"
+
+    with tempfile.TemporaryDirectory() as temp_path:
+        # Run the init command with only template
+        subprocess.check_call(
+            ["dbos", "init", "-t", template],
+            cwd=temp_path,
+        )
+
+        # Verify dbos-config.yaml
+        config_path = os.path.join(temp_path, "dbos-config.yaml")
+        assert os.path.exists(config_path)
+
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+            assert config["name"] == template
+
+        # Verify main.py
+        main_path = os.path.join(temp_path, "main.py")
+        assert os.path.exists(main_path)
+
+        with open(main_path) as f:
+            main_content = f.read()
+            # Check for the DBOSConfig dictionary with the template name
+            assert f'"name": "{template}"' in main_content


### PR DESCRIPTION
# Fixing App Name Handling in DBOS CLI Init

## PR to address:
Issue #273 : dbos init with git imports should be able to change the app name

## Overview
This PR addresses a problem with the app name handling in the DBOS CLI initialization process, where the app name is over-written or ignored and instead the template name is used as the project name. My changes ensure that when an app name is provided, the app name is correctly used as the project name, instead of the template name. When no app name is provided, the template name is used as the project name. 

## Changes
- Modified `init()` in `cli.py`, added conditional at line 167 to only use template as project name when no other project name was provided. 
- Modified `create_template_from_github()` in `_github_init.py` to use the provided app name instead of the template name. 
- Added test suite to validate app name handling in both scenarios

## Implementation Details
The main changes were in the `create_template_from_github()` function of _github_init.py, where I replaced the template name with the provided app name in the project initialization, after the template name is used to pull the files from github. This ensures that:
1. When an app name is provided, it is used consistently in both `dbos-config.yaml` and `main.py`
2. When no app name is provided, the template name is used as the project name in both files

I also changed the init() function in cli.py to use only use the template name as the project name if no project name was given, where before it would always use the template name as the project name if the template existed within the list of `git_templates`. 

## Testing
Added test suite in `test_cli_init.py` to validate both scenarios:
- `test_init_with_app_name()`: Verifies that when an app name is provided, it is used as the project name
- `test_init_without_app_name()`: Verifies that when no app name is provided, the template name is used as the project name

Both tests verify the correct name is used in:
- `dbos-config.yaml` configuration file
- `main.py` application file

## Example Usage
```yaml
# With app name
dbos init my-app -t dbos-toolbox
# this will create a project based on the dbos-toolbox and name it 'my-app'
# in both the dbos-config.yaml file and in the DBOSConfig object in the main.py file. 

# Without app name (uses template name)
dbos init -t dbos-toolbox
```
# this will create a project based on the dbos-toolbox and name it 'dbos-toolbox'

## Documentation
- Added inline comment explaining the app name handling logic in _github_init.py

## Checklist
- [x] Added tests for new functionality
- [ ] No breaking changes to existing functionality
- [x] Updated documentation
