### PR TITLE
Fix version parsing error for versions with fewer than 3 components

### DIFF
--- a/version/__init__.py
+++ b/version/__init__.py
@@ -38,6 +38,10 @@ def format_version(git_version: SCMVersion) -> str:
 
 
 def guess_next_version(version_number: str) -> str:
-    major, minor, patch = map(int, version_number.split("."))
+    parts = version_number.split(".")
+    # Pad with zeros if there are fewer than 3 parts
+    while len(parts) < 3:
+        parts.append("0")
+    major, minor, patch = map(int, parts[:3])
     minor += 1
     return f"{major}.{minor}.{patch}"


### PR DESCRIPTION
The guess_next_version function was expecting all version numbers to have exactly 3 components (major.minor.patch), but it would fail with a ValueError when encountering versions with only 2 components (e.g., "1.2").

This fix pads the version parts with zeros when there are fewer than 3 components, ensuring the function works correctly with versions like:
- "1.2" -> "1.3.0"
- "1.2.3" -> "1.3.3"

Fixes the metadata generation error when installing from git branches.