### PR TITLE
Fix Executor ID Assignment

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -426,7 +426,7 @@ class SystemDatabase:
         workflow_deadline_epoch_ms: Optional[int] = status["workflow_deadline_epoch_ms"]
 
         # Values to update when a row already exists for this workflow
-        update_values = {
+        update_values: dict[str, Any] = {
             "recovery_attempts": SystemSchema.workflow_status.c.recovery_attempts + 1,
             "updated_at": func.extract("epoch", func.now()) * 1000,
         }

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1446,3 +1446,33 @@ def test_unsetting_timeout(dbos: DBOS) -> None:
     # Verify child two, which doesn't have a timeout, succeeds
     handle = DBOS.retrieve_workflow(child_two)
     assert handle.get_result() == child_two
+
+
+def test_queue_executor_id(dbos: DBOS):
+
+    queue = Queue("test-queue")
+
+    @DBOS.workflow()
+    def example_workflow():
+        return DBOS.workflow_id
+
+    # Set an executor ID
+    original_executor_id = str(uuid.uuid4())
+    GlobalParams.executor_id = original_executor_id
+
+    # Enqueue the workflow, validate its executor ID
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = queue.enqueue(example_workflow)
+    assert handle.get_result() == wfid
+    assert handle.get_status().executor_id == original_executor_id
+
+    # Set a new executor ID
+    new_executor_id = str(uuid.uuid4())
+    GlobalParams.executor_id = new_executor_id
+
+    # Re-enqueue the workflow, verify its executor ID does not change.
+    with SetWorkflowID(wfid):
+        handle = queue.enqueue(example_workflow)
+        assert handle.get_result() == wfid
+    assert handle.get_status().executor_id == original_executor_id

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1448,12 +1448,12 @@ def test_unsetting_timeout(dbos: DBOS) -> None:
     assert handle.get_result() == child_two
 
 
-def test_queue_executor_id(dbos: DBOS):
+def test_queue_executor_id(dbos: DBOS) -> None:
 
     queue = Queue("test-queue")
 
     @DBOS.workflow()
-    def example_workflow():
+    def example_workflow() -> str:
         return DBOS.workflow_id
 
     # Set an executor ID


### PR DESCRIPTION
Re-enqueueing a workflow that is already executing should not change its executor ID.