### PR TITLE
Migration Permissions

### DIFF
--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -74,10 +74,19 @@ class ApplicationDatabase:
 
         # Create the dbos schema and transaction_outputs table in the application database
         with self.engine.begin() as conn:
-            schema_creation_query = sa.text(
-                f"CREATE SCHEMA IF NOT EXISTS {ApplicationSchema.schema}"
-            )
-            conn.execute(schema_creation_query)
+            # Check if schema exists first
+            schema_exists = conn.execute(
+                sa.text(
+                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = :schema_name"
+                ),
+                parameters={"schema_name": ApplicationSchema.schema},
+            ).scalar()
+
+            if not schema_exists:
+                schema_creation_query = sa.text(
+                    f"CREATE SCHEMA {ApplicationSchema.schema}"
+                )
+                conn.execute(schema_creation_query)
 
         inspector = inspect(self.engine)
         if not inspector.has_table(

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -1,3 +1,4 @@
+import sqlalchemy as sa
 import typer
 
 from dbos._app_db import ApplicationDatabase
@@ -34,3 +35,64 @@ def migrate_dbos_databases(app_database_url: str, system_database_url: str):
             sys_db.destroy()
         if app_db:
             app_db.destroy()
+
+
+def grant_dbos_schema_permissions(database_url: str, role_name: str):
+    """
+    Grant all permissions on all tables in the dbos schema to the specified role.
+
+    Args:
+        database_url: The database connection URL
+        role_name: The name of the role to grant permissions to
+    """
+    engine = None
+    try:
+        engine = sa.create_engine(database_url)
+        with engine.connect() as connection:
+            connection.execution_options(isolation_level="AUTOCOMMIT")
+
+            # Grant usage on the dbos schema
+            connection.execute(sa.text(f"GRANT USAGE ON SCHEMA dbos TO {role_name}"))
+
+            # Grant all privileges on all existing tables in dbos schema (includes views)
+            connection.execute(
+                sa.text(
+                    f"GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA dbos TO {role_name}"
+                )
+            )
+
+            # Grant all privileges on all sequences in dbos schema
+            connection.execute(
+                sa.text(
+                    f"GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA dbos TO {role_name}"
+                )
+            )
+
+            # Grant execute on all functions and procedures in dbos schema
+            connection.execute(
+                sa.text(f"GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA dbos TO {role_name}")
+            )
+
+            # Grant default privileges for future objects in dbos schema
+            connection.execute(
+                sa.text(
+                    f"ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT ALL ON TABLES TO {role_name}"
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT ALL ON SEQUENCES TO {role_name}"
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT EXECUTE ON FUNCTIONS TO {role_name}"
+                )
+            )
+
+    except Exception as e:
+        typer.echo(f"Failed to grant permissions to role {role_name}: {e}")
+        raise typer.Exit(code=1)
+    finally:
+        if engine:
+            engine.dispose()

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -1,0 +1,36 @@
+import typer
+
+from dbos._app_db import ApplicationDatabase
+from dbos._sys_db import SystemDatabase
+
+
+def migrate_dbos_databases(app_database_url: str, system_database_url: str):
+    app_db = None
+    sys_db = None
+    try:
+        sys_db = SystemDatabase(
+            system_database_url=system_database_url,
+            engine_kwargs={
+                "pool_timeout": 30,
+                "max_overflow": 0,
+                "pool_size": 2,
+            },
+        )
+        app_db = ApplicationDatabase(
+            database_url=app_database_url,
+            engine_kwargs={
+                "pool_timeout": 30,
+                "max_overflow": 0,
+                "pool_size": 2,
+            },
+        )
+        sys_db.run_migrations()
+        app_db.run_migrations()
+    except Exception as e:
+        typer.echo(f"DBOS migrations failed: {e}")
+        raise typer.Exit(code=1)
+    finally:
+        if sys_db:
+            sys_db.destroy()
+        if app_db:
+            app_db.destroy()

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -5,7 +5,7 @@ from dbos._app_db import ApplicationDatabase
 from dbos._sys_db import SystemDatabase
 
 
-def migrate_dbos_databases(app_database_url: str, system_database_url: str):
+def migrate_dbos_databases(app_database_url: str, system_database_url: str) -> None:
     app_db = None
     sys_db = None
     try:
@@ -37,7 +37,7 @@ def migrate_dbos_databases(app_database_url: str, system_database_url: str):
             app_db.destroy()
 
 
-def grant_dbos_schema_permissions(database_url: str, role_name: str):
+def grant_dbos_schema_permissions(database_url: str, role_name: str) -> None:
     """
     Grant all permissions on all tables in the dbos schema to the specified role.
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,15 +2,29 @@ import subprocess
 
 import sqlalchemy as sa
 
+from dbos import DBOS, DBOSConfig
+
 
 def test_migrate(postgres_db_engine: sa.Engine) -> None:
     database_name = "migrate_test"
+    role_name = "migrate_test_role"
+    role_password = "migrate_test_password"
+
     db_url = postgres_db_engine.url.set(database=database_name).render_as_string(
         hide_password=False
     )
 
     with postgres_db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
+
+        # Drop role if it exists
+        connection.execute(sa.text(f"DROP ROLE IF EXISTS {role_name}"))
+
+        # Create the role
+        connection.execute(
+            sa.text(f"CREATE ROLE {role_name} WITH LOGIN PASSWORD '{role_password}'")
+        )
+
         connection.execute(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
@@ -25,3 +39,26 @@ def test_migrate(postgres_db_engine: sa.Engine) -> None:
             )
         ).scalar()
         assert result == 1
+
+    test_db_url = (
+        postgres_db_engine.url.set(database=database_name)
+        .set(username=role_name)
+        .set(password=role_password)
+    )
+    DBOS.destroy(destroy_registry=True)
+    config: DBOSConfig = {
+        "name": "test_migrate",
+        "database_url": test_db_url,
+        "system_database_url": test_db_url,
+    }
+    DBOS(config=config)
+
+    @DBOS.workflow()
+    def test_workflow() -> str:
+        id = DBOS.workflow_id
+        assert id
+        return id
+
+    DBOS.launch()
+
+    assert test_workflow()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -47,7 +47,7 @@ def test_migrate(postgres_db_engine: sa.Engine) -> None:
         postgres_db_engine.url.set(database=database_name)
         .set(username=role_name)
         .set(password=role_password)
-    )
+    ).render_as_string(hide_password=False)
     DBOS.destroy(destroy_registry=True)
     config: DBOSConfig = {
         "name": "test_migrate",

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,27 @@
+import subprocess
+
+import sqlalchemy as sa
+
+
+def test_migrate(postgres_db_engine: sa.Engine) -> None:
+    database_name = "migrate_test"
+    db_url = postgres_db_engine.url.set(database=database_name).render_as_string(
+        hide_password=False
+    )
+
+    with postgres_db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
+    # Create a system database and verify it exists
+    subprocess.check_call(["dbos", "migrate", "-D", db_url, "-s", db_url])
+    with postgres_db_engine.connect() as c:
+        c.execution_options(isolation_level="AUTOCOMMIT")
+        result = c.execute(
+            sa.text(
+                f"SELECT COUNT(*) FROM pg_database WHERE datname = '{database_name}'"
+            )
+        ).scalar()
+        assert result == 1

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -30,7 +30,9 @@ def test_migrate(postgres_db_engine: sa.Engine) -> None:
         )
 
     # Create a system database and verify it exists
-    subprocess.check_call(["dbos", "migrate", "-D", db_url, "-s", db_url])
+    subprocess.check_call(
+        ["dbos", "migrate", "-D", db_url, "-s", db_url, "-r", role_name]
+    )
     with postgres_db_engine.connect() as c:
         c.execution_options(isolation_level="AUTOCOMMIT")
         result = c.execute(

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -6,6 +6,7 @@ from dbos import DBOS, DBOSConfig
 
 
 def test_migrate(postgres_db_engine: sa.Engine) -> None:
+    """Test that you can migrate with a privileged role and run DBOS with a less-privileged role"""
     database_name = "migrate_test"
     role_name = "migrate_test_role"
     role_password = "migrate_test_password"
@@ -17,16 +18,16 @@ def test_migrate(postgres_db_engine: sa.Engine) -> None:
     with postgres_db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
 
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
         # Drop role if it exists
         connection.execute(sa.text(f"DROP ROLE IF EXISTS {role_name}"))
 
         # Create the role
         connection.execute(
             sa.text(f"CREATE ROLE {role_name} WITH LOGIN PASSWORD '{role_password}'")
-        )
-
-        connection.execute(
-            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
 
     # Create a system database and verify it exists


### PR DESCRIPTION
When creating the DBOS system tables with `dbos migrate` you can now specify an "application role."

```
 Usage: dbos migrate [OPTIONS]

 Create DBOS system tables.

╭─ Options ──────────────────────────────────────────────────────────────╮
│ --db-url      -D      TEXT  Your DBOS application database URL         │
│                             [default: None]                            │
│ --sys-db-url  -s      TEXT  Your DBOS system database URL              │
│                             [default: None]                            │
│ --app-role    -r      TEXT  The role with which you will run your DBOS │
│                             application                                │
│                             [default: None]                            │
│ --help                      Show this message and exit.                │
╰────────────────────────────────────────────────────────────────────────╯
```

If you specify this role, it is granted all permissions needed to run a DBOS app.

This is most useful in settings where the application runs with an "application role" that does not have sufficient privileges to create the DBOS system database or system tables. Prior to deployment, the dbos migrate command can be run with a privileged user to create DBOS system tables, specifying the application role. Then, the application can safely run with the application role.