### PR TITLE
Remove DBOS atexit Handler

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1376,31 +1376,3 @@ class DBOSConfiguredInstance:
     def __init__(self, config_name: str) -> None:
         self.config_name = config_name
         DBOS.register_instance(self)
-
-
-# Apps that import DBOS probably don't exit.  If they do, let's see if
-#   it looks like startup was abandoned or a call was forgotten...
-def _dbos_exit_hook() -> None:
-    if _dbos_global_registry is None:
-        # Probably used as or for a support module
-        return
-    if _dbos_global_instance is None:
-        print("DBOS exiting; functions were registered but DBOS() was not called")
-        dbos_logger.warning(
-            "DBOS exiting; functions were registered but DBOS() was not called"
-        )
-        return
-    if not _dbos_global_instance._launched:
-        if _dbos_global_instance.fastapi is not None:
-            # FastAPI lifespan middleware will call launch/destroy, so we can ignore this.
-            # This is likely to happen during fastapi dev runs, where the reloader loads the module multiple times.
-            return
-        print("DBOS exiting; DBOS exists but launch() was not called")
-        dbos_logger.warning("DBOS exiting; DBOS exists but launch() was not called")
-        return
-    # If we get here, we're exiting normally
-    _dbos_global_instance.destroy()
-
-
-# Register the exit hook
-atexit.register(_dbos_exit_hook)

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -129,27 +129,3 @@ def test_dbos_singleton_negative(cleanup_test_databases: None) -> None:
     assert "launch" in str(exc_info.value)
 
     DBOS.destroy()
-
-
-def test_dbos_atexit_no_dbos(cleanup_test_databases: None) -> None:
-    # Run the .py as a separate process
-    result = subprocess.run(
-        [sys.executable, path.join("tests", "atexit_no_ctor.py")],
-        capture_output=True,
-        text=True,
-    )
-
-    # Assert that the output contains the warning message
-    assert "DBOS exiting; functions were registered" in result.stdout
-
-
-def test_dbos_atexit_no_launch(cleanup_test_databases: None) -> None:
-    # Run the .py as a separate process
-    result = subprocess.run(
-        [sys.executable, path.join("tests", "atexit_no_launch.py")],
-        capture_output=True,
-        text=True,
-    )
-
-    # Assert that the output contains the warning message
-    assert "DBOS exists but launch() was not called" in result.stdout


### PR DESCRIPTION
The atexit handler prints warning messages if DBOS global instances do not exist, then calls `DBOS.destroy()`. Removing it because it is unintuitive and can often lead to spurious warnings. Calling `DBOS.destroy()` at shutdown is not necessary for safety.