### PR TITLE
fix bugs in backfill start/end TZ handling

### DIFF
--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -161,6 +161,10 @@ def backfill_schedule(
     queue_name = schedule.get("queue_name")
     tz_name = schedule.get("cron_timezone")
     tz = ZoneInfo(tz_name) if tz_name else timezone.utc
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     start_in_tz = start.astimezone(tz)
     it = croniter(schedule["schedule"], start_in_tz, second_at_beginning=True)
     workflow_ids: list[str] = []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -507,6 +507,44 @@ def test_backfill_schedule(dbos: DBOS) -> None:
     DBOS.delete_schedule("backfill-test")
 
 
+def test_backfill_naive_datetime(dbos: DBOS) -> None:
+    """Test timezone-naive datetimes for backfilling — they should be treated as UTC and not throw."""
+    received: list[datetime] = []
+
+    @DBOS.workflow()
+    def wf(scheduled_at: datetime, ctx: Any) -> None:
+        received.append(scheduled_at)
+
+    DBOS.create_schedule(
+        schedule_name="backfill-naive",
+        workflow_fn=wf,
+        schedule="0 * * * *",  # every hour
+    )
+
+    # Naive start and end — equivalent to 00:30..03:30 UTC, yields 01:00, 02:00, 03:00
+    naive_start = datetime(2025, 1, 1, 0, 30, 0)
+    naive_end = datetime(2025, 1, 1, 3, 30, 0)
+
+    handles = DBOS.backfill_schedule("backfill-naive", naive_start, naive_end)
+    assert len(handles) == 3
+    for h in handles:
+        h.get_result()
+
+    expected = [
+        datetime(2025, 1, 1, h, 0, 0, tzinfo=timezone.utc) for h in range(1, 4)
+    ]
+    assert sorted(received) == expected
+
+    # Mixed (aware start, naive end) should also work
+    received.clear()
+    aware_start = datetime(2025, 1, 1, 4, 30, 0, tzinfo=timezone.utc)
+    naive_end_2 = datetime(2025, 1, 1, 6, 30, 0)
+    handles = DBOS.backfill_schedule("backfill-naive", aware_start, naive_end_2)
+    assert len(handles) == 2
+
+    DBOS.delete_schedule("backfill-naive")
+
+
 def test_backfill_with_timezone(dbos: DBOS) -> None:
     received_utc: list[datetime] = []
     received_ny: list[datetime] = []


### PR DESCRIPTION
Two bugs:
- When end time has no TZ, it'll throw when compared to start
- When start time has no tz, `astimezone(tz)` first converts it to the machine's local time, not UTC (then it is converted to `tz`)

<img width="659" height="353" alt="Screenshot 2026-04-27 at 13 18 00" src="https://github.com/user-attachments/assets/62d3c6b5-0129-4da7-8caa-25b6fc75a924" />
