### PR TITLE
Use to_thread for sync transaction functions

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -31,7 +31,7 @@ async def test_async_workflow(dbos: DBOS) -> None:
     async def test_workflow(var1: str, var2: str) -> str:
         nonlocal wf_counter
         wf_counter += 1
-        res1 = test_transaction(var1)
+        res1 = await asyncio.to_thread(test_transaction, var1)
         res2 = await test_step(var2)
         DBOS.logger.info("I'm test_workflow")
         return res1 + res2
@@ -88,7 +88,7 @@ async def test_async_step(dbos: DBOS) -> None:
     async def test_workflow(var1: str, var2: str) -> str:
         nonlocal wf_counter
         wf_counter += 1
-        res1 = test_transaction(var1)
+        res1 = await asyncio.to_thread(test_transaction, var1)
         res2 = await test_step(var2)
         DBOS.logger.info("I'm test_workflow")
         return res1 + res2
@@ -325,6 +325,7 @@ def test_async_tx_raises(config: ConfigFile) -> None:
         async def test_async_tx() -> None:
             pass
 
+    assert "is a coroutine function" in str(exc_info.value)
     # destroy call needed to avoid "functions were registered but DBOS() was not called" warning
     DBOS.destroy(destroy_registry=True)
 

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -148,7 +148,7 @@ async def test_fork_workflow_async(dbos: DBOS) -> None:
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        assert simple_workflow(input_val) == output
+        assert await asyncio.to_thread(simple_workflow, input_val) == output
 
     assert step_one_count == 1
     assert step_two_count == 1

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code="no-redef"
 
+import asyncio
 import datetime
 import logging
 import os
@@ -1668,17 +1669,17 @@ async def test_step_without_dbos(dbos: DBOS, config: DBOSConfig) -> None:
         assert DBOS.workflow_id is None
         return x
 
-    assert step(5) == 5
+    assert await asyncio.to_thread(step, 5) == 5
     assert await async_step(5) == 5
 
     DBOS(config=config)
 
-    assert step(5) == 5
+    assert await asyncio.to_thread(step, 5) == 5
     assert await async_step(5) == 5
 
     DBOS.launch()
 
-    assert step(5) == 5
+    assert await asyncio.to_thread(step, 5) == 5
     assert await async_step(5) == 5
 
     assert len(DBOS.list_workflows()) == 0

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -828,18 +828,18 @@ async def test_callchild_first_asyncio(dbos: DBOS) -> None:
     async def parentWorkflow() -> str:
         handle = await dbos.start_workflow_async(child_workflow)
         child_id = await handle.get_result()
-        stepOne()
-        stepTwo()
+        await stepOne()
+        await stepTwo()
         return child_id
 
     @DBOS.step()
-    def stepOne() -> str:
+    async def stepOne() -> str:
         workflow_id = DBOS.workflow_id
         assert workflow_id is not None
         return workflow_id
 
     @DBOS.step()
-    def stepTwo() -> None:
+    async def stepTwo() -> None:
         return
 
     @DBOS.workflow()


### PR DESCRIPTION
Otherwise, the sync transaction functions will block the entire event loop.