### PR TITLE
CLI Commands Should Emit Valid JSON

### DIFF
--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -497,7 +497,6 @@ def list(
         app_version=appversion,
         name=name,
     )
-
     print(jsonpickle.encode(workflows, unpicklable=False))
 
 


### PR DESCRIPTION
The issue was `rich` mangling some output to make it invalid JSON. Now deliberately using `rich` only for pretty-printing.