### PR TITLE
Execute dequeued workflows immediately

### DIFF
--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -127,21 +127,22 @@ def queue_worker_thread(
 
         try:
             if queue.partition_queue:
-                dequeued_workflows = []
                 queue_partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                 for key in queue_partition_keys:
-                    dequeued_workflows += dbos._sys_db.start_queued_workflows(
+                    dequeued_workflows = dbos._sys_db.start_queued_workflows(
                         queue,
                         GlobalParams.executor_id,
                         GlobalParams.app_version,
                         key,
                     )
+                    for id in dequeued_workflows:
+                        execute_workflow_by_id(dbos, id)
             else:
                 dequeued_workflows = dbos._sys_db.start_queued_workflows(
                     queue, GlobalParams.executor_id, GlobalParams.app_version, None
                 )
-            for id in dequeued_workflows:
-                execute_workflow_by_id(dbos, id)
+                for id in dequeued_workflows:
+                    execute_workflow_by_id(dbos, id)
         except OperationalError as e:
             if isinstance(
                 e.orig, (errors.SerializationFailure, errors.LockNotAvailable)


### PR DESCRIPTION
Avoid the case where "contention detected" exception prevents some workflows on a partitioned queue from running.