### PR TITLE
Run Steps Without DBOS

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1157,13 +1157,16 @@ def decorate_step(
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             rr: Optional[str] = check_required_roles(func, fi)
             # Entering step is allowed:
+            #  No DBOS, just call the original function directly
             #  In a step already, just call the original function directly.
             #  In a workflow (that is not in a step already)
             #  Not in a workflow (we will start the single op workflow)
+            if not dbosreg.dbos or not dbosreg.dbos._launched:
+                # Call the original function directly
+                return func(*args, **kwargs)
             ctx = get_local_dbos_context()
             if ctx and ctx.is_step():
                 # Call the original function directly
-
                 return func(*args, **kwargs)
             if ctx and ctx.is_within_workflow():
                 assert ctx.is_workflow(), "Steps must be called from within workflows"

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1608,3 +1608,29 @@ def test_custom_names(dbos: DBOS) -> None:
     handle = DBOS.start_workflow(workflow, value)  # type: ignore
     assert handle.get_status().name == another_workflow
     assert handle.get_result() == value  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_step_without_dbos(dbos: DBOS, config: DBOSConfig) -> None:
+    DBOS.destroy(destroy_registry=True)
+
+    @DBOS.step()
+    def step(x: int) -> int:
+        return x
+
+    @DBOS.step()
+    async def async_step(x: int) -> int:
+        return x
+
+    assert step(5) == 5
+    assert await async_step(5) == 5
+
+    DBOS(config=config)
+
+    assert step(5) == 5
+    assert await async_step(5) == 5
+
+    DBOS.launch()
+
+    assert step(5) == 5
+    assert await async_step(5) == 5


### PR DESCRIPTION
If a step is called in an environment without DBOS, the step just runs as a normal function. This simplifies sharing code between a DBOS and non-DBOS application; functions may be decorated as steps and called freely from either environment.