### PR TITLE
Remove dbos-config.yaml Consistency Check

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -90,7 +90,6 @@ from ._context import (
 from ._dbos_config import (
     ConfigFile,
     DBOSConfig,
-    check_config_consistency,
     overwrite_config,
     process_config,
     set_env_vars,
@@ -324,7 +323,6 @@ class DBOS:
         unvalidated_config = translate_dbos_config_to_config_file(config)
         if os.environ.get("DBOS__CLOUD") == "true":
             unvalidated_config = overwrite_config(unvalidated_config)
-        check_config_consistency(name=unvalidated_config["name"])
 
         if unvalidated_config is not None:
             self._config: ConfigFile = process_config(data=unvalidated_config)

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -529,26 +529,3 @@ def overwrite_config(provided_config: ConfigFile) -> ConfigFile:
         del provided_config["env"]
 
     return provided_config
-
-
-def check_config_consistency(
-    *,
-    name: str,
-    config_file_path: str = DBOS_CONFIG_PATH,
-) -> None:
-    # First load the config file and check whether it is present
-    try:
-        config = load_config(config_file_path, silent=True, run_process_config=False)
-    except FileNotFoundError:
-        dbos_logger.debug(
-            f"No configuration file {config_file_path} found. Skipping consistency check with provided config."
-        )
-        return
-    except Exception as e:
-        raise e
-
-    # Check the name
-    if name != config["name"]:
-        raise DBOSInitializationError(
-            f"Provided app name '{name}' does not match the app name '{config['name']}' in {config_file_path}."
-        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,6 @@ from dbos import DBOS
 from dbos._dbos_config import (
     ConfigFile,
     DBOSConfig,
-    check_config_consistency,
     configure_db_engine_parameters,
     load_config,
     overwrite_config,
@@ -1094,41 +1093,6 @@ def test_overwrite_config_missing_dbos_database_url(mocker):
         "DBOS_DATABASE_URL environment variable is not set. This is required to connect to the database."
         in str(exc_info.value)
     )
-
-
-####################
-# PROVIDED CONFIGS vs CONFIG FILE
-####################
-
-
-def test_no_discrepancy(mocker):
-    mock_config = """
-    name: "stock-prices" \
-    """
-    mocker.patch(
-        "builtins.open", side_effect=generate_mock_open("dbos-config.yaml", mock_config)
-    )
-    check_config_consistency(name="stock-prices")
-
-
-def test_name_does_no_match(mocker):
-    mock_config = """
-    name: "stock-prices" \
-    """
-    mocker.patch(
-        "builtins.open", side_effect=generate_mock_open("dbos-config.yaml", mock_config)
-    )
-    with pytest.raises(DBOSInitializationError) as exc_info:
-        check_config_consistency(name="stock-prices-wrong")
-    assert (
-        "Provided app name 'stock-prices-wrong' does not match the app name 'stock-prices' in dbos-config.yaml"
-        in str(exc_info.value)
-    )
-
-
-def test_no_config_file():
-    # Handles FileNotFoundError
-    check_config_consistency(name="stock-prices")
 
 
 ####################


### PR DESCRIPTION
Now that `dbos-config.yaml` is no longer used for library configuration, the consistency check is no longer needed.