### PR TITLE
DBOS.asyncio_wait

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -15,6 +15,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    Awaitable,
     Callable,
     Coroutine,
     Dict,
@@ -1288,19 +1289,18 @@ class DBOS:
     @classmethod
     async def asyncio_wait(
         cls,
-        fs: Any,
+        fs: List[Awaitable[Any]],
         *,
         timeout: Optional[float] = None,
         return_when: str = asyncio.ALL_COMPLETED,
-    ) -> tuple[set[Any], set[Any]]:
+    ) -> tuple[set[asyncio.Task[Any]], set[asyncio.Task[Any]]]:
         """
         Durable version of asyncio.wait.
 
-        Has the same signature and behavior as `asyncio.wait`, but checkpoints which
-        futures are done vs pending so the result is deterministic during workflow recovery.
+        Checkpoints which tasks are done vs pending so the result is
+        deterministic during workflow recovery.
 
-        This function must be called from within a workflow.
-        When called outside a workflow, it falls back to regular `asyncio.wait`.
+        When called outside a workflow, falls back to regular `asyncio.wait`.
         """
         cur_ctx = snapshot_step_context()
         fs_list = [asyncio.ensure_future(f) for f in fs]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -722,7 +722,7 @@ async def test_asyncio_wait(dbos: DBOS) -> None:
 
         # Let the slow step finish and wait for it
         gate.set()
-        done2, pending2 = await DBOS.asyncio_wait(pending)
+        done2, pending2 = await DBOS.asyncio_wait(list(pending))
         assert len(done2) == 1
         assert len(pending2) == 0
         assert [t.result() for t in done2] == ["slow_done"]
@@ -820,7 +820,7 @@ async def test_asyncio_wait_first_exception(dbos: DBOS) -> None:
 
         # Let the slow step finish and wait for it
         gate.set()
-        done2, pending2 = await DBOS.asyncio_wait(pending)
+        done2, pending2 = await DBOS.asyncio_wait(list(pending))
         assert len(done2) == 1
         assert len(pending2) == 0
         assert next(iter(done2)).result() == "ok"
@@ -860,7 +860,7 @@ async def test_asyncio_wait_timeout(dbos: DBOS) -> None:
 
         # Unblock and wait for all
         gate.set()
-        done2, pending2 = await DBOS.asyncio_wait(pending)
+        done2, pending2 = await DBOS.asyncio_wait(list(pending))
         assert len(done2) == 2
         assert len(pending2) == 0
         assert sorted([t.result() for t in done2]) == ["a", "b"]


### PR DESCRIPTION
`DBOS.asyncio_wait` is a durable implementation of [`asyncio.wait`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) with the same interface and semantics. In particular, this lets you durably wait for the first of many steps to finish (using `asyncio.FIRST_COMPLETED`), or wait for step completion with a timeout.