### PR TITLE
Fix destroy for asyncio

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -19,8 +19,6 @@ from typing import (
     cast,
 )
 
-import psycopg
-
 from dbos._outcome import Immediate, NoResult, Outcome, Pending
 from dbos._utils import GlobalParams, retriable_postgres_exception
 
@@ -831,10 +829,10 @@ def workflow_wrapper(
             return r
 
         outcome = (
-            wfOutcome.wrap(init_wf)
+            wfOutcome.wrap(init_wf, dbos=dbos)
             .also(DBOSAssumeRole(rr))
             .also(enterWorkflowCtxMgr(attributes))
-            .then(record_get_result)
+            .then(record_get_result, dbos=dbos)
         )
         return outcome()  # type: ignore
 
@@ -1146,7 +1144,7 @@ def decorate_step(
 
             outcome = (
                 stepOutcome.then(record_step_result)
-                .intercept(check_existing_result)
+                .intercept(check_existing_result, dbos=dbos)
                 .also(EnterDBOSStep(attributes))
             )
             return outcome()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,9 @@ def cleanup_test_databases(config: DBOSConfig, db_engine: sa.Engine) -> None:
 
 
 @pytest.fixture()
-def dbos(config: DBOSConfig) -> Generator[DBOS, Any, None]:
+def dbos(
+    config: DBOSConfig, cleanup_test_databases: None
+) -> Generator[DBOS, Any, None]:
     DBOS.destroy(destroy_registry=True)
 
     # This launches for test convenience.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,9 +119,7 @@ def cleanup_test_databases(config: DBOSConfig, db_engine: sa.Engine) -> None:
 
 
 @pytest.fixture()
-def dbos(
-    config: DBOSConfig, cleanup_test_databases: None
-) -> Generator[DBOS, Any, None]:
+def dbos(config: DBOSConfig) -> Generator[DBOS, Any, None]:
     DBOS.destroy(destroy_registry=True)
 
     # This launches for test convenience.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1250,11 +1250,42 @@ def test_destroy_semantics(dbos: DBOS, config: DBOSConfig) -> None:
     var = "test"
     assert test_workflow(var) == var
 
+    # Start the workflow asynchornously
+    wf = dbos.start_workflow(test_workflow, var)
+    assert wf.get_result() == var
+
     DBOS.destroy()
     DBOS(config=config)
     DBOS.launch()
 
     assert test_workflow(var) == var
+
+    wf = dbos.start_workflow(test_workflow, var)
+    assert wf.get_result() == var
+
+
+@pytest.mark.asyncio
+async def test_destroy_semantics_async(dbos: DBOS, config: DBOSConfig) -> None:
+
+    @DBOS.workflow()
+    async def test_workflow(var: str) -> str:
+        return var
+
+    var = "test"
+    assert await test_workflow(var) == var
+
+    # Start the workflow asynchornously
+    wf = await dbos.start_workflow_async(test_workflow, var)
+    assert await wf.get_result() == var
+
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.launch()
+
+    assert await test_workflow(var) == var
+
+    wf = await dbos.start_workflow_async(test_workflow, var)
+    assert await wf.get_result() == var
 
 
 def test_double_decoration(dbos: DBOS) -> None:


### PR DESCRIPTION
This PR fixes a bug where `DBOS.destroy()` shuts down the executor pool but leaves it attached to the event loop. As a result, if DBOS is re-initialized and async functions are invoked directly, the loop still tries to use the destroyed pool and raises a runtime error.

The fix is to let the wrapper functions optionally accept a `dbos` instance. This makes sure the event loop is always configured correctly, even when async workflows are called directly after re-initialization.