### PR TITLE
Implement dynamic schema configuration for system database

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -458,10 +458,13 @@ class DBOS:
             self._background_event_loop.start()
             assert self._config["database_url"] is not None
             assert self._config["database"]["sys_db_engine_kwargs"] is not None
+            # Get the schema configuration, use "dbos" as default
+            schema = self._config.get("system_database_schema") or self._config.get("database", {}).get("system_database_schema", "dbos")
             self._sys_db_field = SystemDatabase.create(
                 system_database_url=get_system_database_url(self._config),
                 engine_kwargs=self._config["database"]["sys_db_engine_kwargs"],
                 debug_mode=debug_mode,
+                schema=schema,
             )
             assert self._config["database"]["db_engine_kwargs"] is not None
             self._app_db_field = ApplicationDatabase.create(

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -37,6 +37,7 @@ class DBOSConfig(TypedDict, total=False):
         application_version (str): Application version
         executor_id (str): Executor ID, used to identify the application instance in distributed environments
         disable_otlp (bool): If True, disables OTLP tracing and logging. Defaults to False.
+        system_database_schema (str): Schema name for DBOS system tables. Defaults to "dbos".
     """
 
     name: str
@@ -55,6 +56,7 @@ class DBOSConfig(TypedDict, total=False):
     application_version: Optional[str]
     executor_id: Optional[str]
     disable_otlp: Optional[bool]
+    system_database_schema: Optional[str]
 
 
 class RuntimeConfig(TypedDict, total=False):
@@ -72,6 +74,7 @@ class DatabaseConfig(TypedDict, total=False):
         sys_db_pool_size (int): System database pool size
         db_engine_kwargs (Dict[str, Any]): SQLAlchemy engine kwargs
         migrate (List[str]): Migration commands to run on startup
+        system_database_schema (str): Schema name for DBOS system tables. Defaults to "dbos".
     """
 
     sys_db_name: Optional[str]
@@ -82,6 +85,7 @@ class DatabaseConfig(TypedDict, total=False):
     sys_db_engine_kwargs: Optional[Dict[str, Any]]
     migrate: Optional[List[str]]
     rollback: Optional[List[str]]  # Will be removed in a future version
+    system_database_schema: Optional[str]
 
 
 class OTLPExporterConfig(TypedDict, total=False):
@@ -115,6 +119,7 @@ class ConfigFile(TypedDict, total=False):
         system_database_url (str): System database URL
         telemetry (TelemetryConfig): Configuration for tracing / logging
         env (Dict[str,str]): Environment variables
+        system_database_schema (str): Schema name for DBOS system tables. Defaults to "dbos".
 
     """
 
@@ -125,6 +130,7 @@ class ConfigFile(TypedDict, total=False):
     system_database_url: Optional[str]
     telemetry: Optional[TelemetryConfig]
     env: Dict[str, str]
+    system_database_schema: Optional[str]
 
 
 def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
@@ -143,6 +149,8 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         db_config["sys_db_pool_size"] = config.get("sys_db_pool_size")
     if "db_engine_kwargs" in config:
         db_config["db_engine_kwargs"] = config.get("db_engine_kwargs")
+    if "system_database_schema" in config:
+        db_config["system_database_schema"] = config.get("system_database_schema")
     if db_config:
         translated_config["database"] = db_config
 
@@ -154,6 +162,9 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
 
     if "system_database_url" in config:
         translated_config["system_database_url"] = config.get("system_database_url")
+    
+    if "system_database_schema" in config:
+        translated_config["system_database_schema"] = config.get("system_database_schema")
 
     # Runtime config
     translated_config["runtimeConfig"] = {"run_admin_server": True}

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -18,6 +18,21 @@ class SystemSchema:
     ### System table schema
     metadata_obj = MetaData(schema="dbos")
     sysdb_suffix = "_dbos_sys"
+    
+    @classmethod
+    def set_schema(cls, schema_name: str) -> None:
+        """
+        Set the schema for all DBOS system tables.
+        
+        Args:
+            schema_name: The name of the schema to use for system tables
+        """
+        cls.metadata_obj.schema = schema_name
+        cls.workflow_status.schema = schema_name
+        cls.operation_outputs.schema = schema_name
+        cls.notifications.schema = schema_name
+        cls.workflow_events.schema = schema_name
+        cls.streams.schema = schema_name
 
     workflow_status = Table(
         "workflow_status",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1444,8 +1444,13 @@ class SystemDatabase(ABC):
         system_database_url: str,
         engine_kwargs: Dict[str, Any],
         debug_mode: bool = False,
+        schema: Optional[str] = None,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
+        # Set the schema if provided
+        if schema is not None:
+            SystemSchema.set_schema(schema)
+        
         if system_database_url.startswith("sqlite"):
             from ._sys_db_sqlite import SQLiteSystemDatabase
 

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -36,12 +36,6 @@ class PostgresSystemDatabase(SystemDatabase):
     def _create_engine(
         self, system_database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
-        # TODO: Make the schema dynamic so this isn't needed
-        SystemSchema.workflow_status.schema = "dbos"
-        SystemSchema.operation_outputs.schema = "dbos"
-        SystemSchema.notifications.schema = "dbos"
-        SystemSchema.workflow_events.schema = "dbos"
-        SystemSchema.streams.schema = "dbos"
         url = sa.make_url(system_database_url).set(drivername="postgresql+psycopg")
         return sa.create_engine(url, **engine_kwargs)
 

--- a/dbos/dbos-config.schema.json
+++ b/dbos/dbos-config.schema.json
@@ -23,6 +23,10 @@
         "type": ["string", "null"],
         "description": "The URL of the system database"
       },
+      "system_database_schema": {
+        "type": ["string", "null"],
+        "description": "The schema name for DBOS system tables (Default: dbos)"
+      },
       "database": {
         "type": "object",
         "additionalProperties": false,
@@ -82,6 +86,10 @@
             "type": "array",
             "description": "Specify a list of user DB rollback commands to run. DEPRECATED",
             "deprecated": true
+          },
+          "system_database_schema": {
+            "type": ["string", "null"],
+            "description": "The schema name for DBOS system tables (Default: dbos)"
           }
         }
       },


### PR DESCRIPTION
Add support for configurable schema name for DBOS system tables instead of hardcoded "dbos" schema. Users can now specify a custom schema via configuration files or programmatically.

My use case requires a schema name that I cannot control and is provided by a platform team.

Changes:
- Add system_database_schema option to DBOSConfig and ConfigFile
- Update JSON schema to include new configuration option
- Add SystemSchema.set_schema() method for dynamic schema assignment
- Modify SystemDatabase.create() to accept optional schema parameter
- Remove hardcoded schema assignments from PostgresSystemDatabase
- Update DBOS initialization to use configured schema with "dbos" fallback

Resolves TODO in _sys_db_postgres.py for making schema dynamic.

🤖 Generated with [Claude Code](https://claude.ai/code)