### PR TITLE
Conductor fork workflow support

### DIFF
--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -201,26 +201,16 @@ class ConductorWebsocket(threading.Thread):
                                         start_step,
                                         application_version=app_version,
                                     )
-                                    new_info = (
-                                        p.WorkflowsOutput.from_workflow_information(
-                                            new_handle.get_status()
-                                        )
-                                    )
+                                new_workflow_id = new_handle.workflow_id
                             except Exception as e:
                                 error_message = f"Exception encountered when forking workflow {workflow_id} to new workflow {new_workflow_id} on step {start_step}, app version {app_version}: {traceback.format_exc()}"
-                                new_info = None
                                 self.dbos.logger.error(error_message)
+                                new_workflow_id = None
 
                             fork_response = p.ForkWorkflowResponse(
                                 type=p.MessageType.FORK_WORKFLOW,
                                 request_id=base_message.request_id,
-                                output=(
-                                    p.WorkflowsOutput.from_workflow_information(
-                                        new_info
-                                    )
-                                    if new_info is not None
-                                    else None
-                                ),
+                                new_workflow_id=new_workflow_id,
                                 error_message=error_message,
                             )
                             websocket.send(fork_response.to_json())

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -280,5 +280,5 @@ class ForkWorkflowRequest(BaseMessage):
 
 @dataclass
 class ForkWorkflowResponse(BaseMessage):
-    output: Optional[WorkflowsOutput]
+    new_workflow_id: Optional[str]
     error_message: Optional[str] = None

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -17,6 +17,7 @@ class MessageType(str, Enum):
     GET_WORKFLOW = "get_workflow"
     EXIST_PENDING_WORKFLOWS = "exist_pending_workflows"
     LIST_STEPS = "list_steps"
+    FORK_WORKFLOW = "fork_workflow"
 
 
 T = TypeVar("T", bound="BaseMessage")
@@ -262,4 +263,22 @@ class ListStepsRequest(BaseMessage):
 @dataclass
 class ListStepsResponse(BaseMessage):
     output: Optional[List[WorkflowSteps]]
+    error_message: Optional[str] = None
+
+
+class ForkWorkflowBody(TypedDict):
+    workflow_id: str
+    start_step: int
+    application_version: Optional[str]
+    new_workflow_id: Optional[str]
+
+
+@dataclass
+class ForkWorkflowRequest(BaseMessage):
+    body: ForkWorkflowBody
+
+
+@dataclass
+class ForkWorkflowResponse(BaseMessage):
+    output: Optional[WorkflowsOutput]
     error_message: Optional[str] = None


### PR DESCRIPTION
Add a new message type `FORK_WORKFLOW`

It supports specifying a new workflow ID, app version, and start step:
```python
class ForkWorkflowBody(TypedDict):
    workflow_id: str
    start_step: int
    application_version: Optional[str]
    new_workflow_id: Optional[str]
```