### PR TITLE
Fix closure bug in Pending._wrap on Python 3.12+

### DIFF
--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -189,7 +189,14 @@ class Pending(Outcome[T]):
             dbos_logger.warning(f"Asyncio task cancelled for workflow or step {func}")
             raise
         except BaseException as exp:
-            return await asyncio.to_thread(after, lambda: Pending._raise(exp))
+            # Rebind the exception to a local that is not subject to the
+            # implicit `del exp` Python performs at the end of an
+            # `except ... as exp:` block. On Python 3.12+ a lambda that
+            # closes over `exp` directly can raise
+            # "cannot access free variable 'exp'" when it runs later on
+            # the asyncio thread pool.
+            saved_exp = exp
+            return await asyncio.to_thread(after, lambda: Pending._raise(saved_exp))
 
     def wrap(
         self,

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -112,3 +112,27 @@ async def test_pending_retry() -> None:
         await o2()
 
     assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_pending_wrap_propagates_exception() -> None:
+    # Regression test for a closure bug in Pending._wrap where the lambda
+    # captured `exp` from `except BaseException as exp:` by reference. On
+    # Python 3.12+ the except target is cleared when the block exits, so
+    # invoking the lambda later (via asyncio.to_thread) raised
+    # "cannot access free variable 'exp'" instead of the original exception.
+
+    class MyError(Exception):
+        pass
+
+    async def raiser() -> int:
+        raise MyError("boom")
+
+    def after(result: Callable[[], int]) -> int:
+        return result()
+
+    o1 = Outcome[int].make(raiser).wrap(lambda: after)
+    assert isinstance(o1, Pending)
+
+    with pytest.raises(MyError, match="boom"):
+        await o1()


### PR DESCRIPTION
The lambda passed to asyncio.to_thread in the BaseException handler captured `exp` from `except BaseException as exp:` by reference. Python implicitly deletes the except target when the block exits, so on Python 3.12+ invoking the lambda later on the thread pool raised "cannot access free variable 'exp'" instead of propagating the original exception.

Rebind the caught exception to a local that survives the except block, and add a regression test.

Fixes dbos-inc/dbos-transact-py#641
