### PR TITLE
fix(client): Await for a coroutine in retrieve_workflow_async() (#449)

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -241,7 +241,7 @@ class DBOSClient:
         return WorkflowHandleClientPolling[R](workflow_id, self._sys_db)
 
     async def retrieve_workflow_async(self, workflow_id: str) -> WorkflowHandleAsync[R]:
-        status = asyncio.to_thread(get_workflow, self._sys_db, workflow_id)
+        status = await asyncio.to_thread(get_workflow, self._sys_db, workflow_id)
         if status is None:
             raise DBOSNonExistentWorkflowError(workflow_id)
         return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)


### PR DESCRIPTION
It seems that an await statement was accidentally forgotten in `retrieve_workflow_async()`. This PR fixes it.