### PR TITLE
Worker Concurrency Fix

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1739,15 +1739,30 @@ class SystemDatabase:
                 available_tasks = max(0, queue.concurrency - total_running_tasks)
                 max_tasks = min(max_tasks, available_tasks)
 
-            # Lookup unstarted/uncompleted tasks (not running)
+            # Retrieve the first max_tasks workflows in the queue.
+            # Only retrieve workflows of the appropriate version (or without version set)
             query = (
                 sa.select(
                     SystemSchema.workflow_queue.c.workflow_uuid,
+                )
+                .select_from(
+                    SystemSchema.workflow_queue.join(
+                        SystemSchema.workflow_status,
+                        SystemSchema.workflow_queue.c.workflow_uuid
+                        == SystemSchema.workflow_status.c.workflow_uuid,
+                    )
                 )
                 .where(SystemSchema.workflow_queue.c.queue_name == queue.name)
                 .where(SystemSchema.workflow_queue.c.started_at_epoch_ms == None)
                 .where(SystemSchema.workflow_queue.c.completed_at_epoch_ms == None)
                 .order_by(SystemSchema.workflow_queue.c.created_at_epoch_ms.asc())
+                .where(
+                    sa.or_(
+                        SystemSchema.workflow_status.c.application_version
+                        == app_version,
+                        SystemSchema.workflow_status.c.application_version.is_(None),
+                    )
+                )
                 .with_for_update(nowait=True)  # Error out early
             )
             # Apply limit only if max_tasks is finite
@@ -1778,15 +1793,6 @@ class SystemDatabase:
                     .where(
                         SystemSchema.workflow_status.c.status
                         == WorkflowStatusString.ENQUEUED.value
-                    )
-                    .where(
-                        sa.or_(
-                            SystemSchema.workflow_status.c.application_version
-                            == app_version,
-                            SystemSchema.workflow_status.c.application_version.is_(
-                                None
-                            ),
-                        )
                     )
                     .values(
                         status=WorkflowStatusString.PENDING.value,


### PR DESCRIPTION
Fix an issue where workflows of the wrong version count against worker concurrency limits. (https://github.com/dbos-inc/dbos-transact-py/pull/333)
