### PR TITLE
chore: add thread name prefix to executor thread pool

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -514,7 +514,7 @@ class DBOS:
                 self._config.get("runtimeConfig", {}).get("max_executor_threads")
                 or sys.maxsize
             )
-            self._executor_field = ThreadPoolExecutor(max_workers=max_executor_threads)
+            self._executor_field = ThreadPoolExecutor(max_workers=max_executor_threads, thread_name_prefix="dbos-executor-")
 
             self._background_event_loop.start()
             assert self._config["database"]["sys_db_engine_kwargs"] is not None


### PR DESCRIPTION
Hey DBOS team 👋 

_Note:_ I made this via the GitHub UI, so may need to run a linter! Let me know what else I should do to make this PR merge-able

## Description

Add a thread name prefix to make it easier to identify which threads are responsible for executing DBOS workflows




