### PR TITLE
Enqueue Doesn't Increment Recovery Attempts

### DIFF
--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -126,7 +126,7 @@ class DBOSDeadLetterQueueError(DBOSException):
 
     def __init__(self, wf_id: str, max_retries: int):
         super().__init__(
-            f"Workflow {wf_id} has been moved to the dead-letter queue after exceeding the maximum of ${max_retries} retries",
+            f"Workflow {wf_id} has been moved to the dead-letter queue after exceeding the maximum of {max_retries} retries",
             dbos_error_code=DBOSErrorCode.DeadLetterQueueError.value,
         )
 


### PR DESCRIPTION
Fixes unintuitive behavior where many enqueues of a workflow (particularly cron) would put it in the DLQ.