### PR TITLE
Fix Queue Timeout

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -392,6 +392,7 @@ class SetWorkflowTimeout:
             else None
         )
         self.saved_workflow_timeout: Optional[int] = None
+        self.saved_workflow_deadline_epoch_ms: Optional[int] = None
 
     def __enter__(self) -> SetWorkflowTimeout:
         # Code to create a basic context
@@ -402,6 +403,8 @@ class SetWorkflowTimeout:
         ctx = assert_current_dbos_context()
         self.saved_workflow_timeout = ctx.workflow_timeout_ms
         ctx.workflow_timeout_ms = self.workflow_timeout_ms
+        self.saved_workflow_deadline_epoch_ms = ctx.workflow_deadline_epoch_ms
+        ctx.workflow_deadline_epoch_ms = None
         return self
 
     def __exit__(
@@ -411,6 +414,9 @@ class SetWorkflowTimeout:
         traceback: Optional[TracebackType],
     ) -> Literal[False]:
         assert_current_dbos_context().workflow_timeout_ms = self.saved_workflow_timeout
+        assert_current_dbos_context().workflow_deadline_epoch_ms = (
+            self.saved_workflow_deadline_epoch_ms
+        )
         # Code to clean up the basic context if we created it
         if self.created_ctx:
             _clear_local_dbos_context()

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -62,6 +62,7 @@ class DBOSErrorCode(Enum):
     WorkflowCancelled = 10
     UnexpectedStep = 11
     QueueDeduplicated = 12
+    AwaitedWorkflowCancelled = 13
     ConflictingRegistrationError = 25
 
 
@@ -204,6 +205,19 @@ class DBOSQueueDeduplicatedError(DBOSException):
             self.__class__,
             (self.workflow_id, self.queue_name, self.deduplication_id),
         )
+
+
+class AwaitedWorkflowCancelledError(DBOSException):
+    def __init__(self, workflow_id: str):
+        self.workflow_id = workflow_id
+        super().__init__(
+            f"Awaited workflow {workflow_id} was cancelled",
+            dbos_error_code=DBOSErrorCode.AwaitedWorkflowCancelled.value,
+        )
+
+    def __reduce__(self) -> Any:
+        # Tell jsonpickle how to reconstruct this object
+        return (self.__class__, (self.workflow_id, self.workflow_id))
 
 
 #######################################

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -207,7 +207,7 @@ class DBOSQueueDeduplicatedError(DBOSException):
         )
 
 
-class AwaitedWorkflowCancelledError(DBOSException):
+class DBOSAwaitedWorkflowCancelledError(DBOSException):
     def __init__(self, workflow_id: str):
         self.workflow_id = workflow_id
         super().__init__(
@@ -217,7 +217,7 @@ class AwaitedWorkflowCancelledError(DBOSException):
 
     def __reduce__(self) -> Any:
         # Tell jsonpickle how to reconstruct this object
-        return (self.__class__, (self.workflow_id, self.workflow_id))
+        return (self.__class__, (self.workflow_id,))
 
 
 #######################################

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1840,8 +1840,13 @@ class SystemDatabase:
                         # If a timeout is set, set the deadline on dequeue
                         workflow_deadline_epoch_ms=sa.case(
                             (
-                                SystemSchema.workflow_status.c.workflow_timeout_ms.isnot(
-                                    None
+                                sa.and_(
+                                    SystemSchema.workflow_status.c.workflow_timeout_ms.isnot(
+                                        None
+                                    ),
+                                    SystemSchema.workflow_status.c.workflow_deadline_epoch_ms.is_(
+                                        None
+                                    ),
                                 ),
                                 sa.func.extract("epoch", sa.func.now()) * 1000
                                 + SystemSchema.workflow_status.c.workflow_timeout_ms,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -925,8 +925,8 @@ class SystemDatabase:
             info.input = inputs
             info.output = output
             info.error = exception
-            info.workflow_timeout_ms = row[18]
-            info.workflow_deadline_epoch_ms = row[19]
+            info.workflow_deadline_epoch_ms = row[18]
+            info.workflow_timeout_ms = row[19]
 
             infos.append(info)
         return infos
@@ -1035,8 +1035,8 @@ class SystemDatabase:
             info.input = inputs
             info.output = output
             info.error = exception
-            info.workflow_timeout_ms = row[18]
-            info.workflow_deadline_epoch_ms = row[19]
+            info.workflow_deadline_epoch_ms = row[18]
+            info.workflow_timeout_ms = row[19]
 
             infos.append(info)
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -842,6 +842,8 @@ class SystemDatabase:
             SystemSchema.workflow_inputs.c.inputs,
             SystemSchema.workflow_status.c.output,
             SystemSchema.workflow_status.c.error,
+            SystemSchema.workflow_status.c.workflow_deadline_epoch_ms,
+            SystemSchema.workflow_status.c.workflow_timeout_ms,
         ).join(
             SystemSchema.workflow_inputs,
             SystemSchema.workflow_status.c.workflow_uuid
@@ -923,6 +925,8 @@ class SystemDatabase:
             info.input = inputs
             info.output = output
             info.error = exception
+            info.workflow_timeout_ms = row[18]
+            info.workflow_deadline_epoch_ms = row[19]
 
             infos.append(info)
         return infos
@@ -952,6 +956,8 @@ class SystemDatabase:
             SystemSchema.workflow_inputs.c.inputs,
             SystemSchema.workflow_status.c.output,
             SystemSchema.workflow_status.c.error,
+            SystemSchema.workflow_status.c.workflow_deadline_epoch_ms,
+            SystemSchema.workflow_status.c.workflow_timeout_ms,
         ).select_from(
             SystemSchema.workflow_queue.join(
                 SystemSchema.workflow_status,
@@ -1029,6 +1035,8 @@ class SystemDatabase:
             info.input = inputs
             info.output = output
             info.error = exception
+            info.workflow_timeout_ms = row[18]
+            info.workflow_deadline_epoch_ms = row[19]
 
             infos.append(info)
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -32,7 +32,7 @@ from dbos._utils import INTERNAL_QUEUE_NAME
 from . import _serialization
 from ._context import get_local_dbos_context
 from ._error import (
-    AwaitedWorkflowCancelledError,
+    DBOSAwaitedWorkflowCancelledError,
     DBOSConflictingWorkflowError,
     DBOSDeadLetterQueueError,
     DBOSNonExistentWorkflowError,
@@ -768,7 +768,7 @@ class SystemDatabase:
                     elif status == WorkflowStatusString.CANCELLED.value:
                         # Raise AwaitedWorkflowCancelledError here, not the cancellation exception
                         # because the awaiting workflow is not being cancelled.
-                        raise AwaitedWorkflowCancelledError(workflow_id)
+                        raise DBOSAwaitedWorkflowCancelledError(workflow_id)
                 else:
                     pass  # CB: I guess we're assuming the WF will show up eventually.
             time.sleep(1)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1511,7 +1511,10 @@ def test_workflow_timeout(dbos: DBOS) -> None:
         handle = DBOS.start_workflow(blocked_workflow)
         status = handle.get_status()
         assert status.workflow_timeout_ms == 100
-        assert status.workflow_deadline_epoch_ms is not None and status.workflow_deadline_epoch_ms > time.time() * 1000
+        assert (
+            status.workflow_deadline_epoch_ms is not None
+            and status.workflow_deadline_epoch_ms > time.time() * 1000
+        )
         with pytest.raises(DBOSWorkflowCancelledError):
             handle.get_result()
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1508,12 +1508,13 @@ def test_workflow_timeout(dbos: DBOS) -> None:
             with SetWorkflowID(wfid):
                 blocked_workflow()
         assert assert_current_dbos_context().workflow_deadline_epoch_ms is None
+        start_time = time.time() * 1000
         handle = DBOS.start_workflow(blocked_workflow)
         status = handle.get_status()
         assert status.workflow_timeout_ms == 100
         assert (
             status.workflow_deadline_epoch_ms is not None
-            and status.workflow_deadline_epoch_ms > time.time() * 1000
+            and status.workflow_deadline_epoch_ms > start_time
         )
         with pytest.raises(DBOSWorkflowCancelledError):
             handle.get_result()

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import InvalidRequestError, OperationalError
 
 from dbos import DBOS, Queue, SetWorkflowID
 from dbos._error import (
+    DBOSAwaitedWorkflowCancelledError,
     DBOSDeadLetterQueueError,
     DBOSMaxStepRetriesExceeded,
     DBOSNotAuthorizedError,
@@ -460,6 +461,11 @@ def test_error_serialization() -> None:
     e = DBOSQueueDeduplicatedError("id", "queue", "dedup")
     d = deserialize_exception(serialize_exception(e))
     assert isinstance(d, DBOSQueueDeduplicatedError)
+    assert str(d) == str(e)
+    # AwaitedWorkflowCancelledError
+    e = DBOSAwaitedWorkflowCancelledError("id")
+    d = deserialize_exception(serialize_exception(e))
+    assert isinstance(d, DBOSAwaitedWorkflowCancelledError)
     assert str(d) == str(e)
 
     # Test safe_deserialize

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1382,6 +1382,7 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
             DBOS.sleep(0.1)
 
     timeout = 3.0
+    enqueue_time = time.time()
     with SetWorkflowTimeout(timeout):
         original_handle = queue.enqueue(blocking_workflow)
 
@@ -1391,7 +1392,7 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
     assert original_status.workflow_timeout_ms == timeout * 1000
     assert (
         original_status.workflow_deadline_epoch_ms is not None
-        and original_status.workflow_deadline_epoch_ms > time.time() * 1000
+        and original_status.workflow_deadline_epoch_ms > enqueue_time * 1000
     )
 
     # Recover the workflow. Verify its deadline remains the same

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1357,7 +1357,10 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
     evt.wait()
     original_status = original_handle.get_status()
     assert original_status.workflow_timeout_ms == timeout * 1000
-    assert original_status.workflow_deadline_epoch_ms is not None and original_status.workflow_deadline_epoch_ms > time.time() * 1000
+    assert (
+        original_status.workflow_deadline_epoch_ms is not None
+        and original_status.workflow_deadline_epoch_ms > time.time() * 1000
+    )
 
     # Recover the workflow. Verify its deadline remains the same
     evt.clear()
@@ -1367,7 +1370,10 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
     recovered_handle = handles[0]
     recovered_status = recovered_handle.get_status()
     assert recovered_status.workflow_timeout_ms == timeout * 1000
-    assert recovered_status.workflow_deadline_epoch_ms == original_status.workflow_deadline_epoch_ms
+    assert (
+        recovered_status.workflow_deadline_epoch_ms
+        == original_status.workflow_deadline_epoch_ms
+    )
 
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         original_handle.get_result()

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -41,6 +41,8 @@ def test_list_workflow(dbos: DBOS) -> None:
     assert output.app_version == GlobalParams.app_version
     assert output.app_id == ""
     assert output.recovery_attempts == 1
+    assert output.workflow_timeout_ms is None
+    assert output.workflow_deadline_epoch_ms is None
 
     # Test searching by status
     outputs = DBOS.list_workflows(status="PENDING")
@@ -222,6 +224,8 @@ def test_queued_workflows(dbos: DBOS) -> None:
         assert workflow.created_at is not None and workflow.created_at > 0
         assert workflow.updated_at is not None and workflow.updated_at > 0
         assert workflow.recovery_attempts == 1
+        assert workflow.workflow_timeout_ms is None
+        assert workflow.workflow_deadline_epoch_ms is None
 
     # Test sort_desc inverts the order
     workflows = DBOS.list_queued_workflows(sort_desc=True)


### PR DESCRIPTION
- Fix an issue where the deadline of an enqueued workflow might be reset during recovery.
- `SetWorkflowTimeout(None)` on a child workflow now properly unsets its timeout.
- Timeout and deadline are now exposed in workflow status.