### PR TITLE
Correctly trace OTLP spans

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -215,10 +215,17 @@ class DBOSContext:
     def end_handler(self, exc_value: Optional[BaseException]) -> None:
         self._end_span(exc_value)
 
-    def get_current_span(self) -> Optional[Span]:
+    """ Return the current DBOS span if any. It must be a span created by DBOS."""
+
+    def get_current_dbos_span(self) -> Optional[Span]:
         if len(self.context_spans) > 0:
             return self.context_spans[-1].span
         return None
+
+    """ Return the current active span if any. It might not be a DBOS span."""
+
+    def get_current_active_span(self) -> Optional[Span]:
+        return dbos_tracer.get_current_span()
 
     def _start_span(self, attributes: TracedAttributes) -> None:
         if dbos_tracer.disable_otlp:
@@ -235,7 +242,7 @@ class DBOSContext:
         attributes["authenticatedUserAssumedRole"] = self.assumed_role
         span = dbos_tracer.start_span(
             attributes,
-            parent=self.context_spans[-1].span if len(self.context_spans) > 0 else None,
+            parent=None,  # It'll use the current active span as the parent
         )
         # Activate the current span
         cm = use_span(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -971,7 +971,7 @@ def decorate_transaction(
                                 dbapi_error
                             ) or dbos._app_db._is_serialization_error(dbapi_error):
                                 # Retry on serialization failure
-                                span = ctx.get_current_span()
+                                span = ctx.get_current_dbos_span()
                                 if span:
                                     span.add_event(
                                         "Transaction Failure",
@@ -1090,7 +1090,7 @@ def decorate_step(
                     exc_info=error,
                 )
                 ctx = assert_current_dbos_context()
-                span = ctx.get_current_span()
+                span = ctx.get_current_dbos_span()
                 if span:
                     span.add_event(
                         f"Step attempt {attempt} failed",

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1297,7 +1297,7 @@ class DBOS:
     def span(cls) -> Span:
         """Return the tracing `Span` associated with the current context."""
         ctx = assert_current_dbos_context()
-        span = ctx.get_current_span()
+        span = ctx.get_current_active_span()
         assert span
         return span
 

--- a/dbos/_logger.py
+++ b/dbos/_logger.py
@@ -39,7 +39,7 @@ class DBOSLogTransformer(logging.Filter):
         if ctx:
             if ctx.is_within_workflow():
                 record.operationUUID = ctx.workflow_id
-            span = ctx.get_current_span()
+            span = ctx.get_current_active_span()
             if span:
                 trace_id = format_trace_id(span.get_span_context().trace_id)
                 record.traceId = trace_id

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -77,5 +77,12 @@ class DBOSTracer:
     def end_span(self, span: Span) -> None:
         span.end()
 
+    def get_current_span(self) -> Optional[Span]:
+        # Return the current active span if any. It might not be a DBOS span.
+        span = trace.get_current_span()
+        if span.get_span_context().is_valid:
+            return span
+        return None
+
 
 dbos_tracer = DBOSTracer()

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e68e0fa0e280f125b7bea5be442006567d8a6945f7a01710655b1fd6ea6b1af6"
+content_hash = "sha256:f309217c7bf4a6726fb70800234be042cdcd5df7a4f14e9053745855121e1a5b"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -57,6 +57,17 @@ dependencies = [
 files = [
     {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
     {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.0"
+requires_python = ">=3.8"
+summary = "Annotate AST trees with source code positions"
+groups = ["dev"]
+files = [
+    {file = "asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2"},
+    {file = "asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7"},
 ]
 
 [[package]]
@@ -485,6 +496,17 @@ files = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+requires_python = ">=3.8"
+summary = "Get the currently executing AST node of a frame, and other information"
+groups = ["dev"]
+files = [
+    {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
+    {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.6"
 requires_python = ">=3.8"
@@ -829,6 +851,24 @@ files = [
 ]
 
 [[package]]
+name = "inline-snapshot"
+version = "0.28.0"
+requires_python = ">=3.8"
+summary = "golden master/snapshot/approval testing library which puts the values right into your source code"
+groups = ["dev"]
+dependencies = [
+    "asttokens>=2.0.5",
+    "executing>=2.2.0",
+    "pytest>=8.3.4",
+    "rich>=13.7.1",
+    "tomli>=2.0.0; python_version < \"3.11\"",
+]
+files = [
+    {file = "inline_snapshot-0.28.0-py3-none-any.whl", hash = "sha256:9988f82ee5e719445bbc437d0dc01e0a3c4c94f0ba910f8ad8b573cf15aa8348"},
+    {file = "inline_snapshot-0.28.0.tar.gz", hash = "sha256:6904bfc383240b6bea64de2f5d2992f04109b13def19395bdd13fb0ebcf5cf20"},
+]
+
+[[package]]
 name = "isort"
 version = "6.0.1"
 requires_python = ">=3.9.0"
@@ -927,7 +967,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 requires_python = ">=3.8"
 summary = "Python port of markdown-it. Markdown parsing, done right!"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "mdurl~=0.1",
 ]
@@ -1011,7 +1051,7 @@ name = "mdurl"
 version = "0.1.2"
 requires_python = ">=3.7"
 summary = "Markdown URL utilities"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -1492,7 +1532,7 @@ name = "pygments"
 version = "2.18.0"
 requires_python = ">=3.8"
 summary = "Pygments is a syntax highlighting package written in Python."
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
@@ -1761,7 +1801,7 @@ name = "rich"
 version = "13.9.4"
 requires_python = ">=3.8.0"
 summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "markdown-it-py>=2.2.0",
     "pygments<3.0.0,>=2.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,5 @@ dev = [
     "pyright>=1.1.398",
     "types-docker>=7.1.0.20241229",
     "pytest-timeout>=2.3.1",
+    "inline-snapshot>=0.28.0",
 ]

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pytest
 from fastapi import FastAPI
@@ -23,7 +23,7 @@ from dbos._utils import GlobalParams
 class BasicSpan:
     content: str
     children: list["BasicSpan"] = field(default_factory=list)
-    parent_id: int | None = field(repr=False, compare=False, default=None)
+    parent_id: Optional[int] = field(repr=False, compare=False, default=None)
 
 
 def test_spans(config: DBOSConfig) -> None:
@@ -123,7 +123,7 @@ def test_spans(config: DBOSConfig) -> None:
 
     # Test the span tree structure
     basic_spans = {
-        span.context.span_id: BasicSpan(
+        span.context.span_id: BasicSpan(  # pyright: ignore[reportOptionalMemberAccess]
             content=span.name, parent_id=span.parent.span_id if span.parent else None
         )
         for span in spans
@@ -247,7 +247,7 @@ async def test_spans_async(dbos: DBOS) -> None:
 
     # Test the span tree structure
     basic_spans = {
-        span.context.span_id: BasicSpan(
+        span.context.span_id: BasicSpan(  # pyright: ignore[reportOptionalMemberAccess]
             content=span.name, parent_id=span.parent.span_id if span.parent else None
         )
         for span in spans

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -42,9 +42,9 @@ def test_spans(config: DBOSConfig) -> None:
 
     @DBOS.workflow()
     def test_workflow() -> None:
-        with my_tracer.start_as_current_span(
+        with my_tracer.start_as_current_span(  # pyright: ignore[reportAttributeAccessIssue]
             "manual_span"
-        ):  # pyright: ignore[reportAttributeAccessIssue]
+        ):
             test_step()
             current_span = DBOS.span
             subspan = DBOS.tracer.start_span(
@@ -169,9 +169,9 @@ async def test_spans_async(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     async def test_workflow() -> None:
-        with my_tracer.start_as_current_span(
+        with my_tracer.start_as_current_span(  # pyright: ignore[reportAttributeAccessIssue]
             "manual_span"
-        ):  # pyright: ignore[reportAttributeAccessIssue]
+        ):
             await test_step()
             current_span = DBOS.span
             subspan = DBOS.tracer.start_span(

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -129,13 +129,13 @@ def test_spans(config: DBOSConfig) -> None:
         for span in spans
     }
     root_span = None
-    for span in basic_spans.values():
-        if span.parent_id is None:
-            root_span = span
+    for basic_span in basic_spans.values():
+        if basic_span.parent_id is None:
+            root_span = basic_span
         else:
-            parent_id = span.parent_id
+            parent_id = basic_span.parent_id
             parent_span = basic_spans[parent_id]
-            parent_span.children.append(span)
+            parent_span.children.append(basic_span)
 
     assert len(spans) == 4
     # Make sure the span tree structure is correct
@@ -253,13 +253,13 @@ async def test_spans_async(dbos: DBOS) -> None:
         for span in spans
     }
     root_span = None
-    for span in basic_spans.values():
-        if span.parent_id is None:
-            root_span = span
+    for basic_span in basic_spans.values():
+        if basic_span.parent_id is None:
+            root_span = basic_span
         else:
-            parent_id = span.parent_id
+            parent_id = basic_span.parent_id
             parent_span = basic_spans[parent_id]
-            parent_span.children.append(span)
+            parent_span.children.append(basic_span)
 
     assert len(spans) == 4
     # Make sure the span tree structure is correct

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -42,7 +42,9 @@ def test_spans(config: DBOSConfig) -> None:
 
     @DBOS.workflow()
     def test_workflow() -> None:
-        with my_tracer.start_as_current_span("manual_span"):
+        with my_tracer.start_as_current_span(
+            "manual_span"
+        ):  # pyright: ignore[reportAttributeAccessIssue]
             test_step()
             current_span = DBOS.span
             subspan = DBOS.tracer.start_span(
@@ -167,7 +169,9 @@ async def test_spans_async(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     async def test_workflow() -> None:
-        with my_tracer.start_as_current_span("manual_span"):
+        with my_tracer.start_as_current_span(
+            "manual_span"
+        ):  # pyright: ignore[reportAttributeAccessIssue]
             await test_step()
             current_span = DBOS.span
             subspan = DBOS.tracer.start_span(


### PR DESCRIPTION
This PR fixes an issue where `DBOS.span` does not return the current active span. Instead, it always returned the span created by DBOS. This would cause incorrect span tree structure.

For example:
```python
@DBOS.workflow()
def test_workflow() -> None:
    with my_tracer.start_as_current_span("manual_span"):
        test_step()
```

Without this PR, the span tree is wrong:
```
test_workflow
|- manual_span
|- test_step
```

With this PR, `test_step` will correctly show as the child of `manual_span`:
```
test_workflow
|- manual_span
    |- test_step
```