### PR TITLE
Debouncing

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Run Unit Tests
       run: pdm run pytest tests
       working-directory: ./
+      timeout-minutes: 30
       env:
         PGPASSWORD: a!b@c$d()e*_,/:;=?@ff[]22
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -33,4 +33,5 @@ __all__ = [
     "WorkflowStatusString",
     "error",
     "Queue",
+    "Debouncer",
 ]

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -9,6 +9,7 @@ from ._context import (
 )
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowHandleAsync
 from ._dbos_config import DBOSConfig
+from ._debouncer import Debouncer
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString

--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -9,7 +9,7 @@ from ._context import (
 )
 from ._dbos import DBOS, DBOSConfiguredInstance, WorkflowHandle, WorkflowHandleAsync
 from ._dbos_config import DBOSConfig
-from ._debouncer import Debouncer
+from ._debouncer import Debouncer, DebouncerClient
 from ._kafka_message import KafkaMessage
 from ._queue import Queue
 from ._sys_db import GetWorkflowsInput, WorkflowStatus, WorkflowStatusString
@@ -34,4 +34,5 @@ __all__ = [
     "error",
     "Queue",
     "Debouncer",
+    "DebouncerClient",
 ]

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -3,6 +3,7 @@ import sys
 import time
 import uuid
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Generator,
@@ -24,7 +25,10 @@ else:
     from typing import NotRequired
 
 from dbos import _serialization
-from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
+
+if TYPE_CHECKING:
+    from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
+
 from dbos._dbos_config import (
     get_application_database_url,
     get_system_database_url,
@@ -224,23 +228,25 @@ class DBOSClient:
 
     def enqueue(
         self, options: EnqueueOptions, *args: Any, **kwargs: Any
-    ) -> WorkflowHandle[R]:
+    ) -> "WorkflowHandle[R]":
         workflow_id = self._enqueue(options, *args, **kwargs)
         return WorkflowHandleClientPolling[R](workflow_id, self._sys_db)
 
     async def enqueue_async(
         self, options: EnqueueOptions, *args: Any, **kwargs: Any
-    ) -> WorkflowHandleAsync[R]:
+    ) -> "WorkflowHandleAsync[R]":
         workflow_id = await asyncio.to_thread(self._enqueue, options, *args, **kwargs)
         return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)
 
-    def retrieve_workflow(self, workflow_id: str) -> WorkflowHandle[R]:
+    def retrieve_workflow(self, workflow_id: str) -> "WorkflowHandle[R]":
         status = get_workflow(self._sys_db, workflow_id)
         if status is None:
             raise DBOSNonExistentWorkflowError(workflow_id)
         return WorkflowHandleClientPolling[R](workflow_id, self._sys_db)
 
-    async def retrieve_workflow_async(self, workflow_id: str) -> WorkflowHandleAsync[R]:
+    async def retrieve_workflow_async(
+        self, workflow_id: str
+    ) -> "WorkflowHandleAsync[R]":
         status = await asyncio.to_thread(get_workflow, self._sys_db, workflow_id)
         if status is None:
             raise DBOSNonExistentWorkflowError(workflow_id)
@@ -311,11 +317,13 @@ class DBOSClient:
     async def cancel_workflow_async(self, workflow_id: str) -> None:
         await asyncio.to_thread(self.cancel_workflow, workflow_id)
 
-    def resume_workflow(self, workflow_id: str) -> WorkflowHandle[Any]:
+    def resume_workflow(self, workflow_id: str) -> "WorkflowHandle[Any]":
         self._sys_db.resume_workflow(workflow_id)
         return WorkflowHandleClientPolling[Any](workflow_id, self._sys_db)
 
-    async def resume_workflow_async(self, workflow_id: str) -> WorkflowHandleAsync[Any]:
+    async def resume_workflow_async(
+        self, workflow_id: str
+    ) -> "WorkflowHandleAsync[Any]":
         await asyncio.to_thread(self.resume_workflow, workflow_id)
         return WorkflowHandleClientAsyncPolling[Any](workflow_id, self._sys_db)
 
@@ -451,7 +459,7 @@ class DBOSClient:
         start_step: int,
         *,
         application_version: Optional[str] = None,
-    ) -> WorkflowHandle[Any]:
+    ) -> "WorkflowHandle[Any]":
         forked_workflow_id = fork_workflow(
             self._sys_db,
             self._app_db,
@@ -467,7 +475,7 @@ class DBOSClient:
         start_step: int,
         *,
         application_version: Optional[str] = None,
-    ) -> WorkflowHandleAsync[Any]:
+    ) -> "WorkflowHandleAsync[Any]":
         forked_workflow_id = await asyncio.to_thread(
             fork_workflow,
             self._sys_db,

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -95,7 +95,7 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 F = TypeVar("F", bound=Callable[..., Any])
 
 TEMP_SEND_WF_NAME = "<temp>.temp_send_workflow"
-DEBOUNCER_WORKFLOW_NAME = "dbos_debouncer_workflow"
+DEBOUNCER_WORKFLOW_NAME = "_dbos_debouncer_workflow"
 
 
 def check_is_in_coroutine() -> bool:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -50,6 +50,7 @@ from ._error import (
     DBOSException,
     DBOSMaxStepRetriesExceeded,
     DBOSNonExistentWorkflowError,
+    DBOSQueueDeduplicatedError,
     DBOSRecoveryError,
     DBOSUnexpectedStepError,
     DBOSWorkflowCancelledError,
@@ -311,10 +312,22 @@ def _init_workflow(
     }
 
     # Synchronously record the status and inputs for workflows
-    wf_status, workflow_deadline_epoch_ms = dbos._sys_db.init_workflow(
-        status,
-        max_recovery_attempts=max_recovery_attempts,
-    )
+    try:
+        wf_status, workflow_deadline_epoch_ms = dbos._sys_db.init_workflow(
+            status,
+            max_recovery_attempts=max_recovery_attempts,
+        )
+    except DBOSQueueDeduplicatedError as e:
+        if ctx.has_parent():
+            result: OperationResultInternal = {
+                "workflow_uuid": ctx.parent_workflow_id,
+                "function_id": ctx.parent_workflow_fid,
+                "function_name": wf_name,
+                "output": None,
+                "error": _serialization.serialize_exception(e),
+            }
+            dbos._sys_db.record_operation_result(result)
+        raise
 
     if workflow_deadline_epoch_ms is not None:
         evt = threading.Event()

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -95,6 +95,7 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 F = TypeVar("F", bound=Callable[..., Any])
 
 TEMP_SEND_WF_NAME = "<temp>.temp_send_workflow"
+DEBOUNCER_WORKFLOW_NAME = "dbos_debouncer_workflow"
 
 
 def check_is_in_coroutine() -> bool:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -391,11 +391,7 @@ class DBOS:
         ) -> None:
             self.send(destination_id, message, topic)
 
-        temp_send_wf = workflow_wrapper(self._registry, send_temp_workflow)
-        set_dbos_func_name(send_temp_workflow, TEMP_SEND_WF_NAME)
-        set_dbos_func_name(temp_send_wf, TEMP_SEND_WF_NAME)
-        set_temp_workflow_type(send_temp_workflow, "send")
-        self._registry.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf, "send")
+        decorate_workflow(self._registry, TEMP_SEND_WF_NAME, None)(send_temp_workflow)
 
         # Register the debouncer workflow
         from dbos._debouncer import debouncer_workflow

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -32,12 +32,14 @@ from opentelemetry.trace import Span
 from rich import print
 
 from dbos._conductor.conductor import ConductorWebsocket
+from dbos._debouncer import debouncer_workflow
 from dbos._sys_db import SystemDatabase, WorkflowStatus
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import fork_workflow, list_queued_workflows, list_workflows
 
 from ._classproperty import classproperty
 from ._core import (
+    DEBOUNCER_WORKFLOW_NAME,
     TEMP_SEND_WF_NAME,
     WorkflowHandleAsyncPolling,
     WorkflowHandlePolling,
@@ -395,6 +397,11 @@ class DBOS:
         set_dbos_func_name(temp_send_wf, TEMP_SEND_WF_NAME)
         set_temp_workflow_type(send_temp_workflow, "send")
         self._registry.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf, "send")
+
+        # Register the debouncer workflow
+        decorate_workflow(self._registry, DEBOUNCER_WORKFLOW_NAME, None)(
+            debouncer_workflow
+        )
 
         for handler in dbos_logger.handlers:
             handler.flush()

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -32,6 +32,7 @@ from opentelemetry.trace import Span
 from rich import print
 
 from dbos._conductor.conductor import ConductorWebsocket
+from dbos._debouncer import debouncer_workflow
 from dbos._sys_db import SystemDatabase, WorkflowStatus
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import fork_workflow, list_queued_workflows, list_workflows
@@ -394,8 +395,6 @@ class DBOS:
         decorate_workflow(self._registry, TEMP_SEND_WF_NAME, None)(send_temp_workflow)
 
         # Register the debouncer workflow
-        from dbos._debouncer import debouncer_workflow
-
         decorate_workflow(self._registry, DEBOUNCER_WORKFLOW_NAME, None)(
             debouncer_workflow
         )

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -32,7 +32,6 @@ from opentelemetry.trace import Span
 from rich import print
 
 from dbos._conductor.conductor import ConductorWebsocket
-from dbos._debouncer import debouncer_workflow
 from dbos._sys_db import SystemDatabase, WorkflowStatus
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import fork_workflow, list_queued_workflows, list_workflows
@@ -399,6 +398,8 @@ class DBOS:
         self._registry.register_wf_function(TEMP_SEND_WF_NAME, temp_send_wf, "send")
 
         # Register the debouncer workflow
+        from dbos._debouncer import debouncer_workflow
+
         decorate_workflow(self._registry, DEBOUNCER_WORKFLOW_NAME, None)(
             debouncer_workflow
         )

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -1,20 +1,29 @@
-from typing import Callable
+import sys
+from typing import Callable, TypeVar
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
 from dbos._context import SetWorkflowID
-from dbos._dbos import DBOS, P, R
 from dbos._serialization import WorkflowInputs
+
+P = ParamSpec("P")  # A generic type for workflow parameters
+R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
 _DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
 
 
-@DBOS.workflow()
-def _debouncer_workflow(
+def debouncer_workflow(
     func: Callable[P, R],
     workflow_id: str,
     timeout: float,
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> None:
+    from dbos._dbos import DBOS
+
     workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
     message = None
     while True:

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -41,12 +41,14 @@ class ContextOptions(TypedDict):
     workflow_timeout_sec: Optional[float]
 
 
-class DebounceOptions(TypedDict):
+# Parameters for the debouncer workflow
+class DebouncerOptions(TypedDict):
     debounce_period_sec: float
     debounce_timeout_sec: Optional[float]
     queue_name: Optional[str]
 
 
+# The message sent from a debounce to the debouncer workflow
 class DebouncerMessage(TypedDict):
     inputs: WorkflowInputs
     message_id: str
@@ -55,7 +57,7 @@ class DebouncerMessage(TypedDict):
 def debouncer_workflow(
     func: Callable[..., Any],
     ctx: ContextOptions,
-    options: DebounceOptions,
+    options: DebouncerOptions,
     *args: Tuple[Any, ...],
     **kwargs: Dict[str, Any],
 ) -> None:
@@ -114,7 +116,7 @@ class Debouncer:
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Queue] = None,
     ):
-        self.options: DebounceOptions = {
+        self.options: DebouncerOptions = {
             "debounce_period_sec": debounce_period_sec,
             "debounce_timeout_sec": debounce_timeout_sec,
             "queue_name": queue.name if queue else None,

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -84,6 +84,8 @@ def debouncer_workflow(
             workflow_inputs = message["inputs"]
             # Acknowledge receipt of the message
             DBOS.set_event(message["message_id"], message["message_id"])
+    # After the timeout or period has elapsed, start the user workflow with the requested context parameters,
+    # either directly or on a queue.
     with SetWorkflowID(ctx["workflow_id"]):
         with SetWorkflowTimeout(ctx["workflow_timeout_sec"]):
             if options["queue_name"]:

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -125,15 +125,16 @@ class Debouncer:
             try:
                 # Attempt to enqueue a debouncer for this workflow.
                 with SetEnqueueOptions(deduplication_id=self.debounce_key):
-                    internal_queue.enqueue(
-                        debouncer_workflow,
-                        func,
-                        ctxOptions,
-                        self.debounce_period_sec,
-                        self.queue_name,
-                        *args,
-                        **kwargs,
-                    )
+                    with SetWorkflowTimeout(None):
+                        internal_queue.enqueue(
+                            debouncer_workflow,
+                            func,
+                            ctxOptions,
+                            self.debounce_period_sec,
+                            self.queue_name,
+                            *args,
+                            **kwargs,
+                        )
                 return WorkflowHandlePolling(user_workflow_id, dbos)
             except DBOSQueueDeduplicatedError:
                 # If there is already a debouncer, send a message to it.

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -119,7 +119,7 @@ def debouncer_workflow(
             func = dbos._registry.workflow_info_map.get(options["workflow_name"], None)
             if not func:
                 raise Exception(
-                    f"Invalid workflow name provided to debouncer: {options["workflow_name"]}"
+                    f"Invalid workflow name provided to debouncer: {options['workflow_name']}"
                 )
             if options["queue_name"]:
                 queue = dbos._registry.queue_info_map.get(options["queue_name"], None)

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -1,36 +1,57 @@
-import sys
-from typing import Callable, TypeVar
+import uuid
+from typing import Any, Callable, Dict, Tuple
 
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec
-
-from dbos._context import SetWorkflowID
+from dbos._context import SetEnqueueOptions, SetWorkflowID
+from dbos._core import WorkflowHandlePolling
+from dbos._dbos import DBOS, P, R, WorkflowHandle, _get_dbos_instance
+from dbos._error import DBOSQueueDeduplicatedError
 from dbos._serialization import WorkflowInputs
-
-P = ParamSpec("P")  # A generic type for workflow parameters
-R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
 _DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
 
 
 def debouncer_workflow(
-    func: Callable[P, R],
+    func: Callable[..., Any],
     workflow_id: str,
-    timeout: float,
-    *args: P.args,
-    **kwargs: P.kwargs,
+    debounce_period_sec: float,
+    *args: Tuple[Any, ...],
+    **kwargs: Dict[str, Any],
 ) -> None:
-    from dbos._dbos import DBOS
 
     workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
     message = None
     while True:
-        message = DBOS.recv(_DEBOUNCER_TOPIC, timeout_seconds=timeout)
+        message = DBOS.recv(_DEBOUNCER_TOPIC, timeout_seconds=debounce_period_sec)
         if message is None:
             break
         else:
             workflow_inputs = message
     with SetWorkflowID(workflow_id):
         DBOS.start_workflow(func, *workflow_inputs["args"], **workflow_inputs["kwargs"])
+
+
+class Debouncer:
+
+    def __init__(self, debounce_key: str, debounce_period_sec: float):
+        self.debounce_key = debounce_key
+        self.debounce_period_sec = debounce_period_sec
+
+    def debounce(
+        self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs
+    ) -> WorkflowHandle[R]:
+        workflow_id = str(uuid.uuid4())
+        dbos = _get_dbos_instance()
+        internal_queue = dbos._registry.get_internal_queue()
+        try:
+            with SetEnqueueOptions(deduplication_id=self.debounce_key):
+                internal_queue.enqueue(
+                    debouncer_workflow,
+                    func,
+                    workflow_id,
+                    self.debounce_period_sec,
+                    *args,
+                    **kwargs,
+                )
+        except DBOSQueueDeduplicatedError as e:
+            print("OOPS")
+        return WorkflowHandlePolling(workflow_id, dbos)

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -203,8 +203,9 @@ class Debouncer(Generic[P, R]):
         dbos = _get_dbos_instance()
         internal_queue = dbos._registry.get_internal_queue()
 
-        # If a workflow ID is requested with SetWorkflowID,
-        # use that ID for the user workflow and not the debouncer.
+        # Read all workflow settings from context, pass them through ContextOptions
+        # into the debouncer to apply to the user workflow, then reset the context
+        # so workflow settings aren't applied to the debouncer.
         with DBOSContextEnsure():
             ctx = assert_current_dbos_context()
 

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -56,6 +56,8 @@ class Debouncer:
         dbos = _get_dbos_instance()
         internal_queue = dbos._registry.get_internal_queue()
 
+        # If a workflow ID is requested with SetWorkflowID,
+        # use that ID for the user workflow and not the debouncer.
         with DBOSContextEnsure():
             ctx = assert_current_dbos_context()
             user_workflow_id = ctx.assign_workflow_id()

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -1,0 +1,27 @@
+from typing import Callable
+
+from dbos._context import SetWorkflowID
+from dbos._dbos import DBOS, P, R
+from dbos._serialization import WorkflowInputs
+
+_DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
+
+
+@DBOS.workflow()
+def _debouncer_workflow(
+    func: Callable[P, R],
+    workflow_id: str,
+    timeout: float,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> None:
+    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
+    message = None
+    while True:
+        message = DBOS.recv(_DEBOUNCER_TOPIC, timeout_seconds=timeout)
+        if message is None:
+            break
+        else:
+            workflow_inputs = message
+    with SetWorkflowID(workflow_id):
+        DBOS.start_workflow(func, *workflow_inputs["args"], **workflow_inputs["kwargs"])

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -37,7 +37,7 @@ def debouncer_workflow(
 
 class Debouncer:
 
-    def __init__(self, debounce_key: str, debounce_period_sec: float):
+    def __init__(self, *, debounce_key: str, debounce_period_sec: float):
         self.debounce_key = debounce_key
         self.debounce_period_sec = debounce_period_sec
 

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -13,7 +13,12 @@ class WorkflowInputs(TypedDict):
 
 def _validate_item(data: Any) -> None:
     if isinstance(data, (types.MethodType)):
-        raise TypeError("Serialized data item should not be a function")
+        raise TypeError("Serialized data item should not be a class method")
+    if isinstance(data, (types.FunctionType)):
+        if jsonpickle.decode(jsonpickle.encode(data, unpicklable=True)) is None:
+            raise TypeError(
+                "Serialized function should be defined at the top level of a module"
+            )
 
 
 def serialize(data: Any) -> str:

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -12,7 +12,7 @@ class WorkflowInputs(TypedDict):
 
 
 def _validate_item(data: Any) -> None:
-    if isinstance(data, (types.FunctionType, types.MethodType)):
+    if isinstance(data, (types.MethodType)):
         raise TypeError("Serialized data item should not be a function")
 
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1248,7 +1248,10 @@ class SystemDatabase(ABC):
     def check_child_workflow(
         self, workflow_uuid: str, function_id: int
     ) -> Optional[str]:
-        sql = sa.select(SystemSchema.operation_outputs.c.child_workflow_id).where(
+        sql = sa.select(
+            SystemSchema.operation_outputs.c.child_workflow_id,
+            SystemSchema.operation_outputs.c.error,
+        ).where(
             SystemSchema.operation_outputs.c.workflow_uuid == workflow_uuid,
             SystemSchema.operation_outputs.c.function_id == function_id,
         )
@@ -1260,7 +1263,10 @@ class SystemDatabase(ABC):
 
         if row is None:
             return None
-        return str(row[0])
+        elif row[1]:
+            raise _serialization.deserialize_exception(row[1])
+        else:
+            return str(row[0])
 
     @db_retry()
     def send(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1087,33 +1087,49 @@ def test_nonserializable_values(dbos: DBOS) -> None:
 
     with pytest.raises(Exception) as exc_info:
         test_ns_transaction("h")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
     with pytest.raises(Exception) as exc_info:
         test_ns_wf("g")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
 
     wfh = DBOS.start_workflow(test_reg_wf, "a")
     with pytest.raises(Exception) as exc_info:
         DBOS.send(wfh.workflow_id, invalid_return, "sss")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
     wfh.get_result()
 
     with pytest.raises(Exception) as exc_info:
         test_ns_event("e")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
 
     with pytest.raises(Exception) as exc_info:
         test_bad_wf1("a")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
     with pytest.raises(Exception) as exc_info:
         test_bad_wf2("b")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
     with pytest.raises(Exception) as exc_info:
         test_bad_wf3("c")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
     with pytest.raises(Exception) as exc_info:
         test_bad_wf4("d")
-    assert "data item should not be a function" in str(exc_info.value)
+    assert "Serialized function should be defined at the top level of a module" in str(
+        exc_info.value
+    )
 
 
 def test_multi_set_event(dbos: DBOS) -> None:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,0 +1,18 @@
+import uuid
+
+from dbos import DBOS, WorkflowHandle
+
+
+def test_debouncer(dbos: DBOS) -> None:
+    from dbos._debouncer import _debouncer_workflow
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    assert workflow(5) == 5
+
+    wfid = str(uuid.uuid4())
+    _debouncer_workflow(workflow, wfid, 0, 5)
+    handle: WorkflowHandle[int] = DBOS.retrieve_workflow(wfid, existing_workflow=False)
+    assert handle.get_result() == 5

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,19 +1,32 @@
 import uuid
 
-from dbos import DBOS, WorkflowHandle
+from dbos import DBOS, Debouncer, WorkflowHandle
 from dbos._core import DEBOUNCER_WORKFLOW_NAME
+
+
+def workflow(x: int) -> int:
+    return x
+
+
+def test_debouncer_workflow(dbos: DBOS) -> None:
+
+    DBOS.workflow()(workflow)
+    value = 5
+
+    wfid = str(uuid.uuid4())
+    debouncer_workflow = dbos._registry.workflow_info_map[DEBOUNCER_WORKFLOW_NAME]
+    debouncer_workflow(workflow, wfid, 0, value)
+    handle: WorkflowHandle[int] = DBOS.retrieve_workflow(wfid, existing_workflow=False)
+    assert handle.get_result() == value
 
 
 def test_debouncer(dbos: DBOS) -> None:
 
-    @DBOS.workflow()
-    def workflow(x: int) -> int:
-        return x
+    DBOS.workflow()(workflow)
+    value = 5
 
-    assert workflow(5) == 5
-
-    wfid = str(uuid.uuid4())
-    debouncer_workflow = dbos._registry.workflow_info_map[DEBOUNCER_WORKFLOW_NAME]
-    debouncer_workflow(workflow, wfid, 0, 5)
-    handle: WorkflowHandle[int] = DBOS.retrieve_workflow(wfid, existing_workflow=False)
-    assert handle.get_result() == 5
+    debouncer = Debouncer("key", 0)
+    handle = debouncer.debounce(workflow, value)
+    assert handle.get_result() == value
+    handle = debouncer.debounce(workflow, value)
+    assert handle.get_result() == value

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -49,6 +49,7 @@ def test_debouncer_timeout(dbos: DBOS) -> None:
     DBOS.workflow()(workflow)
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
+    # Set a huge period but small timeout, verify workflows start after the timeout
     debouncer = Debouncer(
         debounce_key="key", debounce_period_sec=10000000, debounce_timeout_sec=2
     )
@@ -82,6 +83,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert second_handle.get_result() == second_value
     assert second_handle.get_status().queue_name == queue.name
 
+    # Test SetWorkflowTimeout works
     with SetWorkflowTimeout(1.0):
         third_handle = debouncer.debounce(workflow, third_value)
         fourth_handle = debouncer.debounce(workflow, fourth_value)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -21,7 +21,7 @@ def test_debouncer(dbos: DBOS) -> None:
     DBOS.workflow()(workflow)
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
-    def debouncer_test():
+    def debouncer_test() -> None:
         debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
 
         first_handle = debouncer.debounce(workflow, first_value)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -21,6 +21,10 @@ def test_debouncer(dbos: DBOS) -> None:
     DBOS.workflow()(workflow)
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
+    @DBOS.step()
+    def generate_uuid() -> str:
+        return str(uuid.uuid4())
+
     def debouncer_test() -> None:
         debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
 
@@ -38,7 +42,7 @@ def test_debouncer(dbos: DBOS) -> None:
         assert fourth_handle.get_result() == fourth_value
 
         # Test SetWorkflowID works
-        wfid = str(uuid.uuid4())
+        wfid = generate_uuid()
         with SetWorkflowID(wfid):
             handle = debouncer.debounce(workflow, first_value)
         assert handle.workflow_id == wfid
@@ -54,9 +58,9 @@ def test_debouncer(dbos: DBOS) -> None:
         debouncer_test_workflow()
 
     # Rerun the workflow, verify it still works
-    # dbos._sys_db.update_workflow_outcome(wfid, "PENDING")
-    # with SetWorkflowID(wfid):
-    #     debouncer_test_workflow()
+    dbos._sys_db.update_workflow_outcome(wfid, "PENDING")
+    with SetWorkflowID(wfid):
+        debouncer_test_workflow()
 
 
 def test_debouncer_timeout(dbos: DBOS) -> None:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -132,7 +132,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert second_handle.get_status().queue_name == queue.name
 
     # Test SetWorkflowTimeout works
-    with SetWorkflowTimeout(1.0):
+    with SetWorkflowTimeout(5.0):
         third_handle = debouncer.debounce(debounce_period_sec, third_value)
         fourth_handle = debouncer.debounce(debounce_period_sec, fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
@@ -140,7 +140,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert third_handle.get_result() == fourth_value
     assert fourth_handle.get_result() == fourth_value
     assert fourth_handle.get_status().queue_name == queue.name
-    assert fourth_handle.get_status().workflow_timeout_ms == 1000.0
+    assert fourth_handle.get_status().workflow_timeout_ms == 5000.0
     assert fourth_handle.get_status().workflow_deadline_epoch_ms
 
     # Test SetWorkflowID works

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,10 +1,10 @@
 import uuid
 
 from dbos import DBOS, WorkflowHandle
+from dbos._core import DEBOUNCER_WORKFLOW_NAME
 
 
 def test_debouncer(dbos: DBOS) -> None:
-    from dbos._debouncer import _debouncer_workflow
 
     @DBOS.workflow()
     def workflow(x: int) -> int:
@@ -13,6 +13,7 @@ def test_debouncer(dbos: DBOS) -> None:
     assert workflow(5) == 5
 
     wfid = str(uuid.uuid4())
-    _debouncer_workflow(workflow, wfid, 0, 5)
+    debouncer_workflow = dbos._registry.workflow_info_map[DEBOUNCER_WORKFLOW_NAME]
+    debouncer_workflow(workflow, wfid, 0, 5)
     handle: WorkflowHandle[int] = DBOS.retrieve_workflow(wfid, existing_workflow=False)
     assert handle.get_result() == 5

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -180,20 +180,22 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
     queue = Queue("test-queue")
 
-    debouncer = DebouncerClient(client, debounce_key="key", debounce_period_sec=2)
-
     options: EnqueueOptions = {
         "workflow_name": workflow.__name__,
         "queue_name": queue.name,
     }
-    first_handle: WorkflowHandle[int] = debouncer.debounce(options, first_value)
-    second_handle: WorkflowHandle[int] = debouncer.debounce(options, second_value)
+    debouncer = DebouncerClient(
+        client, options, debounce_key="key", debounce_period_sec=2
+    )
+
+    first_handle: WorkflowHandle[int] = debouncer.debounce(first_value)
+    second_handle: WorkflowHandle[int] = debouncer.debounce(second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
 
-    third_handle: WorkflowHandle[int] = debouncer.debounce(options, third_value)
-    fourth_handle: WorkflowHandle[int] = debouncer.debounce(options, fourth_value)
+    third_handle: WorkflowHandle[int] = debouncer.debounce(third_value)
+    fourth_handle: WorkflowHandle[int] = debouncer.debounce(fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
@@ -201,7 +203,7 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
 
     wfid = str(uuid.uuid4())
     options["workflow_id"] = wfid
-    handle: WorkflowHandle[int] = debouncer.debounce(options, first_value)
+    handle: WorkflowHandle[int] = debouncer.debounce(first_value)
     assert handle.workflow_id == wfid
     assert handle.get_result() == first_value
 
@@ -213,27 +215,25 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
     queue = Queue("test-queue")
 
-    debouncer = DebouncerClient(client, debounce_key="key", debounce_period_sec=2)
-
     options: EnqueueOptions = {
         "workflow_name": workflow_async.__name__,
         "queue_name": queue.name,
     }
-    first_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        options, first_value
+    debouncer = DebouncerClient(
+        client, options, debounce_key="key", debounce_period_sec=2
     )
+
+    first_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(first_value)
     second_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        options, second_value
+        second_value
     )
     assert first_handle.workflow_id == second_handle.workflow_id
     assert await first_handle.get_result() == second_value
     assert await second_handle.get_result() == second_value
 
-    third_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        options, third_value
-    )
+    third_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(third_value)
     fourth_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        options, fourth_value
+        fourth_value
     )
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
@@ -242,8 +242,6 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
 
     wfid = str(uuid.uuid4())
     options["workflow_id"] = wfid
-    handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        options, first_value
-    )
+    handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(first_value)
     assert handle.workflow_id == wfid
     assert await handle.get_result() == first_value

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,6 +1,8 @@
+import uuid
+
 import pytest
 
-from dbos import DBOS, Debouncer
+from dbos import DBOS, Debouncer, SetWorkflowID
 
 
 def workflow(x: int) -> int:
@@ -30,6 +32,13 @@ def test_debouncer(dbos: DBOS) -> None:
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
     assert fourth_handle.get_result() == fourth_value
+
+    # Test SetWorkflowID works
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = debouncer.debounce(workflow, first_value)
+    assert handle.workflow_id == wfid
+    assert handle.get_result() == first_value
 
 
 @pytest.mark.asyncio

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -44,6 +44,29 @@ def test_debouncer(dbos: DBOS) -> None:
     assert handle.get_result() == first_value
 
 
+def test_debouncer_timeout(dbos: DBOS) -> None:
+
+    DBOS.workflow()(workflow)
+    first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
+
+    debouncer = Debouncer(
+        debounce_key="key", debounce_period_sec=10000000, debounce_timeout_sec=2
+    )
+
+    first_handle = debouncer.debounce(workflow, first_value)
+    second_handle = debouncer.debounce(workflow, second_value)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.get_result() == second_value
+    assert second_handle.get_result() == second_value
+
+    third_handle = debouncer.debounce(workflow, third_value)
+    fourth_handle = debouncer.debounce(workflow, fourth_value)
+    assert third_handle.workflow_id != first_handle.workflow_id
+    assert third_handle.workflow_id == fourth_handle.workflow_id
+    assert third_handle.get_result() == fourth_value
+    assert fourth_handle.get_result() == fourth_value
+
+
 def test_debouncer_queue(dbos: DBOS) -> None:
 
     DBOS.workflow()(workflow)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -35,16 +35,18 @@ def test_debouncer(dbos: DBOS) -> None:
         return str(uuid.uuid4())
 
     def debouncer_test() -> None:
-        debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
+        debouncer = Debouncer.create(
+            workflow, debounce_key="key", debounce_period_sec=2
+        )
 
-        first_handle = debouncer.debounce(workflow, first_value)
-        second_handle = debouncer.debounce(workflow, second_value)
+        first_handle = debouncer.debounce(first_value)
+        second_handle = debouncer.debounce(second_value)
         assert first_handle.workflow_id == second_handle.workflow_id
         assert first_handle.get_result() == second_value
         assert second_handle.get_result() == second_value
 
-        third_handle = debouncer.debounce(workflow, third_value)
-        fourth_handle = debouncer.debounce(workflow, fourth_value)
+        third_handle = debouncer.debounce(third_value)
+        fourth_handle = debouncer.debounce(fourth_value)
         assert third_handle.workflow_id != first_handle.workflow_id
         assert third_handle.workflow_id == fourth_handle.workflow_id
         assert third_handle.get_result() == fourth_value
@@ -53,7 +55,7 @@ def test_debouncer(dbos: DBOS) -> None:
         # Test SetWorkflowID works
         wfid = generate_uuid()
         with SetWorkflowID(wfid):
-            handle = debouncer.debounce(workflow, first_value)
+            handle = debouncer.debounce(first_value)
         assert handle.workflow_id == wfid
         assert handle.get_result() == first_value
 
@@ -78,18 +80,21 @@ def test_debouncer_timeout(dbos: DBOS) -> None:
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
     # Set a huge period but small timeout, verify workflows start after the timeout
-    debouncer = Debouncer(
-        debounce_key="key", debounce_period_sec=10000000, debounce_timeout_sec=2
+    debouncer = Debouncer.create(
+        workflow,
+        debounce_key="key",
+        debounce_period_sec=10000000,
+        debounce_timeout_sec=2,
     )
 
-    first_handle = debouncer.debounce(workflow, first_value)
-    second_handle = debouncer.debounce(workflow, second_value)
+    first_handle = debouncer.debounce(first_value)
+    second_handle = debouncer.debounce(second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
 
-    third_handle = debouncer.debounce(workflow, third_value)
-    fourth_handle = debouncer.debounce(workflow, fourth_value)
+    third_handle = debouncer.debounce(third_value)
+    fourth_handle = debouncer.debounce(fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
@@ -102,10 +107,12 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
     queue = Queue("test-queue")
 
-    debouncer = Debouncer(debounce_key="key", debounce_period_sec=2, queue=queue)
+    debouncer = Debouncer.create(
+        workflow, debounce_key="key", debounce_period_sec=2, queue=queue
+    )
 
-    first_handle = debouncer.debounce(workflow, first_value)
-    second_handle = debouncer.debounce(workflow, second_value)
+    first_handle = debouncer.debounce(first_value)
+    second_handle = debouncer.debounce(second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
@@ -113,8 +120,8 @@ def test_debouncer_queue(dbos: DBOS) -> None:
 
     # Test SetWorkflowTimeout works
     with SetWorkflowTimeout(1.0):
-        third_handle = debouncer.debounce(workflow, third_value)
-        fourth_handle = debouncer.debounce(workflow, fourth_value)
+        third_handle = debouncer.debounce(third_value)
+        fourth_handle = debouncer.debounce(fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
@@ -126,7 +133,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     # Test SetWorkflowID works
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = debouncer.debounce(workflow, first_value)
+        handle = debouncer.debounce(first_value)
     assert handle.workflow_id == wfid
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
@@ -137,7 +144,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     with SetEnqueueOptions(
         priority=1, deduplication_id="test", app_version=test_version
     ):
-        handle = debouncer.debounce(workflow, first_value)
+        handle = debouncer.debounce(first_value)
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
     assert handle.get_status().app_version == test_version
@@ -149,16 +156,18 @@ async def test_debouncer_async(dbos: DBOS) -> None:
     DBOS.workflow()(workflow_async)
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
-    debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
+    debouncer = Debouncer.create_async(
+        workflow_async, debounce_key="key", debounce_period_sec=2
+    )
 
-    first_handle = await debouncer.debounce_async(workflow_async, first_value)
-    second_handle = await debouncer.debounce_async(workflow_async, second_value)
+    first_handle = await debouncer.debounce_async(first_value)
+    second_handle = await debouncer.debounce_async(second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert await first_handle.get_result() == second_value
     assert await second_handle.get_result() == second_value
 
-    third_handle = await debouncer.debounce_async(workflow_async, third_value)
-    fourth_handle = await debouncer.debounce_async(workflow_async, fourth_value)
+    third_handle = await debouncer.debounce_async(third_value)
+    fourth_handle = await debouncer.debounce_async(fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert await third_handle.get_result() == fourth_value

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -14,27 +14,41 @@ async def workflow_async(x: int) -> int:
 def test_debouncer(dbos: DBOS) -> None:
 
     DBOS.workflow()(workflow)
-    first_value = 4
-    second_value = 5
+    first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
-    debouncer = Debouncer("key", 2)
+    debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
+
     first_handle = debouncer.debounce(workflow, first_value)
     second_handle = debouncer.debounce(workflow, second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
 
+    third_handle = debouncer.debounce(workflow, third_value)
+    fourth_handle = debouncer.debounce(workflow, fourth_value)
+    assert third_handle.workflow_id != first_handle.workflow_id
+    assert third_handle.workflow_id == fourth_handle.workflow_id
+    assert third_handle.get_result() == fourth_value
+    assert fourth_handle.get_result() == fourth_value
+
 
 @pytest.mark.asyncio
 async def test_debouncer_async(dbos: DBOS) -> None:
 
     DBOS.workflow()(workflow_async)
-    first_value = 4
-    second_value = 5
+    first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
-    debouncer = Debouncer("key", 2)
+    debouncer = Debouncer(debounce_key="key", debounce_period_sec=2)
+
     first_handle = await debouncer.debounce_async(workflow_async, first_value)
     second_handle = await debouncer.debounce_async(workflow_async, second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert await first_handle.get_result() == second_value
     assert await second_handle.get_result() == second_value
+
+    third_handle = await debouncer.debounce_async(workflow_async, third_value)
+    fourth_handle = await debouncer.debounce_async(workflow_async, fourth_value)
+    assert third_handle.workflow_id != first_handle.workflow_id
+    assert third_handle.workflow_id == fourth_handle.workflow_id
+    assert await third_handle.get_result() == fourth_value
+    assert await fourth_handle.get_result() == fourth_value

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -35,18 +35,18 @@ def test_debouncer(dbos: DBOS) -> None:
         return str(uuid.uuid4())
 
     def debouncer_test() -> None:
-        debouncer = Debouncer.create(
-            workflow, debounce_key="key", debounce_period_sec=2
-        )
+        debouncer = Debouncer.create(workflow, debounce_key="key")
 
-        first_handle = debouncer.debounce(first_value)
-        second_handle = debouncer.debounce(second_value)
+        debounce_period = 2
+
+        first_handle = debouncer.debounce(debounce_period, first_value)
+        second_handle = debouncer.debounce(debounce_period, second_value)
         assert first_handle.workflow_id == second_handle.workflow_id
         assert first_handle.get_result() == second_value
         assert second_handle.get_result() == second_value
 
-        third_handle = debouncer.debounce(third_value)
-        fourth_handle = debouncer.debounce(fourth_value)
+        third_handle = debouncer.debounce(debounce_period, third_value)
+        fourth_handle = debouncer.debounce(debounce_period, fourth_value)
         assert third_handle.workflow_id != first_handle.workflow_id
         assert third_handle.workflow_id == fourth_handle.workflow_id
         assert third_handle.get_result() == fourth_value
@@ -55,7 +55,7 @@ def test_debouncer(dbos: DBOS) -> None:
         # Test SetWorkflowID works
         wfid = generate_uuid()
         with SetWorkflowID(wfid):
-            handle = debouncer.debounce(first_value)
+            handle = debouncer.debounce(debounce_period, first_value)
         assert handle.workflow_id == wfid
         assert handle.get_result() == first_value
 
@@ -83,22 +83,36 @@ def test_debouncer_timeout(dbos: DBOS) -> None:
     debouncer = Debouncer.create(
         workflow,
         debounce_key="key",
-        debounce_period_sec=10000000,
         debounce_timeout_sec=2,
     )
+    long_debounce_period = 10000000
 
-    first_handle = debouncer.debounce(first_value)
-    second_handle = debouncer.debounce(second_value)
+    first_handle = debouncer.debounce(long_debounce_period, first_value)
+    second_handle = debouncer.debounce(long_debounce_period, second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
 
-    third_handle = debouncer.debounce(third_value)
-    fourth_handle = debouncer.debounce(fourth_value)
+    third_handle = debouncer.debounce(long_debounce_period, third_value)
+    fourth_handle = debouncer.debounce(long_debounce_period, fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
     assert fourth_handle.get_result() == fourth_value
+
+    # Submit first with a long period then with a short one, verify workflows start on time
+    debouncer = Debouncer.create(
+        workflow,
+        debounce_key="key",
+    )
+    short_debounce_period = 1
+
+    first_handle = debouncer.debounce(long_debounce_period, first_value)
+    second_handle = debouncer.debounce(short_debounce_period, second_value)
+    assert fourth_handle.workflow_id != first_handle.workflow_id
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.get_result() == second_value
+    assert second_handle.get_result() == second_value
 
 
 def test_debouncer_queue(dbos: DBOS) -> None:
@@ -107,12 +121,11 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
     queue = Queue("test-queue")
 
-    debouncer = Debouncer.create(
-        workflow, debounce_key="key", debounce_period_sec=2, queue=queue
-    )
+    debouncer = Debouncer.create(workflow, debounce_key="key", queue=queue)
+    debounce_period_sec = 2
 
-    first_handle = debouncer.debounce(first_value)
-    second_handle = debouncer.debounce(second_value)
+    first_handle = debouncer.debounce(debounce_period_sec, first_value)
+    second_handle = debouncer.debounce(debounce_period_sec, second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
@@ -120,8 +133,8 @@ def test_debouncer_queue(dbos: DBOS) -> None:
 
     # Test SetWorkflowTimeout works
     with SetWorkflowTimeout(1.0):
-        third_handle = debouncer.debounce(third_value)
-        fourth_handle = debouncer.debounce(fourth_value)
+        third_handle = debouncer.debounce(debounce_period_sec, third_value)
+        fourth_handle = debouncer.debounce(debounce_period_sec, fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
@@ -133,7 +146,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     # Test SetWorkflowID works
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = debouncer.debounce(first_value)
+        handle = debouncer.debounce(debounce_period_sec, first_value)
     assert handle.workflow_id == wfid
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
@@ -144,7 +157,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     with SetEnqueueOptions(
         priority=1, deduplication_id="test", app_version=test_version
     ):
-        handle = debouncer.debounce(first_value)
+        handle = debouncer.debounce(debounce_period_sec, first_value)
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
     assert handle.get_status().app_version == test_version
@@ -156,18 +169,17 @@ async def test_debouncer_async(dbos: DBOS) -> None:
     DBOS.workflow()(workflow_async)
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
 
-    debouncer = Debouncer.create_async(
-        workflow_async, debounce_key="key", debounce_period_sec=2
-    )
+    debouncer = Debouncer.create_async(workflow_async, debounce_key="key")
+    debounce_period_sec = 2
 
-    first_handle = await debouncer.debounce_async(first_value)
-    second_handle = await debouncer.debounce_async(second_value)
+    first_handle = await debouncer.debounce_async(debounce_period_sec, first_value)
+    second_handle = await debouncer.debounce_async(debounce_period_sec, second_value)
     assert first_handle.workflow_id == second_handle.workflow_id
     assert await first_handle.get_result() == second_value
     assert await second_handle.get_result() == second_value
 
-    third_handle = await debouncer.debounce_async(third_value)
-    fourth_handle = await debouncer.debounce_async(fourth_value)
+    third_handle = await debouncer.debounce_async(debounce_period_sec, third_value)
+    fourth_handle = await debouncer.debounce_async(debounce_period_sec, fourth_value)
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert await third_handle.get_result() == fourth_value
@@ -184,18 +196,25 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
         "workflow_name": workflow.__name__,
         "queue_name": queue.name,
     }
-    debouncer = DebouncerClient(
-        client, options, debounce_key="key", debounce_period_sec=2
-    )
+    debouncer = DebouncerClient(client, options, debounce_key="key")
+    debounce_period_sec = 2
 
-    first_handle: WorkflowHandle[int] = debouncer.debounce(first_value)
-    second_handle: WorkflowHandle[int] = debouncer.debounce(second_value)
+    first_handle: WorkflowHandle[int] = debouncer.debounce(
+        debounce_period_sec, first_value
+    )
+    second_handle: WorkflowHandle[int] = debouncer.debounce(
+        debounce_period_sec, second_value
+    )
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == second_value
     assert second_handle.get_result() == second_value
 
-    third_handle: WorkflowHandle[int] = debouncer.debounce(third_value)
-    fourth_handle: WorkflowHandle[int] = debouncer.debounce(fourth_value)
+    third_handle: WorkflowHandle[int] = debouncer.debounce(
+        debounce_period_sec, third_value
+    )
+    fourth_handle: WorkflowHandle[int] = debouncer.debounce(
+        debounce_period_sec, fourth_value
+    )
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
     assert third_handle.get_result() == fourth_value
@@ -203,7 +222,7 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
 
     wfid = str(uuid.uuid4())
     options["workflow_id"] = wfid
-    handle: WorkflowHandle[int] = debouncer.debounce(first_value)
+    handle: WorkflowHandle[int] = debouncer.debounce(debounce_period_sec, first_value)
     assert handle.workflow_id == wfid
     assert handle.get_result() == first_value
 
@@ -219,21 +238,24 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
         "workflow_name": workflow_async.__name__,
         "queue_name": queue.name,
     }
-    debouncer = DebouncerClient(
-        client, options, debounce_key="key", debounce_period_sec=2
-    )
+    debouncer = DebouncerClient(client, options, debounce_key="key")
+    debounce_period_sec = 2
 
-    first_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(first_value)
+    first_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
+        debounce_period_sec, first_value
+    )
     second_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        second_value
+        debounce_period_sec, second_value
     )
     assert first_handle.workflow_id == second_handle.workflow_id
     assert await first_handle.get_result() == second_value
     assert await second_handle.get_result() == second_value
 
-    third_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(third_value)
+    third_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
+        debounce_period_sec, third_value
+    )
     fourth_handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
-        fourth_value
+        debounce_period_sec, fourth_value
     )
     assert third_handle.workflow_id != first_handle.workflow_id
     assert third_handle.workflow_id == fourth_handle.workflow_id
@@ -242,6 +264,8 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
 
     wfid = str(uuid.uuid4())
     options["workflow_id"] = wfid
-    handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(first_value)
+    handle: WorkflowHandleAsync[int] = await debouncer.debounce_async(
+        debounce_period_sec, first_value
+    )
     assert handle.workflow_id == wfid
     assert await handle.get_result() == first_value

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -23,10 +23,12 @@ def test_debouncer_workflow(dbos: DBOS) -> None:
 def test_debouncer(dbos: DBOS) -> None:
 
     DBOS.workflow()(workflow)
-    value = 5
+    first_value = 4
+    second_value = 5
 
-    debouncer = Debouncer("key", 0)
-    handle = debouncer.debounce(workflow, value)
-    assert handle.get_result() == value
-    handle = debouncer.debounce(workflow, value)
-    assert handle.get_result() == value
+    debouncer = Debouncer("key", 2)
+    first_handle = debouncer.debounce(workflow, first_value)
+    second_handle = debouncer.debounce(workflow, second_value)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.get_result() == second_value
+    assert second_handle.get_result() == second_value

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -26,7 +26,7 @@ from dbos import (
 )
 from dbos._context import assert_current_dbos_context
 from dbos._dbos import WorkflowHandleAsync
-from dbos._error import DBOSAwaitedWorkflowCancelledError
+from dbos._error import DBOSAwaitedWorkflowCancelledError, DBOSQueueDeduplicatedError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from dbos._utils import GlobalParams
@@ -1167,6 +1167,43 @@ def test_queue_deduplication(dbos: DBOS) -> None:
         with SetWorkflowID(wfid2):
             handle2 = queue.enqueue(test_workflow, "def")
     assert handle2.get_result() == "def-c-p"
+
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_queue_deduplication_recovery(dbos: DBOS) -> None:
+    queue_name = "test_dedup_queue"
+    queue = Queue(queue_name)
+    workflow_event = threading.Event()
+    dedup_id = "my_dedup_id"
+
+    @DBOS.workflow()
+    def child_workflow() -> None:
+        workflow_event.wait()
+
+    @DBOS.workflow()
+    def test_workflow() -> None:
+        with SetEnqueueOptions(deduplication_id=dedup_id):
+            handle = queue.enqueue(child_workflow)
+            with pytest.raises(DBOSQueueDeduplicatedError):
+                queue.enqueue(child_workflow)
+        return handle.workflow_id
+
+    parent_id = str(uuid.uuid4())
+    with SetWorkflowID(parent_id):
+        child_id = test_workflow()
+    handle = DBOS.retrieve_workflow(child_id)
+    workflow_event.set()
+    handle.get_result()
+
+    steps = DBOS.list_workflow_steps(parent_id)
+    assert len(steps) == 2
+    assert steps[0]["child_workflow_id"] == child_id
+    assert isinstance(steps[1]["error"], DBOSQueueDeduplicatedError)
+
+    dbos._sys_db.update_workflow_outcome(parent_id, "PENDING")
+    with SetWorkflowID(parent_id):
+        assert test_workflow() == child_id
 
     assert queue_entries_are_cleaned_up(dbos)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1182,7 +1182,7 @@ def test_queue_deduplication_recovery(dbos: DBOS) -> None:
         workflow_event.wait()
 
     @DBOS.workflow()
-    def test_workflow() -> None:
+    def test_workflow() -> str:
         with SetEnqueueOptions(deduplication_id=dedup_id):
             handle = queue.enqueue(child_workflow)
             with pytest.raises(DBOSQueueDeduplicatedError):
@@ -1192,7 +1192,7 @@ def test_queue_deduplication_recovery(dbos: DBOS) -> None:
     parent_id = str(uuid.uuid4())
     with SetWorkflowID(parent_id):
         child_id = test_workflow()
-    handle = DBOS.retrieve_workflow(child_id)
+    handle: WorkflowHandle[str] = DBOS.retrieve_workflow(child_id)
     workflow_event.set()
     handle.get_result()
 


### PR DESCRIPTION
Workflows can now be debounced. Debouncing delays workflow execution until some time has passed since the workflow has last been called. This is useful for preventing wasted work when a workflow may be triggered multiple times in quick succession.
For example, if a user is editing a form, we can debounce every change to the form and perform a synchronization workflow only after they haven't edited the form for a certain period of time.

### Debouncer.create

```python
Debouncer.create(
    workflow: Callable[P, R],
    *,
    debounce_key: str,
    debounce_timeout_sec: Optional[float] = None,
    queue: Optional[Queue] = None,
) -> Debouncer[P, R]
```

**Parameters:**
- `workflow`: The workflow to debounce.
- `debounce_key`: The **unique** debounce key for this debouncer. Used to group workflows that will be debounced.
- `debounce_timeout_sec`: After this time elapses since the first time a workflow is submitted from this debouncer, the workflow is started regardless of the debounce period.
- `queue`: When starting a workflow after debouncing, enqueue it on this queue instead of executing it directly.

### debounce

```python
debouncer.debounce(
    debounce_period_sec: float,
    *args: P.args,
    **kwargs: P.kwargs,
) -> WorkflowHandle[R]
```

Submit a workflow for execution but delay it by `debounce_period_sec`.
Returns a handle to the workflow.
The workflow may be debounced again, which further delays its execution (up to `debounce_timeout_sec`).
When the workflow eventually executes, it uses the **last** set of inputs passed into `debounce`.

After the workflow begins execution, the next call to `debounce` starts the debouncing process again for a new workflow execution.

**Example Syntax**:

```python
@DBOS.workflow()
def process_input(user_input):
    ...

# Each time a user submits a new input, debounce the process_input workflow.
# The workflow will wait until 60 seconds after the user stops submitting new inputs,
# then process the last input submitted.
def on_user_input_submit(user_id, user_input):
    debounce_period_sec = 60
    debouncer = Debouncer.create(process_input, debounce_key=user_id)
    debouncer.debounce(debounce_period_sec, user_input)
```