### PR TITLE
Cleaner Errors

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -404,9 +404,9 @@ def _execute_workflow_wthread(
                     return dbos._background_event_loop.submit_coroutine(
                         cast(Pending[R], result)()
                     )
-            except Exception:
+            except Exception as e:
                 dbos.logger.error(
-                    f"Exception encountered in asynchronous workflow: {traceback.format_exc()}"
+                    f"Exception encountered in asynchronous workflow:", exc_info=e
                 )
                 raise
 
@@ -430,9 +430,9 @@ async def _execute_workflow_async(
                     _get_wf_invoke_func(dbos, status)
                 )
                 return await result()
-            except Exception:
+            except Exception as e:
                 dbos.logger.error(
-                    f"Exception encountered in asynchronous workflow: {traceback.format_exc()}"
+                    f"Exception encountered in asynchronous workflow:", exc_info=e
                 )
                 raise
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -521,8 +521,8 @@ class DBOS:
                 handler.flush()
             add_otlp_to_all_loggers()
             add_transformer_to_all_loggers()
-        except Exception:
-            dbos_logger.error(f"DBOS failed to launch: {traceback.format_exc()}")
+        except Exception as e:
+            dbos_logger.error(f"DBOS failed to launch:", exc_info=e)
             raise
 
     @classmethod

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -1,5 +1,4 @@
 import threading
-import traceback
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypedDict
 
 from psycopg import errors

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -1,7 +1,5 @@
-import os
 import threading
 import time
-import traceback
 from typing import TYPE_CHECKING, Any, List
 
 from dbos._utils import GlobalParams
@@ -39,9 +37,9 @@ def startup_recovery_thread(
             time.sleep(1)
         except Exception as e:
             dbos.logger.error(
-                f"Exception encountered when recovering workflows: {traceback.format_exc()}"
+                f"Exception encountered when recovering workflows:", exc_info=e
             )
-            raise e
+            raise
 
 
 def recover_pending_workflows(
@@ -59,9 +57,9 @@ def recover_pending_workflows(
                 workflow_handles.append(handle)
             except Exception as e:
                 dbos.logger.error(
-                    f"Exception encountered when recovering workflows: {traceback.format_exc()}"
+                    f"Exception encountered when recovering workflows:", exc_info=e
                 )
-                raise e
+                raise
         dbos.logger.info(
             f"Recovering {len(pending_workflows)} workflows for executor {executor_id} from version {GlobalParams.app_version}"
         )

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -1,5 +1,4 @@
 import threading
-import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -34,9 +33,9 @@ def scheduler_loop(
         with SetWorkflowID(f"sched-{func.__qualname__}-{nextExecTime.isoformat()}"):
             try:
                 scheduler_queue.enqueue(func, nextExecTime, datetime.now(timezone.utc))
-            except Exception:
+            except Exception as e:
                 dbos_logger.warning(
-                    f"Exception encountered in scheduler thread: {traceback.format_exc()})"
+                    f"Exception encountered in scheduler thread:", exc_info=e
                 )
 
 

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -1,4 +1,5 @@
 import threading
+import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -33,9 +34,9 @@ def scheduler_loop(
         with SetWorkflowID(f"sched-{func.__qualname__}-{nextExecTime.isoformat()}"):
             try:
                 scheduler_queue.enqueue(func, nextExecTime, datetime.now(timezone.utc))
-            except Exception as e:
+            except Exception:
                 dbos_logger.warning(
-                    f"Exception encountered in scheduler thread:", exc_info=e
+                    f"Exception encountered in scheduler thread: {traceback.format_exc()})"
                 )
 
 


### PR DESCRIPTION
Instead of logging the traceback of an error, pass `exc_info` to the logger.