### PR TITLE
Streaming API

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1317,10 +1317,6 @@ class DBOS:
         """
         Write a value to a stream.
 
-        This function writes a value to a stream identified by the key within the current workflow.
-        The value is appended to the first unused offset in the stream.
-        This function can only be called from within a workflow and runs as a workflow step.
-
         Args:
             key(str): The stream key / name within the workflow
             value(Any): A serializable value to write to the stream
@@ -1341,11 +1337,7 @@ class DBOS:
     @classmethod
     def close_stream(cls, key: str) -> None:
         """
-        Close a stream by writing a sentinel value.
-
-        This function closes a stream identified by the key within the current workflow
-        by writing a special sentinel value at the first unused offset.
-        This function can only be called from within a workflow and runs as a workflow step.
+        Close a stream.
 
         Args:
             key(str): The stream key / name within the workflow
@@ -1369,8 +1361,7 @@ class DBOS:
         Read values from a stream as a generator.
 
         This function reads values from a stream identified by the workflow_id and key,
-        yielding each value in order until the stream is closed (sentinel value encountered).
-        This function can be called from anywhere and does not run as a workflow step.
+        yielding each value in order until the stream is closed.
 
         Args:
             workflow_id(str): The workflow instance ID that owns the stream

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1323,7 +1323,7 @@ class DBOS:
 
         """
         cur_ctx = get_local_dbos_context()
-        if cur_ctx is None or not cur_ctx.is_workflow():
+        if cur_ctx is None or not cur_ctx.is_within_workflow():
             raise DBOSException("write_stream() must be called from within a workflow")
 
         def fn() -> None:

--- a/dbos/_migrations/versions/01ce9f07bd10_streaming.py
+++ b/dbos/_migrations/versions/01ce9f07bd10_streaming.py
@@ -32,10 +32,7 @@ def upgrade() -> None:
             onupdate="CASCADE",
             ondelete="CASCADE",
         ),
-        sa.PrimaryKeyConstraint("workflow_uuid"),
-        sa.UniqueConstraint(
-            "workflow_uuid", "key", "offset", name="uq_streams_workflow_key_offset"
-        ),
+        sa.PrimaryKeyConstraint("workflow_uuid", "key", "offset"),
         schema="dbos",
     )
 

--- a/dbos/_migrations/versions/01ce9f07bd10_streaming.py
+++ b/dbos/_migrations/versions/01ce9f07bd10_streaming.py
@@ -1,0 +1,45 @@
+"""streaming
+
+Revision ID: 01ce9f07bd10
+Revises: d994145b47b6
+Create Date: 2025-08-05 10:20:46.424975
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "01ce9f07bd10"
+down_revision: Union[str, None] = "d994145b47b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create streams table
+    op.create_table(
+        "streams",
+        sa.Column("workflow_uuid", sa.Text(), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("offset", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workflow_uuid"],
+            ["dbos.workflow_status.workflow_uuid"],
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("workflow_uuid"),
+        sa.UniqueConstraint(
+            "workflow_uuid", "key", "offset", name="uq_streams_workflow_key_offset"
+        ),
+        schema="dbos",
+    )
+
+
+def downgrade() -> None:
+    # Drop streams table
+    op.drop_table("streams", schema="dbos")

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -143,12 +143,9 @@ class SystemSchema:
                 "workflow_status.workflow_uuid", onupdate="CASCADE", ondelete="CASCADE"
             ),
             nullable=False,
-            primary_key=True,
         ),
         Column("key", Text, nullable=False),
         Column("value", Text, nullable=False),
         Column("offset", Integer, nullable=False),
-        UniqueConstraint(
-            "workflow_uuid", "key", "offset", name="uq_streams_workflow_key_offset"
-        ),
+        PrimaryKeyConstraint("workflow_uuid", "key", "offset"),
     )

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -132,3 +132,23 @@ class SystemSchema:
         Column("value", Text, nullable=False),
         PrimaryKeyConstraint("workflow_uuid", "key"),
     )
+
+    streams = Table(
+        "streams",
+        metadata_obj,
+        Column(
+            "workflow_uuid",
+            Text,
+            ForeignKey(
+                "workflow_status.workflow_uuid", onupdate="CASCADE", ondelete="CASCADE"
+            ),
+            nullable=False,
+            primary_key=True,
+        ),
+        Column("key", Text, nullable=False),
+        Column("value", Text, nullable=False),
+        Column("offset", Integer, nullable=False),
+        UniqueConstraint(
+            "workflow_uuid", "key", "offset", name="uq_streams_workflow_key_offset"
+        ),
+    )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -243,6 +243,7 @@ class StepInfo(TypedDict):
 
 
 _dbos_null_topic = "__null__topic__"
+_dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
 
 
 class ConditionCount(TypedDict):
@@ -1881,6 +1882,64 @@ class SystemDatabase:
         except Exception as e:
             dbos_logger.error(f"Error connecting to the DBOS system database: {e}")
             raise
+
+    @db_retry()
+    def write_stream(self, workflow_uuid: str, key: str, value: Any) -> None:
+        """Write a key-value pair to the stream at the first unused offset."""
+        if self._debug_mode:
+            raise Exception("called write_stream in debug mode")
+
+        with self.engine.begin() as c:
+            # Find the maximum offset for this workflow_uuid and key combination
+            max_offset_result = c.execute(
+                sa.select(sa.func.max(SystemSchema.streams.c.offset)).where(
+                    SystemSchema.streams.c.workflow_uuid == workflow_uuid,
+                    SystemSchema.streams.c.key == key,
+                )
+            ).fetchone()
+
+            # Next offset is max + 1, or 0 if no records exist
+            next_offset = (
+                (max_offset_result[0] + 1) if max_offset_result is not None else 0
+            )
+
+            # Serialize the value before storing
+            serialized_value = _serialization.serialize(value)
+
+            # Insert the new stream entry
+            c.execute(
+                sa.insert(SystemSchema.streams).values(
+                    workflow_uuid=workflow_uuid,
+                    key=key,
+                    value=serialized_value,
+                    offset=next_offset,
+                )
+            )
+
+    def close_stream(self, workflow_uuid: str, key: str) -> None:
+        """Write a sentinel value to the stream at the first unused offset to mark it as closed."""
+        self.write_stream(workflow_uuid, key, _dbos_stream_closed_sentinel)
+
+    @db_retry()
+    def read_stream(self, workflow_uuid: str, key: str, offset: int) -> Any:
+        """Read the value at the specified offset for the given workflow_uuid and key."""
+
+        with self.engine.begin() as c:
+            result = c.execute(
+                sa.select(SystemSchema.streams.c.value).where(
+                    SystemSchema.streams.c.workflow_uuid == workflow_uuid,
+                    SystemSchema.streams.c.key == key,
+                    SystemSchema.streams.c.offset == offset,
+                )
+            ).fetchone()
+
+            if result is None:
+                raise ValueError(
+                    f"No value found for workflow_uuid={workflow_uuid}, key={key}, offset={offset}"
+                )
+
+            # Deserialize the value before returning
+            return _serialization.deserialize(result[0])
 
     def garbage_collect(
         self, cutoff_epoch_timestamp_ms: Optional[int], rows_threshold: Optional[int]

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1900,7 +1900,9 @@ class SystemDatabase:
 
             # Next offset is max + 1, or 0 if no records exist
             next_offset = (
-                (max_offset_result[0] + 1) if max_offset_result is not None else 0
+                (max_offset_result[0] + 1)
+                if max_offset_result is not None and max_offset_result[0] is not None
+                else 0
             )
 
             # Serialize the value before storing

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -301,7 +301,9 @@ def test_stream_write_from_step(dbos: DBOS) -> None:
         if call_count < 4:
             raise RuntimeError(f"Step failed on attempt {call_count}")
 
-        return DBOS.step_id
+        step_id = DBOS.step_id
+        assert step_id is not None
+        return step_id
 
     @DBOS.workflow()
     def workflow_with_failing_step() -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -341,3 +341,104 @@ def test_stream_write_from_step(dbos: DBOS) -> None:
 
     # Verify the step was called exactly 4 times (3 failures + 1 success)
     assert call_count == 4
+
+
+def test_async_stream_basic_write_read(dbos: DBOS) -> None:
+    """Test basic async stream write and read functionality."""
+    import asyncio
+
+    async def async_stream_test() -> None:
+        test_values = [
+            "async_hello",
+            123,
+            {"async_key": "async_value"},
+            [10, 20, 30],
+            None,
+        ]
+        stream_key = "async_test_stream"
+
+        @DBOS.workflow()
+        async def async_writer_workflow() -> None:
+            for value in test_values:
+                await DBOS.write_stream_async(stream_key, value)
+            await DBOS.close_stream_async(stream_key)
+
+        # Start the writer workflow
+        wfid = str(uuid.uuid4())
+        with SetWorkflowID(wfid):
+            await async_writer_workflow()
+
+        # Read the stream
+        read_values = []
+        async for value in DBOS.read_stream_async(wfid, stream_key):
+            read_values.append(value)
+
+        assert read_values == test_values
+
+    # Run the async test
+    asyncio.run(async_stream_test())
+
+
+def test_async_stream_concurrent_write_read(dbos: DBOS) -> None:
+    """Test async reading from a stream while it's being written to."""
+    import asyncio
+
+    async def async_concurrent_test() -> None:
+        stream_key = "async_concurrent_stream"
+        num_values = 5
+
+        @DBOS.workflow()
+        async def async_writer_workflow() -> None:
+            for i in range(num_values):
+                await DBOS.write_stream_async(stream_key, f"async_value_{i}")
+                # Small delay to simulate real work
+                await DBOS.sleep_async(0.1)
+            await DBOS.close_stream_async(stream_key)
+
+        # Start the writer workflow
+        wfid = str(uuid.uuid4())
+        with SetWorkflowID(wfid):
+            writer_handle = await DBOS.start_workflow_async(async_writer_workflow)
+
+        # Start reading immediately (while writing)
+        read_values = []
+        start_time = time.time()
+
+        async for value in DBOS.read_stream_async(wfid, stream_key):
+            read_values.append(value)
+            # Ensure we're not waiting too long for each value
+            assert time.time() - start_time < 30  # Safety timeout
+
+        # Wait for writer to complete
+        await writer_handle.get_result()
+
+        # Verify all values were read
+        expected_values = [f"async_value_{i}" for i in range(num_values)]
+        assert read_values == expected_values
+
+    # Run the async test
+    asyncio.run(async_concurrent_test())
+
+
+def test_async_stream_empty_stream(dbos: DBOS) -> None:
+    """Test async reading from an empty stream (only close marker)."""
+    import asyncio
+
+    async def async_empty_test() -> None:
+        @DBOS.workflow()
+        async def async_empty_stream_workflow() -> None:
+            await DBOS.close_stream_async("async_empty_stream")
+
+        # Start the workflow
+        wfid = str(uuid.uuid4())
+        with SetWorkflowID(wfid):
+            await async_empty_stream_workflow()
+
+        # Read the empty stream
+        values = []
+        async for value in DBOS.read_stream_async(wfid, "async_empty_stream"):
+            values.append(value)
+        assert values == []
+
+    # Run the async test
+    asyncio.run(async_empty_test())


### PR DESCRIPTION
This PR adds an API for streaming data from workflows.

```python
def write_stream(cls, key: str, value: Any) -> None:
    """
    Write a value to a stream.

    Args:
        key(str): The stream key / name within the workflow
        value(Any): A serializable value to write to the stream

    """

def close_stream(cls, key: str) -> None:
    """
    Close a stream.

    Args:
        key(str): The stream key / name within the workflow

    """

def read_stream(cls, workflow_id: str, key: str) -> Generator[Any, Any, None]:
    """
    Read values from a stream as a generator.

    This function reads values from a stream identified by the workflow_id and key,
    yielding each value in order until the stream is closed.

    Args:
        workflow_id(str): The workflow instance ID that owns the stream
        key(str): The stream key / name within the workflow

    Yields:
        Any: Each value in the stream until the stream is closed

    """
```

Streams are append-only and immutable and can be read from anywhere.

Streams can be written to from a workflow or its steps. Writing to a stream from a workflow is done with exactly-once semantics. Writing to a stream from a step is at-least-once; if a step fails and is retried, it may write to the stream multiple times.