### PR TITLE
Deprecate programmatic config file

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -8,7 +8,7 @@ from ._context import (
     SetWorkflowTimeout,
 )
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowHandleAsync
-from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url
+from ._dbos_config import ConfigFile, DBOSConfig
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString
@@ -31,7 +31,6 @@ __all__ = [
     "WorkflowHandleAsync",
     "WorkflowStatus",
     "WorkflowStatusString",
-    "get_dbos_database_url",
     "error",
     "Queue",
 ]

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -8,7 +8,7 @@ from ._context import (
     SetWorkflowTimeout,
 )
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowHandleAsync
-from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url, load_config
+from ._dbos_config import ConfigFile, DBOSConfig, get_dbos_database_url
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString
@@ -31,7 +31,6 @@ __all__ = [
     "WorkflowHandleAsync",
     "WorkflowStatus",
     "WorkflowStatusString",
-    "load_config",
     "get_dbos_database_url",
     "error",
     "Queue",

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -8,13 +8,12 @@ from ._context import (
     SetWorkflowTimeout,
 )
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowHandleAsync
-from ._dbos_config import ConfigFile, DBOSConfig
+from ._dbos_config import DBOSConfig
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString
 
 __all__ = [
-    "ConfigFile",
     "DBOSConfig",
     "DBOS",
     "DBOSClient",

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -35,7 +35,7 @@ class ConductorWebsocket(threading.Thread):
         self.websocket: Optional[Connection] = None
         self.evt = evt
         self.dbos = dbos
-        self.app_name = dbos.config["name"]
+        self.app_name = dbos._config["name"]
         self.url = (
             conductor_url.rstrip("/") + f"/websocket/{self.app_name}/{conductor_key}"
         )

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -94,8 +94,6 @@ from ._dbos_config import (
     ConfigFile,
     DBOSConfig,
     check_config_consistency,
-    is_dbos_configfile,
-    load_config,
     overwrite_config,
     process_config,
     set_env_vars,
@@ -160,7 +158,7 @@ class DBOSRegistry:
         self.queue_info_map: dict[str, Queue] = {}
         self.pollers: list[RegisteredJob] = []
         self.dbos: Optional[DBOS] = None
-        self.config: Optional[ConfigFile] = None
+        self.config: Optional[DBOSConfig] = None
 
     def register_wf_function(self, name: str, wrapped_func: F, functype: str) -> None:
         if name in self.function_type_map:
@@ -264,7 +262,7 @@ class DBOS:
     def __new__(
         cls: Type[DBOS],
         *,
-        config: Optional[Union[ConfigFile, DBOSConfig]] = None,
+        config: DBOSConfig,
         fastapi: Optional["FastAPI"] = None,
         flask: Optional["Flask"] = None,
         conductor_url: Optional[str] = None,
@@ -277,7 +275,7 @@ class DBOS:
                 _dbos_global_registry is not None
                 and _dbos_global_registry.config is not None
             ):
-                if config is not None and config is not _dbos_global_registry.config:
+                if config is not _dbos_global_registry.config:
                     raise DBOSException(
                         f"DBOS configured multiple times with conflicting information"
                     )
@@ -286,7 +284,7 @@ class DBOS:
             _dbos_global_instance = super().__new__(cls)
             _dbos_global_instance.__init__(fastapi=fastapi, config=config, flask=flask, conductor_url=conductor_url, conductor_key=conductor_key)  # type: ignore
         else:
-            if (config is not None and _dbos_global_instance.config is not config) or (
+            if (_dbos_global_instance._provided_config is not config) or (
                 _dbos_global_instance.fastapi is not fastapi
             ):
                 raise DBOSException(
@@ -309,7 +307,7 @@ class DBOS:
     def __init__(
         self,
         *,
-        config: Optional[Union[ConfigFile, DBOSConfig]] = None,
+        config: DBOSConfig,
         fastapi: Optional["FastAPI"] = None,
         flask: Optional["Flask"] = None,
         conductor_url: Optional[str] = None,
@@ -320,6 +318,7 @@ class DBOS:
 
         self._initialized: bool = True
 
+        self._provided_config: DBOSConfig = config
         self._launched: bool = False
         self._debug_mode: bool = False
         self._sys_db_field: Optional[SystemDatabase] = None
@@ -342,26 +341,11 @@ class DBOS:
 
         init_logger()
 
-        unvalidated_config: Optional[ConfigFile] = None
-
-        if config is None:
-            # If no config is provided, load it from dbos-config.yaml
-            unvalidated_config = load_config(run_process_config=False)
-        elif is_dbos_configfile(config):
-            dbos_logger.warning(
-                "ConfigFile config strutcture detected. This will be deprecated in favor of DBOSConfig in an upcoming release."
-            )
-            unvalidated_config = cast(ConfigFile, config)
-            if os.environ.get("DBOS__CLOUD") == "true":
-                unvalidated_config = overwrite_config(unvalidated_config)
-            check_config_consistency(name=unvalidated_config["name"])
-        else:
-            unvalidated_config = translate_dbos_config_to_config_file(
-                cast(DBOSConfig, config)
-            )
-            if os.environ.get("DBOS__CLOUD") == "true":
-                unvalidated_config = overwrite_config(unvalidated_config)
-            check_config_consistency(name=unvalidated_config["name"])
+        # Translate user provided config to an internal format
+        unvalidated_config = translate_dbos_config_to_config_file(config)
+        if os.environ.get("DBOS__CLOUD") == "true":
+            unvalidated_config = overwrite_config(unvalidated_config)
+        check_config_consistency(name=unvalidated_config["name"])
 
         if unvalidated_config is not None:
             self._config: ConfigFile = process_config(data=unvalidated_config)
@@ -1085,21 +1069,6 @@ class DBOS:
     def logger(cls) -> Logger:
         """Return the DBOS `Logger` for the current context."""
         return dbos_logger  # TODO get from context if appropriate...
-
-    @classproperty
-    def config(cls) -> ConfigFile:
-        """Return the DBOS `ConfigFile` for the current context."""
-        global _dbos_global_instance
-        if _dbos_global_instance is not None:
-            return _dbos_global_instance._config
-        reg = _get_or_create_dbos_registry()
-        if reg.config is not None:
-            return reg.config
-        loaded_config = (
-            load_config()
-        )  # This will return the processed & validated config (with defaults)
-        reg.config = loaded_config
-        return loaded_config
 
     @classproperty
     def sql_session(cls) -> Session:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -158,7 +158,6 @@ class DBOSRegistry:
         self.queue_info_map: dict[str, Queue] = {}
         self.pollers: list[RegisteredJob] = []
         self.dbos: Optional[DBOS] = None
-        self.config: Optional[DBOSConfig] = None
 
     def register_wf_function(self, name: str, wrapped_func: F, functype: str) -> None:
         if name in self.function_type_map:
@@ -271,16 +270,6 @@ class DBOS:
         global _dbos_global_instance
         global _dbos_global_registry
         if _dbos_global_instance is None:
-            if (
-                _dbos_global_registry is not None
-                and _dbos_global_registry.config is not None
-            ):
-                if config is not _dbos_global_registry.config:
-                    raise DBOSException(
-                        f"DBOS configured multiple times with conflicting information"
-                    )
-                config = _dbos_global_registry.config
-
             _dbos_global_instance = super().__new__(cls)
             _dbos_global_instance.__init__(fastapi=fastapi, config=config, flask=flask, conductor_url=conductor_url, conductor_key=conductor_key)  # type: ignore
         return _dbos_global_instance

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -283,13 +283,6 @@ class DBOS:
 
             _dbos_global_instance = super().__new__(cls)
             _dbos_global_instance.__init__(fastapi=fastapi, config=config, flask=flask, conductor_url=conductor_url, conductor_key=conductor_key)  # type: ignore
-        else:
-            if (_dbos_global_instance._provided_config is not config) or (
-                _dbos_global_instance.fastapi is not fastapi
-            ):
-                raise DBOSException(
-                    f"DBOS Initialized multiple times with conflicting configuration / fastapi information"
-                )
         return _dbos_global_instance
 
     @classmethod
@@ -318,7 +311,6 @@ class DBOS:
 
         self._initialized: bool = True
 
-        self._provided_config: DBOSConfig = config
         self._launched: bool = False
         self._debug_mode: bool = False
         self._sys_db_field: Optional[SystemDatabase] = None

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, TypedDict, cast
 import yaml
 from jsonschema import ValidationError, validate
 from rich import print
-from sqlalchemy import URL, make_url
+from sqlalchemy import make_url
 
 from ._error import DBOSInitializationError
 from ._logger import dbos_logger
@@ -241,32 +241,6 @@ def _substitute_env_vars(content: str, silent: bool = False) -> str:
     content = re.sub(secret_regex, replace_secret_func, content)
     # Then replace environment variables
     return re.sub(env_regex, replace_env_func, content)
-
-
-def get_dbos_database_url(config_file_path: str = DBOS_CONFIG_PATH) -> str:
-    """
-    Retrieve application database URL from configuration `.yaml` file.
-
-    Loads the DBOS `ConfigFile` from the specified path (typically `dbos-config.yaml`),
-        and returns the database URL for the application database.
-
-    Args:
-        config_file_path (str): The path to the yaml configuration file.
-
-    Returns:
-        str: Database URL for the application database
-
-    """
-    dbos_config = load_config(config_file_path, run_process_config=True)
-    db_url = URL.create(
-        "postgresql+psycopg",
-        username=dbos_config["database"]["username"],
-        password=dbos_config["database"]["password"],
-        host=dbos_config["database"]["hostname"],
-        port=dbos_config["database"]["port"],
-        database=dbos_config["database"]["app_db_name"],
-    )
-    return db_url.render_as_string(hide_password=False)
 
 
 def load_config(

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -3,6 +3,7 @@ import os
 import re
 from importlib import resources
 from typing import Any, Dict, List, Optional, TypedDict, cast
+from urllib.parse import quote
 
 import yaml
 from jsonschema import ValidationError, validate
@@ -361,7 +362,7 @@ def process_config(
     data["database"]["password"] = (
         os.getenv("DBOS_DBPASSWORD")
         or data["database"].get("password")
-        or os.environ.get("PGPASSWORD")
+        or quote(os.environ.get("PGPASSWORD"))
         or "dbos"
     )
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -1,14 +1,8 @@
 import json
 import os
 import re
-import sys
 from importlib import resources
-from typing import Any, Dict, List, Optional, TypedDict, Union, cast
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeGuard
-else:
-    from typing import TypeGuard
+from typing import Any, Dict, List, Optional, TypedDict, cast
 
 import yaml
 from jsonschema import ValidationError, validate
@@ -144,28 +138,6 @@ class ConfigFile(TypedDict, total=False):
     database_url: Optional[str]
     telemetry: Optional[TelemetryConfig]
     env: Dict[str, str]
-
-
-def is_dbos_configfile(data: Union[ConfigFile, DBOSConfig]) -> TypeGuard[DBOSConfig]:
-    """
-    Type guard to check if the provided data is a DBOSConfig.
-
-    Args:
-        data: The configuration object to check
-
-    Returns:
-        True if the data is a DBOSConfig, False otherwise
-    """
-    return (
-        isinstance(data, dict)
-        and "name" in data
-        and (
-            "runtimeConfig" in data
-            or "database" in data
-            or "env" in data
-            or "telemetry" in data
-        )
-    )
 
 
 def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -3,7 +3,6 @@ import os
 import re
 from importlib import resources
 from typing import Any, Dict, List, Optional, TypedDict, cast
-from urllib.parse import quote
 
 import yaml
 from jsonschema import ValidationError, validate
@@ -362,7 +361,7 @@ def process_config(
     data["database"]["password"] = (
         os.getenv("DBOS_DBPASSWORD")
         or data["database"].get("password")
-        or quote(os.environ.get("PGPASSWORD"))
+        or os.environ.get("PGPASSWORD")
         or "dbos"
     )
 

--- a/dbos/_templates/dbos-db-starter/__package/main.py
+++ b/dbos/_templates/dbos-db-starter/__package/main.py
@@ -15,7 +15,7 @@ from dbos import DBOS
 from .schema import dbos_hello
 
 app = FastAPI()
-DBOS(fastapi=app)
+DBOS(fastapi=app, config={"name": "dbos-db-starter"})
 
 # Next, let's write a function that greets visitors.
 # To make it more interesting, we'll keep track of how

--- a/dbos/_templates/dbos-db-starter/__package/main.py.dbos
+++ b/dbos/_templates/dbos-db-starter/__package/main.py.dbos
@@ -6,16 +6,21 @@
 
 # First, let's do imports, create a FastAPI app, and initialize DBOS.
 
+import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 
-from dbos import DBOS
+from dbos import DBOS, DBOSConfig
 
 from .schema import dbos_hello
 
 app = FastAPI()
-DBOS(fastapi=app, config={"name": "${project_name}"})
+dbos_config: DBOSConfig = {
+    "name": "${project_name}",
+    "database_url": os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
+}
+DBOS(fastapi=app, config=dbos_config)
 
 # Next, let's write a function that greets visitors.
 # To make it more interesting, we'll keep track of how

--- a/dbos/_templates/dbos-db-starter/__package/main.py.dbos
+++ b/dbos/_templates/dbos-db-starter/__package/main.py.dbos
@@ -15,7 +15,7 @@ from dbos import DBOS
 from .schema import dbos_hello
 
 app = FastAPI()
-DBOS(fastapi=app, config={"name": "dbos-db-starter"})
+DBOS(fastapi=app, config={"name": "${project_name}"})
 
 # Next, let's write a function that greets visitors.
 # To make it more interesting, we'll keep track of how

--- a/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
+++ b/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
@@ -1,6 +1,6 @@
-import re
 import os
 from logging.config import fileConfig
+from urllib.parse import quote
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -15,7 +15,7 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # Programmatically set the sqlalchemy.url field to the DBOS application database URL
-conn_string = os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
+conn_string = os.environ.get("DBOS_DATABASE_URL", f"postgresql+psycopg://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/${default_db_name}?connect_timeout=5")
 config.set_main_option("sqlalchemy.url", conn_string)
 
 # add your model's MetaData object here

--- a/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
+++ b/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
@@ -1,6 +1,6 @@
+import re
 import os
 from logging.config import fileConfig
-from urllib.parse import quote
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -15,7 +15,7 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # Programmatically set the sqlalchemy.url field to the DBOS application database URL
-conn_string = os.environ.get("DBOS_DATABASE_URL", f"postgresql+psycopg://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/${default_db_name}?connect_timeout=5")
+conn_string = os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
 config.set_main_option("sqlalchemy.url", conn_string)
 
 # add your model's MetaData object here

--- a/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
+++ b/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
@@ -14,7 +14,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# programmatically set the sqlalchemy.url field from DBOS Config
+# Programmatically set the sqlalchemy.url field to the DBOS application database URL
 conn_string = os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
 config.set_main_option("sqlalchemy.url", conn_string)
 

--- a/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
+++ b/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
@@ -1,10 +1,9 @@
 import re
+import os
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-
-from dbos import get_dbos_database_url
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -16,13 +15,8 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # programmatically set the sqlalchemy.url field from DBOS Config
-# Alembic requires the % in URL-escaped parameters to itself be escaped to %%.
-escaped_conn_string = re.sub(
-    r"%(?=[0-9A-Fa-f]{2})",
-    "%%",
-    get_dbos_database_url(),
-)
-config.set_main_option("sqlalchemy.url", escaped_conn_string)
+conn_string = os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
+config.set_main_option("sqlalchemy.url", conn_string)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
+++ b/dbos/_templates/dbos-db-starter/migrations/env.py.dbos
@@ -16,7 +16,13 @@ if config.config_file_name is not None:
 
 # Programmatically set the sqlalchemy.url field to the DBOS application database URL
 conn_string = os.environ.get("DBOS_DATABASE_URL", "postgresql+psycopg://postgres:dbos@localhost:5432/${default_db_name}?connect_timeout=5")
-config.set_main_option("sqlalchemy.url", conn_string)
+# Alembic requires the % in URL-escaped parameters to itself be escaped to %%
+escaped_conn_string = re.sub(
+    r"%(?=[0-9A-Fa-f]{2})",
+    "%%",
+    conn_string,
+)
+config.set_main_option("sqlalchemy.url", escaped_conn_string)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/dbos/cli/_template_init.py
+++ b/dbos/cli/_template_init.py
@@ -7,6 +7,8 @@ from typing import Any
 import tomlkit
 from rich import print
 
+from dbos._dbos_config import _app_name_to_db_name
+
 
 def get_templates_directory() -> str:
     import dbos
@@ -64,6 +66,7 @@ def copy_template(src_dir: str, project_name: str, config_mode: bool) -> None:
 """
     ctx = {
         "project_name": project_name,
+        "default_db_name": _app_name_to_db_name(project_name),
         "package_name": package_name,
         "start_command": f"python3 -m {package_name}.main",
         "migration_section": default_migration_section,

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -34,7 +34,7 @@ def start_client(db_url: Optional[str] = None) -> DBOSClient:
         database_url = os.getenv("DBOS_DATABASE_URL")
     if database_url is None:
         raise ValueError(
-            "no --db-url flag or DBOS_DATABASE_URL environment variable were set."
+            "No --db-url flag or DBOS_DATABASE_URL environment variable were set. Please provide either."
         )
 
     return DBOSClient(database_url=database_url)

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -6,7 +6,6 @@ import time
 import typing
 from os import path
 from typing import Any, Optional
-from urllib.parse import quote
 
 import jsonpickle  # type: ignore
 import sqlalchemy as sa

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -17,10 +17,9 @@ from typing_extensions import Annotated
 
 from dbos._debug import debug_workflow, parse_start_command
 
-from .. import load_config
 from .._app_db import ApplicationDatabase
 from .._client import DBOSClient
-from .._dbos_config import _is_valid_app_name
+from .._dbos_config import _is_valid_app_name, load_config
 from .._docker_pg_helper import start_docker_pg, stop_docker_pg
 from .._schemas.system_database import SystemSchema
 from .._sys_db import SystemDatabase, reset_system_database

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -32,12 +32,11 @@ def start_client(db_url: Optional[str] = None) -> DBOSClient:
     database_url = db_url
     if database_url is None:
         database_url = os.getenv("DBOS_DATABASE_URL")
-        if database_url is None:
-            config = load_config(silent=True)
-            database = config["database"]
-            username = quote(database["username"])
-            password = quote(database["password"])
-            database_url = f"postgresql://{username}:{password}@{database['hostname']}:{database['port']}/{database['app_db_name']}"
+    if database_url is None:
+        raise ValueError(
+            "no --db-url flag or DBOS_DATABASE_URL environment variable were set."
+        )
+
     return DBOSClient(database_url=database_url)
 
 

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -33,7 +33,7 @@ def start_client(db_url: Optional[str] = None) -> DBOSClient:
         database_url = os.getenv("DBOS_DATABASE_URL")
     if database_url is None:
         raise ValueError(
-            "No --db-url flag or DBOS_DATABASE_URL environment variable were set. Please provide either."
+            "Missing database URL: please set it using the --db-url flag or the DBOS_DATABASE_URL environment variable."
         )
 
     return DBOSClient(database_url=database_url)

--- a/tests/atexit_no_launch.py
+++ b/tests/atexit_no_launch.py
@@ -1,5 +1,5 @@
 from dbos import DBOS
-from dbos._dbos_config import ConfigFile
+from dbos._dbos_config import DBOSConfig
 
 
 @DBOS.workflow()
@@ -7,21 +7,10 @@ def my_function(foo: str) -> str:
     return foo
 
 
-def default_config() -> ConfigFile:
+def default_config() -> DBOSConfig:
     return {
         "name": "forgot-launch",
-        "database": {
-            "hostname": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": "doesntmatter",
-            "app_db_name": "doesntmatter",
-        },
-        "runtimeConfig": {
-            "start": ["doesntmatter"],
-        },
-        "telemetry": {},
-        "env": {},
+        "database_url": f"postgresql://postgres:doesntmatter@localhost:5432/notneeded",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def build_wheel() -> str:
 def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database_url": f'postgresql://postgres:{quote(os.environ.get("PGPASSWORD", "dbos"))}@localhost:5432/dbostestpy',
+        "database_url": f'postgresql://postgres:{quote(os.environ.get("PGPASSWORD", "dbos"), safe='')}@localhost:5432/dbostestpy',
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,9 @@ import sqlalchemy as sa
 from fastapi import FastAPI
 from flask import Flask
 
-from dbos import DBOS, ConfigFile, DBOSClient
+from dbos import DBOS, DBOSClient, DBOSConfig
 from dbos._app_db import ApplicationDatabase
+from dbos._dbos_config import translate_dbos_config_to_config_file
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import SystemDatabase
 
@@ -24,41 +25,37 @@ def build_wheel() -> str:
     return wheel_files[0]
 
 
-def default_config() -> ConfigFile:
+def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database": {
-            "hostname": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": os.environ.get("PGPASSWORD", "dbos"),
-            "app_db_name": "dbostestpy",
-        },
+        "database_url": f'postgresql://postgres:{os.environ.get("PGPASSWORD", "dbos")}@localhost:5432/dbostestpy',
     }
 
 
 @pytest.fixture()
-def config() -> ConfigFile:
+def config() -> DBOSConfig:
     return default_config()
 
 
 @pytest.fixture()
-def sys_db(config: ConfigFile) -> Generator[SystemDatabase, Any, None]:
-    sys_db = SystemDatabase(config["database"])
+def sys_db(config: DBOSConfig) -> Generator[SystemDatabase, Any, None]:
+    cfg = translate_dbos_config_to_config_file(config)
+    sys_db = SystemDatabase(cfg["database"])
     yield sys_db
     sys_db.destroy()
 
 
 @pytest.fixture()
-def app_db(config: ConfigFile) -> Generator[ApplicationDatabase, Any, None]:
-    app_db = ApplicationDatabase(config["database"])
+def app_db(config: DBOSConfig) -> Generator[ApplicationDatabase, Any, None]:
+    cfg = translate_dbos_config_to_config_file(config)
+    app_db = ApplicationDatabase(cfg["database"])
     yield app_db
     app_db.destroy()
 
 
 @pytest.fixture(scope="session")
 def postgres_db_engine() -> sa.Engine:
-    cfg = default_config()
+    cfg = translate_dbos_config_to_config_file(default_config())
     postgres_db_url = sa.URL.create(
         "postgresql+psycopg",
         username=cfg["database"]["username"],
@@ -71,8 +68,9 @@ def postgres_db_engine() -> sa.Engine:
 
 
 @pytest.fixture()
-def cleanup_test_databases(config: ConfigFile, postgres_db_engine: sa.Engine) -> None:
-    app_db_name = config["database"]["app_db_name"]
+def cleanup_test_databases(config: DBOSConfig, postgres_db_engine: sa.Engine) -> None:
+    cfg = translate_dbos_config_to_config_file(config)
+    app_db_name = cfg["database"]["app_db_name"]
     sys_db_name = f"{app_db_name}_dbos_sys"
 
     with postgres_db_engine.connect() as connection:
@@ -108,7 +106,7 @@ def cleanup_test_databases(config: ConfigFile, postgres_db_engine: sa.Engine) ->
 
 @pytest.fixture()
 def dbos(
-    config: ConfigFile, cleanup_test_databases: None
+    config: DBOSConfig, cleanup_test_databases: None
 ) -> Generator[DBOS, Any, None]:
     DBOS.destroy(destroy_registry=True)
 
@@ -125,19 +123,16 @@ def dbos(
 
 
 @pytest.fixture()
-def client(config: ConfigFile) -> Generator[DBOSClient, Any, None]:
-    database = config["database"]
-    username = quote(database["username"])
-    password = quote(database["password"])
-    database_url = f"postgresql://{username}:{password}@{database['hostname']}:{database['port']}/{database['app_db_name']}"
-    client = DBOSClient(database_url)
+def client(config: DBOSConfig) -> Generator[DBOSClient, Any, None]:
+    assert config["database_url"] is not None
+    client = DBOSClient(config["database_url"])
     yield client
     client.destroy()
 
 
 @pytest.fixture()
 def dbos_fastapi(
-    config: ConfigFile, cleanup_test_databases: None
+    config: DBOSConfig, cleanup_test_databases: None
 ) -> Generator[Tuple[DBOS, FastAPI], Any, None]:
     DBOS.destroy(destroy_registry=True)
     app = FastAPI()
@@ -153,7 +148,7 @@ def dbos_fastapi(
 
 @pytest.fixture()
 def dbos_flask(
-    config: ConfigFile, cleanup_test_databases: None
+    config: DBOSConfig, cleanup_test_databases: None
 ) -> Generator[Tuple[DBOS, Flask], Any, None]:
     DBOS.destroy(destroy_registry=True)
     app = Flask(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def build_wheel() -> str:
 def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database_url": f'postgresql://postgres:{os.environ.get("PGPASSWORD", "dbos")}@localhost:5432/dbostestpy',
+        "database_url": f'postgresql://postgres:{quote(os.environ.get("PGPASSWORD", "dbos"))}@localhost:5432/dbostestpy',
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def build_wheel() -> str:
 def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database_url": f'postgresql://postgres:{quote(os.environ.get("PGPASSWORD", "dbos"), safe='')}@localhost:5432/dbostestpy',
+        "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'), safe='')}@localhost:5432/dbostestpy",
     }
 
 

--- a/tests/queuedworkflow.py
+++ b/tests/queuedworkflow.py
@@ -8,7 +8,7 @@ from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID
 def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
+        "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'), safe='')}@localhost:5432/dbostestpy",
     }
 
 

--- a/tests/queuedworkflow.py
+++ b/tests/queuedworkflow.py
@@ -1,24 +1,13 @@
 # Public API
 import os
 
-from dbos import DBOS, ConfigFile, Queue, SetWorkflowID
+from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID
 
 
-def default_config() -> ConfigFile:
+def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database": {
-            "hostname": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": os.environ["PGPASSWORD"],
-            "app_db_name": "dbostestpy",
-        },
-        "runtimeConfig": {
-            "start": ["python3 main.py"],
-        },
-        "telemetry": {},
-        "env": {},
+        "database_url": f"postgresql://postgres:{os.environ.get('PGPASSWORD', 'dbos')}@localhost:5432/dbostestpy",
     }
 
 

--- a/tests/queuedworkflow.py
+++ b/tests/queuedworkflow.py
@@ -1,5 +1,6 @@
 # Public API
 import os
+from urllib.parse import quote
 
 from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID
 
@@ -7,7 +8,7 @@ from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID
 def default_config() -> DBOSConfig:
     return {
         "name": "test-app",
-        "database_url": f"postgresql://postgres:{os.environ.get('PGPASSWORD', 'dbos')}@localhost:5432/dbostestpy",
+        "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
     }
 
 

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -70,7 +70,7 @@ def test_admin_endpoints(dbos: DBOS) -> None:
         assert event.is_set()
 
 
-def test_deactivate(dbos: DBOS, config: ConfigFile) -> None:
+def test_deactivate(dbos: DBOS, config: DBOSConfig) -> None:
     wf_counter: int = 0
 
     queue = Queue("example-queue")

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from requests.exceptions import ConnectionError
 
 # Public API
-from dbos import DBOS, ConfigFile, DBOSConfig, Queue, SetWorkflowID, _workflow_commands
+from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID, _workflow_commands
 from dbos._error import DBOSWorkflowCancelledError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import SystemDatabase, WorkflowStatusString
@@ -121,7 +121,7 @@ def test_deactivate(dbos: DBOS, config: ConfigFile) -> None:
         assert event.is_set()
 
 
-def test_admin_recovery(config: ConfigFile) -> None:
+def test_admin_recovery(config: DBOSConfig) -> None:
     os.environ["DBOS__VMID"] = "testexecutor"
     os.environ["DBOS__APPVERSION"] = "testversion"
     os.environ["DBOS__APPID"] = "testappid"
@@ -191,30 +191,14 @@ def test_admin_recovery(config: ConfigFile) -> None:
     assert succeeded, "Workflow did not recover"
 
 
-def test_admin_diff_port(cleanup_test_databases: None) -> None:
+def test_admin_diff_port(config: DBOSConfig, cleanup_test_databases: None) -> None:
     # Initialize singleton
     DBOS.destroy()  # In case of other tests leaving it
 
-    config_string = """name: test-app
-language: python
-database:
-  hostname: localhost
-  port: 5432
-  username: postgres
-  password: ${PGPASSWORD}
-  app_db_name: dbostestpy
-runtimeConfig:
-  start:
-    - python3 main.py
-  admin_port: 8001
-"""
-    # Write the config to a text file for the moment
-    with open("dbos-config.yaml", "w") as file:
-        file.write(config_string)
-
     try:
         # Initialize DBOS
-        DBOS()
+        config["admin_port"] = 8001
+        DBOS(config=config)
         DBOS.launch()
 
         # Test GET /dbos-healthz
@@ -224,17 +208,13 @@ runtimeConfig:
     finally:
         # Clean up after the test
         DBOS.destroy()
-        os.remove("dbos-config.yaml")
 
 
-def test_disable_admin_server(cleanup_test_databases: None) -> None:
+def test_disable_admin_server(config: DBOSConfig, cleanup_test_databases: None) -> None:
     # Initialize singleton
     DBOS.destroy()  # In case of other tests leaving it
 
-    config: DBOSConfig = {
-        "name": "test-app",
-        "run_admin_server": False,
-    }
+    config["run_admin_server"] = False
     try:
         DBOS(config=config)
         DBOS.launch()
@@ -246,13 +226,10 @@ def test_disable_admin_server(cleanup_test_databases: None) -> None:
         DBOS.destroy()
 
 
-def test_busy_admin_server_port_does_not_throw() -> None:
+def test_busy_admin_server_port_does_not_throw(config: DBOSConfig) -> None:
     # Initialize singleton
     DBOS.destroy()  # In case of other tests leaving it
 
-    config: DBOSConfig = {
-        "name": "test-app",
-    }
     server_thread = None
     stop_event = threading.Event()
     try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ from typing import Optional, TypedDict
 import pytest
 import sqlalchemy as sa
 
-from dbos import DBOS, ConfigFile, DBOSClient, EnqueueOptions, SetWorkflowID
+from dbos import DBOS, DBOSClient, DBOSConfig, EnqueueOptions, SetWorkflowID
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
 from dbos._sys_db import SystemDatabase
 from dbos._utils import GlobalParams
@@ -152,7 +152,7 @@ def test_client_enqueue_wrong_appver(dbos: DBOS, client: DBOSClient) -> None:
 
 
 def test_client_enqueue_idempotent(
-    config: ConfigFile, client: DBOSClient, sys_db: SystemDatabase
+    config: DBOSConfig, client: DBOSClient, sys_db: SystemDatabase
 ) -> None:
     DBOS.destroy(destroy_registry=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -380,28 +380,23 @@ def test_process_config_with_db_url_taking_precedence_over_database():
 
 # Note this exercise going through the db wizard
 def test_process_config_load_defaults():
-    save_pgpassword = '#^aze@//^"'
-    os.environ["PGPASSWORD"] = save_pgpassword
-    try:
-        config: ConfigFile = {
-            "name": "some-app",
-        }
-        processed_config = process_config(data=config)
-        assert processed_config["name"] == "some-app"
-        assert processed_config["database"]["app_db_name"] == "some_app"
-        assert processed_config["database"]["hostname"] == "localhost"
-        assert processed_config["database"]["port"] == 5432
-        assert processed_config["database"]["username"] == "postgres"
-        assert processed_config["database"]["password"] == quote(
-            os.environ.get("PGPASSWORD", "dbos")
-        )
-        assert processed_config["database"]["connectionTimeoutMillis"] == 10000
-        assert processed_config["database"]["app_db_pool_size"] == 20
-        assert processed_config["database"]["sys_db_pool_size"] == 20
-        assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
-        assert processed_config["runtimeConfig"]["run_admin_server"] == True
-    finally:
-        os.environ["PGPASSWORD"] = save_pgpassword
+    config: ConfigFile = {
+        "name": "some-app",
+    }
+    processed_config = process_config(data=config)
+    assert processed_config["name"] == "some-app"
+    assert processed_config["database"]["app_db_name"] == "some_app"
+    assert processed_config["database"]["hostname"] == "localhost"
+    assert processed_config["database"]["port"] == 5432
+    assert processed_config["database"]["username"] == "postgres"
+    assert processed_config["database"]["password"] == os.environ.get(
+        "PGPASSWORD", "dbos"
+    )
+    assert processed_config["database"]["connectionTimeoutMillis"] == 10000
+    assert processed_config["database"]["app_db_pool_size"] == 20
+    assert processed_config["database"]["sys_db_pool_size"] == 20
+    assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
+    assert processed_config["runtimeConfig"]["run_admin_server"] == True
 
 
 def test_process_config_load_default_with_None_database_url():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,7 +89,7 @@ def test_load_valid_config_file(mocker):
           hostname: 'localhost'
           port: 5432
           username: 'postgres'
-          password: ${PGPASSWORD}
+          password: '${PGPASSWORD}'
           app_db_name: 'some db'
           connectionTimeoutMillis: 3000
         env:
@@ -156,7 +156,7 @@ def test_load_config_database_url_and_database(mocker):
             hostname: 'localhost'
             port: 5432
             username: 'postgres'
-            password: ${PGPASSWORD}
+            password: '${PGPASSWORD}'
             app_db_name: 'some db'
             connectionTimeoutMillis: 3000
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ import pytest_mock
 from sqlalchemy import URL, event
 
 # Public API
-from dbos import DBOS, get_dbos_database_url
+from dbos import DBOS
 from dbos._dbos_config import (
     ConfigFile,
     DBOSConfig,
@@ -1248,31 +1248,6 @@ def test_configured_app_db_connect_timeout():
         pass
 
     dbos.destroy()
-
-
-def test_get_dbos_database_url(mocker):
-    mock_config = """
-        name: "some-app"
-        database:
-          hostname: 'localhost'
-          port: 5432
-          username: 'postgres'
-          password: ${PGPASSWORD}
-          app_db_name: 'some_db'
-    """
-    mocker.patch(
-        "builtins.open", side_effect=generate_mock_open(mock_filename, mock_config)
-    )
-
-    expected_url = URL.create(
-        "postgresql+psycopg",
-        username="postgres",
-        password=os.environ.get("PGPASSWORD"),
-        host="localhost",
-        port=5432,
-        database="some_db",
-    ).render_as_string(hide_password=False)
-    assert get_dbos_database_url() == expected_url
 
 
 def test_db_engine_kwargs():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -380,23 +380,28 @@ def test_process_config_with_db_url_taking_precedence_over_database():
 
 # Note this exercise going through the db wizard
 def test_process_config_load_defaults():
-    config: ConfigFile = {
-        "name": "some-app",
-    }
-    processed_config = process_config(data=config)
-    assert processed_config["name"] == "some-app"
-    assert processed_config["database"]["app_db_name"] == "some_app"
-    assert processed_config["database"]["hostname"] == "localhost"
-    assert processed_config["database"]["port"] == 5432
-    assert processed_config["database"]["username"] == "postgres"
-    assert processed_config["database"]["password"] == os.environ.get(
-        "PGPASSWORD", "dbos"
-    )
-    assert processed_config["database"]["connectionTimeoutMillis"] == 10000
-    assert processed_config["database"]["app_db_pool_size"] == 20
-    assert processed_config["database"]["sys_db_pool_size"] == 20
-    assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
-    assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    save_pgpassword = '#^aze@//^"'
+    os.environ["PGPASSWORD"] = save_pgpassword
+    try:
+        config: ConfigFile = {
+            "name": "some-app",
+        }
+        processed_config = process_config(data=config)
+        assert processed_config["name"] == "some-app"
+        assert processed_config["database"]["app_db_name"] == "some_app"
+        assert processed_config["database"]["hostname"] == "localhost"
+        assert processed_config["database"]["port"] == 5432
+        assert processed_config["database"]["username"] == "postgres"
+        assert processed_config["database"]["password"] == quote(
+            os.environ.get("PGPASSWORD", "dbos")
+        )
+        assert processed_config["database"]["connectionTimeoutMillis"] == 10000
+        assert processed_config["database"]["app_db_pool_size"] == 20
+        assert processed_config["database"]["sys_db_pool_size"] == 20
+        assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
+        assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    finally:
+        os.environ["PGPASSWORD"] = save_pgpassword
 
 
 def test_process_config_load_default_with_None_database_url():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,12 +64,12 @@ def test_dbosconfig_type_provided():
         "name": "some-app",
     }
     dbos = DBOS(config=config)
-    assert dbos.config["name"] == "some-app"
-    assert dbos.config["database"]["hostname"] == "localhost"
-    assert dbos.config["database"]["port"] == 5432
-    assert dbos.config["database"]["username"] == "postgres"
-    assert dbos.config["database"]["password"] == os.environ["PGPASSWORD"]
-    assert dbos.config["database"]["app_db_name"] == "some_app"
+    assert dbos._config["name"] == "some-app"
+    assert dbos._config["database"]["hostname"] == "localhost"
+    assert dbos._config["database"]["port"] == 5432
+    assert dbos._config["database"]["username"] == "postgres"
+    assert dbos._config["database"]["password"] == os.environ["PGPASSWORD"]
+    assert dbos._config["database"]["app_db_name"] == "some_app"
     dbos.destroy()
 
 
@@ -1183,6 +1183,7 @@ def test_no_config_file():
 
 
 def test_configured_pool_sizes():
+    DBOS.destroy()
     config: DBOSConfig = {
         "name": "test-app",
         "app_db_pool_size": 42,
@@ -1199,6 +1200,7 @@ def test_configured_pool_sizes():
 
 
 def test_default_pool_params():
+    DBOS.destroy()
     config: DBOSConfig = {
         "name": "test-app",
     }
@@ -1224,6 +1226,7 @@ def test_default_pool_params():
 
 
 def test_configured_app_db_connect_timeout():
+    DBOS.destroy()
     config: DBOSConfig = {
         "name": "test-app",
         "database_url": f"postgresql://postgres:@localhost:5432/dbname?connect_timeout=7",
@@ -1273,6 +1276,7 @@ def test_get_dbos_database_url(mocker):
 
 
 def test_db_engine_kwargs():
+    DBOS.destroy()
     config: DBOSConfig = {
         "name": "test-app",
         "db_engine_kwargs": {

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 # Public API
 from dbos import (
     DBOS,
-    ConfigFile,
+    DBOSConfig,
     SetWorkflowID,
     SetWorkflowTimeout,
     WorkflowHandle,
@@ -561,7 +561,7 @@ def test_recovery_temp_workflow(dbos: DBOS) -> None:
     assert txn_counter == 1
 
 
-def test_recovery_thread(config: ConfigFile) -> None:
+def test_recovery_thread(config: DBOSConfig) -> None:
     wf_counter: int = 0
     test_var = "dbos"
 
@@ -1171,7 +1171,7 @@ def test_multi_set_event(dbos: DBOS) -> None:
 
 
 def test_debug_logging(
-    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: ConfigFile
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: DBOSConfig
 ) -> None:
     wfid = str(uuid.uuid4())
     dest_wfid = str(uuid.uuid4())
@@ -1270,7 +1270,7 @@ def test_debug_logging(
     logging.getLogger("dbos").propagate = original_propagate
 
 
-def test_destroy_semantics(dbos: DBOS, config: ConfigFile) -> None:
+def test_destroy_semantics(dbos: DBOS, config: DBOSConfig) -> None:
 
     @DBOS.workflow()
     def test_workflow(var: str) -> str:
@@ -1301,7 +1301,7 @@ def test_double_decoration(dbos: DBOS) -> None:
 
 
 def test_duplicate_registration(
-    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: ConfigFile
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: DBOSConfig
 ) -> None:
     original_propagate = logging.getLogger("dbos").propagate
     caplog.set_level(logging.WARNING, "dbos")
@@ -1357,7 +1357,7 @@ def test_duplicate_registration(
     logging.getLogger("dbos").propagate = original_propagate
 
 
-def test_app_version(config: ConfigFile) -> None:
+def test_app_version(config: DBOSConfig) -> None:
     def is_hex(s: str) -> bool:
         return all(c in "0123456789abcdefABCDEF" for c in s)
 
@@ -1424,7 +1424,7 @@ def test_app_version(config: ConfigFile) -> None:
     del os.environ["DBOS__APPVERSION"]
 
 
-def test_recovery_appversion(config: ConfigFile) -> None:
+def test_recovery_appversion(config: DBOSConfig) -> None:
     input = 5
     os.environ["DBOS__VMID"] = "testexecutor"
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 import sqlalchemy as sa
 
-from dbos import DBOS, ConfigFile, SetWorkflowID
+from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._dbos import _get_dbos_instance
 from dbos._debug import PythonModule, parse_start_command
 from dbos._schemas.system_database import SystemSchema
@@ -58,7 +58,7 @@ def get_recovery_attempts(wfuuid: str) -> int:
         return int(recovery_attempts)
 
 
-def test_wf_debug(dbos: DBOS, config: ConfigFile) -> None:
+def test_wf_debug(dbos: DBOS, config: DBOSConfig) -> None:
     wf_counter: int = 0
     step_counter: int = 0
 
@@ -101,7 +101,7 @@ def test_wf_debug(dbos: DBOS, config: ConfigFile) -> None:
     assert actual_retry_attempts == expected_retry_attempts
 
 
-def test_wf_debug_exception(dbos: DBOS, config: ConfigFile) -> None:
+def test_wf_debug_exception(dbos: DBOS, config: DBOSConfig) -> None:
     wf_counter: int = 0
     step_counter: int = 0
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 # Public API
-from dbos import DBOS, ConfigFile
+from dbos import DBOS, DBOSConfig
 
 # Private API because this is a unit test
 from dbos._context import assert_current_dbos_context
@@ -160,7 +160,7 @@ def test_endpoint_recovery(dbos_fastapi: Tuple[DBOS, FastAPI]) -> None:
 
 @pytest.mark.asyncio
 async def test_custom_lifespan(
-    config: ConfigFile, cleanup_test_databases: None
+    config: DBOSConfig, cleanup_test_databases: None
 ) -> None:
     resource = None
     port = 8000

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -56,7 +56,6 @@ def test_package(build_wheel: str, postgres_db_engine: sa.Engine) -> None:
             subprocess.check_call(
                 ["dbos", "init", template_name, "--template", template_name],
                 cwd=temp_path,
-                env=venv,
             )
 
             # Run schema migration
@@ -133,7 +132,6 @@ def test_reset(postgres_db_engine: sa.Engine) -> None:
         subprocess.check_call(
             ["dbos", "init", app_name, "--template", "dbos-db-starter"],
             cwd=temp_path,
-            env=env,
         )
 
         # Create a system database and verify it exists

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -166,7 +166,7 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
             ["dbos", "init", app_name, "--template", "dbos-toolbox"],
             cwd=temp_path,
         )
-        subprocess.check_call(["dbos", "reset", "-y"], cwd=temp_path)
+        subprocess.check_call(["dbos", "reset", "-y", "-D", db_url], cwd=temp_path)
         subprocess.check_call(["dbos", "migrate"], cwd=temp_path)
 
         # Get some workflows enqueued on the toolbox, then kill the toolbox
@@ -223,12 +223,12 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
         assert isinstance(get_steps_data, list)
         assert len(get_steps_data) == 10
 
-        # cancel the workflow and check the status is CANCELED
+        # cancel the workflow and check the status is CANCELLED
         subprocess.check_output(
             ["dbos", "workflow", "cancel", wf_id, "--db-url", db_url], cwd=temp_path
         )
         output = subprocess.check_output(
-            ["dbos", "workflow", "get", wf_id], cwd=temp_path
+            ["dbos", "workflow", "get", wf_id, "-D", db_url], cwd=temp_path
         )
         get_wf_data = json.loads(output)
         assert isinstance(get_wf_data, dict)
@@ -239,7 +239,7 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
             ["dbos", "workflow", "resume", wf_id, "--db-url", db_url], cwd=temp_path
         )
         output = subprocess.check_output(
-            ["dbos", "workflow", "get", wf_id], cwd=temp_path
+            ["dbos", "workflow", "get", wf_id, "-D", db_url], cwd=temp_path
         )
         get_wf_data = json.loads(output)
         assert isinstance(get_wf_data, dict)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -223,12 +223,16 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
         assert isinstance(get_steps_data, list)
         assert len(get_steps_data) == 10
 
+        # From now pass database url in the environment
+        env = os.environ.copy()
+        env["DBOS_DATABASE_URL"] = db_url
+
         # cancel the workflow and check the status is CANCELLED
         subprocess.check_output(
-            ["dbos", "workflow", "cancel", wf_id, "--db-url", db_url], cwd=temp_path
+            ["dbos", "workflow", "cancel", wf_id], cwd=temp_path, env=env
         )
         output = subprocess.check_output(
-            ["dbos", "workflow", "get", wf_id, "-D", db_url], cwd=temp_path
+            ["dbos", "workflow", "get", wf_id], cwd=temp_path, env=env
         )
         get_wf_data = json.loads(output)
         assert isinstance(get_wf_data, dict)
@@ -236,10 +240,10 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
 
         # resume the workflow and check the status is ENQUEUED
         subprocess.check_output(
-            ["dbos", "workflow", "resume", wf_id, "--db-url", db_url], cwd=temp_path
+            ["dbos", "workflow", "resume", wf_id], cwd=temp_path, env=env
         )
         output = subprocess.check_output(
-            ["dbos", "workflow", "get", wf_id, "-D", db_url], cwd=temp_path
+            ["dbos", "workflow", "get", wf_id], cwd=temp_path, env=env
         )
         get_wf_data = json.loads(output)
         assert isinstance(get_wf_data, dict)
@@ -247,7 +251,7 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
 
         # restart the workflow and check it has a new ID and its status is ENQUEUED
         output = subprocess.check_output(
-            ["dbos", "workflow", "restart", wf_id, "--db-url", db_url], cwd=temp_path
+            ["dbos", "workflow", "restart", wf_id], cwd=temp_path, env=env
         )
         restart_wf_data = json.loads(output)
         assert isinstance(restart_wf_data, dict)
@@ -256,8 +260,9 @@ def test_workflow_commands(postgres_db_engine: sa.Engine) -> None:
 
         # fork the workflow at step 5 and check it has a new ID and its status is ENQUEUED
         output = subprocess.check_output(
-            ["dbos", "workflow", "fork", wf_id, "--step", "5", "--db-url", db_url],
+            ["dbos", "workflow", "fork", wf_id, "--step", "5"],
             cwd=temp_path,
+            env=env,
         )
         fork_wf_data = json.loads(output)
         assert isinstance(fork_wf_data, dict)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 from dbos import (
     DBOS,
-    ConfigFile,
+    DBOSConfig,
     DBOSConfiguredInstance,
     Queue,
     SetEnqueueOptions,
@@ -426,21 +426,10 @@ def run_dbos_test_in_process(
     start_signal: multiprocessing.synchronize.Event,
     end_signal: multiprocessing.synchronize.Event,
 ) -> None:
-    dbos_config: ConfigFile = {
+    dbos_config: DBOSConfig = {
         "name": "test-app",
-        "database": {
-            "hostname": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": os.environ["PGPASSWORD"],
-            "app_db_name": "dbostestpy",
-        },
-        "runtimeConfig": {
-            "start": ["python3 main.py"],
-            "admin_port": 8001 + i,
-        },
-        "telemetry": {},
-        "env": {},
+        "database_url": f"postgres://postgres:{os.environ.get('PGPASSWORD', 'dbos')}@localhost:5432/dbostestpy",
+        "admin_port": 8001 + i,
     }
     dbos = DBOS(config=dbos_config)
     DBOS.launch()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -429,7 +429,7 @@ def run_dbos_test_in_process(
 ) -> None:
     dbos_config: DBOSConfig = {
         "name": "test-app",
-        "database_url": f"postgres://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
+        "database_url": f"postgres://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'), safe='')}@localhost:5432/dbostestpy",
         "admin_port": 8001 + i,
     }
     dbos = DBOS(config=dbos_config)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -8,6 +8,7 @@ import threading
 import time
 import uuid
 from typing import List
+from urllib.parse import quote
 
 import pytest
 import sqlalchemy as sa
@@ -428,7 +429,7 @@ def run_dbos_test_in_process(
 ) -> None:
     dbos_config: DBOSConfig = {
         "name": "test-app",
-        "database_url": f"postgres://postgres:{os.environ.get('PGPASSWORD', 'dbos')}@localhost:5432/dbostestpy",
+        "database_url": f"postgres://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
         "admin_port": 8001 + i,
     }
     dbos = DBOS(config=dbos_config)

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import time
 from os import path
+from urllib.parse import quote
 
 import pytest
 
@@ -146,7 +147,7 @@ def test_config_before_singleton(cleanup_test_databases: None) -> None:
 
         config: DBOSConfig = {
             "name": "test-app",
-            "database_url": f"postgresql://postgres:{os.environ.get('PGPASSWORD', 'dbos')}@localhost:5432/dbostestpy",
+            "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
         }
         dbos: DBOS = DBOS(config=config)
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -121,12 +121,7 @@ def test_dbos_singleton_negative(cleanup_test_databases: None) -> None:
     #    then imports more
     from tests.classdefs import DBOSTestClass
 
-    dbos: DBOS = DBOS(config=default_config())
-
-    # Don't initialize DBOS twice
-    with pytest.raises(Exception) as exc_info:
-        DBOS(config=default_config())
-    assert "conflicting configuration" in str(exc_info.value)
+    DBOS(config=default_config())
 
     # Something should have launched
     with pytest.raises(Exception) as exc_info:
@@ -134,26 +129,6 @@ def test_dbos_singleton_negative(cleanup_test_databases: None) -> None:
     assert "launch" in str(exc_info.value)
 
     DBOS.destroy()
-
-
-def test_config_before_singleton(cleanup_test_databases: None) -> None:
-    # Initialize singleton
-    DBOS.destroy()  # In case of other tests leaving it
-
-    try:
-        # Simulate an app that does some imports of its own code, then defines DBOS,
-        #    then imports more
-        from tests.classdefs import DBOSTestClass
-
-        config: DBOSConfig = {
-            "name": "test-app",
-            "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'))}@localhost:5432/dbostestpy",
-        }
-        dbos: DBOS = DBOS(config=config)
-
-    finally:
-        # Initialize singleton
-        DBOS.destroy()  # In case of other tests leaving it
 
 
 def test_dbos_atexit_no_dbos(cleanup_test_databases: None) -> None:

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -6,14 +6,7 @@ from typing import Any
 import pytest
 
 # Public API
-from dbos import (
-    DBOS,
-    ConfigFile,
-    Queue,
-    SetWorkflowID,
-    WorkflowStatusString,
-    _workflow_commands,
-)
+from dbos import DBOS, Queue, SetWorkflowID, WorkflowStatusString, _workflow_commands
 from dbos._app_db import ApplicationDatabase
 from dbos._sys_db import SystemDatabase
 from dbos._utils import GlobalParams
@@ -166,7 +159,7 @@ def test_list_workflow_end_times_positive(dbos: DBOS) -> None:
     assert len(output) == 2, f"Expected list length to be 2, but got {len(output)}"
 
 
-def test_get_workflow(dbos: DBOS, config: ConfigFile, sys_db: SystemDatabase) -> None:
+def test_get_workflow(dbos: DBOS, sys_db: SystemDatabase) -> None:
     @DBOS.workflow()
     def simple_workflow() -> None:
         print("Executed Simple workflow")


### PR DESCRIPTION
Deprecate ConfigFile as programmatic input

- New config object is the only possible input, not optional anymore (only "name" is required in the config)
- `config` is now a mandatory parameter to DBOS() (only the application name is required in the configuration)
- Launch doesn't load from config file by default anymore
- Remove the `DBOS.config` singleton property that was doing some mambo jumbo to find the "current configuration", including falling back on `dbos-config.yaml`
- CLI: throws if database url isn't provided by CLI flag or environment variable