### PR TITLE
Allow dynamic queue set_concurrency

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -18,7 +18,7 @@ from ._dbos import (
 from ._dbos_config import DBOSConfig
 from ._debouncer import Debouncer, DebouncerClient
 from ._kafka_message import KafkaMessage
-from ._queue import Queue
+from ._queue import Queue, QueueRateLimit
 from ._serialization import Serializer
 from ._sys_db import (
     ClientScheduleInput,
@@ -52,6 +52,7 @@ __all__ = [
     "WorkflowStatusString",
     "error",
     "Queue",
+    "QueueRateLimit",
     "Debouncer",
     "DebouncerClient",
     "Serializer",

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -66,7 +66,7 @@ from ._core import (
     write_stream,
 )
 from ._croniter import croniter  # type: ignore
-from ._queue import Queue, queue_thread
+from ._queue import Queue, QueueRateLimit, queue_thread
 from ._recovery import recover_pending_workflows, startup_recovery_thread
 from ._registrations import (
     DEFAULT_MAX_RECOVERY_ATTEMPTS,
@@ -324,7 +324,13 @@ class DBOS:
         global _dbos_global_registry
         if _dbos_global_instance is None:
             _dbos_global_instance = super().__new__(cls)
-            _dbos_global_instance.__init__(fastapi=fastapi, config=config, flask=flask, conductor_url=conductor_url, conductor_key=conductor_key)  # type: ignore
+            _dbos_global_instance.__init__(
+                fastapi=fastapi,
+                config=config,
+                flask=flask,
+                conductor_url=conductor_url,
+                conductor_key=conductor_key,
+            )  # type: ignore
         return _dbos_global_instance
 
     @classmethod
@@ -667,10 +673,75 @@ class DBOS:
                 "reset_system_database has no effect because global DBOS object does not exist"
             )
 
+    @classmethod
+    def set_queue_concurrency(
+        cls,
+        queue_name: str,
+        concurrency: Optional[int] = None,
+        *,
+        worker_concurrency: Optional[int] = None,
+    ) -> None:
+        """Dynamically update a queue's concurrency limits at runtime.
+
+        This is the static alternative to ``Queue.set_concurrency()`` for
+        situations where the ``Queue`` instance is not readily available
+        (e.g. multi-tenant code that computes limits dynamically).
+
+        Changes are persisted to the database and propagate to all workers
+        within one polling cycle. Changes survive process restarts.
+
+        Args:
+            queue_name: Name of the queue to update.
+            concurrency: New global concurrency limit. Pass ``None`` to remove.
+            worker_concurrency: New per-worker concurrency limit. Pass ``None`` to remove.
+        """
+        if (
+            worker_concurrency is not None
+            and concurrency is not None
+            and worker_concurrency > concurrency
+        ):
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        dbos = _get_dbos_instance()
+        if queue_name in dbos._registry.queue_info_map:
+            q = dbos._registry.queue_info_map[queue_name]
+            q.concurrency = concurrency
+            q.worker_concurrency = worker_concurrency
+        dbos._sys_db.set_queue_concurrency(queue_name, concurrency, worker_concurrency)
+
+    @classmethod
+    def set_queue_limiter(
+        cls,
+        queue_name: str,
+        limiter: Optional[QueueRateLimit] = None,
+    ) -> None:
+        """Dynamically update a queue's rate limiter at runtime.
+
+        This is the static alternative to ``Queue.set_limiter()`` for
+        situations where the ``Queue`` instance is not readily available.
+
+        Changes are persisted to the database and propagate to all workers
+        within one polling cycle. Changes survive process restarts.
+
+        Args:
+            queue_name: Name of the queue to update.
+            limiter: New rate-limit config, or ``None`` to remove the limiter.
+        """
+        dbos = _get_dbos_instance()
+        if queue_name in dbos._registry.queue_info_map:
+            q = dbos._registry.queue_info_map[queue_name]
+            q.limiter = limiter
+        limiter_limit = limiter["limit"] if limiter is not None else None
+        limiter_period_ms = (
+            int(limiter["period"] * 1000) if limiter is not None else None
+        )
+        dbos._sys_db.set_queue_limiter(queue_name, limiter_limit, limiter_period_ms)
+
     def _reset_system_database(self) -> None:
-        assert (
-            not self._launched
-        ), "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
+        assert not self._launched, (
+            "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
+        )
 
         SystemDatabase.reset_system_database(get_system_database_url(self._config))
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -272,6 +272,19 @@ CREATE TABLE "{schema}".workflow_schedules (
 """
 
 
+def get_dbos_migration_ten(schema: str) -> str:
+    return f"""
+CREATE TABLE "{schema}".queue_config (
+    queue_name TEXT PRIMARY KEY,
+    concurrency INTEGER,
+    worker_concurrency INTEGER,
+    limiter_limit INTEGER,
+    limiter_period_ms BIGINT,
+    updated_at_epoch_ms BIGINT NOT NULL
+);
+"""
+
+
 def get_dbos_migrations(schema: str, use_listen_notify: bool) -> list[str]:
     return [
         get_dbos_migration_one(schema, use_listen_notify),
@@ -283,6 +296,7 @@ def get_dbos_migrations(schema: str, use_listen_notify: bool) -> list[str]:
         get_dbos_migration_seven(schema),
         get_dbos_migration_eight(schema),
         get_dbos_migration_nine(schema),
+        get_dbos_migration_ten(schema),
     ]
 
 
@@ -424,6 +438,17 @@ CREATE TABLE workflow_schedules (
 );
 """
 
+sqlite_migration_ten = """
+CREATE TABLE queue_config (
+    queue_name TEXT PRIMARY KEY,
+    concurrency INTEGER,
+    worker_concurrency INTEGER,
+    limiter_limit INTEGER,
+    limiter_period_ms INTEGER,
+    updated_at_epoch_ms INTEGER NOT NULL
+);
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -434,4 +459,5 @@ sqlite_migrations = [
     sqlite_migration_seven,
     sqlite_migration_eight,
     sqlite_migration_nine,
+    sqlite_migration_ten,
 ]

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -71,6 +71,59 @@ class Queue:
             raise Exception(f"Queue {name} has already been declared")
         registry.queue_info_map[self.name] = self
 
+    def set_concurrency(
+        self,
+        concurrency: Optional[int] = None,
+        *,
+        worker_concurrency: Optional[int] = None,
+    ) -> None:
+        """Dynamically update this queue's concurrency limits at runtime.
+
+        Changes take effect on this worker immediately and are persisted to
+        the database so that all other workers pick them up within one
+        polling cycle. Changes survive process restarts.
+
+        Args:
+            concurrency: New global concurrency limit (max workflows PENDING
+                across all workers). Pass ``None`` to remove the limit.
+            worker_concurrency: New per-worker concurrency limit. Pass
+                ``None`` to remove the limit.
+        """
+        if (
+            worker_concurrency is not None
+            and concurrency is not None
+            and worker_concurrency > concurrency
+        ):
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        self.concurrency = concurrency
+        self.worker_concurrency = worker_concurrency
+        from ._dbos import _get_dbos_instance
+
+        dbos = _get_dbos_instance()
+        dbos._sys_db.set_queue_concurrency(self.name, concurrency, worker_concurrency)
+
+    def set_limiter(self, limiter: Optional[QueueRateLimit]) -> None:
+        """Dynamically update this queue's rate limiter at runtime.
+
+        Changes take effect on this worker immediately and are persisted to
+        the database so that all other workers pick them up within one
+        polling cycle. Changes survive process restarts.
+
+        Args:
+            limiter: New rate-limit config, or ``None`` to remove the limiter.
+        """
+        self.limiter = limiter
+        limiter_limit = limiter["limit"] if limiter is not None else None
+        limiter_period_ms = (
+            int(limiter["period"] * 1000) if limiter is not None else None
+        )
+        from ._dbos import _get_dbos_instance
+
+        dbos = _get_dbos_instance()
+        dbos._sys_db.set_queue_limiter(self.name, limiter_limit, limiter_period_ms)
+
     def enqueue(
         self, func: "Callable[P, R]", *args: P.args, **kwargs: P.kwargs
     ) -> "WorkflowHandle[R]":

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -37,6 +37,7 @@ class SystemSchema:
         cls.streams.schema = schema_name
         cls.workflow_events_history.schema = schema_name
         cls.workflow_schedules.schema = schema_name
+        cls.queue_config.schema = schema_name
 
     workflow_status = Table(
         "workflow_status",
@@ -198,4 +199,15 @@ class SystemSchema:
         Column("schedule", Text, nullable=False),
         Column("status", Text, nullable=False, server_default="ACTIVE"),
         Column("context", Text, nullable=False),
+    )
+
+    queue_config = Table(
+        "queue_config",
+        metadata_obj,
+        Column("queue_name", Text, primary_key=True),
+        Column("concurrency", Integer, nullable=True),
+        Column("worker_concurrency", Integer, nullable=True),
+        Column("limiter_limit", Integer, nullable=True),
+        Column("limiter_period_ms", BigInteger, nullable=True),
+        Column("updated_at_epoch_ms", BigInteger, nullable=False),
     )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -328,7 +328,6 @@ def db_retry(
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
-
                     # Determine if this is a retriable exception
                     if not retriable_postgres_exception(
                         e
@@ -353,7 +352,6 @@ def db_retry(
 
 
 class SystemDatabase(ABC):
-
     @staticmethod
     def create(
         system_database_url: str,
@@ -1288,7 +1286,7 @@ class SystemDatabase(ABC):
         wf_executor_id = wf_executor_id_row[0]
         if self.executor_id is not None and wf_executor_id != self.executor_id:
             dbos_logger.debug(
-                f'Resetting executor_id from {wf_executor_id} to {self.executor_id} for workflow {result["workflow_uuid"]}'
+                f"Resetting executor_id from {wf_executor_id} to {self.executor_id} for workflow {result['workflow_uuid']}"
             )
             conn.execute(
                 sa.update(SystemSchema.workflow_status)
@@ -1434,9 +1432,9 @@ class SystemDatabase(ABC):
         operation_output_rows = conn.execute(operation_output_sql).all()
 
         # Check if the workflow exists
-        assert (
-            len(workflow_status_rows) > 0
-        ), f"Error: Workflow {workflow_id} does not exist"
+        assert len(workflow_status_rows) > 0, (
+            f"Error: Workflow {workflow_id} does not exist"
+        )
 
         # Get workflow status
         workflow_status = workflow_status_rows[0][0]
@@ -1986,6 +1984,66 @@ class SystemDatabase(ABC):
             rows = c.execute(query).fetchall()
             return [row[0] for row in rows]
 
+    def set_queue_concurrency(
+        self,
+        queue_name: str,
+        concurrency: Optional[int],
+        worker_concurrency: Optional[int],
+    ) -> None:
+        """Persist runtime concurrency overrides for a queue to the database."""
+        now_ms = int(time.time() * 1000)
+        with self.engine.begin() as c:
+            cmd = (
+                self.dialect.insert(SystemSchema.queue_config)
+                .values(
+                    queue_name=queue_name,
+                    concurrency=concurrency,
+                    worker_concurrency=worker_concurrency,
+                    limiter_limit=None,
+                    limiter_period_ms=None,
+                    updated_at_epoch_ms=now_ms,
+                )
+                .on_conflict_do_update(
+                    index_elements=["queue_name"],
+                    set_={
+                        "concurrency": concurrency,
+                        "worker_concurrency": worker_concurrency,
+                        "updated_at_epoch_ms": now_ms,
+                    },
+                )
+            )
+            c.execute(cmd)
+
+    def set_queue_limiter(
+        self,
+        queue_name: str,
+        limiter_limit: Optional[int],
+        limiter_period_ms: Optional[int],
+    ) -> None:
+        """Persist a runtime rate-limiter override for a queue to the database."""
+        now_ms = int(time.time() * 1000)
+        with self.engine.begin() as c:
+            cmd = (
+                self.dialect.insert(SystemSchema.queue_config)
+                .values(
+                    queue_name=queue_name,
+                    concurrency=None,
+                    worker_concurrency=None,
+                    limiter_limit=limiter_limit,
+                    limiter_period_ms=limiter_period_ms,
+                    updated_at_epoch_ms=now_ms,
+                )
+                .on_conflict_do_update(
+                    index_elements=["queue_name"],
+                    set_={
+                        "limiter_limit": limiter_limit,
+                        "limiter_period_ms": limiter_period_ms,
+                        "updated_at_epoch_ms": now_ms,
+                    },
+                )
+            )
+            c.execute(cmd)
+
     def start_queued_workflows(
         self,
         queue: "Queue",
@@ -1994,15 +2052,44 @@ class SystemDatabase(ABC):
         queue_partition_key: Optional[str],
     ) -> List[str]:
         start_time_ms = int(time.time() * 1000)
-        if queue.limiter is not None:
-            limiter_period_ms = int(queue.limiter["period"] * 1000)
         with self.engine.begin() as c:
             # Execute with snapshot isolation to ensure multiple workers respect limits
             if self.engine.dialect.name == "postgresql":
                 c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
 
+            # Read any runtime-overridden config for this queue from the DB.
+            # DB values take precedence over the in-memory Queue definition so
+            # that changes made via set_concurrency() / set_limiter() propagate
+            # to all workers without a restart.
+            db_cfg = c.execute(
+                sa.select(SystemSchema.queue_config).where(
+                    SystemSchema.queue_config.c.queue_name == queue.name
+                )
+            ).fetchone()
+
+            if db_cfg is not None:
+                effective_concurrency: Optional[int] = db_cfg.concurrency
+                effective_worker_concurrency: Optional[int] = db_cfg.worker_concurrency
+                if (
+                    db_cfg.limiter_limit is not None
+                    and db_cfg.limiter_period_ms is not None
+                ):
+                    effective_limiter: Optional[Dict[str, Any]] = {
+                        "limit": db_cfg.limiter_limit,
+                        "period": db_cfg.limiter_period_ms / 1000.0,
+                    }
+                else:
+                    effective_limiter = queue.limiter
+            else:
+                effective_concurrency = queue.concurrency
+                effective_worker_concurrency = queue.worker_concurrency
+                effective_limiter = queue.limiter
+
+            if effective_limiter is not None:
+                limiter_period_ms = int(effective_limiter["period"] * 1000)
+
             # If there is a limiter, compute how many functions have started in its period.
-            if queue.limiter is not None:
+            if effective_limiter is not None:
                 query = (
                     sa.select(sa.func.count())
                     .select_from(SystemSchema.workflow_status)
@@ -2022,12 +2109,15 @@ class SystemDatabase(ABC):
                         == queue_partition_key
                     )
                 num_recent_queries = c.execute(query).fetchone()[0]  # type: ignore
-                if num_recent_queries >= queue.limiter["limit"]:
+                if num_recent_queries >= effective_limiter["limit"]:
                     return []
 
             # Compute max_tasks, the number of workflows that can be dequeued given local and global concurrency limits,
             max_tasks = 100  # To minimize contention with large queues, never dequeue more than 100 tasks
-            if queue.worker_concurrency is not None or queue.concurrency is not None:
+            if (
+                effective_worker_concurrency is not None
+                or effective_concurrency is not None
+            ):
                 # Count how many workflows on this queue are currently PENDING both locally and globally.
                 pending_tasks_query = (
                     sa.select(
@@ -2051,31 +2141,31 @@ class SystemDatabase(ABC):
                 pending_workflows_dict = {row[0]: row[1] for row in pending_workflows}
                 local_pending_workflows = pending_workflows_dict.get(executor_id, 0)
 
-                if queue.worker_concurrency is not None:
+                if effective_worker_concurrency is not None:
                     # Print a warning if the local concurrency limit is violated
-                    if local_pending_workflows > queue.worker_concurrency:
+                    if local_pending_workflows > effective_worker_concurrency:
                         dbos_logger.warning(
-                            f"The number of local pending workflows ({local_pending_workflows}) on queue {queue.name} exceeds the local concurrency limit ({queue.worker_concurrency})"
+                            f"The number of local pending workflows ({local_pending_workflows}) on queue {queue.name} exceeds the local concurrency limit ({effective_worker_concurrency})"
                         )
                     max_tasks = max(
-                        0, queue.worker_concurrency - local_pending_workflows
+                        0, effective_worker_concurrency - local_pending_workflows
                     )
 
-                if queue.concurrency is not None:
+                if effective_concurrency is not None:
                     global_pending_workflows = sum(pending_workflows_dict.values())
                     # Print a warning if the global concurrency limit is violated
-                    if global_pending_workflows > queue.concurrency:
+                    if global_pending_workflows > effective_concurrency:
                         dbos_logger.warning(
-                            f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({queue.concurrency})"
+                            f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({effective_concurrency})"
                         )
                     available_tasks = max(
-                        0, queue.concurrency - global_pending_workflows
+                        0, effective_concurrency - global_pending_workflows
                     )
                     max_tasks = min(max_tasks, available_tasks)
 
             # Retrieve the first max_tasks workflows in the queue.
             # Only retrieve workflows of the local version (or without version set)
-            skip_locks = queue.concurrency is None
+            skip_locks = effective_concurrency is None
             query = (
                 sa.select(
                     SystemSchema.workflow_status.c.workflow_uuid,
@@ -2125,8 +2215,8 @@ class SystemDatabase(ABC):
             for id in dequeued_ids:
                 # If we have a limiter, stop dequeueing workflows when the number
                 # of workflows started this period exceeds the limit.
-                if queue.limiter is not None:
-                    if len(ret_ids) + num_recent_queries >= queue.limiter["limit"]:
+                if effective_limiter is not None:
+                    if len(ret_ids) + num_recent_queries >= effective_limiter["limit"]:
                         break
 
                 # To start a workflow, first set its status to PENDING and update its executor ID
@@ -2330,7 +2420,6 @@ class SystemDatabase(ABC):
         )
         while True:
             with self.engine.begin() as c:
-
                 recorded_output = self._check_operation_execution_txn(
                     workflow_uuid, function_id, function_name, conn=c
                 )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1771,3 +1771,104 @@ def test_listen_queue(dbos: DBOS, config: DBOSConfig) -> None:
     assert DBOS.retrieve_workflow(handle_two.workflow_id).get_result()
     # Verify the internal queue works
     assert DBOS.fork_workflow(handle_two.workflow_id, 0).get_result()
+
+
+def test_set_concurrency(dbos: DBOS) -> None:
+    """Queue.set_concurrency() dynamically raises the global concurrency limit."""
+    workflow_event = threading.Event()
+    main_event1 = threading.Event()
+    main_event2 = threading.Event()
+
+    @DBOS.workflow()
+    def blocking_workflow(idx: int) -> int:
+        if idx == 1:
+            main_event1.set()
+        elif idx == 2:
+            main_event2.set()
+        workflow_event.wait()
+        return idx
+
+    # Start with concurrency=1 — only one workflow runs at a time.
+    queue = Queue("test_queue", concurrency=1)
+    handle1 = queue.enqueue(blocking_workflow, 1)
+    handle2 = queue.enqueue(blocking_workflow, 2)
+
+    # Wait for wf1 to start; wf2 must stay ENQUEUED while the limit holds.
+    main_event1.wait(timeout=10)
+    time.sleep(2)
+    assert handle2.get_status().status == "ENQUEUED"
+
+    # Raise the limit to 2 — wf2 should now be dequeued and start running.
+    queue.set_concurrency(2)
+    assert main_event2.wait(timeout=10), "wf2 did not start after set_concurrency(2)"
+
+    # Release both workflows and verify results.
+    workflow_event.set()
+    assert handle1.get_result() == 1
+    assert handle2.get_result() == 2
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_set_limiter(dbos: DBOS) -> None:
+    """Queue.set_limiter() dynamically removes a rate limiter so blocked work proceeds."""
+    flag = False
+
+    @DBOS.workflow()
+    def quick_workflow() -> None:
+        pass
+
+    @DBOS.workflow()
+    def flag_workflow() -> None:
+        nonlocal flag
+        flag = True
+
+    # Tight limiter: at most 1 workflow started per 60 seconds.
+    queue = Queue("test_queue", limiter={"limit": 1, "period": 60})
+
+    # First workflow consumes the rate-limit budget.
+    queue.enqueue(quick_workflow).get_result()
+
+    # Second workflow stays ENQUEUED because the budget is exhausted.
+    handle2 = queue.enqueue(flag_workflow)
+    time.sleep(2)
+    assert not flag
+    assert handle2.get_status().status == "ENQUEUED"
+
+    # Remove the limiter entirely — the second workflow should now be dequeued.
+    queue.set_limiter(None)
+    assert handle2.get_result() is None
+    assert flag
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_dbos_set_queue_concurrency(dbos: DBOS) -> None:
+    """DBOS.set_queue_concurrency() is a static alternative to Queue.set_concurrency()."""
+    workflow_event = threading.Event()
+    main_event1 = threading.Event()
+    main_event2 = threading.Event()
+
+    @DBOS.workflow()
+    def blocking_workflow(idx: int) -> int:
+        if idx == 1:
+            main_event1.set()
+        elif idx == 2:
+            main_event2.set()
+        workflow_event.wait()
+        return idx
+
+    queue = Queue("test_queue", concurrency=1)
+    handle1 = queue.enqueue(blocking_workflow, 1)
+    handle2 = queue.enqueue(blocking_workflow, 2)
+
+    main_event1.wait(timeout=10)
+    time.sleep(2)
+    assert handle2.get_status().status == "ENQUEUED"
+
+    # Use the static DBOS API instead of the Queue instance.
+    DBOS.set_queue_concurrency("test_queue", 2)
+    assert main_event2.wait(timeout=10), "wf2 did not start after DBOS.set_queue_concurrency(2)"
+
+    workflow_event.set()
+    assert handle1.get_result() == 1
+    assert handle2.get_result() == 2
+    assert queue_entries_are_cleaned_up(dbos)


### PR DESCRIPTION
1. Added queue_config table to store runtime concurrency/limiter overrides per queue                               
                                                                                                     
2. What changed: Added migration 10 to create the queue_config table for both Postgres and SQLite
 
3. Added set_queue_concurrency() and set_queue_limiter() DB methods; start_queued_workflows() now reads effective limits from DB before enforcing them

4. Added Queue.set_concurrency() and Queue.set_limiter() to update limits locally and persist them to the DB

5. Added DBOS.set_queue_concurrency() and DBOS.set_queue_limiter() static classmethods for use without a Queue instance

6. What changed: Exported QueueRateLimit so users can import it directly from dbos

 7. Added 3 tests covering set_concurrency(), set_limiter(), and DBOS.set_queue_concurrency()
  