### PR TITLE
Remove Temp Workflows for Direct Calls

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1156,18 +1156,11 @@ def decorate_step(
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            rr: Optional[str] = check_required_roles(func, fi)
-            # Entering step is allowed:
-            #  No DBOS, just call the original function directly
-            #  In a step already, just call the original function directly.
-            #  In a workflow (that is not in a step already)
-            #  Not in a workflow (we will start the single op workflow)
-            if not dbosreg.dbos or not dbosreg.dbos._launched:
-                # Call the original function directly
-                return func(*args, **kwargs)
+            # If the step is called from a workflow, run it as a step.
+            # Otherwise, run it as a normal function.
             ctx = get_local_dbos_context()
-            if ctx and ctx.is_within_workflow():
-                assert ctx.is_workflow(), "Steps must be called from within workflows"
+            if ctx and ctx.is_workflow():
+                rr: Optional[str] = check_required_roles(func, fi)
                 with DBOSAssumeRole(rr):
                     return invoke_step(*args, **kwargs)
             else:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1166,17 +1166,12 @@ def decorate_step(
                 # Call the original function directly
                 return func(*args, **kwargs)
             ctx = get_local_dbos_context()
-            if ctx and ctx.is_step():
-                # Call the original function directly
-                return func(*args, **kwargs)
             if ctx and ctx.is_within_workflow():
                 assert ctx.is_workflow(), "Steps must be called from within workflows"
                 with DBOSAssumeRole(rr):
                     return invoke_step(*args, **kwargs)
             else:
-                tempwf = dbosreg.workflow_info_map.get("<temp>." + step_name)
-                assert tempwf
-                return tempwf(*args, **kwargs)
+                return func(*args, **kwargs)
 
         wrapper = (
             _mark_coroutine(wrapper) if inspect.iscoroutinefunction(func) else wrapper  # type: ignore

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -307,15 +307,11 @@ def test_temp_workflow(dbos: DBOS) -> None:
     assert res == "var"
 
     wfs = dbos._sys_db.get_workflows(gwi)
-    assert len(wfs) == 2
+    assert len(wfs) == 1
 
     wfi1 = dbos._sys_db.get_workflow_status(wfs[0].workflow_id)
     assert wfi1
     assert wfi1["name"].startswith("<temp>")
-
-    wfi2 = dbos._sys_db.get_workflow_status(wfs[1].workflow_id)
-    assert wfi2
-    assert wfi2["name"].startswith("<temp>")
 
     assert txn_counter == 1
     assert step_counter == 1
@@ -350,7 +346,7 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
     def test_retried_step(var: str) -> str:
         nonlocal retried_step_counter
         retried_step_counter += 1
-        raise Exception(var)
+        raise ValueError(var)
 
     with pytest.raises(Exception) as exc_info:
         test_transaction("tval")
@@ -360,12 +356,12 @@ def test_temp_workflow_errors(dbos: DBOS) -> None:
         test_step("cval")
     assert "cval" == str(exc_info.value)
 
-    with pytest.raises(DBOSMaxStepRetriesExceeded) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         test_retried_step("rval")
 
     assert txn_counter == 1
     assert step_counter == 1
-    assert retried_step_counter == 3
+    assert retried_step_counter == 1
 
 
 def test_recovery_workflow(dbos: DBOS) -> None:
@@ -1103,9 +1099,6 @@ def test_nonserializable_values(dbos: DBOS) -> None:
         test_ns_transaction("h")
     assert "data item should not be a function" in str(exc_info.value)
     with pytest.raises(Exception) as exc_info:
-        test_ns_step("f")
-    assert "data item should not be a function" in str(exc_info.value)
-    with pytest.raises(Exception) as exc_info:
         test_ns_wf("g")
     assert "data item should not be a function" in str(exc_info.value)
 
@@ -1645,22 +1638,14 @@ def test_custom_names(dbos: DBOS) -> None:
 async def test_step_without_dbos(dbos: DBOS, config: DBOSConfig) -> None:
     DBOS.destroy(destroy_registry=True)
 
-    is_dbos_active = False
-
     @DBOS.step()
     def step(x: int) -> int:
-        if is_dbos_active:
-            assert DBOS.workflow_id is not None
-        else:
-            assert DBOS.workflow_id is None
+        assert DBOS.workflow_id is None
         return x
 
     @DBOS.step()
     async def async_step(x: int) -> int:
-        if is_dbos_active:
-            assert DBOS.workflow_id is not None
-        else:
-            assert DBOS.workflow_id is None
+        assert DBOS.workflow_id is None
         return x
 
     assert step(5) == 5
@@ -1672,7 +1657,6 @@ async def test_step_without_dbos(dbos: DBOS, config: DBOSConfig) -> None:
     assert await async_step(5) == 5
 
     DBOS.launch()
-    is_dbos_active = True
 
     assert step(5) == 5
     assert await async_step(5) == 5

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -181,7 +181,8 @@ def test_queue_step(dbos: DBOS) -> None:
         handle = queue.enqueue(test_step, "abc")
     assert handle.get_result() == "abc1"
     with SetWorkflowID(wfid):
-        assert test_step("abc") == "abc1"
+        handle = queue.enqueue(test_step, "abc")
+    assert handle.get_result() == "abc1"
     assert step_counter == 1
 
 


### PR DESCRIPTION
Calling a step directly from outside a workflow now always results in it being called as a normal Python function. Steps are now only retried if called from within workflows. Steps can still be enqueued.