### PR TITLE
Increase thread pool

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -297,7 +297,6 @@ class DBOS:
 
         self._launched: bool = False
         self._debug_mode: bool = False
-        self._configured_threadpool: bool = False
         self._sys_db_field: Optional[SystemDatabase] = None
         self._app_db_field: Optional[ApplicationDatabase] = None
         self._registry: DBOSRegistry = _get_or_create_dbos_registry()
@@ -410,7 +409,7 @@ class DBOS:
                 GlobalParams.executor_id = str(uuid.uuid4())
             dbos_logger.info(f"Executor ID: {GlobalParams.executor_id}")
             dbos_logger.info(f"Application version: {GlobalParams.app_version}")
-            self._executor_field = ThreadPoolExecutor(max_workers=64)
+            self._executor_field = ThreadPoolExecutor(max_workers=sys.maxsize)
             self._background_event_loop.start()
             assert self._config["database_url"] is not None
             assert self._config["database"]["sys_db_engine_kwargs"] is not None
@@ -941,11 +940,8 @@ class DBOS:
 
         This function is called before the first call to asyncio.to_thread.
         """
-        if _get_dbos_instance()._configured_threadpool:
-            return
         loop = asyncio.get_running_loop()
         loop.set_default_executor(_get_dbos_instance()._executor)
-        _get_dbos_instance()._configured_threadpool = True
 
     @classmethod
     def resume_workflow(cls, workflow_id: str) -> WorkflowHandle[Any]:

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -1,6 +1,5 @@
 import asyncio
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Coroutine, Optional, TypeVar
 
 
@@ -34,17 +33,15 @@ class BackgroundEventLoop:
 
     def _run_event_loop(self) -> None:
         self._loop = asyncio.new_event_loop()
-        with ThreadPoolExecutor(max_workers=64) as thread_pool:
-            self._loop.set_default_executor(thread_pool)
-            asyncio.set_event_loop(self._loop)
+        asyncio.set_event_loop(self._loop)
 
-            self._running = True
-            self._ready.set()  # Signal that the loop is ready
+        self._running = True
+        self._ready.set()  # Signal that the loop is ready
 
-            try:
-                self._loop.run_forever()
-            finally:
-                self._loop.close()
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.close()
 
     async def _shutdown(self) -> None:
         if self._loop is None:


### PR DESCRIPTION
- Make the pool size a `sys.maxsize` to prevent deadlock. To control resources, use queues concurrency limit.
- Always set the pool to the global DBOS executor pool. Remove the background pool.