### PR TITLE
Make sure the event loop has a large enough thread pool

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -602,7 +602,6 @@ async def start_workflow_async(
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> "WorkflowHandleAsync[R]":
-
     # If the function has a class, add the class object as its first argument
     fself: Optional[object] = None
     if hasattr(func, "__self__"):

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -947,9 +947,9 @@ class DBOS:
         """
         if _get_dbos_instance()._configured_threadpool:
             return
-        _get_dbos_instance()._configured_threadpool = True
         loop = asyncio.get_running_loop()
         loop.set_default_executor(_get_dbos_instance()._executor)
+        _get_dbos_instance()._configured_threadpool = True
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -299,6 +299,7 @@ class DBOS:
 
         self._launched: bool = False
         self._debug_mode: bool = False
+        self._configured_threadpool: bool = False
         self._sys_db_field: Optional[SystemDatabase] = None
         self._app_db_field: Optional[ApplicationDatabase] = None
         self._registry: DBOSRegistry = _get_or_create_dbos_registry()
@@ -719,6 +720,7 @@ class DBOS:
         **kwargs: P.kwargs,
     ) -> WorkflowHandleAsync[R]:
         """Invoke a workflow function on the event loop, returning a handle to the ongoing execution."""
+        await cls._configure_asyncio_thread_pool()
         return await start_workflow_async(
             _get_dbos_instance(), func, None, True, *args, **kwargs
         )
@@ -736,6 +738,7 @@ class DBOS:
     async def get_workflow_status_async(
         cls, workflow_id: str
     ) -> Optional[WorkflowStatus]:
+        await cls._configure_asyncio_thread_pool()
         """Return the status of a workflow execution."""
         return await asyncio.to_thread(cls.get_workflow_status, workflow_id)
 
@@ -757,6 +760,7 @@ class DBOS:
     ) -> WorkflowHandleAsync[R]:
         """Return a `WorkflowHandle` for a workflow execution."""
         dbos = _get_dbos_instance()
+        await cls._configure_asyncio_thread_pool()
         if existing_workflow:
             stat = await dbos.get_workflow_status_async(workflow_id)
             if stat is None:
@@ -775,6 +779,7 @@ class DBOS:
         cls, destination_id: str, message: Any, topic: Optional[str] = None
     ) -> None:
         """Send a message to a workflow execution."""
+        await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(lambda: DBOS.send(destination_id, message, topic))
 
     @classmethod
@@ -797,6 +802,7 @@ class DBOS:
         This function is to be called from within a workflow.
         `recv_async` will return the message sent on `topic`, asyncronously waiting if necessary.
         """
+        await cls._configure_asyncio_thread_pool()
         return await asyncio.to_thread(lambda: DBOS.recv(topic, timeout_seconds))
 
     @classmethod
@@ -835,6 +841,7 @@ class DBOS:
         It is important to use `DBOS.sleep` or `DBOS.sleep_async` (as opposed to any other sleep) within workflows,
         as the DBOS sleep methods are durable and completed sleeps will be skipped during recovery.
         """
+        await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(lambda: DBOS.sleep(seconds))
 
     @classmethod
@@ -869,6 +876,7 @@ class DBOS:
             value(Any): A serializable value to associate with the key
 
         """
+        await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(lambda: DBOS.set_event(key, value))
 
     @classmethod
@@ -901,6 +909,7 @@ class DBOS:
             timeout_seconds(float): The amount of time to wait, in case `set_event` has not yet been called byt the workflow
 
         """
+        await cls._configure_asyncio_thread_pool()
         return await asyncio.to_thread(
             lambda: DBOS.get_event(workflow_id, key, timeout_seconds)
         )
@@ -928,6 +937,19 @@ class DBOS:
         return _get_dbos_instance()._sys_db.call_function_as_step(
             fn, "DBOS.cancelWorkflow"
         )
+
+    @classmethod
+    async def _configure_asyncio_thread_pool(cls) -> None:
+        """
+        Configure the thread pool for asyncio.to_thread.
+
+        This function is called before the first call to asyncio.to_thread.
+        """
+        if _get_dbos_instance()._configured_threadpool:
+            return
+        _get_dbos_instance()._configured_threadpool = True
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(_get_dbos_instance()._executor)
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Coroutine, Optional, TypeVar
 
 
@@ -33,15 +34,17 @@ class BackgroundEventLoop:
 
     def _run_event_loop(self) -> None:
         self._loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._loop)
+        with ThreadPoolExecutor(max_workers=64) as thread_pool:
+            self._loop.set_default_executor(thread_pool)
+            asyncio.set_event_loop(self._loop)
 
-        self._running = True
-        self._ready.set()  # Signal that the loop is ready
+            self._running = True
+            self._ready.set()  # Signal that the loop is ready
 
-        try:
-            self._loop.run_forever()
-        finally:
-            self._loop.close()
+            try:
+                self._loop.run_forever()
+            finally:
+                self._loop.close()
 
     async def _shutdown(self) -> None:
         if self._loop is None:


### PR DESCRIPTION
- By default the thread pool size is too small. We set the event loop to use the `DBOS._executor` pool.
- Also set the thread pool for the background event loop.
- Add a test to make sure that all concurrent tasks can finish within reasonable time.