### PR TITLE
Main Event Loop

### DIFF
--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -63,7 +63,7 @@ class BackgroundEventLoop:
         await asyncio.gather(*tasks, return_exceptions=True)
         self._loop.stop()
 
-    def set_main_loop(self):
+    def set_main_loop(self) -> None:
         """
         Set the main loop to the currently running event loop.
         Should be called from the main thread.

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -7,6 +7,9 @@ class BackgroundEventLoop:
     """
     This is the event loop to which DBOS submits any coroutines that are not started from within an event loop.
     In particular, coroutines submitted to queues (such as from scheduled workflows) run on this event loop.
+
+    If a main event loop is known (whether because an event loop existed in the thread that called DBOS.launch
+    or because a FastAPI event loop was detected) then coroutines are submitted there instead.
     """
 
     def __init__(self) -> None:

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -20,12 +20,7 @@ class BackgroundEventLoop:
         if self._running:
             return
 
-        try:
-            self.set_main_loop(asyncio.get_running_loop())
-        except:
-            # There's no event loop on the main thread
-            pass
-
+        self.set_main_loop()
         self._thread = threading.Thread(target=self._run_event_loop, daemon=True)
         self._thread.start()
         self._ready.wait()  # Wait until the loop is running
@@ -65,8 +60,16 @@ class BackgroundEventLoop:
         await asyncio.gather(*tasks, return_exceptions=True)
         self._loop.stop()
 
-    def set_main_loop(self, loop: asyncio.AbstractEventLoop):
-        self._main_loop = loop
+    def set_main_loop(self):
+        """
+        Set the main loop to the currently running event loop.
+        Should be called from the main thread.
+        """
+        try:
+            self._main_loop = asyncio.get_running_loop()
+        except:
+            # There's no running event loop to set
+            pass
 
     T = TypeVar("T")
 

--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -44,11 +44,10 @@ class LifespanMiddleware:
         if scope["type"] == "lifespan":
 
             async def wrapped_send(message: MutableMapping[str, Any]) -> None:
-                if (
-                    message["type"] == "lifespan.startup.complete"
-                    and not self.dbos._launched
-                ):
-                    self.dbos._launch()
+                if message["type"] == "lifespan.startup.complete":
+                    self.dbos._background_event_loop.set_main_loop()
+                    if not self.dbos._launched:
+                        self.dbos._launch()
                 elif message["type"] == "lifespan.shutdown.complete":
                     self.dbos._destroy()
                 await send(message)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -7,7 +7,14 @@ import pytest
 import sqlalchemy as sa
 
 # Public API
-from dbos import DBOS, Queue, SetWorkflowID, SetWorkflowTimeout, WorkflowHandleAsync
+from dbos import (
+    DBOS,
+    DBOSConfig,
+    Queue,
+    SetWorkflowID,
+    SetWorkflowTimeout,
+    WorkflowHandleAsync,
+)
 from dbos._context import assert_current_dbos_context
 from dbos._dbos import WorkflowHandle
 from dbos._dbos_config import ConfigFile
@@ -564,3 +571,21 @@ async def test_max_parallel_workflows(dbos: DBOS) -> None:
     assert (
         end_time - begin_time < 10
     ), "All enqueued tasks should complete in less than 10 seconds"
+
+
+@pytest.mark.asyncio
+async def test_main_loop(dbos: DBOS, config: DBOSConfig):
+    DBOS.destroy(destroy_registry=True)
+    dbos = DBOS(config=config)
+    DBOS.launch()
+
+    queue = Queue("queue")
+
+    @DBOS.workflow()
+    async def test_workflow() -> int:
+        await DBOS.sleep_async(0.1)
+        return id(asyncio.get_running_loop())
+
+    # Verify the enqueued task is submitted into the main event loop
+    handle = await queue.enqueue_async(test_workflow)
+    assert await handle.get_result() == id(asyncio.get_running_loop())

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -574,7 +574,7 @@ async def test_max_parallel_workflows(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_main_loop(dbos: DBOS, config: DBOSConfig):
+async def test_main_loop(dbos: DBOS, config: DBOSConfig) -> None:
     DBOS.destroy(destroy_registry=True)
     dbos = DBOS(config=config)
     DBOS.launch()

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -168,7 +168,7 @@ async def test_custom_lifespan(
         }
 
     @DBOS.workflow()
-    async def queue_workflow():
+    async def queue_workflow() -> int:
         return id(asyncio.get_event_loop())
 
     uvicorn_config = uvicorn.Config(


### PR DESCRIPTION
If an event loop exists in the main thread (the thread that called `DBOS.launch`), submit coroutines to that event loop instead of to the background event loop. 

This is more intuitive behavior, for example, if using DBOS queues alongside FastAPI, enqueued workflows run in the same event loop as FastAPI.