### PR TITLE
Queue Thread Exponential Backoff

### DIFF
--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -96,7 +96,7 @@ class Queue:
 
 def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     default_polling_interval = 1.0
-    max_polling_interval = 30.0
+    max_polling_interval = 60.0
     while not stop_event.is_set():
         if stop_event.wait(timeout=default_polling_interval):
             return
@@ -118,7 +118,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                         default_polling_interval * random.uniform(1, 2),
                     )
                     dbos.logger.warning(
-                        f"Contention detected in queue thread for {queue.name}. Increasing polling interval to {default_polling_interval}."
+                        f"Contention detected in queue thread for {queue.name}. Increasing polling interval to {default_polling_interval:.2f}."
                     )
                 else:
                     dbos.logger.warning(f"Exception encountered in queue thread: {e}")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -95,8 +95,8 @@ class Queue:
 
 
 def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
-    default_polling_interval = 1
-    max_polling_interval = 30
+    default_polling_interval = 1.0
+    max_polling_interval = 30.0
     while not stop_event.is_set():
         if stop_event.wait(timeout=default_polling_interval):
             return

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -95,10 +95,10 @@ class Queue:
 
 
 def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
-    default_polling_interval = 1.0
+    polling_interval = 1.0
     max_polling_interval = 60.0
     while not stop_event.is_set():
-        if stop_event.wait(timeout=default_polling_interval):
+        if stop_event.wait(timeout=polling_interval):
             return
         queues = dict(dbos._registry.queue_info_map)
         for _, queue in queues.items():
@@ -113,12 +113,12 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                     e.orig, (errors.SerializationFailure, errors.LockNotAvailable)
                 ):
                     # If a serialization error is encountered, increase the timeout with jitter
-                    default_polling_interval = min(
+                    polling_interval = min(
                         max_polling_interval,
-                        default_polling_interval * random.uniform(1, 2),
+                        polling_interval * random.uniform(1, 2),
                     )
                     dbos.logger.warning(
-                        f"Contention detected in queue thread for {queue.name}. Increasing polling interval to {default_polling_interval:.2f}."
+                        f"Contention detected in queue thread for {queue.name}. Increasing polling interval to {polling_interval:.2f}."
                     )
                 else:
                     dbos.logger.warning(f"Exception encountered in queue thread: {e}")

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1650,7 +1650,7 @@ class SystemDatabase:
                     return []
 
             # Compute max_tasks, the number of workflows that can be dequeued given local and global concurrency limits,
-            max_tasks = float("inf")
+            max_tasks = 50  # To minimize contention with large queues, never dequeue more than 50 tasks
             if queue.worker_concurrency is not None or queue.concurrency is not None:
                 # Count how many workflows on this queue are currently PENDING both locally and globally.
                 pending_tasks_query = (
@@ -1720,9 +1720,7 @@ class SystemDatabase:
                 )
             else:
                 query = query.order_by(SystemSchema.workflow_status.c.created_at.asc())
-            # Apply limit only if max_tasks is finite
-            if max_tasks != float("inf"):
-                query = query.limit(int(max_tasks))
+            query = query.limit(int(max_tasks))
 
             rows = c.execute(query).fetchall()
 


### PR DESCRIPTION
At scale, process queue threads polling the database every second may overwhelm it. This adds exponential backoff for queue thread polling.