### PR TITLE
nit: use dbos_logger instead of print for Conductor message

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -569,8 +569,8 @@ class DBOS:
                 conductor_registration_url = (
                     f"https://console.dbos.dev/self-host?appname={app_name}"
                 )
-                print(
-                    f"To view and manage workflows, connect to DBOS Conductor at:{conductor_registration_url}"
+                dbos_logger.info(
+                    f"To view and manage workflows, connect to DBOS Conductor at: {conductor_registration_url}"
                 )
 
             # Flush handlers and add OTLP to all loggers if enabled


### PR DESCRIPTION
Replace print() call with dbos_logger.info() for consistency with existing logging patterns. This allows suppression via logging config.