### PR TITLE
Password not required in database_url

### DIFF
--- a/dbos/_admin_server.py
+++ b/dbos/_admin_server.py
@@ -5,7 +5,7 @@ import re
 import threading
 from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import TYPE_CHECKING, Any, List, Optional, TypedDict, Dict
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict
 
 from dbos._workflow_commands import garbage_collect, global_timeout
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -431,7 +431,6 @@ def is_valid_database_url(database_url: str) -> bool:
     url = make_url(database_url)
     required_fields = [
         ("username", "Username must be specified in the connection URL"),
-        ("password", "Password must be specified in the connection URL"),
         ("host", "Host must be specified in the connection URL"),
         ("database", "Database name must be specified in the connection URL"),
     ]

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -557,6 +557,7 @@ def test_get_workflow_by_id(dbos: DBOS) -> None:
         response.status_code == 404
     ), f"Expected status code 404, but got {response.status_code}"
 
+
 def test_admin_garbage_collect(dbos: DBOS) -> None:
 
     @DBOS.workflow()
@@ -617,11 +618,15 @@ def test_queued_workflows_endpoint(dbos: DBOS) -> None:
 
     # Test basic queued workflows endpoint
     response = requests.post("http://localhost:3001/queues", json={}, timeout=5)
-    assert response.status_code == 200, f"Expected status 200, got {response.status_code}"
+    assert (
+        response.status_code == 200
+    ), f"Expected status 200, got {response.status_code}"
 
     queued_workflows = response.json()
     assert isinstance(queued_workflows, list), "Response should be a list"
-    assert len(queued_workflows) == 3, f"Expected 3 queued workflows, got {len(queued_workflows)}"
+    assert (
+        len(queued_workflows) == 3
+    ), f"Expected 3 queued workflows, got {len(queued_workflows)}"
 
     # Test with filters
     filters = {"queue_name": "test-queue-1", "limit": 1}
@@ -630,7 +635,9 @@ def test_queued_workflows_endpoint(dbos: DBOS) -> None:
 
     filtered_workflows = response.json()
     assert isinstance(filtered_workflows, list), "Response should be a list"
-    assert len(filtered_workflows) == 1, f"Expected 1 workflow, got {len(filtered_workflows)}"
+    assert (
+        len(filtered_workflows) == 1
+    ), f"Expected 1 workflow, got {len(filtered_workflows)}"
 
     # Test with non-existent queue name
     filters = {"queue_name": "non-existent-queue"}
@@ -638,5 +645,7 @@ def test_queued_workflows_endpoint(dbos: DBOS) -> None:
     assert response.status_code == 200
 
     empty_result = response.json()
-    assert isinstance(empty_result, list), "Response should be a list even for non-existent queue"
+    assert isinstance(
+        empty_result, list
+    ), "Response should be a list even for non-existent queue"
     assert len(empty_result) == 0, "Expected no workflows for non-existent queue"


### PR DESCRIPTION
Do not require password to be set when the user explicitly pass in a database url.
This will not affect the behavior for other cases (e.g., config file).

Closes https://github.com/dbos-inc/dbos-transact-py/issues/372