### PR TITLE
Advisory Lock Timeout

### DIFF
--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -53,18 +53,34 @@ class PostgresSystemDatabase(SystemDatabase):
 
         assert self.schema
         # Use an advisory lock to serialize concurrent migrations.
-        # Some Postgres implementations do not support advisory locks,
-        # so fall back to running without a lock if the call fails.
+        # Try to acquire the lock for up to 30 seconds. If another process
+        # holds it, return without running migrations ourselves, rather than
+        # hanging startup indefinitely.
+        # Some Postgres implementations do not support advisory locks, so
+        # fall back to running without a lock if the call fails.
         MIGRATION_LOCK_ID = 1234567890
+        MIGRATION_LOCK_TIMEOUT_SEC = 30
         locked = False
         conn = self.engine.connect()
         try:
             try:
-                conn.execute(
-                    sa.text("SELECT pg_advisory_lock(:lock_id)"),
-                    {"lock_id": MIGRATION_LOCK_ID},
-                )
-                locked = True
+                deadline = time.monotonic() + MIGRATION_LOCK_TIMEOUT_SEC
+                while True:
+                    got = conn.execute(
+                        sa.text("SELECT pg_try_advisory_lock(:lock_id)"),
+                        {"lock_id": MIGRATION_LOCK_ID},
+                    ).scalar()
+                    if got:
+                        locked = True
+                        break
+                    if time.monotonic() >= deadline:
+                        dbos_logger.warning(
+                            f"Could not acquire migration advisory lock within "
+                            f"{MIGRATION_LOCK_TIMEOUT_SEC}s. Skipping migrations."
+                        )
+                        conn.close()
+                        return
+                    time.sleep(1)
             except Exception:
                 conn.close()
             ensure_dbos_schema(self.engine, self.schema)

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -75,8 +75,8 @@ class PostgresSystemDatabase(SystemDatabase):
                         break
                     if time.monotonic() >= deadline:
                         dbos_logger.warning(
-                            f"Could not acquire migration advisory lock within "
-                            f"{MIGRATION_LOCK_TIMEOUT_SEC}s. Attempting migrations without lock"
+                            f"Could not acquire migration advisory lock within {MIGRATION_LOCK_TIMEOUT_SEC}s. "
+                            f"Attempting migrations without lock."
                         )
                         conn.close()
                         break

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -53,8 +53,8 @@ class PostgresSystemDatabase(SystemDatabase):
 
         assert self.schema
         # Use an advisory lock to serialize concurrent migrations.
-        # Try to acquire the lock for up to 30 seconds. If another process
-        # holds it, return without running migrations ourselves, rather than
+        # Try to acquire the lock for up to 30 seconds. If we can't, log a
+        # warning and proceed to run migrations without it, rather than
         # hanging startup indefinitely.
         # Some Postgres implementations do not support advisory locks, so
         # fall back to running without a lock if the call fails.
@@ -76,10 +76,10 @@ class PostgresSystemDatabase(SystemDatabase):
                     if time.monotonic() >= deadline:
                         dbos_logger.warning(
                             f"Could not acquire migration advisory lock within "
-                            f"{MIGRATION_LOCK_TIMEOUT_SEC}s. Skipping migrations."
+                            f"{MIGRATION_LOCK_TIMEOUT_SEC}s. Attempting migrations without lock"
                         )
                         conn.close()
-                        return
+                        break
                     time.sleep(1)
             except Exception:
                 conn.close()

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -56,13 +56,17 @@ class PostgresSystemDatabase(SystemDatabase):
         # Try to acquire the lock for up to 30 seconds. If we can't, log a
         # warning and proceed to run migrations without it, rather than
         # hanging startup indefinitely.
-        # Some Postgres implementations do not support advisory locks, so
-        # fall back to running without a lock if the call fails.
         MIGRATION_LOCK_ID = 1234567890
         MIGRATION_LOCK_TIMEOUT_SEC = 30
         locked = False
-        conn = self.engine.connect()
-        try:
+        # Use AUTOCOMMIT so the lock connection does not sit idle-in-transaction
+        # while migrations run. CockroachDB's online schema changes wait for
+        # older transactions to drain, which deadlocks against an idle-in-tx
+        # lock connection. Session-level advisory locks are independent of
+        # transaction state, so AUTOCOMMIT is safe.
+        with self.engine.connect().execution_options(
+            isolation_level="AUTOCOMMIT"
+        ) as conn:
             try:
                 deadline = time.monotonic() + MIGRATION_LOCK_TIMEOUT_SEC
                 while True:
@@ -78,20 +82,16 @@ class PostgresSystemDatabase(SystemDatabase):
                             f"Could not acquire migration advisory lock within {MIGRATION_LOCK_TIMEOUT_SEC}s. "
                             f"Attempting migrations without lock."
                         )
-                        conn.close()
                         break
                     time.sleep(1)
-            except Exception:
-                conn.close()
-            ensure_dbos_schema(self.engine, self.schema)
-            run_dbos_migrations(self.engine, self.schema, self.use_listen_notify)
-        finally:
-            if locked:
-                conn.execute(
-                    sa.text("SELECT pg_advisory_unlock(:lock_id)"),
-                    {"lock_id": MIGRATION_LOCK_ID},
-                )
-                conn.close()
+                ensure_dbos_schema(self.engine, self.schema)
+                run_dbos_migrations(self.engine, self.schema, self.use_listen_notify)
+            finally:
+                if locked:
+                    conn.execute(
+                        sa.text("SELECT pg_advisory_unlock(:lock_id)"),
+                        {"lock_id": MIGRATION_LOCK_ID},
+                    )
 
     def _cleanup_connections(self) -> None:
         """Clean up PostgreSQL-specific connections."""

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -60,9 +60,7 @@ class PostgresSystemDatabase(SystemDatabase):
         MIGRATION_LOCK_TIMEOUT_SEC = 30
         locked = False
         # Use AUTOCOMMIT so the lock connection does not sit idle-in-transaction
-        # while migrations run. CockroachDB's online schema changes wait for
-        # older transactions to drain, which deadlocks against an idle-in-tx
-        # lock connection. Session-level advisory locks are independent of
+        # while migrations run. Session-level advisory locks are independent of
         # transaction state, so AUTOCOMMIT is safe.
         with self.engine.connect().execution_options(
             isolation_level="AUTOCOMMIT"


### PR DESCRIPTION
If a process crashes while holding the migration advisory lock, Postgres may be slow to release it. This adds a timeout when acquiring the lock so process startup is not blocked.

Closes https://github.com/dbos-inc/dbos-transact-py/issues/636