### PR TITLE
Retention policy in Conductor

### DIFF
--- a/dbos/_admin_server.py
+++ b/dbos/_admin_server.py
@@ -139,8 +139,8 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             self._end_headers()
         elif self.path == _global_timeout_path:
             inputs = json.loads(post_data.decode("utf-8"))
-            timeout_ms = inputs.get("timeout_ms", None)
-            global_timeout(self.dbos, timeout_ms)
+            cutoff_epoch_timestamp_ms = inputs.get("cutoff_epoch_timestamp_ms", None)
+            global_timeout(self.dbos, cutoff_epoch_timestamp_ms)
             self.send_response(204)
             self._end_headers()
         else:

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -18,6 +18,7 @@ class MessageType(str, Enum):
     EXIST_PENDING_WORKFLOWS = "exist_pending_workflows"
     LIST_STEPS = "list_steps"
     FORK_WORKFLOW = "fork_workflow"
+    RETENTION = "retention"
 
 
 T = TypeVar("T", bound="BaseMessage")
@@ -279,4 +280,21 @@ class ForkWorkflowRequest(BaseMessage):
 @dataclass
 class ForkWorkflowResponse(BaseMessage):
     new_workflow_id: Optional[str]
+    error_message: Optional[str] = None
+
+
+class RetentionBody(TypedDict):
+    gc_cutoff_epoch_ms: Optional[int]
+    gc_rows_threshold: Optional[int]
+    timeout_cutoff_epoch_ms: Optional[int]
+
+
+@dataclass
+class RetentionRequest(BaseMessage):
+    body: RetentionBody
+
+
+@dataclass
+class RetentionResponse(BaseMessage):
+    success: bool
     error_message: Optional[str] = None

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -141,8 +141,7 @@ def garbage_collect(
         dbos._app_db.garbage_collect(cutoff_epoch_timestamp_ms, pending_workflow_ids)
 
 
-def global_timeout(dbos: "DBOS", timeout_ms: int) -> None:
-    cutoff_epoch_timestamp_ms = int(time.time() * 1000) - timeout_ms
+def global_timeout(dbos: "DBOS", cutoff_epoch_timestamp_ms: int) -> None:
     cutoff_iso = datetime.fromtimestamp(cutoff_epoch_timestamp_ms / 1000).isoformat()
     for workflow in dbos.list_workflows(
         status=WorkflowStatusString.PENDING.value, end_time=cutoff_iso

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -484,10 +484,10 @@ def test_admin_global_timeout(dbos: DBOS) -> None:
 
     handle = DBOS.start_workflow(workflow)
     time.sleep(1)
-
+    cutoff_epoch_timestamp_ms = int(time.time() * 1000) - 1000
     response = requests.post(
         f"http://localhost:3001/dbos-global-timeout",
-        json={"timeout_ms": 1000},
+        json={"cutoff_epoch_timestamp_ms": cutoff_epoch_timestamp_ms},
         timeout=5,
     )
     response.raise_for_status()

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -737,7 +737,8 @@ def test_global_timeout(dbos: DBOS) -> None:
     # Wait one second, start one final workflow, then timeout all workflows started more than one second ago
     time.sleep(1)
     final_handle = DBOS.start_workflow(blocked_workflow)
-    global_timeout(dbos, 1000)
+    cutoff_epoch_timestamp_ms = int(time.time() * 1000) - 1000
+    global_timeout(dbos, cutoff_epoch_timestamp_ms)
 
     # Verify all workflows started before the global timeout are cancelled
     for handle in handles:


### PR DESCRIPTION
Implement the retention policy protocol in Conductor.
- A new message type `retention`. This will trigger both garbage collection and global timeout.
- Change the input of global timeout to a cut off timestamp instead of an interval. This change will make it easier to support batch cancellation.