### PR TITLE
Handling Database Disconnections

### DIFF
--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -41,5 +41,5 @@ jobs:
       working-directory: ./
 
     - name: Run Chaos Tests
-      run: pdm run pytest chaos-tests
+      run: pdm run pytest --timeout 600 chaos-tests
       working-directory: ./

--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -1,0 +1,45 @@
+name: Run Chaos Tests
+
+on:
+    push:
+      branches:
+        - main
+        - release/*
+    pull_request:
+      branches:
+        - main
+        - release/*
+      types:
+        - ready_for_review
+        - opened
+        - reopened
+        - synchronize
+    workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Setup PDM
+      uses: pdm-project/setup-pdm@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
+
+    - name: Install Dependencies
+      run: pdm install
+      working-directory: ./
+
+    - name: Run Chaos Tests
+      run: pdm run pytest chaos-tests
+      working-directory: ./

--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -1,19 +1,9 @@
 name: Run Chaos Tests
 
 on:
-    push:
-      branches:
-        - main
-        - release/*
-    pull_request:
-      branches:
-        - main
-        - release/*
-      types:
-        - ready_for_review
-        - opened
-        - reopened
-        - synchronize
+    schedule:
+        # Runs every hour on the hour
+        - cron: '0 * * * *'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -94,7 +94,7 @@ jobs:
       working-directory: ./
 
     - name: Run Unit Tests
-      run: pdm run pytest
+      run: pdm run pytest tests
       working-directory: ./
       env:
         PGPASSWORD: a!b@c$d()e*_,/:;=?@ff[]22

--- a/chaos-tests/conftest.py
+++ b/chaos-tests/conftest.py
@@ -55,27 +55,28 @@ def cleanup_test_databases(config: DBOSConfig, postgres: None) -> None:
 
 class PostgresChaosMonkey:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.stop_event = threading.Event()
         self.chaos_thread: Optional[threading.Thread] = None
 
-    def start(self):
-        self.stop_event.clear()
-
-        def _chaos_thread():
+    def start(self) -> None:
+        def _chaos_thread() -> None:
             while not self.stop_event.is_set():
                 wait_time = random.uniform(5, 20)
                 if not self.stop_event.wait(wait_time):
-                    print(f"🐒 ChaosMonkey strikes after {wait_time:.2f} seconds! Restarting Postgres...")
+                    print(
+                        f"🐒 ChaosMonkey strikes after {wait_time:.2f} seconds! Restarting Postgres..."
+                    )
                     stop_docker_pg()
                     down_time = random.uniform(0, 5)
                     time.sleep(down_time)
                     start_docker_pg()
 
+        self.stop_event.clear()
         self.chaos_thread = threading.Thread(target=_chaos_thread)
         self.chaos_thread.start()
 
-    def stop(self):
+    def stop(self) -> None:
         if self.chaos_thread is None:
             return
         self.stop_event.set()

--- a/chaos-tests/conftest.py
+++ b/chaos-tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import random
 import threading
+import time
 from typing import Any, Generator, Optional
 from urllib.parse import quote
 
@@ -54,9 +55,7 @@ def cleanup_test_databases(config: DBOSConfig, postgres: None) -> None:
 
 class PostgresChaosMonkey:
 
-    def __init__(self, min_time=5, max_time=20):
-        self.min_time = min_time
-        self.max_time = max_time
+    def __init__(self):
         self.stop_event = threading.Event()
         self.chaos_thread: Optional[threading.Thread] = None
 
@@ -65,12 +64,12 @@ class PostgresChaosMonkey:
 
         def _chaos_thread():
             while not self.stop_event.is_set():
-                wait_time = random.uniform(self.min_time, self.max_time)
+                wait_time = random.uniform(5, 20)
                 if not self.stop_event.wait(wait_time):
-                    print(
-                        "\n🐒 ChaosMonkey strikes after {wait_time:.2f} seconds! Restarting Postgres..."
-                    )
+                    print(f"🐒 ChaosMonkey strikes after {wait_time:.2f} seconds! Restarting Postgres...")
                     stop_docker_pg()
+                    down_time = random.uniform(0, 5)
+                    time.sleep(down_time)
                     start_docker_pg()
 
         self.chaos_thread = threading.Thread(target=_chaos_thread)

--- a/chaos-tests/conftest.py
+++ b/chaos-tests/conftest.py
@@ -1,0 +1,79 @@
+import os
+from typing import Any, Generator
+from urllib.parse import quote
+
+import pytest
+import sqlalchemy as sa
+
+from dbos import DBOS, DBOSConfig
+
+
+def default_config() -> DBOSConfig:
+    return {
+        "name": "test-app",
+        "database_url": f"postgresql://postgres:{quote(os.environ.get('PGPASSWORD', 'dbos'), safe='')}@localhost:5432/dbostestpy",
+    }
+
+
+@pytest.fixture()
+def config() -> DBOSConfig:
+    return default_config()
+
+
+@pytest.fixture(scope="session")
+def postgres_db_engine() -> sa.Engine:
+    cfg = default_config()
+    assert cfg["database_url"] is not None
+    return sa.create_engine(
+        sa.make_url(cfg["database_url"]).set(
+            drivername="postgresql+psycopg",
+            database="postgres",
+        ),
+        connect_args={
+            "connect_timeout": 30,
+        },
+    )
+
+
+@pytest.fixture()
+def cleanup_test_databases(config: DBOSConfig, postgres_db_engine: sa.Engine) -> None:
+    assert config["database_url"] is not None
+    app_db_name = sa.make_url(config["database_url"]).database
+    sys_db_name = f"{app_db_name}_dbos_sys"
+
+    with postgres_db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(
+                f"""
+            SELECT pg_terminate_backend(pg_stat_activity.pid)
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '{app_db_name}'
+            AND pid <> pg_backend_pid()
+        """
+            )
+        )
+        connection.execute(sa.text(f"DROP DATABASE IF EXISTS {app_db_name}"))
+        connection.execute(
+            sa.text(
+                f"""
+            SELECT pg_terminate_backend(pg_stat_activity.pid)
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '{sys_db_name}'
+            AND pid <> pg_backend_pid()
+        """
+            )
+        )
+        connection.execute(sa.text(f"DROP DATABASE IF EXISTS {sys_db_name}"))
+
+
+@pytest.fixture()
+def dbos(
+    config: DBOSConfig, cleanup_test_databases: None
+) -> Generator[DBOS, Any, None]:
+    DBOS.destroy(destroy_registry=True)
+    dbos = DBOS(config=config)
+    DBOS.launch()
+
+    yield dbos
+    DBOS.destroy(destroy_registry=True)

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,7 +1,6 @@
 from dbos import DBOS
 
-
-def test_workflow(dbos: DBOS):
+def test_workflow(dbos: DBOS) -> None:
 
     def step_one(x: int) -> int:
         return x + 1
@@ -11,11 +10,12 @@ def test_workflow(dbos: DBOS):
 
     @DBOS.workflow()
     def workflow(x: int) -> int:
+        DBOS.sleep(1)
         x = step_one(x)
         x = step_two(x)
         return x
 
-    input = 5
-    output = input + 3
+    num_workflows = 5
 
-    assert workflow(input) == output
+    for i in range(num_workflows):
+        assert workflow(i) == i + 3

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,10 +1,11 @@
 from dbos import DBOS
 
+
 def test_workflow(dbos: DBOS):
 
     def step_one(x: int) -> int:
         return x + 1
-    
+
     def step_two(x: int) -> int:
         return x + 2
 
@@ -13,7 +14,7 @@ def test_workflow(dbos: DBOS):
         x = step_one(x)
         x = step_two(x)
         return x
-    
+
     input = 5
     output = input + 3
 

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,3 +1,5 @@
+import uuid
+
 import sqlalchemy as sa
 
 from dbos import DBOS
@@ -29,3 +31,22 @@ def test_workflow(dbos: DBOS) -> None:
 
     for i in range(num_workflows):
         assert workflow(i) == i + 6
+
+
+def test_recv(dbos: DBOS):
+
+    topic = "test_topic"
+
+    @DBOS.workflow()
+    def recv_workflow():
+        return DBOS.recv(topic, timeout_seconds=10)
+
+    num_workflows = 1000
+
+    for i in range(num_workflows):
+        handle = DBOS.start_workflow(recv_workflow)
+
+        value = str(uuid.uuid4())
+        DBOS.send(handle.workflow_id, value, topic)
+
+        assert handle.get_result() == value

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,5 +1,6 @@
 from dbos import DBOS
 
+
 def test_workflow(dbos: DBOS) -> None:
 
     def step_one(x: int) -> int:
@@ -15,7 +16,7 @@ def test_workflow(dbos: DBOS) -> None:
         x = step_two(x)
         return x
 
-    num_workflows = 5
+    num_workflows = 100
 
     for i in range(num_workflows):
         assert workflow(i) == i + 3

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,22 +1,31 @@
+import sqlalchemy as sa
+
 from dbos import DBOS
 
 
 def test_workflow(dbos: DBOS) -> None:
 
+    @DBOS.step()
     def step_one(x: int) -> int:
         return x + 1
 
+    @DBOS.step()
     def step_two(x: int) -> int:
         return x + 2
 
+    @DBOS.transaction()
+    def txn_one(x: int) -> int:
+        DBOS.sql_session.execute(sa.text("SELECT 1")).fetchall()
+        return x + 3
+
     @DBOS.workflow()
     def workflow(x: int) -> int:
-        DBOS.sleep(1)
         x = step_one(x)
         x = step_two(x)
+        x = txn_one(x)
         return x
 
-    num_workflows = 100
+    num_workflows = 5000
 
     for i in range(num_workflows):
-        assert workflow(i) == i + 3
+        assert workflow(i) == i + 6

--- a/chaos-tests/test_workflows.py
+++ b/chaos-tests/test_workflows.py
@@ -1,0 +1,20 @@
+from dbos import DBOS
+
+def test_workflow(dbos: DBOS):
+
+    def step_one(x: int) -> int:
+        return x + 1
+    
+    def step_two(x: int) -> int:
+        return x + 2
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        x = step_one(x)
+        x = step_two(x)
+        return x
+    
+    input = 5
+    output = input + 3
+
+    assert workflow(input) == output

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -231,7 +231,7 @@ class DBOSClient:
             "workflow_deadline_epoch_ms": None,
         }
         with self._sys_db.engine.begin() as conn:
-            self._sys_db.insert_workflow_status(
+            self._sys_db._insert_workflow_status(
                 status, conn, max_recovery_attempts=None
             )
         self._sys_db.send(status["workflow_uuid"], 0, destination_id, message, topic)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -109,6 +109,7 @@ class DBOSClient:
             },
             sys_db_name=system_database,
         )
+        self._sys_db.check_connection()
         self._app_db = ApplicationDatabase(
             database_url=database_url,
             engine_kwargs={

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -20,8 +20,10 @@ from typing import (
     cast,
 )
 
+import psycopg
+
 from dbos._outcome import Immediate, NoResult, Outcome, Pending
-from dbos._utils import GlobalParams
+from dbos._utils import GlobalParams, retriable_postgres_exception
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
 
@@ -932,12 +934,18 @@ def decorate_transaction(
                                 )
                                 break
                         except DBAPIError as dbapi_error:
-                            if dbapi_error.orig.sqlstate == "40001":  # type: ignore
+                            driver_error = cast(
+                                Optional[psycopg.OperationalError], dbapi_error.orig
+                            )
+                            if retriable_postgres_exception(dbapi_error) or (
+                                driver_error is not None
+                                and driver_error.sqlstate == "40001"
+                            ):
                                 # Retry on serialization failure
                                 span = ctx.get_current_span()
                                 if span:
                                     span.add_event(
-                                        "Transaction Serialization Failure",
+                                        "Transaction Failure",
                                         {"retry_wait_seconds": retry_wait_seconds},
                                     )
                                 time.sleep(retry_wait_seconds)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -407,6 +407,7 @@ def configure_db_engine_parameters(
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
     }
     # If user-provided kwargs are present, use them instead
     user_kwargs = data.get("db_engine_kwargs")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -95,12 +95,8 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                 if not isinstance(
                     e.orig, (errors.SerializationFailure, errors.LockNotAvailable)
                 ):
-                    dbos.logger.warning(
-                        f"Exception encountered in queue thread: {traceback.format_exc()}"
-                    )
-            except Exception:
+                    dbos.logger.warning(f"Exception encountered in queue thread: {e}")
+            except Exception as e:
                 if not stop_event.is_set():
                     # Only print the error if the thread is not stopping
-                    dbos.logger.warning(
-                        f"Exception encountered in queue thread: {traceback.format_exc()}"
-                    )
+                    dbos.logger.warning(f"Exception encountered in queue thread: {e}")

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -365,7 +365,7 @@ class SystemDatabase:
             self.notification_conn.close()
         self.engine.dispose()
 
-    def insert_workflow_status(
+    def _insert_workflow_status(
         self,
         status: WorkflowStatusInternal,
         conn: sa.Connection,
@@ -765,7 +765,7 @@ class SystemDatabase:
                     pass  # CB: I guess we're assuming the WF will show up eventually.
             time.sleep(1)
 
-    def update_workflow_inputs(
+    def _update_workflow_inputs(
         self, workflow_uuid: str, inputs: str, conn: sa.Connection
     ) -> None:
         if self._debug_mode:
@@ -1638,7 +1638,7 @@ class SystemDatabase:
             )
         return value
 
-    def enqueue(
+    def _enqueue(
         self,
         workflow_id: str,
         queue_name: str,
@@ -1973,17 +1973,17 @@ class SystemDatabase:
         Synchronously record the status and inputs for workflows in a single transaction
         """
         with self.engine.begin() as conn:
-            wf_status, workflow_deadline_epoch_ms = self.insert_workflow_status(
+            wf_status, workflow_deadline_epoch_ms = self._insert_workflow_status(
                 status, conn, max_recovery_attempts=max_recovery_attempts
             )
             # TODO: Modify the inputs if they were changed by `update_workflow_inputs`
-            self.update_workflow_inputs(status["workflow_uuid"], inputs, conn)
+            self._update_workflow_inputs(status["workflow_uuid"], inputs, conn)
 
             if (
                 status["queue_name"] is not None
                 and wf_status == WorkflowStatusString.ENQUEUED.value
             ):
-                self.enqueue(
+                self._enqueue(
                     status["workflow_uuid"],
                     status["queue_name"],
                     conn,

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -27,6 +27,9 @@ def retriable_postgres_exception(e: DBAPIError) -> bool:
         # Failure to establish connection
         if "connection failed" in str(driver_error):
             return True
+        # Error within database transaction
+        elif "server closed the connection unexpectedly" in str(driver_error):
+            return True
         # Connection timeout
         if isinstance(driver_error, psycopg.errors.ConnectionTimeout):
             return True

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -21,6 +21,8 @@ class GlobalParams:
 
 
 def retriable_postgres_exception(e: DBAPIError) -> bool:
+    if e.connection_invalidated:
+        return True
     if isinstance(e.orig, psycopg.OperationalError):
         driver_error: psycopg.OperationalError = e.orig
         pgcode = driver_error.sqlstate or ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from flask import Flask
 
 from dbos import DBOS, DBOSClient, DBOSConfig
 from dbos._app_db import ApplicationDatabase
-from dbos._dbos_config import translate_dbos_config_to_config_file
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import SystemDatabase
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,27 +94,11 @@ def cleanup_test_databases(config: DBOSConfig, postgres_db_engine: sa.Engine) ->
     with postgres_db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(
-            sa.text(
-                f"""
-            SELECT pg_terminate_backend(pg_stat_activity.pid)
-            FROM pg_stat_activity
-            WHERE pg_stat_activity.datname = '{app_db_name}'
-            AND pid <> pg_backend_pid()
-        """
-            )
+            sa.text(f"DROP DATABASE IF EXISTS {app_db_name} WITH (FORCE)")
         )
-        connection.execute(sa.text(f"DROP DATABASE IF EXISTS {app_db_name}"))
         connection.execute(
-            sa.text(
-                f"""
-            SELECT pg_terminate_backend(pg_stat_activity.pid)
-            FROM pg_stat_activity
-            WHERE pg_stat_activity.datname = '{sys_db_name}'
-            AND pid <> pg_backend_pid()
-        """
-            )
+            sa.text(f"DROP DATABASE IF EXISTS {sys_db_name} WITH (FORCE)")
         )
-        connection.execute(sa.text(f"DROP DATABASE IF EXISTS {sys_db_name}"))
 
     # Clean up environment variables
     os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def dbos(
 
 
 @pytest.fixture()
-def client(config: DBOSConfig) -> Generator[DBOSClient, Any, None]:
+def client(config: DBOSConfig, dbos: DBOS) -> Generator[DBOSClient, Any, None]:
     assert config["database_url"] is not None
     client = DBOSClient(config["database_url"])
     yield client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from typing import Optional, TypedDict
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import DBAPIError
 
 from dbos import DBOS, DBOSClient, DBOSConfig, EnqueueOptions, SetWorkflowID
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
@@ -565,3 +566,8 @@ def test_enqueue_with_priority(dbos: DBOS, client: DBOSClient) -> None:
 
     # Should be in the order of priority
     assert inorder_results == ["abc", "ghi", "def"]
+
+
+def test_client_bad_url() -> None:
+    with pytest.raises(DBAPIError) as exc_info:
+        DBOSClient("postgresql://postgres:fakepassword@localhost:5433/fake_database")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -237,6 +237,7 @@ def test_process_config_full():
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 1},
     }
     assert configFile["database"]["sys_db_engine_kwargs"] == {
@@ -244,6 +245,7 @@ def test_process_config_full():
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 27,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 1},
     }
     assert configFile["runtimeConfig"]["start"] == ["python3 main.py"]
@@ -402,12 +404,14 @@ def test_configure_db_engine_parameters_defaults():
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
     assert data["sys_db_engine_kwargs"] == {
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
 
@@ -422,12 +426,14 @@ def test_configure_db_engine_parameters_custom_sys_db_pool_sizes():
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
     assert data["sys_db_engine_kwargs"] == {
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 35,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
 
@@ -582,12 +588,14 @@ def test_configure_db_engine_parameters_empty_user_kwargs():
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
     assert data["sys_db_engine_kwargs"] == {
         "pool_timeout": 30,
         "max_overflow": 0,
         "pool_size": 20,
+        "pool_pre_ping": True,
         "connect_args": {"connect_timeout": 10},
     }
 
@@ -1148,12 +1156,12 @@ def test_configured_pool_default():
     assert dbos._app_db.engine.pool._pool.maxsize == 20
     assert dbos._app_db.engine.pool._timeout == 30
     assert dbos._app_db.engine.pool._max_overflow == 0
-    assert dbos._app_db.engine.pool._pre_ping == False
+    assert dbos._app_db.engine.pool._pre_ping == True
 
     assert dbos._sys_db.engine.pool._pool.maxsize == 20
     assert dbos._sys_db.engine.pool._timeout == 30
     assert dbos._sys_db.engine.pool._max_overflow == 0
-    assert dbos._sys_db.engine.pool._pre_ping == False
+    assert dbos._sys_db.engine.pool._pre_ping == True
 
     # force the release of connections so we can intercept on connect.
     app_db_engine = dbos._app_db.engine


### PR DESCRIPTION
If a workflow encounters a database connection issue while performing an operation, block the workflow and retry the operation until it reconnects and succeeds.

In other words, if DBOS loses its database connection, everything pauses until the connection is recovered, trading off availability for correctness.

Add a suite of new "chaos tests" that validate DBOS can successfully execute workflows in the presence of random database disconnects and restarts.