### PR TITLE
Partitioned Queues

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -62,6 +62,7 @@ class EnqueueOptions(TypedDict):
     workflow_timeout: NotRequired[float]
     deduplication_id: NotRequired[str]
     priority: NotRequired[int]
+    queue_partition_key: NotRequired[str]
 
 
 def validate_enqueue_options(options: EnqueueOptions) -> None:
@@ -178,6 +179,7 @@ class DBOSClient:
             "deduplication_id": options.get("deduplication_id"),
             "priority": options.get("priority"),
             "app_version": options.get("app_version"),
+            "queue_partition_key": options.get("queue_partition_key")
         }
 
         inputs: WorkflowInputs = {
@@ -214,6 +216,7 @@ class DBOSClient:
                 else 0
             ),
             "inputs": _serialization.serialize_args(inputs),
+            "queue_partition_key": enqueue_options_internal["queue_partition_key"],
         }
 
         self._sys_db.init_workflow(
@@ -277,6 +280,7 @@ class DBOSClient:
             "deduplication_id": None,
             "priority": 0,
             "inputs": _serialization.serialize_args({"args": (), "kwargs": {}}),
+            "queue_partition_key": None,
         }
         with self._sys_db.engine.begin() as conn:
             self._sys_db._insert_workflow_status(

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -179,7 +179,7 @@ class DBOSClient:
             "deduplication_id": options.get("deduplication_id"),
             "priority": options.get("priority"),
             "app_version": options.get("app_version"),
-            "queue_partition_key": options.get("queue_partition_key")
+            "queue_partition_key": options.get("queue_partition_key"),
         }
 
         inputs: WorkflowInputs = {

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -118,6 +118,8 @@ class DBOSContext:
         self.deduplication_id: Optional[str] = None
         # A user-specified priority for the enqueuing workflow.
         self.priority: Optional[int] = None
+        # If the workflow is enqueued on a partitioned queue, its partition key
+        self.queue_partition_key: Optional[str] = None
 
     def create_child(self) -> DBOSContext:
         rv = DBOSContext()
@@ -473,6 +475,7 @@ class SetEnqueueOptions:
         deduplication_id: Optional[str] = None,
         priority: Optional[int] = None,
         app_version: Optional[str] = None,
+        queue_partition_key: Optional[str] = None,
     ) -> None:
         self.created_ctx = False
         self.deduplication_id: Optional[str] = deduplication_id
@@ -485,6 +488,8 @@ class SetEnqueueOptions:
         self.saved_priority: Optional[int] = None
         self.app_version: Optional[str] = app_version
         self.saved_app_version: Optional[str] = None
+        self.queue_partition_key = queue_partition_key
+        self.saved_queue_partition_key: Optional[str] = None
 
     def __enter__(self) -> SetEnqueueOptions:
         # Code to create a basic context
@@ -499,6 +504,8 @@ class SetEnqueueOptions:
         ctx.priority = self.priority
         self.saved_app_version = ctx.app_version
         ctx.app_version = self.app_version
+        self.saved_queue_partition_key = ctx.queue_partition_key
+        ctx.queue_partition_key = self.queue_partition_key
         return self
 
     def __exit__(
@@ -511,6 +518,7 @@ class SetEnqueueOptions:
         curr_ctx.deduplication_id = self.saved_deduplication_id
         curr_ctx.priority = self.saved_priority
         curr_ctx.app_version = self.saved_app_version
+        curr_ctx.queue_partition_key = self.saved_queue_partition_key
         # Code to clean up the basic context if we created it
         if self.created_ctx:
             _clear_local_dbos_context()

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -307,6 +307,7 @@ def _init_workflow(
             else 0
         ),
         "inputs": _serialization.serialize_args(inputs),
+        "queue_partition_key": enqueue_options["queue_partition_key"] if enqueue_options is not None else None
     }
 
     # Synchronously record the status and inputs for workflows
@@ -563,6 +564,7 @@ def start_workflow(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
         priority=local_ctx.priority if local_ctx is not None else None,
         app_version=local_ctx.app_version if local_ctx is not None else None,
+        queue_partition_key=local_ctx.queue_partition_key if local_ctx is not None else None,
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 
@@ -656,6 +658,7 @@ async def start_workflow_async(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
         priority=local_ctx.priority if local_ctx is not None else None,
         app_version=local_ctx.app_version if local_ctx is not None else None,
+        queue_partition_key=local_ctx.queue_partition_key if local_ctx is not None else None,
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -307,7 +307,11 @@ def _init_workflow(
             else 0
         ),
         "inputs": _serialization.serialize_args(inputs),
-        "queue_partition_key": enqueue_options["queue_partition_key"] if enqueue_options is not None else None
+        "queue_partition_key": (
+            enqueue_options["queue_partition_key"]
+            if enqueue_options is not None
+            else None
+        ),
     }
 
     # Synchronously record the status and inputs for workflows
@@ -564,7 +568,9 @@ def start_workflow(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
         priority=local_ctx.priority if local_ctx is not None else None,
         app_version=local_ctx.app_version if local_ctx is not None else None,
-        queue_partition_key=local_ctx.queue_partition_key if local_ctx is not None else None,
+        queue_partition_key=(
+            local_ctx.queue_partition_key if local_ctx is not None else None
+        ),
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 
@@ -658,7 +664,9 @@ async def start_workflow_async(
         deduplication_id=local_ctx.deduplication_id if local_ctx is not None else None,
         priority=local_ctx.priority if local_ctx is not None else None,
         app_version=local_ctx.app_version if local_ctx is not None else None,
-        queue_partition_key=local_ctx.queue_partition_key if local_ctx is not None else None,
+        queue_partition_key=(
+            local_ctx.queue_partition_key if local_ctx is not None else None
+        ),
     )
     new_wf_id, new_wf_ctx = _get_new_wf()
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -231,7 +231,7 @@ CREATE TABLE dbos.event_dispatch_kv (
 );
 """
 
-postgres_migration_two="""
+postgres_migration_two = """
 ALTER TABLE dbos.workflow_status ADD COLUMN queue_partition_key TEXT;
 """
 
@@ -322,7 +322,7 @@ CREATE TABLE streams (
 );
 """
 
-sqlite_migration_two="""
+sqlite_migration_two = """
 ALTER TABLE workflow_status ADD COLUMN queue_partition_key TEXT;
 """
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -76,7 +76,7 @@ def run_alembic_migrations(engine: sa.Engine) -> None:
         )
 
 
-def run_dbos_migrations(engine: sa.Engine) -> None:
+def run_postgres_migrations(engine: sa.Engine) -> None:
     """Run DBOS-managed migrations by executing each SQL command in dbos_migrations."""
     with engine.begin() as conn:
         # Get current migration version
@@ -85,7 +85,7 @@ def run_dbos_migrations(engine: sa.Engine) -> None:
         last_applied = current_version[0] if current_version else 0
 
         # Apply migrations starting from the next version
-        for i, migration_sql in enumerate(dbos_migrations, 1):
+        for i, migration_sql in enumerate(postgres_migrations, 1):
             if i <= last_applied:
                 continue
 
@@ -109,7 +109,7 @@ def run_dbos_migrations(engine: sa.Engine) -> None:
             last_applied = i
 
 
-dbos_migration_one = """
+postgres_migration_one = """
 -- Enable uuid extension for generating UUIDs
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
@@ -318,5 +318,5 @@ CREATE TABLE streams (
 );
 """
 
-dbos_migrations = [dbos_migration_one]
+postgres_migrations = [postgres_migration_one]
 sqlite_migrations = [sqlite_migration_one]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -231,6 +231,10 @@ CREATE TABLE dbos.event_dispatch_kv (
 );
 """
 
+postgres_migration_two="""
+ALTER TABLE dbos.workflow_status ADD COLUMN queue_partition_key TEXT;
+"""
+
 
 def get_sqlite_timestamp_expr() -> str:
     """Get SQLite timestamp expression with millisecond precision for Python >= 3.12."""
@@ -318,5 +322,9 @@ CREATE TABLE streams (
 );
 """
 
-postgres_migrations = [postgres_migration_one]
-sqlite_migrations = [sqlite_migration_one]
+sqlite_migration_two="""
+ALTER TABLE workflow_status ADD COLUMN queue_partition_key TEXT;
+"""
+
+postgres_migrations = [postgres_migration_one, postgres_migration_two]
+sqlite_migrations = [sqlite_migration_one, sqlite_migration_two]

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -80,6 +80,14 @@ class Queue:
             dbos_logger.warning(
                 f"Priority is not enabled for queue {self.name}. Setting priority will not have any effect."
             )
+        if (
+            self.partition_queue is not None
+            and context is None
+            or context.queue_partition_key is None
+        ):
+            raise Exception(
+                f"A workflow cannot be enqueued on partitioned queue {self.name} without a partition key"
+            )
 
         dbos = _get_dbos_instance()
         return start_workflow(dbos, func, self.name, False, *args, **kwargs)

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -43,6 +43,7 @@ class Queue:
         *,  # Disable positional arguments from here on
         worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> None:
         if (
             worker_concurrency is not None
@@ -57,6 +58,7 @@ class Queue:
         self.worker_concurrency = worker_concurrency
         self.limiter = limiter
         self.priority_enabled = priority_enabled
+        self.partition_queue = partition_queue
         from ._dbos import _get_or_create_dbos_registry
 
         registry = _get_or_create_dbos_registry()

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -60,6 +60,7 @@ class SystemSchema:
         Column("deduplication_id", Text(), nullable=True),
         Column("inputs", Text()),
         Column("priority", Integer(), nullable=False, server_default=text("'0'::int")),
+        Column("queue_partition_key", Text()),
         Index("workflow_status_created_at_index", "created_at"),
         Index("workflow_status_executor_id_index", "executor_id"),
         Index("workflow_status_status_index", "status"),

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1642,7 +1642,11 @@ class SystemDatabase(ABC):
             return [row[0] for row in rows]
 
     def start_queued_workflows(
-        self, queue: "Queue", executor_id: str, app_version: str
+        self,
+        queue: "Queue",
+        executor_id: str,
+        app_version: str,
+        queue_partition_key: Optional[str],
     ) -> List[str]:
         if self._debug_mode:
             return []
@@ -1661,6 +1665,10 @@ class SystemDatabase(ABC):
                     sa.select(sa.func.count())
                     .select_from(SystemSchema.workflow_status)
                     .where(SystemSchema.workflow_status.c.queue_name == queue.name)
+                    .where(
+                        SystemSchema.workflow_status.c.queue_partition_key
+                        == queue_partition_key
+                    )
                     .where(
                         SystemSchema.workflow_status.c.status
                         != WorkflowStatusString.ENQUEUED.value
@@ -1685,6 +1693,10 @@ class SystemDatabase(ABC):
                     )
                     .select_from(SystemSchema.workflow_status)
                     .where(SystemSchema.workflow_status.c.queue_name == queue.name)
+                    .where(
+                        SystemSchema.workflow_status.c.queue_partition_key
+                        == queue_partition_key
+                    )
                     .where(
                         SystemSchema.workflow_status.c.status
                         == WorkflowStatusString.PENDING.value
@@ -1726,6 +1738,10 @@ class SystemDatabase(ABC):
                 )
                 .select_from(SystemSchema.workflow_status)
                 .where(SystemSchema.workflow_status.c.queue_name == queue.name)
+                .where(
+                    SystemSchema.workflow_status.c.queue_partition_key
+                    == queue_partition_key
+                )
                 .where(
                     SystemSchema.workflow_status.c.status
                     == WorkflowStatusString.ENQUEUED.value

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import DBAPIError
 from dbos._migration import (
     ensure_dbos_schema,
     run_alembic_migrations,
-    run_dbos_migrations,
+    run_postgres_migrations,
 )
 from dbos._schemas.system_database import SystemSchema
 
@@ -70,7 +70,7 @@ class PostgresSystemDatabase(SystemDatabase):
         if not using_dbos_migrations:
             # Complete the Alembic migrations, create the dbos_migrations table
             run_alembic_migrations(self.engine)
-        run_dbos_migrations(self.engine)
+        run_postgres_migrations(self.engine)
 
     def _cleanup_connections(self) -> None:
         """Clean up PostgreSQL-specific connections."""

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1572,3 +1572,18 @@ async def test_enqueue_version_async(dbos: DBOS) -> None:
     # Change the global version, verify it works
     GlobalParams.app_version = future_version
     assert await handle.get_result() == input
+
+def test_queue_partitions(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    queue = Queue("queue")
+    input = 5
+
+    partition_key = "abc"
+    with SetEnqueueOptions(queue_partition_key=partition_key):
+        handle = queue.enqueue(workflow, input)
+
+    assert handle.get_result() == input

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1611,7 +1611,7 @@ async def test_enqueue_version_async(dbos: DBOS) -> None:
     assert await handle.get_result() == input
 
 
-def test_queue_partitions(dbos: DBOS) -> None:
+def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
 
     blocking_event = threading.Event()
     waiting_event = threading.Event()
@@ -1658,6 +1658,16 @@ def test_queue_partitions(dbos: DBOS) -> None:
     blocking_event.set()
     assert blocked_blocked_handle.get_result()
     assert blocked_normal_handle.get_result()
+
+    # Confirm client enqueue works with partitions
+    client_handle = client.enqueue(
+        {
+            "queue_name": queue.name,
+            "workflow_name": normal_workflow.__qualname__,
+            "queue_partition_key": blocked_partition_key,
+        }
+    )
+    assert client_handle.get_result()
 
     # You can only enqueue on a partitioned queue with a partition key
     with pytest.raises(Exception):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1573,6 +1573,7 @@ async def test_enqueue_version_async(dbos: DBOS) -> None:
     GlobalParams.app_version = future_version
     assert await handle.get_result() == input
 
+
 def test_queue_partitions(dbos: DBOS) -> None:
 
     @DBOS.workflow()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1621,3 +1621,7 @@ def test_queue_partitions(dbos: DBOS) -> None:
     blocking_event.set()
     assert blocked_blocked_handle.get_result()
     assert blocked_normal_handle.get_result()
+
+    # You can only enqueue on a partitioned queue with a partition key
+    with pytest.raises(Exception):
+        queue.enqueue(normal_workflow)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1580,7 +1580,7 @@ def test_queue_partitions(dbos: DBOS) -> None:
     def workflow(x: int) -> int:
         return x
 
-    queue = Queue("queue")
+    queue = Queue("queue", partition_queue=True)
     input = 5
 
     partition_key = "abc"

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,7 +7,11 @@ import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfig
-from dbos._migration import postgres_migrations, run_alembic_migrations, sqlite_migrations
+from dbos._migration import (
+    postgres_migrations,
+    run_alembic_migrations,
+    sqlite_migrations,
+)
 
 # Private API because this is a unit test
 from dbos._schemas.system_database import SystemSchema

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfig
-from dbos._migration import dbos_migrations, run_alembic_migrations, sqlite_migrations
+from dbos._migration import postgres_migrations, run_alembic_migrations, sqlite_migrations
 
 # Private API because this is a unit test
 from dbos._schemas.system_database import SystemSchema
@@ -40,7 +40,7 @@ def test_systemdb_migration(dbos: DBOS, skip_with_sqlite: None) -> None:
         )
         migrations_rows = migrations_result.fetchall()
         assert len(migrations_rows) == 1
-        assert migrations_rows[0][0] == len(dbos_migrations)
+        assert migrations_rows[0][0] == len(postgres_migrations)
 
 
 def test_alembic_migrations_compatibility(
@@ -91,7 +91,7 @@ def test_alembic_migrations_compatibility(
         )
         migrations_rows = migrations_result.fetchall()
         assert len(migrations_rows) == 1
-        assert migrations_rows[0][0] == len(dbos_migrations)
+        assert migrations_rows[0][0] == len(postgres_migrations)
 
     assert DBOS.list_workflows() == []
 


### PR DESCRIPTION
This PR allows you to create "partitioned queues." 

Partitioned queues let you distribute work across dynamically created queue partitions.  When you enqueue a workflow on a partitioned queue, you must supply a "queue partition key." Partitioned queues dequeue workflows and apply flow control limits for individual partitions, not for the entire queue. Essentially, this is a way to dynamically create "virtual queues" at runtime.

For example, let's say you want to run at most three tasks at once per user. You can do this with a partitioned queue where the partition key is the user ID:

```python
queue = Queue("queue", partition_queue=True, worker_concurrency=1)

@DBOS.workflow()
def process_task(task: Task):
  ...

def on_user_task_submission(user_id: str, task: Task):
    with SetEnqueueOptions(queue_partition_key=user_id):
        queue.enqueue(process_task, task)
```