### PR TITLE
ensure entrypoint parent folder is in the module search path (#374)

### DIFF
--- a/dbos/_debug.py
+++ b/dbos/_debug.py
@@ -15,11 +15,11 @@ class PythonModule:
 
 
 def debug_workflow(workflow_id: str, entrypoint: Union[str, PythonModule]) -> None:
-    # include the current directory (represented by empty string) in the search path
-    # if it not already included
-    if "" not in sys.path:
-        sys.path.insert(0, "")
     if isinstance(entrypoint, str):
+        # ensure the entrypoint parent directory is in sys.path
+        parent = str(Path(entrypoint).parent)
+        if parent not in sys.path:
+            sys.path.insert(0, parent)
         runpy.run_path(entrypoint)
     elif isinstance(entrypoint, PythonModule):
         runpy.run_module(entrypoint.module_name)


### PR DESCRIPTION
[This SO answer](https://stackoverflow.com/a/62923810) provides good detail about the difference between launching a python file (aka `python app/main.py`) and launching a python module (aka `python -m widget_store.main`). In particular for this PR, launching a file automatically adds the file's parent directory to `sys.path` while launching a module adds the current directory.

`dbos debug` was always ensuring the current directory (represented by empty string) was in `sys.path`, so it was failing when attempting to debug a file in a subdirectory. This code fixes that + isolates the change to `sys.path` to only happen for file launch. Module launch does not require `sys.path` changes because `dbos debug` is already launching in the debugger as a module so the current directory will already be on the path