### PR TITLE
Database-Backed Queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .dbos/
+.claude/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dbos/_admin_server.py
+++ b/dbos/_admin_server.py
@@ -88,7 +88,13 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             from ._dbos import _get_or_create_dbos_registry
 
             registry = _get_or_create_dbos_registry()
-            for queue in registry.queue_info_map.values():
+            queues = dict(registry.queue_info_map)
+            try:
+                for q in self.dbos._sys_db.list_queues():
+                    queues.setdefault(q.name, q)
+            except Exception as e:
+                dbos_logger.warning(f"Exception listing database-backed queues: {e}")
+            for queue in queues.values():
                 queue_metadata = {
                     "name": queue.name,
                     "concurrency": queue.concurrency,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -326,6 +326,12 @@ class DBOSClient:
 
         :returns: A :class:`Queue` bound to this client's system database.
         """
+        Queue._validate_queue(
+            concurrency=concurrency,
+            worker_concurrency=worker_concurrency,
+            polling_interval_sec=polling_interval_sec,
+            limiter=limiter,
+        )
         if on_conflict == "always_update":
             update_existing = True
         elif on_conflict == "never_update":

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -364,7 +364,7 @@ class DBOSClient:
         return self._sys_db.get_queue(name, client_system_database=self._sys_db)
 
     def delete_queue(self, name: str) -> None:
-        """Delete a database-backed queue by name. No-op if it does not exist."""
+        """Delete a database-backed queue. Pending workflows on it are unrecoverable."""
         self._sys_db.delete_queue(name)
 
     def retrieve_workflow(self, workflow_id: str) -> "WorkflowHandle[R]":

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -295,7 +295,7 @@ class DBOSClient:
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
-        Defaults to ``"always_update"``. ``"update_if_latest_version"`` is
+        ``on_conflict`` defaults to ``"always_update"``. ``"update_if_latest_version"`` is
         rejected because clients are not associated with an application
         version. See :meth:`DBOS.register_queue` for the other semantics.
         """

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -24,7 +24,7 @@ from dbos._context import MaxPriority, MinPriority
 from dbos._core import DEFAULT_POLLING_INTERVAL
 from dbos._queue import Queue, QueueConflictResolution, QueueRateLimit
 from dbos._sys_db import SystemDatabase
-from dbos._utils import GlobalParams, generate_uuid
+from dbos._utils import generate_uuid
 
 if TYPE_CHECKING:
     from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
@@ -291,19 +291,25 @@ class DBOSClient:
         priority_enabled: bool = False,
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
-        on_conflict: QueueConflictResolution = "update_if_latest_version",
+        on_conflict: QueueConflictResolution = "always_update",
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
-        See :meth:`DBOS.register_queue` for ``on_conflict`` semantics.
+        Defaults to ``"always_update"``. ``"update_if_latest_version"`` is
+        rejected because clients are not associated with an application
+        version. See :meth:`DBOS.register_queue` for the other semantics.
         """
         if on_conflict == "always_update":
             update_existing = True
         elif on_conflict == "never_update":
             update_existing = False
         else:
-            latest = self._sys_db.get_latest_application_version()
-            update_existing = latest["version_name"] == GlobalParams.app_version
+            raise DBOSException(
+                "DBOSClient.register_queue does not support "
+                "on_conflict='update_if_latest_version' because clients are "
+                "not associated with an application version. Use "
+                "'always_update' or 'never_update'."
+            )
 
         self._sys_db.upsert_queue(
             name=name,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -284,9 +284,9 @@ class DBOSClient:
     def register_queue(
         self,
         name: str,
+        *,
         concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
-        *,
         worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -363,6 +363,10 @@ class DBOSClient:
         """Retrieve a database-backed queue by name from the client."""
         return self._sys_db.get_queue(name, client_system_database=self._sys_db)
 
+    def delete_queue(self, name: str) -> None:
+        """Delete a database-backed queue by name. No-op if it does not exist."""
+        self._sys_db.delete_queue(name)
+
     def retrieve_workflow(self, workflow_id: str) -> "WorkflowHandle[R]":
         status = get_workflow(self._sys_db, workflow_id)
         if status is None:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -22,8 +22,9 @@ import sqlalchemy as sa
 
 from dbos._context import MaxPriority, MinPriority
 from dbos._core import DEFAULT_POLLING_INTERVAL
+from dbos._queue import Queue, QueueConflictResolution, QueueRateLimit
 from dbos._sys_db import SystemDatabase
-from dbos._utils import generate_uuid
+from dbos._utils import GlobalParams, generate_uuid
 
 if TYPE_CHECKING:
     from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
@@ -279,6 +280,49 @@ class DBOSClient:
     ) -> "WorkflowHandleAsync[R]":
         workflow_id = await asyncio.to_thread(self._enqueue, options, *args, **kwargs)
         return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)
+
+    def register_queue(
+        self,
+        name: str,
+        concurrency: Optional[int] = None,
+        limiter: Optional[QueueRateLimit] = None,
+        *,
+        worker_concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
+        polling_interval_sec: float = 1.0,
+        on_conflict: QueueConflictResolution = "update_if_latest_version",
+    ) -> Queue:
+        """Register a queue from a client and persist it to the system database.
+
+        See :meth:`DBOS.register_queue` for ``on_conflict`` semantics.
+        """
+        if on_conflict == "always_update":
+            update_existing = True
+        elif on_conflict == "never_update":
+            update_existing = False
+        else:
+            latest = self._sys_db.get_latest_application_version()
+            update_existing = latest["version_name"] == GlobalParams.app_version
+
+        self._sys_db.upsert_queue(
+            name=name,
+            concurrency=concurrency,
+            worker_concurrency=worker_concurrency,
+            rate_limit_max=limiter["limit"] if limiter else None,
+            rate_limit_period_sec=limiter["period"] if limiter else None,
+            priority_enabled=priority_enabled,
+            partition_queue=partition_queue,
+            polling_interval_sec=polling_interval_sec,
+            update_existing=update_existing,
+        )
+        queue = self._sys_db.get_queue(name, client_system_database=self._sys_db)
+        assert queue is not None, f"Queue {name} missing from database after upsert"
+        return queue
+
+    def retrieve_queue(self, name: str) -> Optional[Queue]:
+        """Retrieve a database-backed queue by name from the client."""
+        return self._sys_db.get_queue(name, client_system_database=self._sys_db)
 
     def retrieve_workflow(self, workflow_id: str) -> "WorkflowHandle[R]":
         status = get_workflow(self._sys_db, workflow_id)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -295,9 +295,36 @@ class DBOSClient:
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
-        ``on_conflict`` defaults to ``"always_update"``. ``"update_if_latest_version"`` is
-        rejected because clients are not associated with an application
-        version. See :meth:`DBOS.register_queue` for the other semantics.
+        :param name: Unique name of the queue. Used as the lookup key in the
+            ``queues`` table and on every ``enqueue`` call.
+        :param concurrency: Maximum number of workflows from this queue that may
+            be running globally (across all executors) at once. ``None`` (the
+            default) means no global limit.
+        :param limiter: Rate limit configuration of the form
+            ``{"limit": int, "period": float}``. At most ``limit`` workflows
+            from the queue will start within any rolling window of ``period``
+            seconds. ``None`` disables rate limiting.
+        :param worker_concurrency: Maximum number of workflows from this queue
+            that may be running on a single executor at once. ``None`` means no
+            per-executor limit. May be combined with ``concurrency``.
+        :param priority_enabled: When ``True``, callers may set a workflow
+            priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
+            are dequeued first. When ``False``, supplying a priority raises an
+            error at enqueue time.
+        :param partition_queue: When ``True``, every enqueue must specify a
+            ``queue_partition_key`` and concurrency / worker_concurrency limits
+            are applied per partition rather than to the queue as a whole.
+            Deduplication is not supported on partitioned queues.
+        :param polling_interval_sec: How often (in seconds) the worker thread
+            wakes up to look for runnable workflows on this queue. Smaller
+            values reduce dequeue latency at the cost of more database load.
+        :param on_conflict: Behavior when a queue with the same name already
+            exists in the database. Defaults to ``"always_update"``.
+            ``"update_if_latest_version"`` is rejected because clients are not
+            associated with an application version. ``"never_update"`` leaves
+            the existing row unchanged.
+
+        :returns: A :class:`Queue` bound to this client's system database.
         """
         if on_conflict == "always_update":
             update_existing = True

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -919,6 +919,48 @@ class ConductorWebsocket(threading.Thread):
                                     error_message=error_message,
                                 ).to_json()
                             )
+                        elif msg_type == p.MessageType.LIST_QUEUES:
+                            queues_output: list[p.QueueOutput] = []
+                            try:
+                                queues_output = [
+                                    p.QueueOutput.from_queue(q)
+                                    for q in self.dbos._sys_db.list_queues()
+                                ]
+                            except Exception:
+                                error_message = (
+                                    f"Exception encountered when listing queues: "
+                                    f"{traceback.format_exc()}"
+                                )
+                                self.dbos.logger.error(error_message)
+                            websocket.send(
+                                p.ListQueuesResponse(
+                                    type=p.MessageType.LIST_QUEUES,
+                                    request_id=base_message.request_id,
+                                    output=queues_output,
+                                    error_message=error_message,
+                                ).to_json()
+                            )
+                        elif msg_type == p.MessageType.GET_QUEUE:
+                            get_queue_msg = p.GetQueueRequest.from_json(message)
+                            queue_output: p.QueueOutput | None = None
+                            try:
+                                q = self.dbos._sys_db.get_queue(get_queue_msg.name)
+                                if q is not None:
+                                    queue_output = p.QueueOutput.from_queue(q)
+                            except Exception:
+                                error_message = (
+                                    f"Exception encountered when getting queue "
+                                    f"'{get_queue_msg.name}': {traceback.format_exc()}"
+                                )
+                                self.dbos.logger.error(error_message)
+                            websocket.send(
+                                p.GetQueueResponse(
+                                    type=p.MessageType.GET_QUEUE,
+                                    request_id=base_message.request_id,
+                                    output=queue_output,
+                                    error_message=error_message,
+                                ).to_json()
+                            )
                         else:
                             self.dbos.logger.warning(
                                 f"Unexpected message type: {msg_type}"

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Type, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypedDict, TypeVar, Union
 
 from dbos._serialization import Serializer
 from dbos._sys_db import (
@@ -11,6 +11,9 @@ from dbos._sys_db import (
     WorkflowSchedule,
     WorkflowStatus,
 )
+
+if TYPE_CHECKING:
+    from dbos._queue import Queue
 
 
 class MessageType(str, Enum):
@@ -44,6 +47,8 @@ class MessageType(str, Enum):
     GET_WORKFLOW_STREAMS = "get_workflow_streams"
     GET_WORKFLOW_AGGREGATES = "get_workflow_aggregates"
     FORK_FROM_FAILURE = "fork_from_failure"
+    LIST_QUEUES = "list_queues"
+    GET_QUEUE = "get_queue"
 
 
 T = TypeVar("T", bound="BaseMessage")
@@ -763,4 +768,54 @@ class WorkflowAggregateOutput:
 @dataclass
 class GetWorkflowAggregatesResponse(BaseMessage):
     output: List[WorkflowAggregateOutput]
+    error_message: Optional[str] = None
+
+
+# --- Queue messages ---
+
+
+@dataclass
+class QueueOutput:
+    name: str
+    concurrency: Optional[int]
+    worker_concurrency: Optional[int]
+    rate_limit_max: Optional[int]
+    rate_limit_period_sec: Optional[float]
+    priority_enabled: bool
+    partition_queue: bool
+    polling_interval_sec: float
+
+    @classmethod
+    def from_queue(cls, q: "Queue") -> "QueueOutput":
+        return cls(
+            name=q.name,
+            concurrency=q._concurrency,
+            worker_concurrency=q._worker_concurrency,
+            rate_limit_max=q._limiter["limit"] if q._limiter else None,
+            rate_limit_period_sec=q._limiter["period"] if q._limiter else None,
+            priority_enabled=q._priority_enabled,
+            partition_queue=q._partition_queue,
+            polling_interval_sec=q._polling_interval_sec,
+        )
+
+
+@dataclass
+class ListQueuesRequest(BaseMessage):
+    pass
+
+
+@dataclass
+class ListQueuesResponse(BaseMessage):
+    output: List[QueueOutput]
+    error_message: Optional[str] = None
+
+
+@dataclass
+class GetQueueRequest(BaseMessage):
+    name: str
+
+
+@dataclass
+class GetQueueResponse(BaseMessage):
+    output: Optional[QueueOutput]
     error_message: Optional[str] = None

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -786,9 +786,9 @@ class DBOS:
     def register_queue(
         cls,
         name: str,
+        *,
         concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
-        *,
         worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1030,6 +1030,34 @@ class DBOS:
         )
 
     @classmethod
+    def enqueue_workflow(
+        cls,
+        queue_name: str,
+        func: Callable[P, R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> WorkflowHandle[R]:
+        """Enqueue a workflow on a database-backed queue, returning a handle to the ongoing execution."""
+        queue = cls.retrieve_queue(queue_name)
+        if queue is None:
+            raise DBOSException(f"Queue {queue_name} is not registered")
+        return queue.enqueue(func, *args, **kwargs)
+
+    @classmethod
+    async def enqueue_workflow_async(
+        cls,
+        queue_name: str,
+        func: Callable[P, Coroutine[Any, Any, R]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> WorkflowHandleAsync[R]:
+        """Async version of :meth:`enqueue_workflow`."""
+        queue = cls.retrieve_queue(queue_name)
+        if queue is None:
+            raise DBOSException(f"Queue {queue_name} is not registered")
+        return await queue.enqueue_async(func, *args, **kwargs)
+
+    @classmethod
     @overload
     def run_step(
         cls,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -831,6 +831,12 @@ class DBOS:
 
         :returns: A :class:`Queue` reflecting the persisted configuration.
         """
+        Queue._validate_queue(
+            concurrency=concurrency,
+            worker_concurrency=worker_concurrency,
+            polling_interval_sec=polling_interval_sec,
+            limiter=limiter,
+        )
         dbos = _get_dbos_instance()
 
         if on_conflict == "always_update":

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -809,16 +809,6 @@ class DBOS:
         - ``"never_update"``: leave the existing row unchanged.
         """
         dbos = _get_dbos_instance()
-        queue = Queue(
-            name,
-            concurrency,
-            limiter,
-            worker_concurrency=worker_concurrency,
-            priority_enabled=priority_enabled,
-            partition_queue=partition_queue,
-            polling_interval_sec=polling_interval_sec,
-            database_backed_queue=True,
-        )
 
         if on_conflict == "always_update":
             update_existing = True
@@ -829,17 +819,17 @@ class DBOS:
             update_existing = latest["version_name"] == GlobalParams.app_version
 
         dbos._sys_db.upsert_queue(
-            name=queue.name,
-            concurrency=queue.concurrency,
-            worker_concurrency=queue.worker_concurrency,
-            rate_limit_max=queue.limiter["limit"] if queue.limiter else None,
-            rate_limit_period_sec=(queue.limiter["period"] if queue.limiter else None),
-            priority_enabled=queue.priority_enabled,
-            partition_queue=queue.partition_queue,
-            polling_interval_sec=queue.polling_interval_sec,
+            name=name,
+            concurrency=concurrency,
+            worker_concurrency=worker_concurrency,
+            rate_limit_max=limiter["limit"] if limiter else None,
+            rate_limit_period_sec=limiter["period"] if limiter else None,
+            priority_enabled=priority_enabled,
+            partition_queue=partition_queue,
+            polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
         )
-        return queue
+        return dbos.retrieve_queue(name)
 
     @classmethod
     def retrieve_queue(cls, name: str) -> Optional[Queue]:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -803,7 +803,7 @@ class DBOS:
 
         - ``"update_if_latest_version"`` (default): overwrite the existing row
           only when the running application version is the latest registered
-          version. Older versions in a rolling deploy will not clobber the
+          version. Older versions in a rolling deploy will not overwrite the
           newer config.
         - ``"always_update"``: always overwrite the existing row.
         - ``"never_update"``: leave the existing row unchanged.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -2337,7 +2337,11 @@ class DBOS:
         if not croniter.is_valid(schedule, second_at_beginning=True):
             raise DBOSException(f"Invalid cron schedule: '{schedule}'")
         dbos = _get_dbos_instance()
-        if queue_name is not None and queue_name not in dbos._registry.queue_info_map:
+        if (
+            queue_name is not None
+            and queue_name not in dbos._registry.queue_info_map
+            and dbos._sys_db.get_queue(queue_name) is None
+        ):
             raise DBOSException(
                 f"Queue '{queue_name}' is not declared. Please create the queue before using it in a schedule."
             )
@@ -2607,6 +2611,7 @@ class DBOS:
             if (
                 entry_queue_name is not None
                 and entry_queue_name not in dbos._registry.queue_info_map
+                and dbos._sys_db.get_queue(entry_queue_name) is None
             ):
                 raise DBOSException(
                     f"Queue '{entry_queue_name}' is not declared. Please create the queue before using it in a schedule."

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -72,7 +72,7 @@ from ._core import (
     write_stream,
 )
 from ._croniter import croniter  # type: ignore
-from ._queue import Queue, queue_thread
+from ._queue import Queue, QueueConflictResolution, QueueRateLimit, queue_thread
 from ._recovery import recover_pending_workflows, startup_recovery_thread
 from ._registrations import (
     DEFAULT_MAX_RECOVERY_ATTEMPTS,
@@ -781,6 +781,95 @@ class DBOS:
     @classmethod
     def register_instance(cls, inst: object) -> None:
         return _get_or_create_dbos_registry().register_instance(inst)
+
+    @classmethod
+    def register_queue(
+        cls,
+        name: str,
+        concurrency: Optional[int] = None,
+        limiter: Optional[QueueRateLimit] = None,
+        *,
+        worker_concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
+        polling_interval_sec: float = 1.0,
+        on_conflict: QueueConflictResolution = "update_if_latest_version",
+    ) -> Queue:
+        """
+        Register a queue and persist its configuration to the system database.
+
+        ``on_conflict`` controls behavior when a queue with the same name already
+        exists in the database:
+
+        - ``"update_if_latest_version"`` (default): overwrite the existing row
+          only when the running application version is the latest registered
+          version. Older versions in a rolling deploy will not clobber the
+          newer config.
+        - ``"always_update"``: always overwrite the existing row.
+        - ``"never_update"``: leave the existing row unchanged.
+        """
+        dbos = _get_dbos_instance()
+        queue = Queue(
+            name,
+            concurrency,
+            limiter,
+            worker_concurrency=worker_concurrency,
+            priority_enabled=priority_enabled,
+            partition_queue=partition_queue,
+            polling_interval_sec=polling_interval_sec,
+            database_backed_queue=True,
+        )
+
+        if on_conflict == "always_update":
+            update_existing = True
+        elif on_conflict == "never_update":
+            update_existing = False
+        else:
+            latest = dbos._sys_db.get_latest_application_version()
+            update_existing = latest["version_name"] == GlobalParams.app_version
+
+        dbos._sys_db.upsert_queue(
+            name=queue.name,
+            concurrency=queue.concurrency,
+            worker_concurrency=queue.worker_concurrency,
+            rate_limit_max=queue.limiter["limit"] if queue.limiter else None,
+            rate_limit_period_sec=(queue.limiter["period"] if queue.limiter else None),
+            priority_enabled=queue.priority_enabled,
+            partition_queue=queue.partition_queue,
+            polling_interval_sec=queue.polling_interval_sec,
+            update_existing=update_existing,
+        )
+        return queue
+
+    @classmethod
+    def retrieve_queue(cls, name: str) -> Optional[Queue]:
+        """
+        Retrieve a database-backed queue by name.
+
+        Returns None if no queue with the given name has been registered in the
+        system database. The returned Queue is not added to the in-memory queue
+        registry.
+        """
+        dbos = _get_dbos_instance()
+        row = dbos._sys_db.get_queue(name)
+        if row is None:
+            return None
+        limiter: Optional[QueueRateLimit] = None
+        if row["rate_limit_max"] is not None:
+            limiter = {
+                "limit": row["rate_limit_max"],
+                "period": row["rate_limit_period_sec"],
+            }
+        return Queue(
+            row["name"],
+            row["concurrency"],
+            limiter,
+            worker_concurrency=row["worker_concurrency"],
+            priority_enabled=row["priority_enabled"],
+            partition_queue=row["partition_queue"],
+            polling_interval_sec=row["polling_interval_sec"],
+            database_backed_queue=True,
+        )
 
     # Decorators for DBOS functionality
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -829,7 +829,9 @@ class DBOS:
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
         )
-        return dbos.retrieve_queue(name)
+        queue = dbos.retrieve_queue(name)
+        assert queue is not None, f"Queue {name} missing from database after upsert"
+        return queue
 
     @classmethod
     def retrieve_queue(cls, name: str) -> Optional[Queue]:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -787,9 +787,9 @@ class DBOS:
         cls,
         name: str,
         *,
+        worker_concurrency: Optional[int] = None,
         concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
-        worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
@@ -798,15 +798,38 @@ class DBOS:
         """
         Register a queue and persist its configuration to the system database.
 
-        ``on_conflict`` controls behavior when a queue with the same name already
-        exists in the database:
+        :param name: Unique name of the queue.
+        :param worker_concurrency: Maximum number of workflows from this queue
+            that may be running on a single executor at once. ``None`` means no
+            per-executor limit. May be combined with ``concurrency``.
+        :param concurrency: Maximum number of workflows from this queue that may
+            be running globally (across all executors) at once. ``None`` (the
+            default) means no global limit.
+        :param limiter: Rate limit configuration of the form
+            ``{"limit": int, "period": float}``. At most ``limit`` workflows
+            from the queue will start within any rolling window of ``period``
+            seconds. ``None`` disables rate limiting.
+        :param priority_enabled: When ``True``, callers may set a workflow
+            priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
+            are dequeued first. When ``False``, supplying a priority raises an
+            error at enqueue time.
+        :param partition_queue: When ``True``, every enqueue must specify a
+            ``queue_partition_key`` and concurrency / worker_concurrency limits
+            are applied per partition rather than to the queue as a whole.
+            Deduplication is not supported on partitioned queues.
+        :param polling_interval_sec: How often (in seconds) the worker thread
+            wakes up to look for runnable workflows on this queue.
+        :param on_conflict: Behavior when a queue with the same name already
+            exists in the database:
 
-        - ``"update_if_latest_version"`` (default): overwrite the existing row
-          only when the running application version is the latest registered
-          version. Older versions in a rolling deploy will not overwrite the
-          newer config.
-        - ``"always_update"``: always overwrite the existing row.
-        - ``"never_update"``: leave the existing row unchanged.
+            - ``"update_if_latest_version"`` (default): overwrite the existing
+              row only when the running application version is the latest
+              registered version. Older versions in a rolling deploy will not
+              overwrite the newer config.
+            - ``"always_update"``: always overwrite the existing row.
+            - ``"never_update"``: leave the existing row unchanged.
+
+        :returns: A :class:`Queue` reflecting the persisted configuration.
         """
         dbos = _get_dbos_instance()
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -390,7 +390,7 @@ class DBOS:
         self._app_db_field: Optional[ApplicationDatabase] = None
         self._registry: DBOSRegistry = _get_or_create_dbos_registry()
         self._registry.dbos = self
-        self._listening_queues: Optional[List[Queue]] = None
+        self._listening_queues: Optional[List[str]] = None
         self._admin_server_field: Optional[AdminServer] = None
         # Stop internal background threads (queue thread, timeout threads, etc.)
         self.background_thread_stop_events: List[threading.Event] = []
@@ -3030,19 +3030,19 @@ class DBOS:
         return dbos_tracer
 
     @classmethod
-    def listen_queues(cls, queues: List[Queue]) -> None:
+    def listen_queues(cls, queues: List[Union[Queue, str]]) -> None:
         """
         Configure this DBOS process to only listen to (dequeue workflows from) specific queues.
 
         Args:
-            queues(List[Queue]): The list of queues to listen to
+            queues: The queues to listen to, either as ``Queue`` objects or as queue names.
         """
         dbos = _get_dbos_instance()
         if dbos._launched:
             raise DBOSException("listen_queues called after DBOS is launched")
         if dbos._listening_queues is not None:
             raise DBOSException("listen_queues called more than once")
-        dbos._listening_queues = queues
+        dbos._listening_queues = [q if isinstance(q, str) else q.name for q in queues]
 
     @classmethod
     def alert_handler(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -873,6 +873,11 @@ class DBOS:
         """
         return _get_dbos_instance()._sys_db.get_queue(name)
 
+    @classmethod
+    def delete_queue(cls, name: str) -> None:
+        """Delete a database-backed queue by name. No-op if it does not exist."""
+        _get_dbos_instance()._sys_db.delete_queue(name)
+
     # Decorators for DBOS functionality
     @classmethod
     def workflow(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -850,26 +850,7 @@ class DBOS:
         system database. The returned Queue is not added to the in-memory queue
         registry.
         """
-        dbos = _get_dbos_instance()
-        row = dbos._sys_db.get_queue(name)
-        if row is None:
-            return None
-        limiter: Optional[QueueRateLimit] = None
-        if row["rate_limit_max"] is not None:
-            limiter = {
-                "limit": row["rate_limit_max"],
-                "period": row["rate_limit_period_sec"],
-            }
-        return Queue(
-            row["name"],
-            row["concurrency"],
-            limiter,
-            worker_concurrency=row["worker_concurrency"],
-            priority_enabled=row["priority_enabled"],
-            partition_queue=row["partition_queue"],
-            polling_interval_sec=row["polling_interval_sec"],
-            database_backed_queue=True,
-        )
+        return _get_dbos_instance()._sys_db.get_queue(name)
 
     # Decorators for DBOS functionality
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -875,7 +875,7 @@ class DBOS:
 
     @classmethod
     def delete_queue(cls, name: str) -> None:
-        """Delete a database-backed queue by name. No-op if it does not exist."""
+        """Delete a database-backed queue. Pending workflows on it are unrecoverable."""
         _get_dbos_instance()._sys_db.delete_queue(name)
 
     # Decorators for DBOS functionality

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -14,6 +14,7 @@ from typing import (
     Tuple,
     TypedDict,
     TypeVar,
+    Union,
 )
 
 from dbos._client import (
@@ -49,6 +50,14 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
 
 _DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
+
+
+def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
+    if queue is None:
+        return None
+    if isinstance(queue, Queue):
+        return queue.name
+    return queue
 
 
 # Options saved from the local context to pass through to the debounced function
@@ -159,12 +168,12 @@ class Debouncer(Generic[P, R]):
         workflow_name: str,
         *,
         debounce_timeout_sec: Optional[float] = None,
-        queue: Optional[Queue] = None,
+        queue: Optional[Union[Queue, str]] = None,
     ):
         self.func_name = workflow_name
         self.options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
-            "queue_name": queue.name if queue else None,
+            "queue_name": _resolve_queue_name(queue),
             "workflow_name": workflow_name,
         }
 
@@ -173,7 +182,7 @@ class Debouncer(Generic[P, R]):
         workflow: Callable[P, R],
         *,
         debounce_timeout_sec: Optional[float] = None,
-        queue: Optional[Queue] = None,
+        queue: Optional[Union[Queue, str]] = None,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -189,7 +198,7 @@ class Debouncer(Generic[P, R]):
         workflow: Callable[P, Coroutine[Any, Any, R]],
         *,
         debounce_timeout_sec: Optional[float] = None,
-        queue: Optional[Queue] = None,
+        queue: Optional[Union[Queue, str]] = None,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -317,12 +326,12 @@ class DebouncerClient:
         workflow_options: EnqueueOptions,
         *,
         debounce_timeout_sec: Optional[float] = None,
-        queue: Optional[Queue] = None,
+        queue: Optional[Union[Queue, str]] = None,
     ):
         self.workflow_options = workflow_options
         self.debouncer_options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
-            "queue_name": queue.name if queue else None,
+            "queue_name": _resolve_queue_name(queue),
             "workflow_name": workflow_options["workflow_name"],
         }
         self.client = client

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -133,6 +133,8 @@ def debouncer_workflow(
             if options["queue_name"]:
                 queue = dbos._registry.queue_info_map.get(options["queue_name"], None)
                 if not queue:
+                    queue = dbos._sys_db.get_queue(options["queue_name"])
+                if not queue:
                     raise Exception(
                         f"Invalid queue name provided to debouncer: {options['queue_name']}"
                     )

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -493,6 +493,24 @@ ALTER FUNCTION "{schema}".workflow_events_function() SET search_path = pg_catalo
     return migration
 
 
+def get_dbos_migration_twentyone(schema: str) -> str:
+    return f"""
+CREATE TABLE "{schema}".queues (
+    queue_id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    name TEXT NOT NULL UNIQUE,
+    concurrency INTEGER,
+    worker_concurrency INTEGER,
+    rate_limit_max INTEGER,
+    rate_limit_period_sec DOUBLE PRECISION,
+    priority_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    partition_queue BOOLEAN NOT NULL DEFAULT FALSE,
+    polling_interval_sec DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    created_at BIGINT NOT NULL DEFAULT (EXTRACT(epoch FROM now()) * 1000.0)::bigint,
+    updated_at BIGINT NOT NULL DEFAULT (EXTRACT(epoch FROM now()) * 1000.0)::bigint
+);
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -517,6 +535,7 @@ def get_dbos_migrations(
         get_dbos_migration_eighteen(schema),
         get_dbos_migration_nineteen(schema),
         get_dbos_migration_twenty(schema, use_listen_notify, is_cockroach),
+        get_dbos_migration_twentyone(schema),
     ]
 
 
@@ -706,6 +725,22 @@ sqlite_migration_nineteen = """
 CREATE INDEX "idx_operation_outputs_completed_at_function_name" ON "operation_outputs" ("completed_at_epoch_ms", "function_name");
 """
 
+sqlite_migration_twentyone = f"""
+CREATE TABLE queues (
+    queue_id TEXT PRIMARY KEY DEFAULT (hex(randomblob(16))),
+    name TEXT NOT NULL UNIQUE,
+    concurrency INTEGER,
+    worker_concurrency INTEGER,
+    rate_limit_max INTEGER,
+    rate_limit_period_sec REAL,
+    priority_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    partition_queue BOOLEAN NOT NULL DEFAULT FALSE,
+    polling_interval_sec REAL NOT NULL DEFAULT 1.0,
+    created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+    updated_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()}
+);
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -726,4 +761,5 @@ sqlite_migrations = [
     sqlite_migration_eighteen,
     sqlite_migration_nineteen,
     # There is no SQLite version of migration twenty
+    sqlite_migration_twentyone,
 ]

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -11,6 +11,7 @@ from psycopg import errors
 from sqlalchemy.exc import OperationalError
 
 from dbos._context import DBOSContext, get_local_dbos_context
+from dbos._error import DBOSException
 from dbos._logger import dbos_logger
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
@@ -63,13 +64,15 @@ class Queue:
         if polling_interval_sec <= 0.0:
             raise ValueError("polling_interval_sec must be positive")
         self.name = name
-        self.concurrency = concurrency
-        self.worker_concurrency = worker_concurrency
-        self.limiter = limiter
-        self.priority_enabled = priority_enabled
-        self.partition_queue = partition_queue
-        self.polling_interval_sec = polling_interval_sec
         self.database_backed_queue = database_backed_queue
+        # Local cache of configurable params. Property getters consult this
+        # for in-memory queues and the database for database-backed queues.
+        self._concurrency = concurrency
+        self._worker_concurrency = worker_concurrency
+        self._limiter = limiter
+        self._priority_enabled = priority_enabled
+        self._partition_queue = partition_queue
+        self._polling_interval_sec = polling_interval_sec
 
         # Database-backed queues skip the in-memory global registry; their
         # source of truth is the queues table.
@@ -82,6 +85,115 @@ class Queue:
         if self.name in registry.queue_info_map and self.name != INTERNAL_QUEUE_NAME:
             raise Exception(f"Queue {name} has already been declared")
         registry.queue_info_map[self.name] = self
+
+    def _require_database_backed(self) -> None:
+        if not self.database_backed_queue:
+            raise DBOSException(
+                f"Cannot configure queue {self.name}: dynamic configuration is "
+                "only supported for queues registered via DBOS.register_queue."
+            )
+
+    def _read_from_db(self) -> "Queue":
+        from ._dbos import _get_dbos_instance
+
+        latest = _get_dbos_instance()._sys_db.get_queue(self.name)
+        if latest is None:
+            raise DBOSException(f"Queue {self.name} not found in the database")
+        return latest
+
+    def _write_to_db(self, fields: dict[str, Any]) -> None:
+        from ._dbos import _get_dbos_instance
+
+        _get_dbos_instance()._sys_db.update_queue(self.name, fields)
+
+    @property
+    def concurrency(self) -> Optional[int]:
+        if self.database_backed_queue:
+            self._concurrency = self._read_from_db()._concurrency
+        return self._concurrency
+
+    def set_concurrency(self, value: Optional[int]) -> None:
+        self._require_database_backed()
+        if (
+            value is not None
+            and self._worker_concurrency is not None
+            and self._worker_concurrency > value
+        ):
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        self._write_to_db({"concurrency": value})
+        self._concurrency = value
+
+    @property
+    def worker_concurrency(self) -> Optional[int]:
+        if self.database_backed_queue:
+            self._worker_concurrency = self._read_from_db()._worker_concurrency
+        return self._worker_concurrency
+
+    def set_worker_concurrency(self, value: Optional[int]) -> None:
+        self._require_database_backed()
+        if (
+            value is not None
+            and self._concurrency is not None
+            and value > self._concurrency
+        ):
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        self._write_to_db({"worker_concurrency": value})
+        self._worker_concurrency = value
+
+    @property
+    def limiter(self) -> Optional[QueueRateLimit]:
+        if self.database_backed_queue:
+            self._limiter = self._read_from_db()._limiter
+        return self._limiter
+
+    def set_limiter(self, value: Optional[QueueRateLimit]) -> None:
+        self._require_database_backed()
+        self._write_to_db(
+            {
+                "rate_limit_max": value["limit"] if value else None,
+                "rate_limit_period_sec": value["period"] if value else None,
+            }
+        )
+        self._limiter = value
+
+    @property
+    def priority_enabled(self) -> bool:
+        if self.database_backed_queue:
+            self._priority_enabled = self._read_from_db()._priority_enabled
+        return self._priority_enabled
+
+    def set_priority_enabled(self, value: bool) -> None:
+        self._require_database_backed()
+        self._write_to_db({"priority_enabled": value})
+        self._priority_enabled = value
+
+    @property
+    def partition_queue(self) -> bool:
+        if self.database_backed_queue:
+            self._partition_queue = self._read_from_db()._partition_queue
+        return self._partition_queue
+
+    def set_partition_queue(self, value: bool) -> None:
+        self._require_database_backed()
+        self._write_to_db({"partition_queue": value})
+        self._partition_queue = value
+
+    @property
+    def polling_interval_sec(self) -> float:
+        if self.database_backed_queue:
+            self._polling_interval_sec = self._read_from_db()._polling_interval_sec
+        return self._polling_interval_sec
+
+    def set_polling_interval_sec(self, value: float) -> None:
+        self._require_database_backed()
+        if value <= 0.0:
+            raise ValueError("polling_interval_sec must be positive")
+        self._write_to_db({"polling_interval_sec": value})
+        self._polling_interval_sec = value
 
     def enqueue(
         self, func: "Callable[P, R]", *args: P.args, **kwargs: P.kwargs
@@ -143,17 +255,40 @@ def queue_worker_thread(
     stop_event: threading.Event, dbos: "DBOS", queue: Queue
 ) -> None:
     """Worker thread for processing a single queue."""
-    polling_interval = queue.polling_interval_sec
-    min_polling_interval = queue.polling_interval_sec
-    max_polling_interval = max(queue.polling_interval_sec, 120.0)
+    polling_interval = queue._polling_interval_sec
+    max_polling_interval = max(queue._polling_interval_sec, 120.0)
 
     while not stop_event.is_set():
+        # Reload database-backed queue config once per iteration so dynamic
+        # changes (concurrency, polling interval, etc.) take effect without
+        # a restart. If the row was deleted, exit the worker.
+        if queue.database_backed_queue:
+            try:
+                latest = dbos._sys_db.get_queue(queue.name)
+            except Exception as e:
+                dbos.logger.warning(
+                    f"Exception reloading queue {queue.name} from database: {e}"
+                )
+                latest = queue
+            if latest is None:
+                dbos.logger.info(
+                    f"Queue {queue.name} no longer exists in database, stopping worker"
+                )
+                return
+            queue = latest
+
+        min_polling_interval = queue._polling_interval_sec
+        max_polling_interval = max(queue._polling_interval_sec, 120.0)
+        polling_interval = max(
+            min_polling_interval, min(polling_interval, max_polling_interval)
+        )
+
         # Wait for the polling interval with jitter
         if stop_event.wait(timeout=polling_interval * random.uniform(0.95, 1.05)):
             return
 
         try:
-            if queue.partition_queue:
+            if queue._partition_queue:
                 queue_partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                 for key in queue_partition_keys:
                     local_running_count = dbos._active_workflows_set.count_for_queue(

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -19,6 +19,7 @@ from ._core import P, R, execute_workflow_by_id, start_workflow, start_workflow_
 
 if TYPE_CHECKING:
     from ._dbos import DBOS, WorkflowHandle, WorkflowHandleAsync
+    from ._sys_db import SystemDatabase
 
 
 class QueueRateLimit(TypedDict):
@@ -52,6 +53,7 @@ class Queue:
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         database_backed_queue: bool = False,
+        client_system_database: Optional["SystemDatabase"] = None,
     ) -> None:
         if (
             worker_concurrency is not None
@@ -65,6 +67,10 @@ class Queue:
             raise ValueError("polling_interval_sec must be positive")
         self.name = name
         self.database_backed_queue = database_backed_queue
+        # When set, getters/setters use this SystemDatabase instead of the
+        # DBOS singleton's. This allows a DBOSClient to manipulate queues
+        # without depending on a launched DBOS process.
+        self._client_system_database = client_system_database
         # Local cache of configurable params. Property getters consult this
         # for in-memory queues and the database for database-backed queues.
         self._concurrency = concurrency
@@ -93,18 +99,23 @@ class Queue:
                 "only supported for queues registered via DBOS.register_queue."
             )
 
-    def _read_from_db(self) -> "Queue":
+    def _sys_db(self) -> "SystemDatabase":
+        if self._client_system_database is not None:
+            return self._client_system_database
         from ._dbos import _get_dbos_instance
 
-        latest = _get_dbos_instance()._sys_db.get_queue(self.name)
+        return _get_dbos_instance()._sys_db
+
+    def _read_from_db(self) -> "Queue":
+        latest = self._sys_db().get_queue(
+            self.name, client_system_database=self._client_system_database
+        )
         if latest is None:
             raise DBOSException(f"Queue {self.name} not found in the database")
         return latest
 
     def _write_to_db(self, fields: dict[str, Any]) -> None:
-        from ._dbos import _get_dbos_instance
-
-        _get_dbos_instance()._sys_db.update_queue(self.name, fields)
+        self._sys_db().update_queue(self.name, fields)
 
     @property
     def concurrency(self) -> Optional[int]:
@@ -195,9 +206,17 @@ class Queue:
         self._write_to_db({"polling_interval_sec": value})
         self._polling_interval_sec = value
 
+    def _require_dbos_bound(self) -> None:
+        if self._client_system_database is not None:
+            raise DBOSException(
+                f"Cannot enqueue on queue {self.name} from a client-bound Queue "
+                "object. Use DBOSClient.enqueue instead."
+            )
+
     def enqueue(
         self, func: "Callable[P, R]", *args: P.args, **kwargs: P.kwargs
     ) -> "WorkflowHandle[R]":
+        self._require_dbos_bound()
         from ._dbos import _get_dbos_instance
 
         context = get_local_dbos_context()
@@ -233,6 +252,7 @@ class Queue:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> "WorkflowHandleAsync[R]":
+        self._require_dbos_bound()
         from ._dbos import _get_dbos_instance
 
         dbos = _get_dbos_instance()

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -220,18 +220,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     # Check interval for monitoring queue registration changes
     check_interval = 1.0
 
-    if dbos._listening_queues is not None:
-        dbos.logger.info(f"Listening to {len(dbos._listening_queues)} queues:")
-        for name in dbos._listening_queues:
-            dbos_logger.info(f"Queue: {name}")
-    else:
-        listening_queues = [
-            q
-            for q in dbos._registry.queue_info_map.values()
-            if q.name != INTERNAL_QUEUE_NAME
-        ]
-        dbos.logger.info(f"Listening to {len(listening_queues)} queues:")
-        log_queues(listening_queues)
+    log_queues(dbos, dbos._listening_queues)
 
     while not stop_event.is_set():
         if dbos._listening_queues is not None:
@@ -303,9 +292,27 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                 )
 
 
-def log_queues(queues: list[Queue]) -> None:
-    """Helper function to log queues on DBOS launch."""
-    for q in queues:
+def log_queues(dbos: "DBOS", listening_queues: Optional[list[str]]) -> None:
+    """Log all queues this process will listen to on DBOS launch.
+
+    Combines in-memory registered queues with database-backed queues, applies
+    the listen_queues filter if any, and excludes the internal queue.
+    """
+    queues: dict[str, Queue] = dict(dbos._registry.queue_info_map)
+    try:
+        for q in dbos._sys_db.list_queues():
+            queues.setdefault(q.name, q)
+    except Exception as e:
+        dbos.logger.warning(f"Exception listing database-backed queues: {e}")
+
+    if listening_queues is not None:
+        listening_set = set(listening_queues)
+        queues = {n: q for n, q in queues.items() if n in listening_set}
+
+    queues.pop(INTERNAL_QUEUE_NAME, None)
+
+    dbos.logger.info(f"Listening to {len(queues)} queues:")
+    for q in queues.values():
         opts = []
         if q.concurrency is not None:
             opts.append(f"concurrency={q.concurrency}")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -183,6 +183,10 @@ class Queue:
 
     def set_limiter(self, value: Optional[QueueRateLimit]) -> None:
         self._require_database_backed()
+        if value is not None and (
+            value.get("limit") is None or value.get("period") is None
+        ):
+            raise ValueError("limiter must specify both 'limit' and 'period'")
         self._write_to_db(
             {
                 "rate_limit_max": value["limit"] if value else None,

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -213,34 +213,29 @@ class Queue:
                 "object. Use DBOSClient.enqueue instead."
             )
 
-    def enqueue(
-        self, func: "Callable[P, R]", *args: P.args, **kwargs: P.kwargs
-    ) -> "WorkflowHandle[R]":
+    def _validate_enqueue(self, ctx: Optional[DBOSContext]) -> None:
         self._require_dbos_bound()
-        from ._dbos import _get_dbos_instance
-
-        context = get_local_dbos_context()
-        if (
-            context is not None
-            and context.priority is not None
-            and not self.priority_enabled
-        ):
+        if ctx is not None and ctx.priority is not None and not self.priority_enabled:
             raise Exception(
                 f"Priority is not enabled for queue {self.name}. Setting priority will not have any effect."
             )
-        if self.partition_queue and (
-            context is None or context.queue_partition_key is None
-        ):
+        if self.partition_queue and (ctx is None or ctx.queue_partition_key is None):
             raise Exception(
                 f"A workflow cannot be enqueued on partitioned queue {self.name} without a partition key"
             )
-        if context and context.queue_partition_key and not self.partition_queue:
+        if ctx and ctx.queue_partition_key and not self.partition_queue:
             raise Exception(
-                f"You can only use a partition key on a partition-enabled queue. Key {context.queue_partition_key} was used with non-partitioned queue {self.name}"
+                f"You can only use a partition key on a partition-enabled queue. Key {ctx.queue_partition_key} was used with non-partitioned queue {self.name}"
             )
-        if context and context.queue_partition_key and context.deduplication_id:
+        if ctx and ctx.queue_partition_key and ctx.deduplication_id:
             raise Exception("Deduplication is not supported for partitioned queues")
 
+    def enqueue(
+        self, func: "Callable[P, R]", *args: P.args, **kwargs: P.kwargs
+    ) -> "WorkflowHandle[R]":
+        from ._dbos import _get_dbos_instance
+
+        self._validate_enqueue(get_local_dbos_context())
         dbos = _get_dbos_instance()
         return start_workflow(
             dbos, func, args, kwargs, queue_name=self.name, execute_workflow=False
@@ -252,11 +247,11 @@ class Queue:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> "WorkflowHandleAsync[R]":
-        self._require_dbos_bound()
         from ._dbos import _get_dbos_instance
 
-        dbos = _get_dbos_instance()
         ctx = get_local_dbos_context()
+        self._validate_enqueue(ctx)
+        dbos = _get_dbos_instance()
         parent_ctx_copy = copy.copy(ctx)
         child_ctx = DBOSContext.create_start_workflow_child(ctx)
         return await start_workflow_async(

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -1,7 +1,11 @@
 import copy
 import random
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Literal, Optional, TypedDict
+
+QueueConflictResolution = Literal[
+    "update_if_latest_version", "always_update", "never_update"
+]
 
 from psycopg import errors
 from sqlalchemy.exc import OperationalError
@@ -46,6 +50,7 @@ class Queue:
         priority_enabled: bool = False,
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
+        database_backed_queue: bool = False,
     ) -> None:
         if (
             worker_concurrency is not None
@@ -64,6 +69,13 @@ class Queue:
         self.priority_enabled = priority_enabled
         self.partition_queue = partition_queue
         self.polling_interval_sec = polling_interval_sec
+        self.database_backed_queue = database_backed_queue
+
+        # Database-backed queues skip the in-memory global registry; their
+        # source of truth is the queues table.
+        if database_backed_queue:
+            return
+
         from ._dbos import _get_or_create_dbos_registry
 
         registry = _get_or_create_dbos_registry()

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -415,7 +415,16 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             current_queues = dict(dbos._registry.queue_info_map)
             try:
                 for queue in dbos._sys_db.list_queues():
-                    if queue.name in current_queues or queue.name in queue_threads:
+                    if queue.name in dbos._registry.queue_info_map:
+                        dbos.logger.warning(
+                            f"Database-backed queue {queue.name} has the same "
+                            "name as an in-memory queue. The in-memory queue's "
+                            "configuration is being used; the database-backed "
+                            "queue is ignored. Rename one of them to resolve "
+                            "the conflict."
+                        )
+                        continue
+                    if queue.name in queue_threads:
                         continue
                     current_queues[queue.name] = queue
             except Exception as e:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -55,16 +55,12 @@ class Queue:
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
     ) -> None:
-        if (
-            worker_concurrency is not None
-            and concurrency is not None
-            and worker_concurrency > concurrency
-        ):
-            raise ValueError(
-                "worker_concurrency must be less than or equal to concurrency"
-            )
-        if polling_interval_sec <= 0.0:
-            raise ValueError("polling_interval_sec must be positive")
+        Queue._validate_queue(
+            concurrency=concurrency,
+            worker_concurrency=worker_concurrency,
+            polling_interval_sec=polling_interval_sec,
+            limiter=limiter,
+        )
         self.name = name
         self.database_backed_queue = database_backed_queue
         # When set, getters/setters use this SystemDatabase instead of the
@@ -91,6 +87,30 @@ class Queue:
         if self.name in registry.queue_info_map and self.name != INTERNAL_QUEUE_NAME:
             raise Exception(f"Queue {name} has already been declared")
         registry.queue_info_map[self.name] = self
+
+    @staticmethod
+    def _validate_queue(
+        *,
+        concurrency: Optional[int],
+        worker_concurrency: Optional[int],
+        polling_interval_sec: float,
+        limiter: Optional[QueueRateLimit],
+    ) -> None:
+        """Validate queue configuration parameters, raising ValueError on bad input."""
+        if (
+            worker_concurrency is not None
+            and concurrency is not None
+            and worker_concurrency > concurrency
+        ):
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        if polling_interval_sec <= 0.0:
+            raise ValueError("polling_interval_sec must be positive")
+        if limiter is not None and (
+            limiter.get("limit") is None or limiter.get("period") is None
+        ):
+            raise ValueError("limiter must specify both 'limit' and 'period'")
 
     def _require_database_backed(self) -> None:
         if not self.database_backed_queue:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -103,7 +103,7 @@ class Queue:
             and worker_concurrency > concurrency
         ):
             raise ValueError(
-                "worker_concurrency must be less than or equal to concurrency"
+                "concurrency must be greater than or equal to worker_concurrency"
             )
         if polling_interval_sec <= 0.0:
             raise ValueError("polling_interval_sec must be positive")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -221,19 +221,34 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
     check_interval = 1.0
 
     if dbos._listening_queues is not None:
-        listening_queues = dbos._listening_queues
+        dbos.logger.info(f"Listening to {len(dbos._listening_queues)} queues:")
+        for name in dbos._listening_queues:
+            dbos_logger.info(f"Queue: {name}")
     else:
-        listening_queues = list(dbos._registry.queue_info_map.values())
         listening_queues = [
-            q for q in listening_queues if q.name != INTERNAL_QUEUE_NAME
+            q
+            for q in dbos._registry.queue_info_map.values()
+            if q.name != INTERNAL_QUEUE_NAME
         ]
-    dbos.logger.info(f"Listening to {len(listening_queues)} queues:")
-    log_queues(listening_queues)
+        dbos.logger.info(f"Listening to {len(listening_queues)} queues:")
+        log_queues(listening_queues)
 
     while not stop_event.is_set():
         if dbos._listening_queues is not None:
-            # If explicitly listening for queues, only use those queues
-            current_queues = {queue.name: queue for queue in dbos._listening_queues}
+            # If explicitly listening for queues, resolve each name to a Queue
+            # from either the in-memory registry or the database.
+            listening_set = set(dbos._listening_queues)
+            current_queues = {
+                name: q
+                for name, q in dbos._registry.queue_info_map.items()
+                if name in listening_set
+            }
+            try:
+                for queue in dbos._sys_db.list_queues():
+                    if queue.name in listening_set and queue.name not in current_queues:
+                        current_queues[queue.name] = queue
+            except Exception as e:
+                dbos.logger.warning(f"Exception listing database-backed queues: {e}")
             # Always listen to the internal queue
             current_queues[INTERNAL_QUEUE_NAME] = dbos._registry.get_internal_queue()
         else:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -237,8 +237,15 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             # Always listen to the internal queue
             current_queues[INTERNAL_QUEUE_NAME] = dbos._registry.get_internal_queue()
         else:
-            # Else, check all declared queues
+            # Else, check all in-memory and database-backed queues
             current_queues = dict(dbos._registry.queue_info_map)
+            try:
+                for queue in dbos._sys_db.list_queues():
+                    if queue.name in current_queues or queue.name in queue_threads:
+                        continue
+                    current_queues[queue.name] = queue
+            except Exception as e:
+                dbos.logger.warning(f"Exception listing database-backed queues: {e}")
 
         # Transition any DELAYED workflows whose delay has expired to ENQUEUED.
         try:

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     Column,
+    Float,
     ForeignKey,
     Index,
     Integer,
@@ -41,6 +42,7 @@ class SystemSchema:
         cls.workflow_events_history.schema = schema_name
         cls.workflow_schedules.schema = schema_name
         cls.application_versions.schema = schema_name
+        cls.queues.schema = schema_name
 
     workflow_status = Table(
         "workflow_status",
@@ -242,4 +244,25 @@ class SystemSchema:
             BigInteger,
             nullable=False,
         ),
+    )
+
+    queues = Table(
+        "queues",
+        metadata_obj,
+        Column(
+            "queue_id",
+            Text,
+            primary_key=True,
+            server_default=text("gen_random_uuid()::TEXT"),
+        ),
+        Column("name", Text, nullable=False, unique=True),
+        Column("concurrency", Integer, nullable=True),
+        Column("worker_concurrency", Integer, nullable=True),
+        Column("rate_limit_max", Integer, nullable=True),
+        Column("rate_limit_period_sec", Float, nullable=True),
+        Column("priority_enabled", Boolean, nullable=False, server_default="false"),
+        Column("partition_queue", Boolean, nullable=False, server_default="false"),
+        Column("polling_interval_sec", Float, nullable=False, server_default="1.0"),
+        Column("created_at", BigInteger, nullable=False),
+        Column("updated_at", BigInteger, nullable=False),
     )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -17,7 +17,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    Sequence,
     Tuple,
     TypedDict,
     TypeVar,
@@ -66,7 +65,30 @@ from ._serialization import (
 )
 
 if TYPE_CHECKING:
+    from ._queue import Queue, QueueRateLimit
+
+
+def queue_from_db_row(row: sa.Row[Any]) -> "Queue":
+    """Build a database-backed Queue from a queues-table row."""
     from ._queue import Queue
+
+    m = row._mapping
+    limiter: Optional["QueueRateLimit"] = None
+    if m["rate_limit_max"] is not None:
+        limiter = {
+            "limit": m["rate_limit_max"],
+            "period": m["rate_limit_period_sec"],
+        }
+    return Queue(
+        m["name"],
+        m["concurrency"],
+        limiter,
+        worker_concurrency=m["worker_concurrency"],
+        priority_enabled=bool(m["priority_enabled"]),
+        partition_queue=bool(m["partition_queue"]),
+        polling_interval_sec=m["polling_interval_sec"],
+        database_backed_queue=True,
+    )
 
 
 class WorkflowStatusString(Enum):
@@ -4159,32 +4181,17 @@ class SystemDatabase(ABC):
 
     # ── Queue Registration ──────────────────────────────────────
 
-    def get_queue(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_queue(self, name: str) -> Optional["Queue"]:
         with self.engine.begin() as c:
             row = c.execute(
-                sa.select(
-                    SystemSchema.queues.c.name,
-                    SystemSchema.queues.c.concurrency,
-                    SystemSchema.queues.c.worker_concurrency,
-                    SystemSchema.queues.c.rate_limit_max,
-                    SystemSchema.queues.c.rate_limit_period_sec,
-                    SystemSchema.queues.c.priority_enabled,
-                    SystemSchema.queues.c.partition_queue,
-                    SystemSchema.queues.c.polling_interval_sec,
-                ).where(SystemSchema.queues.c.name == name)
+                sa.select(SystemSchema.queues).where(SystemSchema.queues.c.name == name)
             ).fetchone()
-            if row is None:
-                return None
-            return {
-                "name": row[0],
-                "concurrency": row[1],
-                "worker_concurrency": row[2],
-                "rate_limit_max": row[3],
-                "rate_limit_period_sec": row[4],
-                "priority_enabled": bool(row[5]),
-                "partition_queue": bool(row[6]),
-                "polling_interval_sec": row[7],
-            }
+            return queue_from_db_row(row) if row is not None else None
+
+    def list_queues(self) -> List["Queue"]:
+        with self.engine.begin() as c:
+            rows = c.execute(sa.select(SystemSchema.queues)).fetchall()
+            return [queue_from_db_row(row) for row in rows]
 
     def upsert_queue(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2959,17 +2959,19 @@ class SystemDatabase(ABC):
         local_running_count: int = 0,
     ) -> List[str]:
         start_time_ms = int(time.time() * 1000)
-        if queue.limiter is not None:
-            limiter_period_ms = int(queue.limiter["period"] * 1000)
+        # Use the queue's locally cached private state to avoid recursive DB
+        # reads via the @property getters within this transaction.
+        if queue._limiter is not None:
+            limiter_period_ms = int(queue._limiter["period"] * 1000)
         with self.engine.begin() as c:
             # Default to READ COMMITTED except with global concurrency limits or rate limits
             if self.engine.dialect.name == "postgresql" and (
-                queue.concurrency is not None or queue.limiter is not None
+                queue._concurrency is not None or queue._limiter is not None
             ):
                 c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
 
             # If there is a limiter, compute how many functions have started in its period.
-            if queue.limiter is not None:
+            if queue._limiter is not None:
                 query = (
                     sa.select(sa.func.count())
                     .select_from(SystemSchema.workflow_status)
@@ -2993,17 +2995,17 @@ class SystemDatabase(ABC):
                         == queue_partition_key
                     )
                 num_recent_queries = c.execute(query).fetchone()[0]  # type: ignore
-                if num_recent_queries >= queue.limiter["limit"]:
+                if num_recent_queries >= queue._limiter["limit"]:
                     return []
 
             # Compute max_tasks, the number of workflows that can be dequeued given local and global concurrency limits,
             max_tasks = sys.maxsize
 
-            if queue.worker_concurrency is not None:
+            if queue._worker_concurrency is not None:
                 # Use the in-memory registry for this worker's running count — avoids a DB round trip.
-                max_tasks = max(0, queue.worker_concurrency - local_running_count)
+                max_tasks = max(0, queue._worker_concurrency - local_running_count)
 
-            if queue.concurrency is not None:
+            if queue._concurrency is not None:
                 # Global concurrency still requires a DB query since other workers may be running workflows too.
                 global_pending_query = (
                     sa.select(sa.func.count())
@@ -3020,16 +3022,16 @@ class SystemDatabase(ABC):
                         == queue_partition_key
                     )
                 global_pending_workflows = c.execute(global_pending_query).scalar() or 0
-                if global_pending_workflows > queue.concurrency:
+                if global_pending_workflows > queue._concurrency:
                     dbos_logger.warning(
-                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({queue.concurrency})"
+                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({queue._concurrency})"
                     )
-                available_tasks = max(0, queue.concurrency - global_pending_workflows)
+                available_tasks = max(0, queue._concurrency - global_pending_workflows)
                 max_tasks = min(max_tasks, available_tasks)
 
             # Retrieve the first max_tasks workflows in the queue.
             # Only retrieve workflows of the local version (or without version set)
-            skip_locks = queue.concurrency is None
+            skip_locks = queue._concurrency is None
             query = (
                 sa.select(
                     SystemSchema.workflow_status.c.workflow_uuid,
@@ -3057,7 +3059,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.queue_partition_key
                     == queue_partition_key
                 )
-            if queue.priority_enabled:
+            if queue._priority_enabled:
                 query = query.order_by(
                     SystemSchema.workflow_status.c.priority.asc(),
                     SystemSchema.workflow_status.c.created_at.asc(),
@@ -3080,8 +3082,8 @@ class SystemDatabase(ABC):
             for id in dequeued_ids:
                 # If we have a limiter, stop dequeueing workflows when the number
                 # of workflows started this period exceeds the limit.
-                if queue.limiter is not None:
-                    if len(ret_ids) + num_recent_queries >= queue.limiter["limit"]:
+                if queue._limiter is not None:
+                    if len(ret_ids) + num_recent_queries >= queue._limiter["limit"]:
                         break
 
                 # Start the workflow by marking it as PENDING and updating its executor ID.
@@ -4192,6 +4194,19 @@ class SystemDatabase(ABC):
         with self.engine.begin() as c:
             rows = c.execute(sa.select(SystemSchema.queues)).fetchall()
             return [queue_from_db_row(row) for row in rows]
+
+    def update_queue(self, name: str, fields: Dict[str, Any]) -> None:
+        """Apply a partial update to a database-backed queue's row."""
+        if not fields:
+            return
+        values = dict(fields)
+        values["updated_at"] = int(time.time() * 1000)
+        with self.engine.begin() as c:
+            c.execute(
+                sa.update(SystemSchema.queues)
+                .where(SystemSchema.queues.c.name == name)
+                .values(**values)
+            )
 
     def upsert_queue(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -68,7 +68,10 @@ if TYPE_CHECKING:
     from ._queue import Queue, QueueRateLimit
 
 
-def queue_from_db_row(row: sa.Row[Any]) -> "Queue":
+def queue_from_db_row(
+    row: sa.Row[Any],
+    client_system_database: Optional["SystemDatabase"] = None,
+) -> "Queue":
     """Build a database-backed Queue from a queues-table row."""
     from ._queue import Queue
 
@@ -88,6 +91,7 @@ def queue_from_db_row(row: sa.Row[Any]) -> "Queue":
         partition_queue=bool(m["partition_queue"]),
         polling_interval_sec=m["polling_interval_sec"],
         database_backed_queue=True,
+        client_system_database=client_system_database,
     )
 
 
@@ -4183,17 +4187,31 @@ class SystemDatabase(ABC):
 
     # ── Queue Registration ──────────────────────────────────────
 
-    def get_queue(self, name: str) -> Optional["Queue"]:
+    def get_queue(
+        self,
+        name: str,
+        *,
+        client_system_database: Optional["SystemDatabase"] = None,
+    ) -> Optional["Queue"]:
         with self.engine.begin() as c:
             row = c.execute(
                 sa.select(SystemSchema.queues).where(SystemSchema.queues.c.name == name)
             ).fetchone()
-            return queue_from_db_row(row) if row is not None else None
+            if row is None:
+                return None
+            return queue_from_db_row(row, client_system_database=client_system_database)
 
-    def list_queues(self) -> List["Queue"]:
+    def list_queues(
+        self,
+        *,
+        client_system_database: Optional["SystemDatabase"] = None,
+    ) -> List["Queue"]:
         with self.engine.begin() as c:
             rows = c.execute(sa.select(SystemSchema.queues)).fetchall()
-            return [queue_from_db_row(row) for row in rows]
+            return [
+                queue_from_db_row(row, client_system_database=client_system_database)
+                for row in rows
+            ]
 
     def update_queue(self, name: str, fields: Dict[str, Any]) -> None:
         """Apply a partial update to a database-backed queue's row."""

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4157,6 +4157,71 @@ class SystemDatabase(ABC):
                 for row in rows
             ]
 
+    # ── Queue Registration ──────────────────────────────────────
+
+    def get_queue(self, name: str) -> Optional[Dict[str, Any]]:
+        with self.engine.begin() as c:
+            row = c.execute(
+                sa.select(
+                    SystemSchema.queues.c.name,
+                    SystemSchema.queues.c.concurrency,
+                    SystemSchema.queues.c.worker_concurrency,
+                    SystemSchema.queues.c.rate_limit_max,
+                    SystemSchema.queues.c.rate_limit_period_sec,
+                    SystemSchema.queues.c.priority_enabled,
+                    SystemSchema.queues.c.partition_queue,
+                    SystemSchema.queues.c.polling_interval_sec,
+                ).where(SystemSchema.queues.c.name == name)
+            ).fetchone()
+            if row is None:
+                return None
+            return {
+                "name": row[0],
+                "concurrency": row[1],
+                "worker_concurrency": row[2],
+                "rate_limit_max": row[3],
+                "rate_limit_period_sec": row[4],
+                "priority_enabled": bool(row[5]),
+                "partition_queue": bool(row[6]),
+                "polling_interval_sec": row[7],
+            }
+
+    def upsert_queue(
+        self,
+        *,
+        name: str,
+        concurrency: Optional[int],
+        worker_concurrency: Optional[int],
+        rate_limit_max: Optional[int],
+        rate_limit_period_sec: Optional[float],
+        priority_enabled: bool,
+        partition_queue: bool,
+        polling_interval_sec: float,
+        update_existing: bool,
+    ) -> None:
+        values = {
+            "name": name,
+            "concurrency": concurrency,
+            "worker_concurrency": worker_concurrency,
+            "rate_limit_max": rate_limit_max,
+            "rate_limit_period_sec": rate_limit_period_sec,
+            "priority_enabled": priority_enabled,
+            "partition_queue": partition_queue,
+            "polling_interval_sec": polling_interval_sec,
+            "updated_at": int(time.time() * 1000),
+        }
+        with self.engine.begin() as c:
+            stmt = self.dialect.insert(SystemSchema.queues).values(**values)
+            if update_existing:
+                update_set = {k: v for k, v in values.items() if k != "name"}
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["name"],
+                    set_=update_set,
+                )
+            else:
+                stmt = stmt.on_conflict_do_nothing(index_elements=["name"])
+            c.execute(stmt)
+
     def get_latest_application_version(self) -> VersionInfo:
         with self.engine.begin() as c:
             row = c.execute(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4213,6 +4213,13 @@ class SystemDatabase(ABC):
                 for row in rows
             ]
 
+    def delete_queue(self, name: str) -> None:
+        """Delete a database-backed queue's row, if it exists."""
+        with self.engine.begin() as c:
+            c.execute(
+                sa.delete(SystemSchema.queues).where(SystemSchema.queues.c.name == name)
+            )
+
     def update_queue(self, name: str, fields: Dict[str, Any]) -> None:
         """Apply a partial update to a database-backed queue's row."""
         if not fields:

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -16,7 +16,7 @@ class Person(TypedDict):
 # the database-backed queues on the second pass.
 if _dbos_global_instance is not None and _dbos_global_instance._launched:
     DBOS.register_queue("test_queue")
-    DBOS.register_queue("inorder_queue", 1, priority_enabled=True)
+    DBOS.register_queue("inorder_queue", concurrency=1, priority_enabled=True)
 inorder_results: List[str] = []
 
 

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -1,7 +1,8 @@
 import json
 from typing import List, Optional, TypedDict, cast
 
-from dbos import DBOS, Queue
+from dbos import DBOS
+from dbos._dbos import _dbos_global_instance
 
 
 class Person(TypedDict):
@@ -10,8 +11,12 @@ class Person(TypedDict):
     age: int
 
 
-queue = Queue("test_queue")
-inorder_queue = Queue("inorder_queue", 1, priority_enabled=True)
+# This module is imported at test collection time (DBOS not yet launched) and
+# also re-executed via runpy from inside tests (DBOS launched). Only register
+# the database-backed queues on the second pass.
+if _dbos_global_instance is not None and _dbos_global_instance._launched:
+    DBOS.register_queue("test_queue")
+    DBOS.register_queue("inorder_queue", 1, priority_enabled=True)
 inorder_results: List[str] = []
 
 

--- a/tests/queuedworkflow.py
+++ b/tests/queuedworkflow.py
@@ -1,10 +1,8 @@
 # Public API
 import os
 
-from dbos import DBOS, Queue, SetWorkflowID
+from dbos import DBOS, SetWorkflowID
 from tests.conftest import default_config
-
-q = Queue("testq", concurrency=1, limiter={"limit": 1, "period": 1})
 
 
 @DBOS.dbos_class()
@@ -41,6 +39,7 @@ def main() -> None:
         }
     )
     DBOS.launch()
+    DBOS.register_queue("testq", concurrency=1, limiter={"limit": 1, "period": 1})
     DBOS._recover_pending_workflows()
 
     with SetWorkflowID("testqueuedwfcrash"):

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from requests.exceptions import ConnectionError
 
 # Public API
-from dbos import DBOS, DBOSConfig, Queue, SetWorkflowID, WorkflowHandle
+from dbos import DBOS, DBOSConfig, SetWorkflowID, WorkflowHandle
 from dbos._error import DBOSAwaitedWorkflowCancelledError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
@@ -35,10 +35,12 @@ def test_admin_endpoints(dbos: DBOS) -> None:
     assert response.json() == []
 
     # Test GET /dbos-workflow-queues-metadata
-    Queue("q1")
-    Queue("q2", concurrency=1)
-    Queue("q3", concurrency=1, worker_concurrency=1)
-    Queue("q4", concurrency=1, worker_concurrency=1, limiter={"limit": 0, "period": 0})
+    DBOS.register_queue("q1")
+    DBOS.register_queue("q2", concurrency=1)
+    DBOS.register_queue("q3", concurrency=1, worker_concurrency=1)
+    DBOS.register_queue(
+        "q4", concurrency=1, worker_concurrency=1, limiter={"limit": 0, "period": 0}
+    )
     response = requests.get(
         "http://localhost:3001/dbos-workflow-queues-metadata", timeout=5
     )
@@ -74,7 +76,7 @@ def test_admin_endpoints(dbos: DBOS) -> None:
 def test_deactivate(dbos: DBOS, config: DBOSConfig) -> None:
     wf_counter: int = 0
 
-    queue = Queue("example-queue")
+    DBOS.register_queue("example-queue")
 
     @DBOS.scheduled("* * * * * *")
     @DBOS.workflow()
@@ -99,7 +101,7 @@ def test_deactivate(dbos: DBOS, config: DBOSConfig) -> None:
     time.sleep(5)
     assert wf_counter <= val + 2
     # Enqueue a workflow, verify it still runs
-    assert queue.enqueue(regular_workflow).get_result() == 5
+    assert DBOS.enqueue_workflow("example-queue", regular_workflow).get_result() == 5
 
     # Test deferred event receivers
     DBOS.destroy(destroy_registry=True)
@@ -766,8 +768,8 @@ def test_queued_workflows_endpoint(
     """Test the /queues endpoint with various filters and scenarios."""
 
     # Set up a queue for testing
-    test_queue1 = Queue("test-queue-1", concurrency=1)
-    test_queue2 = Queue("test-queue-2", concurrency=1)
+    DBOS.register_queue("test-queue-1", concurrency=1)
+    DBOS.register_queue("test-queue-2", concurrency=1)
 
     @DBOS.workflow()
     def blocking_workflow(i: int) -> str:
@@ -776,9 +778,9 @@ def test_queued_workflows_endpoint(
 
     # Enqueue some workflows to create queued entries
     handles: list[WorkflowHandle[str]] = []
-    handles.append(test_queue1.enqueue(blocking_workflow, 1))
-    handles.append(test_queue1.enqueue(blocking_workflow, 2))
-    handles.append(test_queue2.enqueue(blocking_workflow, 3))
+    handles.append(DBOS.enqueue_workflow("test-queue-1", blocking_workflow, 1))
+    handles.append(DBOS.enqueue_workflow("test-queue-1", blocking_workflow, 2))
+    handles.append(DBOS.enqueue_workflow("test-queue-2", blocking_workflow, 3))
 
     # Test basic queued workflows endpoint
     response = requests.post("http://localhost:3001/queues", json={}, timeout=5)
@@ -817,7 +819,7 @@ def test_queued_workflows_endpoint(
         queued_workflows[0]["UpdatedAt"] is not None
         and len(queued_workflows[0]["UpdatedAt"]) > 0
     )
-    assert queued_workflows[0]["QueueName"] == test_queue1.name
+    assert queued_workflows[0]["QueueName"] == "test-queue-1"
     assert queued_workflows[0]["ApplicationVersion"] == DBOS.application_version
     assert queued_workflows[0]["ExecutorID"] == GlobalParams.executor_id
 
@@ -878,14 +880,14 @@ def test_queued_workflows_endpoint(
     assert len(filtered_workflows) == len(handles)
 
     filters = {
-        "queue_name": test_queue1.name,
+        "queue_name": "test-queue-1",
     }
     response = requests.post("http://localhost:3001/queues", json=filters, timeout=5)
     assert response.status_code == 200
     filtered_workflows = response.json()
     assert len(filtered_workflows) == 2
 
-    filters = {"queue_name": test_queue1.name, "limit": 1, "offset": 1}
+    filters = {"queue_name": "test-queue-1", "limit": 1, "offset": 1}
     response = requests.post("http://localhost:3001/queues", json=filters, timeout=5)
     assert response.status_code == 200
     filtered_workflows = response.json()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -411,7 +411,7 @@ async def test_retrieve_workflow_async(dbos: DBOS) -> None:
 def test_unawaited_workflow(dbos: DBOS) -> None:
     input = 5
     child_id = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     async def child_workflow(x: int) -> int:
@@ -423,7 +423,9 @@ def test_unawaited_workflow(dbos: DBOS) -> None:
         with SetWorkflowID(child_id):
             await DBOS.start_workflow_async(child_workflow, x)
 
-    assert queue.enqueue(parent_workflow, input).get_result() is None
+    assert (
+        DBOS.enqueue_workflow("test_queue", parent_workflow, input).get_result() is None
+    )
     handle: WorkflowHandle[int] = DBOS.retrieve_workflow(
         child_id, existing_workflow=False
     )
@@ -432,7 +434,7 @@ def test_unawaited_workflow(dbos: DBOS) -> None:
 
 def test_unawaited_workflow_exception(dbos: DBOS) -> None:
     child_id = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     async def child_workflow(s: str) -> int:
@@ -446,7 +448,9 @@ def test_unawaited_workflow_exception(dbos: DBOS) -> None:
 
     # Verify the unawaited child properly throws an exception
     input = "alice"
-    assert queue.enqueue(parent_workflow, input).get_result() is None
+    assert (
+        DBOS.enqueue_workflow("test_queue", parent_workflow, input).get_result() is None
+    )
     handle: WorkflowHandle[int] = DBOS.retrieve_workflow(
         child_id, existing_workflow=False
     )
@@ -457,7 +461,9 @@ def test_unawaited_workflow_exception(dbos: DBOS) -> None:
     # Verify it works if run again
     input = "bob"
     child_id = str(uuid.uuid4())
-    assert queue.enqueue(parent_workflow, input).get_result() is None
+    assert (
+        DBOS.enqueue_workflow("test_queue", parent_workflow, input).get_result() is None
+    )
     handle = DBOS.retrieve_workflow(child_id, existing_workflow=False)
     with pytest.raises(Exception) as exc_info:
         handle.get_result()
@@ -525,7 +531,7 @@ async def test_workflow_timeout_async(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_max_parallel_workflows(dbos: DBOS) -> None:
-    queue = Queue("parallel_queue")
+    DBOS.register_queue("parallel_queue")
 
     @DBOS.workflow()
     async def test_workflow(i: int) -> int:
@@ -552,7 +558,9 @@ async def test_max_parallel_workflows(dbos: DBOS) -> None:
     tasks = []
 
     for i in range(50):
-        tasks.append(await queue.enqueue_async(test_workflow, i))
+        tasks.append(
+            await DBOS.enqueue_workflow_async("parallel_queue", test_workflow, i)
+        )
 
     # Wait for all tasks to complete
     for i in range(50):
@@ -570,7 +578,7 @@ async def test_main_loop(dbos: DBOS, config: DBOSConfig) -> None:
     dbos = DBOS(config=config)
     DBOS.launch()
 
-    queue = Queue("queue")
+    DBOS.register_queue("queue")
 
     @DBOS.workflow()
     async def test_workflow() -> int:
@@ -578,7 +586,7 @@ async def test_main_loop(dbos: DBOS, config: DBOSConfig) -> None:
         return id(asyncio.get_running_loop())
 
     # Verify the enqueued task is submitted into the main event loop
-    handle = await queue.enqueue_async(test_workflow)
+    handle = await DBOS.enqueue_workflow_async("queue", test_workflow)
     assert await handle.get_result() == id(asyncio.get_running_loop())
 
 

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -186,7 +186,7 @@ async def test_list_workflows_async(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_list_queued_workflows_async(dbos: DBOS) -> None:
     """Test async list_queued_workflows method."""
-    queue = Queue("test_queue_async")
+    DBOS.register_queue("test_queue_async")
     workflow_event = asyncio.Event()
 
     @DBOS.workflow()
@@ -197,7 +197,9 @@ async def test_list_queued_workflows_async(dbos: DBOS) -> None:
     # Enqueue a workflow but don't let it complete yet
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = await queue.enqueue_async(blocking_workflow, 42)
+        handle = await DBOS.enqueue_workflow_async(
+            "test_queue_async", blocking_workflow, 42
+        )
 
     # List queued workflows async while workflow is still running
     queued_workflows = await DBOS.list_queued_workflows_async(

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -601,7 +601,7 @@ def test_class_queue_recovery(dbos: DBOS) -> None:
     multiplier = 5
 
     wfid = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.dbos_class()
     class TestClass(DBOSConfiguredInstance):
@@ -616,7 +616,7 @@ def test_class_queue_recovery(dbos: DBOS) -> None:
             handles = []
             for i in range(queued_steps):
                 step_enqueues += 1
-                h = queue.enqueue(self.test_step, i)
+                h = DBOS.enqueue_workflow("test_queue", self.test_step, i)
                 handles.append(h)
             return [h.get_result() for h in handles]
 
@@ -673,7 +673,7 @@ def test_class_static_queue_recovery(dbos: DBOS) -> None:
     queued_steps = 5
 
     wfid = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.dbos_class()
     class TestClass:
@@ -685,7 +685,7 @@ def test_class_static_queue_recovery(dbos: DBOS) -> None:
             handles = []
             for i in range(queued_steps):
                 step_enqueues += 1
-                h = queue.enqueue(TestClass.test_step, i)
+                h = DBOS.enqueue_workflow("test_queue", TestClass.test_step, i)
                 handles.append(h)
             return [h.get_result() for h in handles]
 
@@ -743,7 +743,7 @@ def test_class_classmethod_queue_recovery(dbos: DBOS) -> None:
     queued_steps = 5
 
     wfid = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.dbos_class()
     class TestClass:
@@ -758,7 +758,7 @@ def test_class_classmethod_queue_recovery(dbos: DBOS) -> None:
             handles = []
             for i in range(queued_steps):
                 step_enqueues += 1
-                h = queue.enqueue(TestClass.test_step, i)
+                h = DBOS.enqueue_workflow("test_queue", TestClass.test_step, i)
                 handles.append(h)
             return [h.get_result() for h in handles]
 

--- a/tests/test_cockroachdb.py
+++ b/tests/test_cockroachdb.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, urlunparse
 import pytest
 from sqlalchemy import create_engine, text
 
-from dbos import DBOS, DBOSConfig, Queue
+from dbos import DBOS, DBOSConfig
 
 
 def test_cockroachdb() -> None:
@@ -32,8 +32,6 @@ def test_cockroachdb() -> None:
         message: str = DBOS.recv()
         return message
 
-    queue = Queue("queue")
-
     try:
         engine = create_engine(test_url)
         config: DBOSConfig = {
@@ -44,7 +42,8 @@ def test_cockroachdb() -> None:
         }
         DBOS(config=config)
         DBOS.launch()
-        handle = queue.enqueue(workflow)
+        DBOS.register_queue("queue")
+        handle = DBOS.enqueue_workflow("queue", workflow)
         assert DBOS.get_event(handle.workflow_id, key) == value
         DBOS.send(handle.workflow_id, value)
         assert handle.get_result() == value

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -17,7 +17,6 @@ from sqlalchemy.exc import OperationalError
 from dbos import (
     DBOS,
     DBOSConfig,
-    Queue,
     SetWorkflowID,
     SetWorkflowTimeout,
     WorkflowHandle,
@@ -1906,7 +1905,7 @@ def test_custom_names(dbos: DBOS) -> None:
     workflow_name = "workflow_name"
     step_name = "step_name"
     txn_name = "txn_name"
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     @DBOS.workflow(name=workflow_name)
     def workflow() -> str:
@@ -1914,7 +1913,7 @@ def test_custom_names(dbos: DBOS) -> None:
         assert workflow_id is not None
         return workflow_id
 
-    handle = queue.enqueue(workflow)
+    handle = DBOS.enqueue_workflow("test-queue", workflow)
     assert handle.get_status().name == workflow_name
     assert handle.get_result() == handle.workflow_id
     assert DBOS.get_result(handle.workflow_id) == handle.workflow_id
@@ -1925,7 +1924,7 @@ def test_custom_names(dbos: DBOS) -> None:
         assert workflow_id is not None
         return workflow_id
 
-    handle = queue.enqueue(step)
+    handle = DBOS.enqueue_workflow("test-queue", step)
     assert handle.get_status().name == f"<temp>.{step_name}"
     assert handle.get_result() == handle.workflow_id
 
@@ -1935,7 +1934,7 @@ def test_custom_names(dbos: DBOS) -> None:
         assert workflow_id is not None
         return workflow_id
 
-    handle = queue.enqueue(txn)
+    handle = DBOS.enqueue_workflow("test-queue", txn)
     assert handle.get_status().name == f"<temp>.{txn_name}"
     assert handle.get_result() == handle.workflow_id
 

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -145,7 +145,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
         return x
 
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
-    queue = Queue("test-queue", priority_enabled=True)
+    queue = DBOS.register_queue("test-queue", priority_enabled=True)
 
     debouncer = Debouncer.create(workflow, queue=queue)
     debounce_period_sec = 2
@@ -230,11 +230,11 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
         return x
 
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     options: EnqueueOptions = {
         "workflow_name": workflow.__qualname__,
-        "queue_name": queue.name,
+        "queue_name": "test-queue",
     }
     debouncer = DebouncerClient(client, options)
     debounce_period_sec = 2
@@ -277,11 +277,11 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
         return x
 
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     options: EnqueueOptions = {
         "workflow_name": workflow_async.__qualname__,
-        "queue_name": queue.name,
+        "queue_name": "test-queue",
     }
     debouncer = DebouncerClient(client, options)
     debounce_period_sec = 2

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -188,6 +188,14 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert handle.get_status().queue_name == queue.name
     assert handle.get_status().app_version == test_version
 
+    # The queue argument also accepts a queue name as a string.
+    debouncer_by_name = Debouncer.create(workflow, queue=queue.name)
+    name_handle = debouncer_by_name.debounce(
+        "string-key", debounce_period_sec, first_value
+    )
+    assert name_handle.get_result() == first_value
+    assert name_handle.get_status().queue_name == queue.name
+
 
 @pytest.mark.asyncio
 async def test_debouncer_async(dbos: DBOS) -> None:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from psycopg.errors import SerializationFailure
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
-from dbos import DBOS, Queue, SetWorkflowID
+from dbos import DBOS, SetWorkflowID
 from dbos._client import DBOSClient
 from dbos._dbos import WorkflowHandle
 from dbos._dbos_config import DBOSConfig
@@ -290,7 +290,7 @@ def test_nondeterministic_workflow_txn(dbos: DBOS) -> None:
 def test_step_retries(dbos: DBOS) -> None:
     step_counter = 0
 
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
     max_attempts = 2
 
     @DBOS.step(retries_allowed=True, interval_seconds=0, max_attempts=max_attempts)
@@ -305,7 +305,7 @@ def test_step_retries(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def enqueue_failing_step() -> None:
-        queue.enqueue(failing_step).get_result()
+        DBOS.enqueue_workflow("test-queue", failing_step).get_result()
 
     error_message = f"Step {failing_step.__qualname__} has exceeded its maximum of {max_attempts} retries"
 
@@ -327,7 +327,7 @@ def test_step_retries(dbos: DBOS) -> None:
 
     # Test enqueueing the step
     step_counter = 0
-    handle = queue.enqueue(failing_step)
+    handle = DBOS.enqueue_workflow("test-queue", failing_step)
     with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
         handle.get_result()
     assert error_message in str(excinfo.value)
@@ -335,7 +335,7 @@ def test_step_retries(dbos: DBOS) -> None:
 
     # Test enqueuing the workflow
     step_counter = 0
-    handle = queue.enqueue(failing_workflow)
+    handle = DBOS.enqueue_workflow("test-queue", failing_workflow)
     with pytest.raises(DBOSMaxStepRetriesExceeded) as excinfo:
         handle.get_result()
     assert error_message in str(excinfo.value)
@@ -823,9 +823,9 @@ def test_recovery_attempts(dbos: DBOS, config: DBOSConfig) -> None:
             child_workflow()
         event.wait()
 
-    queue = Queue("test_queue", polling_interval_sec=0.1)
+    DBOS.register_queue("test_queue", polling_interval_sec=0.1)
 
-    parent_handle = queue.enqueue(parent_workflow)
+    parent_handle = DBOS.enqueue_workflow("test_queue", parent_workflow)
     child_handle: WorkflowHandle[None] = DBOS.retrieve_workflow(
         child_id, existing_workflow=False
     )

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 # Public API
-from dbos import DBOS, DBOSConfig, Queue
+from dbos import DBOS, DBOSConfig
 
 # Private API because this is a unit test
 from dbos._context import assert_current_dbos_context
@@ -159,12 +159,11 @@ async def test_custom_lifespan(
     DBOS.destroy()
     DBOS(fastapi=app, config=config)
 
-    queue = Queue("queue")
-
     @app.get("/")
     @DBOS.workflow()
     async def resource_workflow() -> Any:
-        handle = await queue.enqueue_async(queue_workflow)
+        DBOS.register_queue("queue")
+        handle = await DBOS.enqueue_workflow_async("queue", queue_workflow)
         return {
             "resource": resource,
             "loop": id(asyncio.get_event_loop()),

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 
 import sqlalchemy as sa
 
-from dbos import DBOS, Queue, WorkflowHandle, pydantic_args_validator
+from dbos import DBOS, WorkflowHandle, pydantic_args_validator
 from dbos._client import DBOSClient
 from dbos._schemas.system_database import SystemSchema
 from dbos._serialization import WorkflowSerializationFormat
@@ -113,7 +113,7 @@ def test_interop_canonical(dbos: DBOS, client: DBOSClient) -> None:
                 "received": msg,
             }
 
-    queue = Queue("interopq")
+    DBOS.register_queue("interopq")
 
     # Start the canonical workflow w/ Enqueue
     wfh: WorkflowHandle[str] = client.enqueue(
@@ -264,7 +264,7 @@ def test_interop_direct_insert(dbos: DBOS) -> None:
                 "received": msg,
             }
 
-    queue = Queue("interopq")
+    DBOS.register_queue("interopq")
 
     wf_id = str(uuid.uuid4())
     with dbos._sys_db.engine.begin() as c:
@@ -385,7 +385,7 @@ def test_interop_kwargs(dbos: DBOS) -> None:
         '{"positionalArgs":[],"namedArgs":{"name":"test","count":42,"tags":["a","b"]}}'
     )
 
-    queue = Queue("interopkq")
+    DBOS.register_queue("interopkq")
 
     wf_id2 = str(uuid.uuid4())
     with dbos._sys_db.engine.begin() as c:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -209,7 +209,7 @@ def test_one_at_a_time_with_limiter(dbos: DBOS) -> None:
 
 
 def test_queue_childwf(dbos: DBOS) -> None:
-    queue = Queue("child_queue", 3)
+    DBOS.register_queue("child_queue", 3)
 
     @DBOS.workflow()
     def test_child_wf(val: str) -> str:
@@ -218,10 +218,10 @@ def test_queue_childwf(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def test_workflow(var1: str, var2: str) -> str:
-        wfh1 = queue.enqueue(test_child_wf, var1)
-        wfh2 = queue.enqueue(test_child_wf, var2)
-        wfh3 = queue.enqueue(test_child_wf, var1)
-        wfh4 = queue.enqueue(test_child_wf, var2)
+        wfh1 = DBOS.enqueue_workflow("child_queue", test_child_wf, var1)
+        wfh2 = DBOS.enqueue_workflow("child_queue", test_child_wf, var2)
+        wfh3 = DBOS.enqueue_workflow("child_queue", test_child_wf, var1)
+        wfh4 = DBOS.enqueue_workflow("child_queue", test_child_wf, var2)
 
         DBOS.sleep(1)
         assert wfh4.get_status().status == "ENQUEUED"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -206,10 +206,10 @@ def test_one_at_a_time(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    queue = Queue("test_queue", 1)
-    handle1 = queue.enqueue(workflow_one)
+    DBOS.register_queue("test_queue", 1)
+    handle1 = DBOS.enqueue_workflow("test_queue", workflow_one)
     assert handle1.get_status().queue_name == "test_queue"
-    handle2 = queue.enqueue(workflow_two)
+    handle2 = DBOS.enqueue_workflow("test_queue", workflow_two)
 
     main_thread_event.wait()
     time.sleep(2)  # Verify the other task isn't scheduled on subsequent poller ticks.
@@ -240,9 +240,9 @@ def test_one_at_a_time_with_limiter(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    queue = Queue("test_queue", concurrency=1, limiter={"limit": 10, "period": 1})
-    handle1 = queue.enqueue(workflow_one)
-    handle2 = queue.enqueue(workflow_two)
+    DBOS.register_queue("test_queue", concurrency=1, limiter={"limit": 10, "period": 1})
+    handle1 = DBOS.enqueue_workflow("test_queue", workflow_one)
+    handle2 = DBOS.enqueue_workflow("test_queue", workflow_two)
 
     main_thread_event.wait()
     time.sleep(2)  # Verify the other task isn't scheduled on subsequent poller ticks.
@@ -299,13 +299,13 @@ def test_queue_step(dbos: DBOS) -> None:
         step_counter += 1
         return var + "1"
 
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_step, "abc")
+        handle = DBOS.enqueue_workflow("test_queue", test_step, "abc")
     assert handle.get_result() == "abc1"
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_step, "abc")
+        handle = DBOS.enqueue_workflow("test_queue", test_step, "abc")
     assert handle.get_result() == "abc1"
     assert step_counter == 1
 
@@ -321,10 +321,10 @@ def test_queue_transaction(dbos: DBOS) -> None:
         step_counter += 1
         return var + "1"
 
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_transaction, "abc")
+        handle = DBOS.enqueue_workflow("test_queue", test_transaction, "abc")
     assert handle.get_result() == "abc1"
     with SetWorkflowID(wfid):
         assert test_transaction("abc") == "abc1"
@@ -340,7 +340,7 @@ def test_limiter(dbos: DBOS) -> None:
 
     limit = 5
     period = 1.8
-    queue = Queue("test_queue", limiter={"limit": limit, "period": period})
+    DBOS.register_queue("test_queue", limiter={"limit": limit, "period": period})
 
     handles: list[WorkflowHandle[float]] = []
     times: list[float] = []
@@ -351,7 +351,7 @@ def test_limiter(dbos: DBOS) -> None:
     # followed by the next wave.
     num_waves = 3
     for _ in range(limit * num_waves):
-        h = queue.enqueue(test_workflow, "abc", "123")
+        h = DBOS.enqueue_workflow("test_queue", test_workflow, "abc", "123")
         handles.append(h)
     for h in handles:
         times.append(h.get_result())
@@ -393,10 +393,10 @@ def test_multiple_queues(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    concurrency_queue = Queue("test_concurrency_queue", 1)
-    handle1 = concurrency_queue.enqueue(workflow_one)
+    DBOS.register_queue("test_concurrency_queue", 1)
+    handle1 = DBOS.enqueue_workflow("test_concurrency_queue", workflow_one)
     assert handle1.get_status().queue_name == "test_concurrency_queue"
-    handle2 = concurrency_queue.enqueue(workflow_two)
+    handle2 = DBOS.enqueue_workflow("test_concurrency_queue", workflow_two)
 
     @DBOS.workflow()
     def limited_workflow(var1: str, var2: str) -> float:
@@ -405,9 +405,7 @@ def test_multiple_queues(dbos: DBOS) -> None:
 
     limit = 5
     period = 1.8
-    limiter_queue = Queue(
-        "test_limit_queue", limiter={"limit": limit, "period": period}
-    )
+    DBOS.register_queue("test_limit_queue", limiter={"limit": limit, "period": period})
 
     handles: list[WorkflowHandle[float]] = []
     times: list[float] = []
@@ -418,7 +416,7 @@ def test_multiple_queues(dbos: DBOS) -> None:
     # followed by the next wave.
     num_waves = 3
     for _ in range(limit * num_waves):
-        h = limiter_queue.enqueue(limited_workflow, "abc", "123")
+        h = DBOS.enqueue_workflow("test_limit_queue", limited_workflow, "abc", "123")
         handles.append(h)
     for h in handles:
         times.append(h.get_result())
@@ -514,9 +512,9 @@ def test_one_at_a_time_with_worker_concurrency(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    queue = Queue("test_queue", worker_concurrency=1)
-    handle1 = queue.enqueue(workflow_one)
-    handle2 = queue.enqueue(workflow_two)
+    DBOS.register_queue("test_queue", worker_concurrency=1)
+    handle1 = DBOS.enqueue_workflow("test_queue", workflow_one)
+    handle2 = DBOS.enqueue_workflow("test_queue", workflow_two)
 
     # Wait until the first task is dequeued
     main_thread_event.wait()
@@ -563,11 +561,8 @@ def run_dbos_test_in_process(
     dbos = DBOS(config=dbos_config)
     DBOS.launch()
 
-    Queue(
-        "test_queue",
-        worker_concurrency=local_concurrency_limit,
-        concurrency=global_concurrency_limit,
-    )
+    # The queue is already registered in the database by the parent process;
+    # the queue manager picks it up via list_queues.
     # Wait to dequeue as many tasks as we can locally
     for _ in range(0, local_concurrency_limit):
         start_event.wait()
@@ -592,14 +587,26 @@ def test_worker_concurrency_with_n_dbos_instances(
     # Ensure children processes do not share global variables (including DBOS instance) with the parent
     multiprocessing.set_start_method("spawn")
 
-    queue = Queue(
-        "test_queue", limiter={"limit": 0, "period": 1}
-    )  # This process cannot dequeue tasks
+    # Re-initialize so the parent opts out of dequeuing — only the children should
+    # dequeue and run workflows.
+    config = default_config()
+    DBOS.destroy()
+    dbos = DBOS(config=config)
+    DBOS.listen_queues([])
+    DBOS.launch()
+
+    DBOS.register_queue(
+        "test_queue",
+        worker_concurrency=local_concurrency_limit,
+        concurrency=global_concurrency_limit,
+    )
 
     # First, start local concurrency limit tasks
     handles = []
     for _ in range(0, local_concurrency_limit):
-        handles.append(queue.enqueue(worker_concurrency_test_workflow))
+        handles.append(
+            DBOS.enqueue_workflow("test_queue", worker_concurrency_test_workflow)
+        )
 
     # Start 2 workers
     processes = []
@@ -638,7 +645,9 @@ def test_worker_concurrency_with_n_dbos_instances(
     # Now enqueue less than the local concurrency limit. Check that the 2nd worker acquired them. We won't have a signal set from the worker so we need to sleep a little.
     handles = []
     for _ in range(0, local_concurrency_limit - 1):
-        handles.append(queue.enqueue(worker_concurrency_test_workflow))
+        handles.append(
+            DBOS.enqueue_workflow("test_queue", worker_concurrency_test_workflow)
+        )
     time.sleep(2)
     executors = []
     for handle in handles:
@@ -651,7 +660,9 @@ def test_worker_concurrency_with_n_dbos_instances(
     # We should have 1 tasks PENDING and 1 ENQUEUED, thus meeting both local and global concurrency limits
     handles = []
     for _ in range(0, 2):
-        handles.append(queue.enqueue(worker_concurrency_test_workflow))
+        handles.append(
+            DBOS.enqueue_workflow("test_queue", worker_concurrency_test_workflow)
+        )
     # we can check the signal because the 2nd executor will set it
     num_dequeued = 0
     while num_dequeued < 2:
@@ -779,9 +790,9 @@ def test_duplicate_workflow_id(dbos: DBOS) -> None:
         )
 
     # Call the same function in a different queue would generate a warning, but is allowed.
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_workflow, "abc")
+        handle = DBOS.enqueue_workflow("test_queue", test_workflow, "abc")
     assert handle.get_result() == "abc"
 
     # Call with a different input still uses the recorded input.
@@ -801,7 +812,7 @@ def test_queue_recovery(dbos: DBOS) -> None:
     queued_steps = 5
 
     wfid = str(uuid.uuid4())
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     def test_workflow() -> list[int]:
@@ -810,7 +821,7 @@ def test_queue_recovery(dbos: DBOS) -> None:
         handles = []
         for i in range(queued_steps):
             step_enqueued += 1
-            h = queue.enqueue(test_step, i)
+            h = DBOS.enqueue_workflow("test_queue", test_step, i)
             handles.append(h)
         return [h.get_result() for h in handles]
 
@@ -868,12 +879,12 @@ def test_queue_concurrency_under_recovery(dbos: DBOS) -> None:
     def noop() -> None:
         pass
 
-    queue = Queue(
+    DBOS.register_queue(
         "test_queue", worker_concurrency=2
     )  # covers global concurrency limit because we have a single process
-    handle1 = queue.enqueue(blocked_workflow, 0)
-    handle2 = queue.enqueue(blocked_workflow, 1)
-    handle3 = queue.enqueue(noop)
+    handle1 = DBOS.enqueue_workflow("test_queue", blocked_workflow, 0)
+    handle2 = DBOS.enqueue_workflow("test_queue", blocked_workflow, 1)
+    handle3 = DBOS.enqueue_workflow("test_queue", noop)
 
     # Wait for the two first workflows to be dequeued
     for e in wf_events:
@@ -943,11 +954,11 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
         return
 
     # Enqueue both the blocked workflow and a regular workflow on a queue with concurrency 1
-    queue = Queue("test_queue", concurrency=1)
+    DBOS.register_queue("test_queue", concurrency=1)
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        blocked_handle = queue.enqueue(stuck_workflow)
-    regular_handle = queue.enqueue(regular_workflow)
+        blocked_handle = DBOS.enqueue_workflow("test_queue", stuck_workflow)
+    regular_handle = DBOS.enqueue_workflow("test_queue", regular_workflow)
 
     # Verify that the blocked workflow starts and is PENDING while the regular workflow remains ENQUEUED.
     start_event.wait()
@@ -982,19 +993,19 @@ def test_timeout_queue(dbos: DBOS) -> None:
         assert assert_current_dbos_context().workflow_deadline_epoch_ms is not None
         return
 
-    queue = Queue("test_queue", concurrency=1, polling_interval_sec=0.1)
+    DBOS.register_queue("test_queue", concurrency=1, polling_interval_sec=0.1)
 
     # Enqueue a few blocked workflow
     num_workflows = 3
     handles: list[WorkflowHandle[None]] = []
     for _ in range(num_workflows):
         with SetWorkflowTimeout(0.1):
-            handle = queue.enqueue(blocking_workflow)
+            handle = DBOS.enqueue_workflow("test_queue", blocking_workflow)
             handles.append(handle)
 
     # Also enqueue a normal workflow
     with SetWorkflowTimeout(1.0):
-        normal_handle = queue.enqueue(normal_workflow)
+        normal_handle = DBOS.enqueue_workflow("test_queue", normal_workflow)
 
     # Verify the blocked workflows are cancelled
     for handle in handles:
@@ -1007,16 +1018,16 @@ def test_timeout_queue(dbos: DBOS) -> None:
     # Verify if a parent called with a timeout enqueues a blocked child
     # the deadline propagates and the child is also cancelled.
     child_id = str(uuid.uuid4())
-    queue = Queue("regular_queue", polling_interval_sec=0.1)
+    DBOS.register_queue("regular_queue", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     def parent_workflow() -> None:
         with SetWorkflowID(child_id):
-            handle = queue.enqueue(blocking_workflow)
+            handle = DBOS.enqueue_workflow("regular_queue", blocking_workflow)
         handle.get_result()
 
     with SetWorkflowTimeout(1.0):
-        handle = queue.enqueue(parent_workflow)
+        handle = DBOS.enqueue_workflow("regular_queue", parent_workflow)
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         handle.get_result()
 
@@ -1028,7 +1039,7 @@ def test_timeout_queue(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def exiting_parent_workflow() -> str:
-        handle = queue.enqueue(blocking_workflow)
+        handle = DBOS.enqueue_workflow("regular_queue", blocking_workflow)
         return handle.get_workflow_id()
 
     with SetWorkflowTimeout(1.0):
@@ -1040,7 +1051,7 @@ def test_timeout_queue(dbos: DBOS) -> None:
     # never starts because the queue is blocked, the deadline propagates
     # and both parent and child are cancelled.
     child_id = str(uuid.uuid4())
-    queue = Queue("stuck_queue", concurrency=1, polling_interval_sec=0.1)
+    DBOS.register_queue("stuck_queue", concurrency=1, polling_interval_sec=0.1)
 
     start_event = threading.Event()
     blocking_event = threading.Event()
@@ -1050,13 +1061,13 @@ def test_timeout_queue(dbos: DBOS) -> None:
         start_event.set()
         blocking_event.wait()
 
-    stuck_handle = queue.enqueue(stuck_workflow)
+    stuck_handle = DBOS.enqueue_workflow("stuck_queue", stuck_workflow)
     start_event.wait()
 
     @DBOS.workflow()
     def blocked_parent_workflow() -> None:
         with SetWorkflowID(child_id):
-            queue.enqueue(blocking_workflow)
+            DBOS.enqueue_workflow("stuck_queue", blocking_workflow)
         while True:
             DBOS.sleep(0.1)
 
@@ -1095,19 +1106,23 @@ async def test_timeout_queue_async(dbos: DBOS, config: DBOSConfig) -> None:
         assert assert_current_dbos_context().workflow_deadline_epoch_ms is not None
         return
 
-    queue = Queue("test_queue_async", concurrency=1, polling_interval_sec=0.1)
+    DBOS.register_queue("test_queue_async", concurrency=1, polling_interval_sec=0.1)
 
     # Enqueue a few blocked workflows
     num_workflows = 3
     handles: list[WorkflowHandleAsync[None]] = []
     for _ in range(num_workflows):
         with SetWorkflowTimeout(0.1):
-            handle = await queue.enqueue_async(blocking_workflow)
+            handle = await DBOS.enqueue_workflow_async(
+                "test_queue_async", blocking_workflow
+            )
             handles.append(handle)
 
     # Also enqueue a normal workflow
     with SetWorkflowTimeout(1.0):
-        normal_handle = await queue.enqueue_async(normal_workflow)
+        normal_handle = await DBOS.enqueue_workflow_async(
+            "test_queue_async", normal_workflow
+        )
 
     # Verify the blocked workflows are cancelled
     for handle in handles:
@@ -1120,16 +1135,20 @@ async def test_timeout_queue_async(dbos: DBOS, config: DBOSConfig) -> None:
     # Verify if a parent called with a timeout enqueues a blocked child
     # the deadline propagates and the child is also cancelled.
     child_id = str(uuid.uuid4())
-    queue = Queue("regular_queue_async", polling_interval_sec=0.1)
+    DBOS.register_queue("regular_queue_async", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     async def parent_workflow() -> None:
         with SetWorkflowID(child_id):
-            handle = await queue.enqueue_async(blocking_workflow)
+            handle = await DBOS.enqueue_workflow_async(
+                "regular_queue_async", blocking_workflow
+            )
         await handle.get_result()
 
     with SetWorkflowTimeout(1.0):
-        handle = await queue.enqueue_async(parent_workflow)
+        handle = await DBOS.enqueue_workflow_async(
+            "regular_queue_async", parent_workflow
+        )
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         await handle.get_result()
 
@@ -1141,7 +1160,9 @@ async def test_timeout_queue_async(dbos: DBOS, config: DBOSConfig) -> None:
 
     @DBOS.workflow()
     async def exiting_parent_workflow() -> str:
-        handle = await queue.enqueue_async(blocking_workflow)
+        handle = await DBOS.enqueue_workflow_async(
+            "regular_queue_async", blocking_workflow
+        )
         return handle.get_workflow_id()
 
     with SetWorkflowTimeout(1.0):
@@ -1153,7 +1174,7 @@ async def test_timeout_queue_async(dbos: DBOS, config: DBOSConfig) -> None:
     # never starts because the queue is blocked, the deadline propagates
     # and both parent and child are cancelled.
     child_id = str(uuid.uuid4())
-    queue = Queue("stuck_queue_async", concurrency=1, polling_interval_sec=0.1)
+    DBOS.register_queue("stuck_queue_async", concurrency=1, polling_interval_sec=0.1)
 
     start_event = asyncio.Event()
     blocking_event = asyncio.Event()
@@ -1163,13 +1184,15 @@ async def test_timeout_queue_async(dbos: DBOS, config: DBOSConfig) -> None:
         start_event.set()
         await blocking_event.wait()
 
-    stuck_handle = await queue.enqueue_async(stuck_workflow)
+    stuck_handle = await DBOS.enqueue_workflow_async(
+        "stuck_queue_async", stuck_workflow
+    )
     await start_event.wait()
 
     @DBOS.workflow()
     async def blocked_parent_workflow() -> None:
         with SetWorkflowID(child_id):
-            await queue.enqueue_async(blocking_workflow)
+            await DBOS.enqueue_workflow_async("stuck_queue_async", blocking_workflow)
         while True:
             await DBOS.sleep_async(0.1)
 
@@ -1203,12 +1226,12 @@ def test_resuming_queued_workflows(dbos: DBOS) -> None:
         return
 
     # Enqueue a blocked workflow and two regular workflows on a queue with concurrency 1
-    queue = Queue("test_queue", concurrency=1)
+    DBOS.register_queue("test_queue", concurrency=1)
     wfid = str(uuid.uuid4())
-    blocked_handle = queue.enqueue(stuck_workflow)
+    blocked_handle = DBOS.enqueue_workflow("test_queue", stuck_workflow)
     with SetWorkflowID(wfid):
-        regular_handle_1 = queue.enqueue(regular_workflow)
-    regular_handle_2 = queue.enqueue(regular_workflow)
+        regular_handle_1 = DBOS.enqueue_workflow("test_queue", regular_workflow)
+    regular_handle_2 = DBOS.enqueue_workflow("test_queue", regular_workflow)
 
     # Verify that the blocked workflow starts and is PENDING while the regular workflows remain ENQUEUED.
     start_event.wait()
@@ -1243,13 +1266,13 @@ def test_resuming_queued_partitioned_workflows(dbos: DBOS) -> None:
         return
 
     # Enqueue a blocked workflow and two regular workflows on a queue with concurrency 1
-    queue = Queue("test_queue", concurrency=1, partition_queue=True)
+    DBOS.register_queue("test_queue", concurrency=1, partition_queue=True)
     wfid = str(uuid.uuid4())
     with SetEnqueueOptions(queue_partition_key="key"):
-        blocked_handle = queue.enqueue(stuck_workflow)
+        blocked_handle = DBOS.enqueue_workflow("test_queue", stuck_workflow)
         with SetWorkflowID(wfid):
-            regular_handle_1 = queue.enqueue(regular_workflow)
-        regular_handle_2 = queue.enqueue(regular_workflow)
+            regular_handle_1 = DBOS.enqueue_workflow("test_queue", regular_workflow)
+        regular_handle_2 = DBOS.enqueue_workflow("test_queue", regular_workflow)
 
     # Verify that the blocked workflow starts and is PENDING while the regular workflows remain ENQUEUED.
     start_event.wait()
@@ -1288,14 +1311,14 @@ def test_dlq_enqueued_workflows(dbos: DBOS) -> None:
         return
 
     # Enqueue both the blocked workflow and a regular workflow on a queue with concurrency 1
-    queue = Queue("test_queue", concurrency=1)
-    blocked_handle = queue.enqueue(blocked_workflow)
-    regular_handle = queue.enqueue(regular_workflow)
+    DBOS.register_queue("test_queue", concurrency=1)
+    blocked_handle = DBOS.enqueue_workflow("test_queue", blocked_workflow)
+    regular_handle = DBOS.enqueue_workflow("test_queue", regular_workflow)
 
     # Enqueue the blocked workflow repeatedly, verify recovery attempts is not increased
     for _ in range(max_recovery_attempts):
         with SetWorkflowID(blocked_handle.workflow_id):
-            queue.enqueue(blocked_workflow)
+            DBOS.enqueue_workflow("test_queue", blocked_workflow)
     recovery_attempts = blocked_handle.get_status().recovery_attempts
     assert recovery_attempts is not None and recovery_attempts <= 1
 
@@ -1364,10 +1387,12 @@ async def test_simple_queue_async(dbos: DBOS) -> None:
         step_counter += 1
         return var + "d"
 
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     with SetWorkflowID(wfid):
-        handle = await queue.enqueue_async(test_workflow, "abc", "123")
+        handle = await DBOS.enqueue_workflow_async(
+            "test_queue", test_workflow, "abc", "123"
+        )
     assert (await handle.get_result()) == "abcd123"
     with SetWorkflowID(wfid):
         assert (await test_workflow("abc", "123")) == "abcd123"
@@ -1377,7 +1402,7 @@ async def test_simple_queue_async(dbos: DBOS) -> None:
 
 def test_queue_deduplication(dbos: DBOS) -> None:
     queue_name = "test_dedup_queue"
-    queue = Queue(queue_name)
+    DBOS.register_queue(queue_name)
     workflow_event = threading.Event()
 
     @DBOS.workflow()
@@ -1388,7 +1413,7 @@ def test_queue_deduplication(dbos: DBOS) -> None:
     @DBOS.workflow()
     def test_workflow(var1: str) -> str:
         # Make sure the child workflow is not blocked by the same deduplication ID
-        child_handle = queue.enqueue(child_workflow, var1)
+        child_handle = DBOS.enqueue_workflow(queue_name, child_workflow, var1)
         workflow_event.wait()
         return child_handle.get_result() + "-p"
 
@@ -1397,26 +1422,26 @@ def test_queue_deduplication(dbos: DBOS) -> None:
     dedup_id = "my_dedup_id"
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid):
-            handle1 = queue.enqueue(test_workflow, "abc")
+            handle1 = DBOS.enqueue_workflow(queue_name, test_workflow, "abc")
     assert handle1.get_status().deduplication_id == dedup_id
 
     # Enqueue the same workflow with a different deduplication ID should be fine.
     with SetEnqueueOptions(deduplication_id="my_other_dedup_id"):
-        another_handle = queue.enqueue(test_workflow, "ghi")
+        another_handle = DBOS.enqueue_workflow(queue_name, test_workflow, "ghi")
 
     # Enqueue a workflow without deduplication ID should be fine.
-    nodedup_handle1 = queue.enqueue(test_workflow, "jkl")
+    nodedup_handle1 = DBOS.enqueue_workflow(queue_name, test_workflow, "jkl")
 
     # Enqueued multiple times without deduplication ID but with different inputs should be fine, but get the result of the first one.
     with SetWorkflowID(wfid):
-        nodedup_handle2 = queue.enqueue(test_workflow, "mno")
+        nodedup_handle2 = DBOS.enqueue_workflow(queue_name, test_workflow, "mno")
 
     # Enqueue the same workflow with the same deduplication ID should raise an exception.
     wfid2 = str(uuid.uuid4())
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid2):
             with pytest.raises(Exception) as exc_info:
-                queue.enqueue(test_workflow, "def")
+                DBOS.enqueue_workflow(queue_name, test_workflow, "def")
         assert (
             f"Workflow {wfid2} was deduplicated due to an existing workflow in queue {queue_name} with deduplication ID {dedup_id}."
             in str(exc_info.value)
@@ -1432,7 +1457,7 @@ def test_queue_deduplication(dbos: DBOS) -> None:
     # Invoke the workflow again with the same deduplication ID now should be fine because it's no longer in the queue.
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid2):
-            handle2 = queue.enqueue(test_workflow, "def")
+            handle2 = DBOS.enqueue_workflow(queue_name, test_workflow, "def")
     assert handle2.get_result() == "def-c-p"
 
     assert queue_entries_are_cleaned_up(dbos)
@@ -1440,7 +1465,7 @@ def test_queue_deduplication(dbos: DBOS) -> None:
 
 def test_queue_deduplication_recovery(dbos: DBOS) -> None:
     queue_name = "test_dedup_queue"
-    queue = Queue(queue_name)
+    DBOS.register_queue(queue_name)
     workflow_event = threading.Event()
     dedup_id = "my_dedup_id"
 
@@ -1451,9 +1476,9 @@ def test_queue_deduplication_recovery(dbos: DBOS) -> None:
     @DBOS.workflow()
     def test_workflow() -> str:
         with SetEnqueueOptions(deduplication_id=dedup_id):
-            handle = queue.enqueue(child_workflow)
+            handle = DBOS.enqueue_workflow(queue_name, child_workflow)
             with pytest.raises(DBOSQueueDeduplicatedError):
-                queue.enqueue(child_workflow)
+                DBOS.enqueue_workflow(queue_name, child_workflow)
         return handle.workflow_id
 
     parent_id = str(uuid.uuid4())
@@ -1477,7 +1502,7 @@ def test_queue_deduplication_recovery(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_queue_deduplication_async(dbos: DBOS) -> None:
     queue_name = "test_dedup_queue_async"
-    queue = Queue(queue_name)
+    DBOS.register_queue(queue_name)
     workflow_event = asyncio.Event()
 
     @DBOS.workflow()
@@ -1488,7 +1513,9 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
     @DBOS.workflow()
     async def test_workflow(var1: str) -> str:
         # Make sure the child workflow is not blocked by the same deduplication ID
-        child_handle = await queue.enqueue_async(child_workflow, var1)
+        child_handle = await DBOS.enqueue_workflow_async(
+            queue_name, child_workflow, var1
+        )
         await workflow_event.wait()
         return (await child_handle.get_result()) + "-p"
 
@@ -1497,25 +1524,33 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
     dedup_id = "my_dedup_id"
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid):
-            handle1 = await queue.enqueue_async(test_workflow, "abc")
+            handle1 = await DBOS.enqueue_workflow_async(
+                queue_name, test_workflow, "abc"
+            )
 
     # Enqueue the same workflow with a different deduplication ID should be fine.
     with SetEnqueueOptions(deduplication_id="my_other_dedup_id"):
-        another_handle = await queue.enqueue_async(test_workflow, "ghi")
+        another_handle = await DBOS.enqueue_workflow_async(
+            queue_name, test_workflow, "ghi"
+        )
 
     # Enqueue a workflow without deduplication ID should be fine.
-    nodedup_handle1 = await queue.enqueue_async(test_workflow, "jkl")
+    nodedup_handle1 = await DBOS.enqueue_workflow_async(
+        queue_name, test_workflow, "jkl"
+    )
 
     # Enqueued multiple times without deduplication ID but with different inputs should be fine, but get the result of the first one.
     with SetWorkflowID(wfid):
-        nodedup_handle2 = await queue.enqueue_async(test_workflow, "mno")
+        nodedup_handle2 = await DBOS.enqueue_workflow_async(
+            queue_name, test_workflow, "mno"
+        )
 
     # Enqueue the same workflow with the same deduplication ID should raise an exception.
     wfid2 = str(uuid.uuid4())
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid2):
             with pytest.raises(Exception) as exc_info:
-                await queue.enqueue_async(test_workflow, "def")
+                await DBOS.enqueue_workflow_async(queue_name, test_workflow, "def")
         assert (
             f"Workflow {wfid2} was deduplicated due to an existing workflow in queue {queue_name} with deduplication ID {dedup_id}."
             in str(exc_info.value)
@@ -1531,7 +1566,9 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
     # Invoke the workflow again with the same deduplication ID now should be fine because it's no longer in the queue.
     with SetEnqueueOptions(deduplication_id=dedup_id):
         with SetWorkflowID(wfid2):
-            handle2 = await queue.enqueue_async(test_workflow, "def")
+            handle2 = await DBOS.enqueue_workflow_async(
+                queue_name, test_workflow, "def"
+            )
     assert (await handle2.get_result()) == "def-c-p"
 
     assert queue_entries_are_cleaned_up(dbos)
@@ -1539,8 +1576,8 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
 
 def test_priority_queue(dbos: DBOS) -> None:
     # Make sure that we can enqueue workflows with different priorities correctly
-    queue = Queue("test_queue_priority", 1, priority_enabled=True)
-    child_queue = Queue("test_queue_child")
+    DBOS.register_queue("test_queue_priority", 1, priority_enabled=True)
+    DBOS.register_queue("test_queue_child")
 
     workflow_event = threading.Event()
     wf_priority_list = []
@@ -1555,31 +1592,33 @@ def test_priority_queue(dbos: DBOS) -> None:
         wf_priority_list.append(priority)
         # Make sure the priority is not propagated
         assert assert_current_dbos_context().priority == None
-        child_handle = child_queue.enqueue(child_workflow, priority)
+        child_handle = DBOS.enqueue_workflow(
+            "test_queue_child", child_workflow, priority
+        )
         workflow_event.wait()
         return child_handle.get_result() + priority
 
     # Enqueue an invalid priority
     with pytest.raises(Exception) as exc_info:
         with SetEnqueueOptions(priority=-100):
-            queue.enqueue(test_workflow, -100)
+            DBOS.enqueue_workflow("test_queue_priority", test_workflow, -100)
     assert "Invalid priority" in str(exc_info.value)
 
     wf_handles: list[WorkflowHandle[int]] = []
     # First, enqueue a workflow without priority
-    handle = queue.enqueue(test_workflow, 0)
+    handle = DBOS.enqueue_workflow("test_queue_priority", test_workflow, 0)
     wf_handles.append(handle)
 
     # Then, enqueue a workflow with priority 1 to 5
     for i in range(1, 6):
         with SetEnqueueOptions(priority=i):
-            handle = queue.enqueue(test_workflow, i)
+            handle = DBOS.enqueue_workflow("test_queue_priority", test_workflow, i)
             assert handle.get_status().priority == i
         wf_handles.append(handle)
 
     # Finally, enqueue two workflows without priority again
-    wf_handles.append(queue.enqueue(test_workflow, 6))
-    wf_handles.append(queue.enqueue(test_workflow, 7))
+    wf_handles.append(DBOS.enqueue_workflow("test_queue_priority", test_workflow, 6))
+    wf_handles.append(DBOS.enqueue_workflow("test_queue_priority", test_workflow, 7))
 
     # The finish sequence should be 0, 6, 7, 1, 2, 3, 4, 5
     workflow_event.set()
@@ -1594,8 +1633,8 @@ def test_priority_queue(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_priority_queue_async(dbos: DBOS) -> None:
     # Make sure that we can enqueue workflows with different priorities correctly
-    queue = Queue("test_queue_priority_async", 1, priority_enabled=True)
-    child_queue = Queue("test_queue_child_async")
+    DBOS.register_queue("test_queue_priority_async", 1, priority_enabled=True)
+    DBOS.register_queue("test_queue_child_async")
 
     workflow_event = asyncio.Event()
     wf_priority_list = []
@@ -1610,30 +1649,42 @@ async def test_priority_queue_async(dbos: DBOS) -> None:
         wf_priority_list.append(priority)
         # Make sure the priority is not propagated
         assert assert_current_dbos_context().priority == None
-        child_handle = await child_queue.enqueue_async(child_workflow, priority)
+        child_handle = await DBOS.enqueue_workflow_async(
+            "test_queue_child_async", child_workflow, priority
+        )
         await workflow_event.wait()
         return (await child_handle.get_result()) + priority
 
     # Enqueue an invalid priority
     with pytest.raises(Exception) as exc_info:
         with SetEnqueueOptions(priority=-100):
-            await queue.enqueue_async(test_workflow, -100)
+            await DBOS.enqueue_workflow_async(
+                "test_queue_priority_async", test_workflow, -100
+            )
     assert "Invalid priority" in str(exc_info.value)
 
     wf_handles: List[WorkflowHandleAsync[int]] = []
     # First, enqueue a workflow without priority
-    handle = await queue.enqueue_async(test_workflow, 0)
+    handle = await DBOS.enqueue_workflow_async(
+        "test_queue_priority_async", test_workflow, 0
+    )
     wf_handles.append(handle)
 
     # Then, enqueue a workflow with priority 1 to 5
     for i in range(1, 6):
         with SetEnqueueOptions(priority=i):
-            handle = await queue.enqueue_async(test_workflow, i)
+            handle = await DBOS.enqueue_workflow_async(
+                "test_queue_priority_async", test_workflow, i
+            )
         wf_handles.append(handle)
 
     # Finally, enqueue two workflows without priority again
-    wf_handles.append(await queue.enqueue_async(test_workflow, 6))
-    wf_handles.append(await queue.enqueue_async(test_workflow, 7))
+    wf_handles.append(
+        await DBOS.enqueue_workflow_async("test_queue_priority_async", test_workflow, 6)
+    )
+    wf_handles.append(
+        await DBOS.enqueue_workflow_async("test_queue_priority_async", test_workflow, 7)
+    )
 
     # The finish sequence should be 0, 6, 7, 1, 2, 3, 4, 5
     workflow_event.set()
@@ -1646,7 +1697,7 @@ async def test_priority_queue_async(dbos: DBOS) -> None:
 
 
 def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> None:
-    queue = Queue("test_worker_concurrency_across_versions", worker_concurrency=1)
+    DBOS.register_queue("test_worker_concurrency_across_versions", worker_concurrency=1)
 
     @DBOS.workflow()
     def test_workflow() -> str:
@@ -1663,7 +1714,9 @@ def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> N
             "app_version": other_version,
         }
     )
-    handle = queue.enqueue(test_workflow)
+    handle = DBOS.enqueue_workflow(
+        "test_worker_concurrency_across_versions", test_workflow
+    )
 
     # Verify the workflow on the current version completes, but the other version is still ENQUEUED
     assert handle.get_result()
@@ -1675,7 +1728,7 @@ def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> N
 
 
 def test_timeout_queue_recovery(dbos: DBOS) -> None:
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
     evt = threading.Event()
 
     @DBOS.workflow()
@@ -1687,7 +1740,7 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
     timeout = 3.0
     enqueue_time = time.time()
     with SetWorkflowTimeout(timeout):
-        original_handle = queue.enqueue(blocking_workflow)
+        original_handle = DBOS.enqueue_workflow("test_queue", blocking_workflow)
 
     # Verify the workflow's timeout is properly configured
     evt.wait()
@@ -1718,7 +1771,7 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
 
 def test_unsetting_timeout(dbos: DBOS) -> None:
 
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     def child() -> str:
@@ -1732,14 +1785,14 @@ def test_unsetting_timeout(dbos: DBOS) -> None:
     def parent(child_one: str, child_two: str) -> None:
         with SetWorkflowID(child_two):
             with SetWorkflowTimeout(None):
-                queue.enqueue(child)
+                DBOS.enqueue_workflow("test_queue", child)
 
         with SetWorkflowID(child_one):
-            queue.enqueue(child)
+            DBOS.enqueue_workflow("test_queue", child)
 
     child_one, child_two = str(uuid.uuid4()), str(uuid.uuid4())
     with SetWorkflowTimeout(2.0):
-        queue.enqueue(parent, child_one, child_two).get_result()
+        DBOS.enqueue_workflow("test_queue", parent, child_one, child_two).get_result()
 
     # Verify child one, which has a propagated timeout, is cancelled
     handle: WorkflowHandle[str] = DBOS.retrieve_workflow(child_one)
@@ -1753,7 +1806,7 @@ def test_unsetting_timeout(dbos: DBOS) -> None:
 
 def test_queue_executor_id(dbos: DBOS) -> None:
 
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     @DBOS.workflow()
     def example_workflow() -> str:
@@ -1768,7 +1821,7 @@ def test_queue_executor_id(dbos: DBOS) -> None:
     # Enqueue the workflow, validate its executor ID
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(example_workflow)
+        handle = DBOS.enqueue_workflow("test-queue", example_workflow)
     assert handle.get_result() == wfid
     assert handle.get_status().executor_id == original_executor_id
 
@@ -1778,7 +1831,7 @@ def test_queue_executor_id(dbos: DBOS) -> None:
 
     # Re-enqueue the workflow, verify its executor ID does not change.
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(example_workflow)
+        handle = DBOS.enqueue_workflow("test-queue", example_workflow)
         assert handle.get_result() == wfid
     assert handle.get_status().executor_id == original_executor_id
 
@@ -1795,7 +1848,7 @@ class OuterType(BaseModel):
 
 
 def test_complex_type(dbos: DBOS) -> None:
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     def workflow(input: OuterType) -> OuterType:
@@ -1805,7 +1858,7 @@ def test_complex_type(dbos: DBOS) -> None:
     inner = InnerType(one="one", two=2)
     outer = OuterType(inner=inner)
 
-    handle = queue.enqueue(workflow, outer)
+    handle = DBOS.enqueue_workflow("test_queue", workflow, outer)
     result = handle.get_result()
 
     def check(result: Any) -> None:
@@ -1826,7 +1879,7 @@ def test_complex_type(dbos: DBOS) -> None:
         event.wait()
         return input
 
-    handle = queue.enqueue(blocked_workflow, outer)
+    handle = DBOS.enqueue_workflow("test_queue", blocked_workflow, outer)
 
     start_event.wait()
     recovery_handle = DBOS._recover_pending_workflows()[0]
@@ -1841,13 +1894,13 @@ def test_enqueue_version(dbos: DBOS) -> None:
     def workflow(x: int) -> int:
         return x
 
-    queue = Queue("queue")
+    DBOS.register_queue("queue")
     input = 5
 
     # Enqueue the app on a different version, verify it has that version
     future_version = str(uuid.uuid4())
     with SetEnqueueOptions(app_version=future_version):
-        handle = queue.enqueue(workflow, input)
+        handle = DBOS.enqueue_workflow("queue", workflow, input)
     assert handle.get_status().app_version == future_version
 
     # Change the global version, verify it works
@@ -1862,13 +1915,13 @@ async def test_enqueue_version_async(dbos: DBOS) -> None:
     async def workflow(x: int) -> int:
         return x
 
-    queue = Queue("queue")
+    DBOS.register_queue("queue")
     input = 5
 
     # Enqueue the app on a different version, verify it has that version
     future_version = str(uuid.uuid4())
     with SetEnqueueOptions(app_version=future_version):
-        handle = await queue.enqueue_async(workflow, input)
+        handle = await DBOS.enqueue_workflow_async("queue", workflow, input)
     assert (await handle.get_status()).app_version == future_version
 
     # Change the global version, verify it works
@@ -1893,7 +1946,7 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
         assert DBOS.workflow_id
         return DBOS.workflow_id
 
-    queue = Queue("queue", partition_queue=True, worker_concurrency=1)
+    DBOS.register_queue("queue", partition_queue=True, worker_concurrency=1)
 
     blocked_partition_key = "blocked"
     normal_partition_key = "normal"
@@ -1902,8 +1955,8 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
     # the blocked partition. Verify the blocked workflow starts
     # but the normal workflow is stuck behind it.
     with SetEnqueueOptions(queue_partition_key=blocked_partition_key):
-        blocked_blocked_handle = queue.enqueue(blocked_workflow)
-        blocked_normal_handle = queue.enqueue(normal_workflow)
+        blocked_blocked_handle = DBOS.enqueue_workflow("queue", blocked_workflow)
+        blocked_normal_handle = DBOS.enqueue_workflow("queue", normal_workflow)
 
     waiting_event.wait()
     assert (
@@ -1919,7 +1972,7 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
     )
     # Enqueue a normal workflow on the other partition and verify it runs normally
     with SetEnqueueOptions(queue_partition_key=normal_partition_key):
-        normal_handle = queue.enqueue(normal_workflow)
+        normal_handle = DBOS.enqueue_workflow("queue", normal_workflow)
 
     assert normal_handle.get_result()
 
@@ -1931,7 +1984,7 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
     # Confirm client enqueue works with partitions
     client_handle: WorkflowHandle[None] = client.enqueue(
         {
-            "queue_name": queue.name,
+            "queue_name": "queue",
             "workflow_name": normal_workflow.__qualname__,
             "queue_partition_key": blocked_partition_key,
         }
@@ -1940,36 +1993,38 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
 
     # You can only enqueue on a partitioned queue with a partition key
     with pytest.raises(Exception):
-        queue.enqueue(normal_workflow)
+        DBOS.enqueue_workflow("queue", normal_workflow)
 
     # Deduplication is not supported for partitioned queues
     with pytest.raises(Exception):
         with SetEnqueueOptions(
             queue_partition_key=normal_partition_key, deduplication_id="key"
         ):
-            queue.enqueue(normal_workflow)
+            DBOS.enqueue_workflow("queue", normal_workflow)
 
     # You can only enqueue with a partition key on a partitioned queue
-    partitionless_queue = Queue("partitionless-queue")
+    DBOS.register_queue("partitionless-queue")
 
     with pytest.raises(Exception):
         with SetEnqueueOptions(queue_partition_key="test"):
-            partitionless_queue.enqueue(normal_workflow)
+            DBOS.enqueue_workflow("partitionless-queue", normal_workflow)
 
 
 def test_polling_interval(dbos: DBOS) -> None:
-    queue = Queue("queue", polling_interval_sec=0.1)
+    DBOS.register_queue("queue", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     def workflow() -> str:
         assert DBOS.workflow_id
         return DBOS.workflow_id
 
-    assert queue.enqueue(workflow).get_result()
+    assert DBOS.enqueue_workflow("queue", workflow).get_result()
 
     for _ in range(10):
         start_time = time.time()
-        assert queue.enqueue(workflow).get_result(polling_interval_sec=0.1)
+        assert DBOS.enqueue_workflow("queue", workflow).get_result(
+            polling_interval_sec=0.1
+        )
         assert time.time() - start_time < 1.0
 
 
@@ -2006,7 +2061,7 @@ def test_listen_queue(dbos: DBOS, config: DBOSConfig) -> None:
 
 def test_wait_first_queue(dbos: DBOS) -> None:
     num_tasks = 5
-    queue = Queue("wait_first_queue", concurrency=num_tasks)
+    DBOS.register_queue("wait_first_queue", concurrency=num_tasks)
 
     go_events = [threading.Event() for _ in range(num_tasks)]
     consumed_events = [threading.Event() for _ in range(num_tasks)]
@@ -2020,7 +2075,7 @@ def test_wait_first_queue(dbos: DBOS) -> None:
     def process_tasks() -> List[str]:
         handles: List[WorkflowHandle[str]] = []
         for i in range(num_tasks):
-            handle = queue.enqueue(process_task, i)
+            handle = DBOS.enqueue_workflow("wait_first_queue", process_task, i)
             handles.append(handle)
 
         results: List[str] = []
@@ -2072,7 +2127,7 @@ def test_wait_first_queue(dbos: DBOS) -> None:
 
 
 def test_delay(dbos: DBOS, client: DBOSClient) -> None:
-    queue = Queue("test_delay_queue", polling_interval_sec=0.1)
+    DBOS.register_queue("test_delay_queue", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     def test_workflow() -> None:
@@ -2083,7 +2138,7 @@ def test_delay(dbos: DBOS, client: DBOSClient) -> None:
     # Test via SetEnqueueOptions
     t_before = int(time.time() * 1000)
     with SetEnqueueOptions(delay_seconds=delay_seconds):
-        handle = queue.enqueue(test_workflow)
+        handle = DBOS.enqueue_workflow("test_delay_queue", test_workflow)
     t_after = int(time.time() * 1000)
 
     status = handle.get_status()
@@ -2103,7 +2158,7 @@ def test_delay(dbos: DBOS, client: DBOSClient) -> None:
     t_before = int(time.time() * 1000)
     client_handle: WorkflowHandle[None] = client.enqueue(
         {
-            "queue_name": queue.name,
+            "queue_name": "test_delay_queue",
             "workflow_name": test_workflow.__qualname__,
             "delay_seconds": delay_seconds,
         }
@@ -2125,7 +2180,7 @@ def test_delay(dbos: DBOS, client: DBOSClient) -> None:
 
     # Delayed workflows appear in list_workflows and list_queued_workflows
     with SetEnqueueOptions(delay_seconds=60.0):
-        listed_handle = queue.enqueue(test_workflow)
+        listed_handle = DBOS.enqueue_workflow("test_delay_queue", test_workflow)
     all_workflows = DBOS.list_workflows(status=WorkflowStatusString.DELAYED.value)
     assert any(w.workflow_id == listed_handle.workflow_id for w in all_workflows)
     queued_workflows = DBOS.list_queued_workflows()
@@ -2133,7 +2188,7 @@ def test_delay(dbos: DBOS, client: DBOSClient) -> None:
 
     # wait_first treats DELAYED as active and unblocks when it completes
     with SetEnqueueOptions(delay_seconds=1.0):
-        wait_handle = queue.enqueue(test_workflow)
+        wait_handle = DBOS.enqueue_workflow("test_delay_queue", test_workflow)
     assert wait_handle.get_status().status == WorkflowStatusString.DELAYED.value
     completed = DBOS.wait_first([wait_handle])
     assert completed.workflow_id == wait_handle.workflow_id
@@ -2143,15 +2198,15 @@ def test_delay(dbos: DBOS, client: DBOSClient) -> None:
     # Deduplication: a second enqueue with the same dedup ID should fail while DELAYED
     dedup_id = str(uuid.uuid4())
     with SetEnqueueOptions(delay_seconds=60.0, deduplication_id=dedup_id):
-        dedup_handle = queue.enqueue(test_workflow)
+        dedup_handle = DBOS.enqueue_workflow("test_delay_queue", test_workflow)
     assert dedup_handle.get_status().status == WorkflowStatusString.DELAYED.value
     with pytest.raises(DBOSQueueDeduplicatedError):
         with SetEnqueueOptions(delay_seconds=60.0, deduplication_id=dedup_id):
-            queue.enqueue(test_workflow)
+            DBOS.enqueue_workflow("test_delay_queue", test_workflow)
 
 
 def test_delay_cancel_resume_list(dbos: DBOS) -> None:
-    queue = Queue("test_delay_cancel_resume_queue", polling_interval_sec=0.1)
+    DBOS.register_queue("test_delay_cancel_resume_queue", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     def test_workflow() -> str:
@@ -2159,7 +2214,9 @@ def test_delay_cancel_resume_list(dbos: DBOS) -> None:
 
     # Cancel a DELAYED workflow — it should never run
     with SetEnqueueOptions(delay_seconds=60.0):
-        cancel_handle = queue.enqueue(test_workflow)
+        cancel_handle = DBOS.enqueue_workflow(
+            "test_delay_cancel_resume_queue", test_workflow
+        )
     assert cancel_handle.get_status().status == WorkflowStatusString.DELAYED.value
     DBOS.cancel_workflow(cancel_handle.workflow_id)
     assert cancel_handle.get_status().status == WorkflowStatusString.CANCELLED.value
@@ -2170,7 +2227,9 @@ def test_delay_cancel_resume_list(dbos: DBOS) -> None:
 
     # Resume a DELAYED workflow — it should run immediately, bypassing the delay
     with SetEnqueueOptions(delay_seconds=60.0):
-        resume_handle = queue.enqueue(test_workflow)
+        resume_handle = DBOS.enqueue_workflow(
+            "test_delay_cancel_resume_queue", test_workflow
+        )
     assert resume_handle.get_status().status == WorkflowStatusString.DELAYED.value
     DBOS.resume_workflow(resume_handle.workflow_id)
     assert resume_handle.get_result() == "done"
@@ -2179,7 +2238,7 @@ def test_delay_cancel_resume_list(dbos: DBOS) -> None:
 
 
 def test_set_workflow_delay(dbos: DBOS) -> None:
-    queue = Queue("test_set_workflow_delay_queue", polling_interval_sec=0.1)
+    DBOS.register_queue("test_set_workflow_delay_queue", polling_interval_sec=0.1)
 
     @DBOS.workflow()
     def test_workflow() -> str:
@@ -2187,7 +2246,7 @@ def test_set_workflow_delay(dbos: DBOS) -> None:
 
     # Enqueue with a long delay, then shorten it with set_workflow_delay
     with SetEnqueueOptions(delay_seconds=600.0):
-        handle = queue.enqueue(test_workflow)
+        handle = DBOS.enqueue_workflow("test_set_workflow_delay_queue", test_workflow)
     assert handle.get_status().status == WorkflowStatusString.DELAYED.value
 
     # Use delay_seconds to set a short delay
@@ -2204,7 +2263,7 @@ def test_set_workflow_delay(dbos: DBOS) -> None:
 
     # Test with delay_until_epoch_ms (absolute timestamp)
     with SetEnqueueOptions(delay_seconds=600.0):
-        handle2 = queue.enqueue(test_workflow)
+        handle2 = DBOS.enqueue_workflow("test_set_workflow_delay_queue", test_workflow)
     assert handle2.get_status().status == WorkflowStatusString.DELAYED.value
 
     soon = int(time.time() * 1000) + 500  # 0.5 seconds from now

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -72,6 +72,79 @@ def test_simple_queue(dbos: DBOS) -> None:
     assert status.dequeued_at > status.created_at
 
 
+def test_queue_crud(dbos: DBOS) -> None:
+    queue_name = f"test_crud_queue_{uuid.uuid4()}"
+
+    # retrieve_queue returns None when nothing is registered.
+    assert DBOS.retrieve_queue(queue_name) is None
+
+    # register_queue persists a fully configured queue.
+    registered = DBOS.register_queue(
+        queue_name,
+        concurrency=10,
+        limiter={"limit": 5, "period": 1.5},
+        worker_concurrency=2,
+        priority_enabled=True,
+        polling_interval_sec=2.5,
+    )
+    assert registered.name == queue_name
+    assert registered.database_backed_queue is True
+    # Database-backed queues are not added to the in-memory registry.
+    assert queue_name not in dbos._registry.queue_info_map
+
+    # retrieve_queue reconstructs the queue from the database.
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.name == queue_name
+    assert retrieved.concurrency == 10
+    assert retrieved.worker_concurrency == 2
+    assert retrieved.limiter == {"limit": 5, "period": 1.5}
+    assert retrieved.priority_enabled is True
+    assert retrieved.partition_queue is False
+    assert retrieved.polling_interval_sec == 2.5
+    assert retrieved.database_backed_queue is True
+    assert queue_name not in dbos._registry.queue_info_map
+
+    # on_conflict="never_update" leaves the existing row alone.
+    DBOS.register_queue(queue_name, concurrency=99, on_conflict="never_update")
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.concurrency == 10
+    assert retrieved.limiter == {"limit": 5, "period": 1.5}
+
+    # on_conflict="always_update" overwrites every column.
+    DBOS.register_queue(queue_name, concurrency=20, on_conflict="always_update")
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.concurrency == 20
+    assert retrieved.worker_concurrency is None
+    assert retrieved.limiter is None
+    assert retrieved.priority_enabled is False
+    assert retrieved.polling_interval_sec == 1.0
+
+    # on_conflict="update_if_latest_version" updates when the running version
+    # is the latest registered version.
+    DBOS.register_queue(
+        queue_name, concurrency=30, on_conflict="update_if_latest_version"
+    )
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.concurrency == 30
+
+    # If a newer application version exists, update_if_latest_version no-ops.
+    newer_version = f"newer-{uuid.uuid4()}"
+    dbos._sys_db.create_application_version(newer_version)
+    dbos._sys_db.update_application_version_timestamp(
+        newer_version, int(time.time() * 1000) + 1_000_000
+    )
+    DBOS.register_queue(
+        queue_name, concurrency=999, on_conflict="update_if_latest_version"
+    )
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.concurrency == 30
+
+
 def test_one_at_a_time(dbos: DBOS) -> None:
     wf_counter = 0
     flag = False

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1930,26 +1930,25 @@ def test_listen_queue(dbos: DBOS, config: DBOSConfig) -> None:
     DBOS.destroy(destroy_registry=True)
     DBOS(config=config)
 
-    queue_one = Queue("queue_one")
-    queue_two = Queue("queue_two")
-
     @DBOS.workflow()
     def workflow() -> str:
         assert DBOS.workflow_id
         return DBOS.workflow_id
 
-    DBOS.listen_queues([queue_one])
+    DBOS.listen_queues(["queue_one"])
     DBOS.launch()
+    DBOS.register_queue("queue_one")
+    DBOS.register_queue("queue_two")
 
     # While only listening to queue one, only workflows enqueued there execute
-    handle_one = queue_one.enqueue(workflow)
-    handle_two = queue_two.enqueue(workflow)
+    handle_one = DBOS.enqueue_workflow("queue_one", workflow)
+    handle_two = DBOS.enqueue_workflow("queue_two", workflow)
     assert handle_one.get_result()
     assert handle_two.get_status().status == "ENQUEUED"
 
     DBOS.destroy()
     DBOS(config=config)
-    DBOS.listen_queues([queue_two])
+    DBOS.listen_queues(["queue_two"])
     DBOS.launch()
 
     # Listening to queue two completes its workflows

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -68,6 +68,53 @@ def test_simple_queue(dbos: DBOS) -> None:
     assert status.dequeued_at > status.created_at
 
 
+def test_in_memory_queues(dbos: DBOS, config: DBOSConfig) -> None:
+    """Cover the legacy `Queue(...)` constructor API and confirm in-memory and
+    database-backed queues coexist correctly.
+    """
+    DBOS.destroy(destroy_registry=True)
+    DBOS(config=config)
+
+    queue_one = Queue("in_memory_queue_one")
+    queue_two = Queue("in_memory_queue_two", concurrency=2)
+
+    # Re-declaring an in-memory queue raises.
+    with pytest.raises(Exception):
+        Queue(queue_one.name)
+
+    @DBOS.workflow()
+    def workflow(val: str) -> str:
+        return val + "!"
+
+    # listen_queues accepts a mix of Queue objects and string names.
+    DBOS.listen_queues([queue_one, "db_backed_queue"])
+    DBOS.launch()
+
+    # Register the database-backed queue post-launch (it requires _sys_db).
+    DBOS.register_queue("db_backed_queue")
+
+    # In-memory listened queue runs workflows.
+    handle_one = queue_one.enqueue(workflow, "hello")
+    assert handle_one.get_result() == "hello!"
+
+    # Database-backed listened queue also runs workflows.
+    handle_db = DBOS.enqueue_workflow("db_backed_queue", workflow, "db")
+    assert handle_db.get_result() == "db!"
+
+    # Workflows enqueued on a queue we are not listening to stay ENQUEUED.
+    handle_two = queue_two.enqueue(workflow, "world")
+    time.sleep(2)
+    assert handle_two.get_status().status == "ENQUEUED"
+
+    # Restart listening to queue_two and confirm the pending workflow runs.
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.listen_queues([queue_two])
+    DBOS.launch()
+
+    assert DBOS.retrieve_workflow(handle_two.workflow_id).get_result() == "world!"
+
+
 def test_queue_crud(dbos: DBOS) -> None:
     queue_name = f"test_crud_queue_{uuid.uuid4()}"
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -360,7 +360,7 @@ def test_one_at_a_time(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    DBOS.register_queue("test_queue", 1)
+    DBOS.register_queue("test_queue", concurrency=1)
     handle1 = DBOS.enqueue_workflow("test_queue", workflow_one)
     assert handle1.get_status().queue_name == "test_queue"
     handle2 = DBOS.enqueue_workflow("test_queue", workflow_two)
@@ -410,7 +410,7 @@ def test_one_at_a_time_with_limiter(dbos: DBOS) -> None:
 
 
 def test_queue_childwf(dbos: DBOS) -> None:
-    DBOS.register_queue("child_queue", 3)
+    DBOS.register_queue("child_queue", concurrency=3)
 
     @DBOS.workflow()
     def test_child_wf(val: str) -> str:
@@ -547,7 +547,7 @@ def test_multiple_queues(dbos: DBOS) -> None:
         nonlocal flag
         flag = True
 
-    DBOS.register_queue("test_concurrency_queue", 1)
+    DBOS.register_queue("test_concurrency_queue", concurrency=1)
     handle1 = DBOS.enqueue_workflow("test_concurrency_queue", workflow_one)
     assert handle1.get_status().queue_name == "test_concurrency_queue"
     handle2 = DBOS.enqueue_workflow("test_concurrency_queue", workflow_two)
@@ -1730,7 +1730,7 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
 
 def test_priority_queue(dbos: DBOS) -> None:
     # Make sure that we can enqueue workflows with different priorities correctly
-    DBOS.register_queue("test_queue_priority", 1, priority_enabled=True)
+    DBOS.register_queue("test_queue_priority", concurrency=1, priority_enabled=True)
     DBOS.register_queue("test_queue_child")
 
     workflow_event = threading.Event()
@@ -1787,7 +1787,9 @@ def test_priority_queue(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_priority_queue_async(dbos: DBOS) -> None:
     # Make sure that we can enqueue workflows with different priorities correctly
-    DBOS.register_queue("test_queue_priority_async", 1, priority_enabled=True)
+    DBOS.register_queue(
+        "test_queue_priority_async", concurrency=1, priority_enabled=True
+    )
     DBOS.register_queue("test_queue_child_async")
 
     workflow_event = asyncio.Event()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,7 +25,11 @@ from dbos import (
 )
 from dbos._context import assert_current_dbos_context
 from dbos._dbos import WorkflowHandleAsync
-from dbos._error import DBOSAwaitedWorkflowCancelledError, DBOSQueueDeduplicatedError
+from dbos._error import (
+    DBOSAwaitedWorkflowCancelledError,
+    DBOSException,
+    DBOSQueueDeduplicatedError,
+)
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from dbos._utils import GlobalParams
@@ -186,6 +190,55 @@ def test_queue_crud(dbos: DBOS) -> None:
     retrieved = DBOS.retrieve_queue(queue_name)
     assert retrieved is not None
     assert retrieved.concurrency == 30
+
+
+def test_queue_dynamic_config(dbos: DBOS) -> None:
+    queue_name = f"test_dyn_queue_{uuid.uuid4()}"
+    queue = DBOS.register_queue(
+        queue_name,
+        concurrency=4,
+        worker_concurrency=2,
+        priority_enabled=False,
+        polling_interval_sec=1.0,
+    )
+
+    # Setters write to the database; getters read from it.
+    queue.set_concurrency(8)
+    queue.set_worker_concurrency(3)
+    queue.set_limiter({"limit": 7, "period": 2.0})
+    queue.set_priority_enabled(True)
+    queue.set_partition_queue(True)
+    queue.set_polling_interval_sec(0.5)
+
+    fresh = DBOS.retrieve_queue(queue_name)
+    for q in [queue, fresh]:
+        assert q is not None
+        assert q.concurrency == 8
+        assert q.worker_concurrency == 3
+        assert q.limiter == {"limit": 7, "period": 2.0}
+        assert q.priority_enabled is True
+        assert q.partition_queue is True
+        assert q.polling_interval_sec == 0.5
+
+    # Setters validate. worker_concurrency cannot exceed concurrency.
+    with pytest.raises(ValueError):
+        queue.set_worker_concurrency(100)
+    # polling_interval must be positive.
+    with pytest.raises(ValueError):
+        queue.set_polling_interval_sec(0.0)
+
+    # Limiter can be cleared.
+    queue.set_limiter(None)
+    q = DBOS.retrieve_queue(queue_name)
+    assert q is not None
+    assert q.limiter is None
+
+    # In-memory queues read from their local fields, not the database.
+    legacy = Queue(f"legacy_dyn_queue_{uuid.uuid4()}", concurrency=2)
+    assert legacy.concurrency == 2
+    # In-memory queues do not support setters.
+    with pytest.raises(DBOSException):
+        legacy.set_concurrency(5)
 
 
 def test_one_at_a_time(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -292,6 +292,20 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     assert handle.get_result() == 42
     assert handle.get_status().queue_name == queue_name
 
+    # Clients have no application version, so update_if_latest_version is
+    # rejected.
+    with pytest.raises(DBOSException):
+        client.register_queue(
+            queue_name, concurrency=1, on_conflict="update_if_latest_version"
+        )
+
+    # The default for clients is always_update: re-registering with new
+    # config overwrites the existing row.
+    client.register_queue(queue_name, concurrency=99)
+    overwritten = DBOS.retrieve_queue(queue_name)
+    assert overwritten is not None
+    assert overwritten.concurrency == 99
+
 
 def test_dynamic_concurrency_takes_effect(dbos: DBOS) -> None:
     """Verify that updating a queue's concurrency at runtime is picked up by

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -241,6 +241,41 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy.set_concurrency(5)
 
 
+def test_dynamic_concurrency_takes_effect(dbos: DBOS) -> None:
+    """Verify that updating a queue's concurrency at runtime is picked up by
+    the worker thread on its next poll iteration.
+    """
+    queue_name = f"test_dyn_runtime_{uuid.uuid4()}"
+    queue = DBOS.register_queue(queue_name, concurrency=1, polling_interval_sec=0.1)
+
+    started = threading.Semaphore(0)
+    release = threading.Event()
+
+    @DBOS.workflow()
+    def blocking() -> None:
+        started.release()
+        release.wait()
+
+    handles = [DBOS.enqueue_workflow(queue_name, blocking) for _ in range(3)]
+
+    # With concurrency=1, only one workflow should start.
+    assert started.acquire(timeout=5)
+    time.sleep(1.0)  # Plenty of poll iterations for a second to start (it shouldn't).
+    assert not started.acquire(blocking=False)
+
+    # Bump concurrency. The worker reloads from DB on its next iteration and
+    # should immediately start the remaining two.
+    queue.set_concurrency(3)
+    assert started.acquire(timeout=5)
+    assert started.acquire(timeout=5)
+
+    # Release all three; everything completes.
+    release.set()
+    for handle in handles:
+        handle.get_result()
+    assert queue_entries_are_cleaned_up(dbos)
+
+
 def test_one_at_a_time(dbos: DBOS) -> None:
     wf_counter = 0
     flag = False

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1852,6 +1852,55 @@ async def test_priority_queue_async(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+@pytest.mark.asyncio
+async def test_enqueue_async_validation(dbos: DBOS) -> None:
+    """Same enqueue-time validation rules should fire for enqueue_async."""
+
+    @DBOS.workflow()
+    async def noop_workflow() -> None:
+        return
+
+    DBOS.register_queue("async_validation_no_priority")
+    DBOS.register_queue("async_validation_priority", priority_enabled=True)
+    DBOS.register_queue("async_validation_partition", partition_queue=True)
+    DBOS.register_queue("async_validation_no_partition")
+
+    # Priority on a non-priority queue
+    with pytest.raises(Exception, match="Priority is not enabled for queue"):
+        with SetEnqueueOptions(priority=1):
+            await DBOS.enqueue_workflow_async(
+                "async_validation_no_priority", noop_workflow
+            )
+
+    # Partition queue requires a partition key
+    with pytest.raises(Exception, match="without a partition key"):
+        await DBOS.enqueue_workflow_async("async_validation_partition", noop_workflow)
+
+    # Partition key on a non-partitioned queue
+    with pytest.raises(
+        Exception, match="only use a partition key on a partition-enabled queue"
+    ):
+        with SetEnqueueOptions(queue_partition_key="key"):
+            await DBOS.enqueue_workflow_async(
+                "async_validation_no_partition", noop_workflow
+            )
+
+    # Deduplication is not supported for partitioned queues
+    with pytest.raises(
+        Exception, match="Deduplication is not supported for partitioned queues"
+    ):
+        with SetEnqueueOptions(queue_partition_key="key", deduplication_id="dedupe"):
+            await DBOS.enqueue_workflow_async(
+                "async_validation_partition", noop_workflow
+            )
+
+    # Sanity check: priority on a priority-enabled queue works
+    handle = await DBOS.enqueue_workflow_async(
+        "async_validation_priority", noop_workflow
+    )
+    await handle.get_result()
+
+
 def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> None:
     DBOS.register_queue("test_worker_concurrency_across_versions", worker_concurrency=1)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -52,11 +52,10 @@ def test_simple_queue(dbos: DBOS) -> None:
         step_counter += 1
         return var + "d"
 
-    queue = Queue("test_queue")
-
-    # Test that redeclaring a queue is an exception
-    with pytest.raises(Exception):
-        Queue(queue.name)
+    DBOS.register_queue("test_queue")
+    queue = DBOS.retrieve_queue("test_queue")
+    assert queue is not None
+    assert queue.database_backed_queue is True
 
     with SetWorkflowID(wfid):
         handle = queue.enqueue(test_workflow, "abc", "123")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -53,12 +53,9 @@ def test_simple_queue(dbos: DBOS) -> None:
         return var + "d"
 
     DBOS.register_queue("test_queue")
-    queue = DBOS.retrieve_queue("test_queue")
-    assert queue is not None
-    assert queue.database_backed_queue is True
 
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(test_workflow, "abc", "123")
+        handle = DBOS.enqueue_workflow("test_queue", test_workflow, "abc", "123")
     assert handle.get_result() == "abcd123"
     with SetWorkflowID(wfid):
         assert test_workflow("abc", "123") == "abcd123"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -241,6 +241,58 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy.set_concurrency(5)
 
 
+def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
+    queue_name = f"test_client_queue_{uuid.uuid4()}"
+
+    # retrieve_queue returns None for an unknown queue.
+    assert client.retrieve_queue(queue_name) is None
+
+    # register_queue persists configuration without depending on the DBOS
+    # singleton's _sys_db.
+    queue = client.register_queue(
+        queue_name,
+        concurrency=4,
+        limiter={"limit": 5, "period": 1.5},
+        worker_concurrency=2,
+        priority_enabled=True,
+        polling_interval_sec=2.5,
+    )
+    assert queue.name == queue_name
+    assert queue.database_backed_queue is True
+    assert queue._client_system_database is client._sys_db
+
+    # Getters route through the client's SystemDatabase.
+    retrieved = client.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved._client_system_database is client._sys_db
+    assert retrieved.concurrency == 4
+    assert retrieved.worker_concurrency == 2
+    assert retrieved.limiter == {"limit": 5, "period": 1.5}
+    assert retrieved.priority_enabled is True
+    assert retrieved.polling_interval_sec == 2.5
+
+    # Setters write through the client's SystemDatabase too.
+    retrieved.set_concurrency(8)
+    fresh = DBOS.retrieve_queue(queue_name)
+    assert fresh is not None
+    assert fresh.concurrency == 8
+
+    # Enqueueing on a client-bound queue is forbidden.
+    @DBOS.workflow()
+    def echo(x: int) -> int:
+        return x
+
+    with pytest.raises(DBOSException):
+        retrieved.enqueue(echo, 42)
+
+    # Speed up the worker so the test finishes quickly, then enqueue through
+    # the DBOS singleton onto the client-registered queue and verify it runs.
+    retrieved.set_polling_interval_sec(0.1)
+    handle = DBOS.enqueue_workflow(queue_name, echo, 42)
+    assert handle.get_result() == 42
+    assert handle.get_status().queue_name == queue_name
+
+
 def test_dynamic_concurrency_takes_effect(dbos: DBOS) -> None:
     """Verify that updating a queue's concurrency at runtime is picked up by
     the worker thread on its next poll iteration.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -306,6 +306,45 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     assert overwritten is not None
     assert overwritten.concurrency == 99
 
+    # delete_queue removes the row; subsequent retrievals return None and
+    # deleting again is a harmless no-op.
+    client.delete_queue(queue_name)
+    assert client.retrieve_queue(queue_name) is None
+    assert DBOS.retrieve_queue(queue_name) is None
+    client.delete_queue(queue_name)
+
+
+def test_queue_delete_and_recreate(dbos: DBOS) -> None:
+    """Create a queue, run a workflow on it, delete it, recreate it, and verify
+    the recreated queue still processes workflows."""
+    queue_name = f"test_delete_recreate_{uuid.uuid4()}"
+
+    @DBOS.workflow()
+    def echo(x: int) -> int:
+        return x
+
+    DBOS.register_queue(queue_name, polling_interval_sec=0.1)
+
+    # Initial queue works.
+    handle1 = DBOS.enqueue_workflow(queue_name, echo, 1)
+    assert handle1.get_result() == 1
+
+    # Delete the queue. Subsequent retrievals should return None.
+    DBOS.delete_queue(queue_name)
+    assert DBOS.retrieve_queue(queue_name) is None
+
+    # Recreate the queue with a different config; the new row should be used.
+    DBOS.register_queue(queue_name, concurrency=5, polling_interval_sec=0.1)
+    recreated = DBOS.retrieve_queue(queue_name)
+    assert recreated is not None
+    assert recreated.concurrency == 5
+
+    # The recreated queue still processes workflows.
+    handle2 = DBOS.enqueue_workflow(queue_name, echo, 2)
+    assert handle2.get_result() == 2
+
+    DBOS.delete_queue(queue_name)
+
 
 def test_dynamic_concurrency_takes_effect(dbos: DBOS) -> None:
     """Verify that updating a queue's concurrency at runtime is picked up by

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1303,7 +1303,7 @@ def test_instance_method_schedule_rejected(dbos: DBOS) -> None:
 
 
 def test_schedule_with_queue_name(dbos: DBOS) -> None:
-    my_queue = Queue("scheduler-test-queue")
+    DBOS.register_queue("scheduler-test-queue")
     received: list[Any] = []
 
     @DBOS.workflow()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -14,7 +14,6 @@ from dbos import (
     DBOS,
     DBOSConfig,
     DBOSPortableJSONSerializer,
-    Queue,
     SetWorkflowID,
     WorkflowHandle,
     pydantic_args_validator,
@@ -84,8 +83,8 @@ def test_custom_serializer(
     }
 
     # Run an enqueued workflow testing workflow communication methods
-    queue = Queue("example_queue")
-    handle = queue.enqueue(recv_workflow, val)
+    DBOS.register_queue("example_queue")
+    handle = DBOS.enqueue_workflow("example_queue", recv_workflow, val)
     ready_evt.wait()
     DBOS.send(handle.workflow_id, val)
     send_evt.set()
@@ -112,7 +111,8 @@ def test_custom_serializer(
     assert "DBOS.recv" in steps[1]["function_name"]
     assert steps[1]["output"] == val
     handle = client.enqueue(
-        {"queue_name": queue.name, "workflow_name": recv_workflow.__qualname__}, val
+        {"queue_name": "example_queue", "workflow_name": recv_workflow.__qualname__},
+        val,
     )
     client.send(handle.workflow_id, val)
     assert handle.get_result() == val
@@ -246,7 +246,7 @@ def test_portable_ser(dbos: DBOS, client: DBOSClient) -> None:
             WFTest.last_wf_id = DBOS.workflow_id
             raise Exception("This is just a plain error")
 
-    queue = Queue("testq")
+    DBOS.register_queue("testq")
 
     def check_wf_ser(wfid: str, ser: str) -> None:
         with dbos._sys_db.engine.connect() as c:
@@ -558,7 +558,7 @@ def test_directinsert_workflows(dbos: DBOS) -> None:
             DBOS.logger.info("defSerPortable was called...")
             return workflow_func(s, x, o, wfid)
 
-    queue = Queue("testq")
+    DBOS.register_queue("testq")
 
     id = str(uuid.uuid4())
     with dbos._sys_db.engine.begin() as c:
@@ -639,7 +639,7 @@ def test_directinsert_invalid_json(dbos: DBOS) -> None:
         ) -> str:
             return f"{s}-{x}"
 
-    queue = Queue("testq_badjson")
+    DBOS.register_queue("testq_badjson")
 
     wf_id = str(uuid.uuid4())
     with dbos._sys_db.engine.begin() as c:
@@ -691,7 +691,7 @@ def test_directinsert_wrong_args(dbos: DBOS) -> None:
         ) -> str:
             return f"{s}-{x}-{o['k']}"
 
-    queue = Queue("testq_wrongargs")
+    DBOS.register_queue("testq_wrongargs")
 
     # Test: missing required positional args (only 1 of 3)
     wf_id = str(uuid.uuid4())
@@ -780,7 +780,7 @@ def test_directinsert_bogus_notification(dbos: DBOS) -> None:
         def recvWorkflow(cls, topic: str) -> Any:
             return DBOS.recv(topic)
 
-    queue = Queue("testq_bogusnotif")
+    DBOS.register_queue("testq_bogusnotif")
 
     # Test 1: Unparseable JSON in notification message
     wf_id = str(uuid.uuid4())
@@ -902,7 +902,7 @@ def test_directinsert_with_pydantic_validation(dbos: DBOS) -> None:
         ) -> str:
             return f"{s}-{x}-{o['k']}"
 
-    queue = Queue("testq_pydantic")
+    DBOS.register_queue("testq_pydantic")
 
     # Test 1: Valid args should succeed
     wf_id_ok = str(uuid.uuid4())
@@ -937,7 +937,9 @@ def test_directinsert_with_pydantic_validation(dbos: DBOS) -> None:
     assert wfh_ok.get_result() == "hello-42-key"
 
     # Test: enqueue round-trip through the queue with portable serialization
-    wfh_enq = queue.enqueue(WFTest.validatedWorkflow, "enqueued", 7, {"k": "val"})
+    wfh_enq = DBOS.enqueue_workflow(
+        "testq_pydantic", WFTest.validatedWorkflow, "enqueued", 7, {"k": "val"}
+    )
     assert wfh_enq.get_result() == "enqueued-7-val"
 
     # Test 2: String where int expected — pydantic should reject it
@@ -1032,7 +1034,7 @@ def test_directinsert_datetime_validation(dbos: DBOS) -> None:
         ) -> str:
             return f"{name}@{due.isoformat()}#{','.join(tags)}"
 
-    queue = Queue("testq_datetime")
+    DBOS.register_queue("testq_datetime")
 
     # Test 1: ISO date string should be coerced to datetime by pydantic
     wf_id_ok = str(uuid.uuid4())
@@ -1076,7 +1078,9 @@ def test_directinsert_datetime_validation(dbos: DBOS) -> None:
 
     # Test: enqueue round-trip with a real datetime object through portable serialization
     dt = datetime(2026, 1, 20, 14, 0, 0)
-    wfh_enq = queue.enqueue(WFTest.datetimeWorkflow, "enqueued", dt, ["live"])
+    wfh_enq = DBOS.enqueue_workflow(
+        "testq_datetime", WFTest.datetimeWorkflow, "enqueued", dt, ["live"]
+    )
     enq_result = wfh_enq.get_result()
     assert "enqueued@2026-01-20T14:00:00" in enq_result
     assert "live" in enq_result
@@ -1228,7 +1232,7 @@ def test_nodejs_invoke(dbos: DBOS) -> None:
                 "received_msg": msg,
             }
 
-    queue = Queue("testq")
+    DBOS.register_queue("testq")
 
     script_path = os.path.join(
         os.path.dirname(__file__), "ts_client", "bundles", "portableinvoke.cjs"

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -8,7 +8,7 @@ from inline_snapshot import snapshot
 from opentelemetry import trace
 from opentelemetry.trace.span import format_trace_id
 
-from dbos import DBOS, DBOSConfig, Queue
+from dbos import DBOS, DBOSConfig
 from dbos._utils import GlobalParams
 from tests.conftest import TestOtelType
 
@@ -414,19 +414,18 @@ def test_queue_span_has_queue_name(
     config["enable_otlp"] = True
     DBOS(config=config)
 
-    queue = Queue("test_queue")
-
     @DBOS.workflow()
     def queued_workflow() -> str:
         return "queued_result"
 
     DBOS.launch()
+    DBOS.register_queue("test_queue")
 
     log_processor.force_flush(timeout_millis=5000)
     log_exporter.clear()
     exporter.clear()
 
-    handle = queue.enqueue(queued_workflow)
+    handle = DBOS.enqueue_workflow("test_queue", queued_workflow)
     result = handle.get_result()
     assert result == "queued_result"
 

--- a/tests/test_sqlite_threading.py
+++ b/tests/test_sqlite_threading.py
@@ -9,7 +9,7 @@ Bug 2: `DBOS._destroy` closes the database BEFORE joining background threads,
 
 import pytest
 
-from dbos import DBOS, DBOSConfig, Queue
+from dbos import DBOS, DBOSConfig
 from dbos._sys_db_sqlite import SQLiteSystemDatabase
 from tests.conftest import default_config, using_sqlite
 
@@ -83,8 +83,8 @@ def test_destroy_joins_threads_before_closing_db(
     def simple_workflow() -> str:
         return "done"
 
-    queue = Queue("destroy_test_queue")
-    handle = queue.enqueue(simple_workflow)
+    DBOS.register_queue("destroy_test_queue")
+    handle = DBOS.enqueue_workflow("destroy_test_queue", simple_workflow)
     result = handle.get_result()
     assert result == "done"
 

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -299,13 +299,13 @@ def test_queued_workflows(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> 
     queued_steps = 5
     step_events = [threading.Event() for _ in range(queued_steps)]
     event = threading.Event()
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.workflow()
     def test_workflow() -> list[int]:
         handles = []
         for i in range(queued_steps):
-            h = queue.enqueue(blocking_step, i)
+            h = DBOS.enqueue_workflow("test_queue", blocking_step, i)
             handles.append(h)
         return [h.get_result() for h in handles]
 
@@ -325,7 +325,7 @@ def test_queued_workflows(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> 
     assert len(workflows) == queued_steps
     for i, workflow in enumerate(workflows):
         assert workflow.status == WorkflowStatusString.PENDING.value
-        assert workflow.queue_name == queue.name
+        assert workflow.queue_name == "test_queue"
         assert workflow.input is not None
         # Verify oldest queue entries appear first
         assert workflow.input["args"][0] == i
@@ -359,7 +359,7 @@ def test_queued_workflows(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> 
     assert len(workflows) == queued_steps + 1
     for i, workflow in enumerate(workflows[1:]):
         assert workflow.status == WorkflowStatusString.PENDING.value
-        assert workflow.queue_name == queue.name
+        assert workflow.queue_name == "test_queue"
         assert workflow.input is not None
         # Verify oldest queue entries appear first
         assert workflow.input["args"][0] == i
@@ -379,13 +379,13 @@ def test_queued_workflows(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> 
     assert len(workflows) == 0
     workflows = DBOS.list_queued_workflows(status=["ENQUEUED", "PENDING"])
     assert len(workflows) == queued_steps
-    workflows = DBOS.list_workflows(queue_name=queue.name)
+    workflows = DBOS.list_workflows(queue_name="test_queue")
     assert len(workflows) == queued_steps
-    workflows = DBOS.list_queued_workflows(queue_name=queue.name)
+    workflows = DBOS.list_queued_workflows(queue_name="test_queue")
     assert len(workflows) == queued_steps
     workflows = DBOS.list_queued_workflows(queue_name="no")
     assert len(workflows) == 0
-    workflows = DBOS.list_queued_workflows(queue_name=[queue.name, "no"])
+    workflows = DBOS.list_queued_workflows(queue_name=["test_queue", "no"])
     assert len(workflows) == queued_steps
     workflows = DBOS.list_queued_workflows(queue_name=["no", "also_no"])
     assert len(workflows) == 0
@@ -750,7 +750,7 @@ def test_callchild_first_async_thread(dbos: DBOS) -> None:
 
 
 def test_list_steps_errors(dbos: DBOS) -> None:
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     @DBOS.step()
     def failing_step() -> None:
@@ -767,7 +767,7 @@ def test_list_steps_errors(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def enqueue_step() -> None:
-        handle = queue.enqueue(failing_step)
+        handle = DBOS.enqueue_workflow("test-queue", failing_step)
         return handle.get_result()
 
     # Test calling a failing step directly
@@ -817,7 +817,7 @@ def test_list_steps_errors(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_list_steps_errors_async(dbos: DBOS) -> None:
-    queue = Queue("test-queue")
+    DBOS.register_queue("test-queue")
 
     @DBOS.step()
     async def failing_step() -> None:
@@ -834,7 +834,7 @@ async def test_list_steps_errors_async(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     async def enqueue_step() -> None:
-        handle = await queue.enqueue_async(failing_step)
+        handle = await DBOS.enqueue_workflow_async("test-queue", failing_step)
         return await handle.get_result()
 
     # Test calling a failing step directly

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -5,14 +5,7 @@ import uuid
 import pytest
 import sqlalchemy as sa
 
-from dbos import (
-    DBOS,
-    DBOSClient,
-    Queue,
-    SetEnqueueOptions,
-    SetWorkflowID,
-    WorkflowHandle,
-)
+from dbos import DBOS, DBOSClient, SetEnqueueOptions, SetWorkflowID, WorkflowHandle
 from dbos._error import DBOSAwaitedWorkflowCancelledError
 from dbos._schemas.application_database import ApplicationSchema
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
@@ -347,7 +340,7 @@ def test_cancel_resume_queue(dbos: DBOS) -> None:
     main_thread_event = threading.Event()
     input = 5
 
-    queue = Queue("test_queue")
+    DBOS.register_queue("test_queue")
 
     @DBOS.step()
     def step_one() -> None:
@@ -371,7 +364,7 @@ def test_cancel_resume_queue(dbos: DBOS) -> None:
     # Verify it stops after step one but before step two
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(simple_workflow, input)
+        handle = DBOS.enqueue_workflow("test_queue", simple_workflow, input)
     main_thread_event.wait()
     DBOS.cancel_workflow(wfid)
     workflow_event.set()
@@ -855,14 +848,14 @@ def test_resume_and_fork_to_queue(dbos: DBOS) -> None:
         b = step_two(x)
         return a + b
 
-    queue = Queue("test_resume_fork_queue")
+    DBOS.register_queue("test_resume_fork_queue")
     input = 5
     output = (input + 1) + (input + 2)
 
     # Enqueue workflow, let step_one run, then cancel before step_two
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = queue.enqueue(simple_workflow, input)
+        handle = DBOS.enqueue_workflow("test_resume_fork_queue", simple_workflow, input)
     main_thread_event.wait()
     DBOS.cancel_workflow(wfid)
     workflow_event.set()
@@ -967,15 +960,15 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
     assert len(workflows) == 0
 
     # ENQUEUED and DELAYED workflows must not be garbage collected
-    queue = Queue("gc_test_queue")
+    DBOS.register_queue("gc_test_queue")
 
     @DBOS.workflow()
     def gc_test_workflow() -> None:
         pass
 
-    enqueued_handle = queue.enqueue(gc_test_workflow)
+    enqueued_handle = DBOS.enqueue_workflow("gc_test_queue", gc_test_workflow)
     with SetEnqueueOptions(delay_seconds=60.0):
-        delayed_handle = queue.enqueue(gc_test_workflow)
+        delayed_handle = DBOS.enqueue_workflow("gc_test_queue", gc_test_workflow)
 
     garbage_collect(
         dbos, cutoff_epoch_timestamp_ms=int(time.time() * 1000), rows_threshold=None


### PR DESCRIPTION
This PR introduces a new database-backed queue API, where queue information is stored in the database. This enables dynamic queue modification and makes queues more observable (for example, through the client or dashboard).

This is not a breaking change. The old in-memory queue API remains fully supported, but is now deprecated, and we recommend switching to database-backed queues.

### Code Examples

Register a database-backed queue and enqueue work onto it:

```python
DBOS.register_queue("email", concurrency=10, limiter={"limit": 100, "period": 60})

@DBOS.workflow()
def send_email(to: str) -> None:
    ...

handle = DBOS.enqueue_workflow("email", send_email, "alice@example.com")
handle.get_result()
```

Retrieve and reconfigure a queue at runtime:

```py
queue = DBOS.retrieve_queue("email")
print(queue.concurrency) # 10 (read from DB)

queue.set_concurrency(50) # written to DB
queue.set_limiter({"limit": 500, "period": 60})
# Workers pick up the new config on their next poll iteration.
```

Manage queues from a client:

```py
client = DBOSClient(system_database_url="postgresql://...")
client.register_queue("email", concurrency=10)
client.enqueue({"queue_name": "email", "workflow_name": "send_email"}, "alice@example.com")
```

Fixes https://github.com/dbos-inc/dbos-transact-py/issues/586