### PR TITLE
Trigger dequeued workflows immediately for partitioned queues. 

### DIFF
--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -120,21 +120,23 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
         for _, queue in queues.items():
             try:
                 if queue.partition_queue:
-                    dequeued_workflows = []
                     queue_partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                     for key in queue_partition_keys:
-                        dequeued_workflows += dbos._sys_db.start_queued_workflows(
+                        dequeued_workflows = dbos._sys_db.start_queued_workflows(
                             queue,
                             GlobalParams.executor_id,
                             GlobalParams.app_version,
                             key,
                         )
+                        for id in dequeued_workflows:
+                            execute_workflow_by_id(dbos, id)
                 else:
                     dequeued_workflows = dbos._sys_db.start_queued_workflows(
                         queue, GlobalParams.executor_id, GlobalParams.app_version, None
                     )
-                for id in dequeued_workflows:
-                    execute_workflow_by_id(dbos, id)
+                    for id in dequeued_workflows:
+                        execute_workflow_by_id(dbos, id)
+
             except OperationalError as e:
                 if isinstance(
                     e.orig, (errors.SerializationFailure, errors.LockNotAvailable)


### PR DESCRIPTION
Avoid the possibility of being interrupted by the exception