### PR TITLE
Optimize Indexes

### DIFF
--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -511,6 +511,20 @@ CREATE TABLE "{schema}".queues (
 """
 
 
+def get_dbos_migration_twentytwo(schema: str) -> str:
+    return f"""
+DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_forked_from";
+CREATE INDEX "idx_workflow_status_forked_from" ON "{schema}"."workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL;
+"""
+
+
+def get_dbos_migration_twentythree(schema: str) -> str:
+    return f"""
+DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_parent_workflow_id";
+CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -536,6 +550,8 @@ def get_dbos_migrations(
         get_dbos_migration_nineteen(schema),
         get_dbos_migration_twenty(schema, use_listen_notify, is_cockroach),
         get_dbos_migration_twentyone(schema),
+        get_dbos_migration_twentytwo(schema),
+        get_dbos_migration_twentythree(schema),
     ]
 
 
@@ -741,6 +757,16 @@ CREATE TABLE queues (
 );
 """
 
+sqlite_migration_twentytwo = """
+DROP INDEX IF EXISTS "idx_workflow_status_forked_from";
+CREATE INDEX "idx_workflow_status_forked_from" ON "workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL;
+"""
+
+sqlite_migration_twentythree = """
+DROP INDEX IF EXISTS "idx_workflow_status_parent_workflow_id";
+CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL;
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -762,4 +788,6 @@ sqlite_migrations = [
     sqlite_migration_nineteen,
     # There is no SQLite version of migration twenty
     sqlite_migration_twentyone,
+    sqlite_migration_twentytwo,
+    sqlite_migration_twentythree,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -556,6 +556,24 @@ DROP INDEX IF EXISTS "{schema}"."workflow_status_status_index";
 """
 
 
+def get_dbos_migration_twentynine(schema: str) -> str:
+    return f"""
+CREATE INDEX "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN ('ENQUEUED', 'PENDING');
+"""
+
+
+def get_dbos_migration_thirty(schema: str) -> str:
+    return f"""
+CREATE INDEX "idx_workflow_status_started" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "started_at_epoch_ms" IS NOT NULL;
+"""
+
+
+def get_dbos_migration_thirtyone(schema: str) -> str:
+    return f"""
+DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_queue_status_started";
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -588,6 +606,9 @@ def get_dbos_migrations(
         get_dbos_migration_twentysix(schema),
         get_dbos_migration_twentyseven(schema),
         get_dbos_migration_twentyeight(schema),
+        get_dbos_migration_twentynine(schema),
+        get_dbos_migration_thirty(schema),
+        get_dbos_migration_thirtyone(schema),
     ]
 
 
@@ -824,6 +845,18 @@ sqlite_migration_twentyeight = """
 DROP INDEX IF EXISTS "workflow_status_status_index";
 """
 
+sqlite_migration_twentynine = """
+CREATE INDEX "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN ('ENQUEUED', 'PENDING');
+"""
+
+sqlite_migration_thirty = """
+CREATE INDEX "idx_workflow_status_started" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "started_at_epoch_ms" IS NOT NULL;
+"""
+
+sqlite_migration_thirtyone = """
+DROP INDEX IF EXISTS "idx_workflow_status_queue_status_started";
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -852,4 +885,7 @@ sqlite_migrations = [
     sqlite_migration_twentysix,
     sqlite_migration_twentyseven,
     sqlite_migration_twentyeight,
+    sqlite_migration_twentynine,
+    sqlite_migration_thirty,
+    sqlite_migration_thirtyone,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -538,6 +538,24 @@ CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "{schema}"."work
 """
 
 
+def get_dbos_migration_twentysix(schema: str) -> str:
+    return f"""
+CREATE INDEX "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = 'PENDING';
+"""
+
+
+def get_dbos_migration_twentyseven(schema: str) -> str:
+    return f"""
+CREATE INDEX "idx_workflow_status_failed" ON "{schema}"."workflow_status" ("status", "created_at") WHERE "status" IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED');
+"""
+
+
+def get_dbos_migration_twentyeight(schema: str) -> str:
+    return f"""
+DROP INDEX IF EXISTS "{schema}"."workflow_status_status_index";
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -567,6 +585,9 @@ def get_dbos_migrations(
         get_dbos_migration_twentythree(schema),
         get_dbos_migration_twentyfour(schema),
         get_dbos_migration_twentyfive(schema),
+        get_dbos_migration_twentysix(schema),
+        get_dbos_migration_twentyseven(schema),
+        get_dbos_migration_twentyeight(schema),
     ]
 
 
@@ -791,6 +812,18 @@ DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id";
 CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
 """
 
+sqlite_migration_twentysix = """
+CREATE INDEX "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = 'PENDING';
+"""
+
+sqlite_migration_twentyseven = """
+CREATE INDEX "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED');
+"""
+
+sqlite_migration_twentyeight = """
+DROP INDEX IF EXISTS "workflow_status_status_index";
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -816,4 +849,7 @@ sqlite_migrations = [
     sqlite_migration_twentythree,
     sqlite_migration_twentyfour,
     sqlite_migration_twentyfive,
+    sqlite_migration_twentysix,
+    sqlite_migration_twentyseven,
+    sqlite_migration_twentyeight,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -4,6 +4,66 @@ import sqlalchemy as sa
 
 from ._logger import dbos_logger
 
+# Migration versions that contain CONCURRENTLY index DDL and must run with
+# autocommit (CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction
+# block on Postgres). On CockroachDB, schema changes are inherently online,
+# so this set is ignored and the regular transactional path is used.
+_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35}
+
+
+def _concurrently(is_cockroach: bool) -> str:
+    """Render the CONCURRENTLY keyword for online index DDL.
+
+    Empty on CockroachDB, where schema changes are online by default and the
+    keyword is not supported."""
+    return "" if is_cockroach else "CONCURRENTLY"
+
+
+def _cleanup_invalid_indexes(engine: sa.Engine, schema: str) -> None:
+    """Drop indexes left in an INVALID state by a prior failed CONCURRENTLY run.
+
+    A failed CREATE INDEX CONCURRENTLY leaves an index marked invalid that
+    will not be used by the planner but blocks recreating the same name.
+    Must be called before retrying an online migration."""
+    with engine.connect() as raw_conn:
+        conn = raw_conn.execution_options(isolation_level="AUTOCOMMIT")
+        rows = conn.execute(
+            sa.text(
+                "SELECT i.relname FROM pg_index ix "
+                "JOIN pg_class i ON i.oid = ix.indexrelid "
+                "JOIN pg_class t ON t.oid = ix.indrelid "
+                "JOIN pg_namespace n ON n.oid = t.relnamespace "
+                "WHERE NOT ix.indisvalid AND n.nspname = :schema"
+            ),
+            {"schema": schema},
+        ).fetchall()
+        for (idx_name,) in rows:
+            dbos_logger.warning(
+                f"Dropping invalid index {schema}.{idx_name} left by a prior failed migration"
+            )
+            conn.execute(
+                sa.text(f'DROP INDEX CONCURRENTLY IF EXISTS "{schema}"."{idx_name}"')
+            )
+
+
+def _bump_migration_version(
+    engine: sa.Engine, schema: str, version: int, last_applied: int
+) -> None:
+    """Update the dbos_migrations version row in its own transaction."""
+    with engine.begin() as conn:
+        if last_applied == 0:
+            conn.execute(
+                sa.text(
+                    f'INSERT INTO "{schema}".dbos_migrations (version) VALUES (:version)'
+                ),
+                {"version": version},
+            )
+        else:
+            conn.execute(
+                sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :version'),
+                {"version": version},
+            )
+
 
 def ensure_dbos_schema(engine: sa.Engine, schema: str) -> None:
     """
@@ -56,13 +116,35 @@ def run_dbos_migrations(
         version_str = conn.execute(sa.text("SELECT version()")).scalar() or ""
         is_cockroach = "cockroachdb" in version_str.lower()
 
-    # Apply each migration in its own transaction
+    # Apply each migration in its own transaction (or autocommit for online ones)
     migrations = get_dbos_migrations(schema, use_listen_notify, is_cockroach)
     for i, migration_sql in enumerate(migrations, 1):
         if i <= last_applied:
             continue
 
         dbos_logger.info(f"Applying DBOS system database schema migration {i}")
+
+        if not migration_sql.strip():
+            dbos_logger.info(f"Migration {i} has no statements; skipping.")
+            _bump_migration_version(engine, schema, i, last_applied)
+            last_applied = i
+            continue
+
+        # Online migrations contain CONCURRENTLY index DDL and must run with
+        # autocommit. On CockroachDB, schema changes are inherently online, so
+        # we use the regular transactional path.
+        if i in _ONLINE_MIGRATIONS and not is_cockroach:
+            # Clean up any invalid indexes left by a prior failed attempt at
+            # this or a later online migration before retrying.
+            _cleanup_invalid_indexes(engine, schema)
+
+            with engine.connect() as raw_conn:
+                conn = raw_conn.execution_options(isolation_level="AUTOCOMMIT")
+                conn.execute(sa.text(migration_sql))
+
+            _bump_migration_version(engine, schema, i, last_applied)
+            last_applied = i
+            continue
 
         with engine.begin() as conn:
             # Migration 10 adds a primary key to the notifications table.
@@ -79,8 +161,6 @@ def run_dbos_migrations(
                 ).scalar()
             ):
                 dbos_logger.info("Migration 10 skipped, primary key already exists")
-            elif not migration_sql.strip():
-                dbos_logger.info(f"Migration {i} has no statements; skipping.")
             else:
                 conn.execute(sa.text(migration_sql))
 
@@ -511,81 +591,88 @@ CREATE TABLE "{schema}".queues (
 """
 
 
-def get_dbos_migration_twentytwo(schema: str) -> str:
-    return f"""
-DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_forked_from";
-CREATE INDEX "idx_workflow_status_forked_from" ON "{schema}"."workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL;
-"""
+def get_dbos_migration_twentytwo(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'DROP INDEX {c} IF EXISTS "{schema}"."idx_workflow_status_forked_from"'
 
 
-def get_dbos_migration_twentythree(schema: str) -> str:
-    return f"""
-DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_parent_workflow_id";
-CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL;
-"""
+def get_dbos_migration_twentythree(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_forked_from" ON "{schema}"."workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
 
 
-def get_dbos_migration_twentyfour(schema: str) -> str:
-    return f"""
-DROP INDEX IF EXISTS "{schema}"."workflow_status_executor_id_index";
-"""
+def get_dbos_migration_twentyfour(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return (
+        f'DROP INDEX {c} IF EXISTS "{schema}"."idx_workflow_status_parent_workflow_id"'
+    )
 
 
 def get_dbos_migration_twentyfive(schema: str, is_cockroach: bool) -> str:
-    # CockroachDB implements unique constraints as indexes and does not support
-    # ALTER TABLE DROP CONSTRAINT for them; it requires DROP INDEX ... CASCADE.
-    # Postgres rejects DROP INDEX on a constraint-backed index, so we dispatch.
-    drop = (
-        f'DROP INDEX IF EXISTS "{schema}"."uq_workflow_status_queue_name_dedup_id" CASCADE;'
-        if is_cockroach
-        else f'ALTER TABLE "{schema}".workflow_status DROP CONSTRAINT IF EXISTS uq_workflow_status_queue_name_dedup_id;'
-    )
-    return f"""
-{drop}
-CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
-"""
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
 
 
-def get_dbos_migration_twentysix(schema: str) -> str:
-    return f"""
-CREATE INDEX "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = 'PENDING';
-"""
+def get_dbos_migration_twentysix(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'DROP INDEX {c} IF EXISTS "{schema}"."workflow_status_executor_id_index"'
 
 
-def get_dbos_migration_twentyseven(schema: str) -> str:
-    return f"""
-CREATE INDEX "idx_workflow_status_failed" ON "{schema}"."workflow_status" ("status", "created_at") WHERE "status" IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED');
-"""
+def get_dbos_migration_twentyseven(schema: str, is_cockroach: bool) -> str:
+    # The new partial unique index uses a different name from the original
+    # constraint to avoid a naming collision: Postgres auto-creates an index
+    # with the constraint name, so we can't reuse it until the constraint is
+    # dropped. Creating with a new name first preserves uniqueness throughout
+    # the transition (both the old constraint and new index enforce identical
+    # semantics, since NULLs are SQL-distinct in the old constraint).
+    c = _concurrently(is_cockroach)
+    return f'CREATE UNIQUE INDEX {c} "uq_workflow_status_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
 
 
-def get_dbos_migration_twentyeight(schema: str) -> str:
-    return f"""
-DROP INDEX IF EXISTS "{schema}"."workflow_status_status_index";
-"""
+def get_dbos_migration_twentyeight(schema: str, is_cockroach: bool) -> str:
+    # CockroachDB implements unique constraints as indexes and rejects
+    # ALTER TABLE DROP CONSTRAINT for them; Postgres rejects DROP INDEX on a
+    # constraint-backed index. Both paths are fast catalog operations, no
+    # CONCURRENTLY needed.
+    if is_cockroach:
+        return f'DROP INDEX IF EXISTS "{schema}"."uq_workflow_status_queue_name_dedup_id" CASCADE'
+    return f'ALTER TABLE "{schema}".workflow_status DROP CONSTRAINT IF EXISTS uq_workflow_status_queue_name_dedup_id'
 
 
-def get_dbos_migration_twentynine(schema: str) -> str:
-    return f"""
-CREATE INDEX "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN ('ENQUEUED', 'PENDING');
-"""
+def get_dbos_migration_twentynine(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
 
 
-def get_dbos_migration_thirty(schema: str) -> str:
-    return f"""
-ALTER TABLE "{schema}"."workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE;
-"""
+def get_dbos_migration_thirty(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_failed" ON "{schema}"."workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
 
 
-def get_dbos_migration_thirtyone(schema: str) -> str:
-    return f"""
-CREATE INDEX "idx_workflow_status_rate_limited" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE;
-"""
+def get_dbos_migration_thirtyone(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'DROP INDEX {c} IF EXISTS "{schema}"."workflow_status_status_index"'
 
 
-def get_dbos_migration_thirtytwo(schema: str) -> str:
-    return f"""
-DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_queue_status_started";
-"""
+def get_dbos_migration_thirtytwo(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
+
+
+def get_dbos_migration_thirtythree(schema: str) -> str:
+    # ALTER TABLE ADD COLUMN with constant default is fast on Postgres 11+
+    # (catalog-only update via attmissingval); runs in a regular transaction.
+    return f'ALTER TABLE "{schema}"."workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE'
+
+
+def get_dbos_migration_thirtyfour(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} "idx_workflow_status_rate_limited" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
+
+
+def get_dbos_migration_thirtyfive(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f'DROP INDEX {c} IF EXISTS "{schema}"."idx_workflow_status_queue_status_started"'
 
 
 def get_dbos_migrations(
@@ -613,17 +700,20 @@ def get_dbos_migrations(
         get_dbos_migration_nineteen(schema),
         get_dbos_migration_twenty(schema, use_listen_notify, is_cockroach),
         get_dbos_migration_twentyone(schema),
-        get_dbos_migration_twentytwo(schema),
-        get_dbos_migration_twentythree(schema),
-        get_dbos_migration_twentyfour(schema),
+        get_dbos_migration_twentytwo(schema, is_cockroach),
+        get_dbos_migration_twentythree(schema, is_cockroach),
+        get_dbos_migration_twentyfour(schema, is_cockroach),
         get_dbos_migration_twentyfive(schema, is_cockroach),
-        get_dbos_migration_twentysix(schema),
-        get_dbos_migration_twentyseven(schema),
-        get_dbos_migration_twentyeight(schema),
-        get_dbos_migration_twentynine(schema),
-        get_dbos_migration_thirty(schema),
-        get_dbos_migration_thirtyone(schema),
-        get_dbos_migration_thirtytwo(schema),
+        get_dbos_migration_twentysix(schema, is_cockroach),
+        get_dbos_migration_twentyseven(schema, is_cockroach),
+        get_dbos_migration_twentyeight(schema, is_cockroach),
+        get_dbos_migration_twentynine(schema, is_cockroach),
+        get_dbos_migration_thirty(schema, is_cockroach),
+        get_dbos_migration_thirtyone(schema, is_cockroach),
+        get_dbos_migration_thirtytwo(schema, is_cockroach),
+        get_dbos_migration_thirtythree(schema),
+        get_dbos_migration_thirtyfour(schema, is_cockroach),
+        get_dbos_migration_thirtyfive(schema, is_cockroach),
     ]
 
 
@@ -829,52 +919,39 @@ CREATE TABLE queues (
 );
 """
 
-sqlite_migration_twentytwo = """
-DROP INDEX IF EXISTS "idx_workflow_status_forked_from";
-CREATE INDEX "idx_workflow_status_forked_from" ON "workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL;
-"""
+sqlite_migration_twentytwo = 'DROP INDEX IF EXISTS "idx_workflow_status_forked_from"'
 
-sqlite_migration_twentythree = """
-DROP INDEX IF EXISTS "idx_workflow_status_parent_workflow_id";
-CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL;
-"""
+sqlite_migration_twentythree = 'CREATE INDEX "idx_workflow_status_forked_from" ON "workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
 
-sqlite_migration_twentyfour = """
-DROP INDEX IF EXISTS "workflow_status_executor_id_index";
-"""
+sqlite_migration_twentyfour = (
+    'DROP INDEX IF EXISTS "idx_workflow_status_parent_workflow_id"'
+)
 
-sqlite_migration_twentyfive = """
-DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id";
-CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
-"""
+sqlite_migration_twentyfive = 'CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
 
-sqlite_migration_twentysix = """
-CREATE INDEX "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = 'PENDING';
-"""
+sqlite_migration_twentysix = 'DROP INDEX IF EXISTS "workflow_status_executor_id_index"'
 
-sqlite_migration_twentyseven = """
-CREATE INDEX "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED');
-"""
+sqlite_migration_twentyseven = 'CREATE UNIQUE INDEX "uq_workflow_status_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
 
-sqlite_migration_twentyeight = """
-DROP INDEX IF EXISTS "workflow_status_status_index";
-"""
+sqlite_migration_twentyeight = (
+    'DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id"'
+)
 
-sqlite_migration_twentynine = """
-CREATE INDEX "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN ('ENQUEUED', 'PENDING');
-"""
+sqlite_migration_twentynine = 'CREATE INDEX "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
 
-sqlite_migration_thirty = """
-ALTER TABLE "workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE;
-"""
+sqlite_migration_thirty = 'CREATE INDEX "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
 
-sqlite_migration_thirtyone = """
-CREATE INDEX "idx_workflow_status_rate_limited" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE;
-"""
+sqlite_migration_thirtyone = 'DROP INDEX IF EXISTS "workflow_status_status_index"'
 
-sqlite_migration_thirtytwo = """
-DROP INDEX IF EXISTS "idx_workflow_status_queue_status_started";
-"""
+sqlite_migration_thirtytwo = 'CREATE INDEX "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
+
+sqlite_migration_thirtythree = 'ALTER TABLE "workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE'
+
+sqlite_migration_thirtyfour = 'CREATE INDEX "idx_workflow_status_rate_limited" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
+
+sqlite_migration_thirtyfive = (
+    'DROP INDEX IF EXISTS "idx_workflow_status_queue_status_started"'
+)
 
 sqlite_migrations = [
     sqlite_migration_one,
@@ -908,4 +985,7 @@ sqlite_migrations = [
     sqlite_migration_thirty,
     sqlite_migration_thirtyone,
     sqlite_migration_thirtytwo,
+    sqlite_migration_thirtythree,
+    sqlite_migration_thirtyfour,
+    sqlite_migration_thirtyfive,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -531,6 +531,13 @@ DROP INDEX IF EXISTS "{schema}"."workflow_status_executor_id_index";
 """
 
 
+def get_dbos_migration_twentyfive(schema: str) -> str:
+    return f"""
+ALTER TABLE "{schema}".workflow_status DROP CONSTRAINT IF EXISTS uq_workflow_status_queue_name_dedup_id;
+CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -559,6 +566,7 @@ def get_dbos_migrations(
         get_dbos_migration_twentytwo(schema),
         get_dbos_migration_twentythree(schema),
         get_dbos_migration_twentyfour(schema),
+        get_dbos_migration_twentyfive(schema),
     ]
 
 
@@ -778,6 +786,11 @@ sqlite_migration_twentyfour = """
 DROP INDEX IF EXISTS "workflow_status_executor_id_index";
 """
 
+sqlite_migration_twentyfive = """
+DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id";
+CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -802,4 +815,5 @@ sqlite_migrations = [
     sqlite_migration_twentytwo,
     sqlite_migration_twentythree,
     sqlite_migration_twentyfour,
+    sqlite_migration_twentyfive,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -531,9 +531,17 @@ DROP INDEX IF EXISTS "{schema}"."workflow_status_executor_id_index";
 """
 
 
-def get_dbos_migration_twentyfive(schema: str) -> str:
+def get_dbos_migration_twentyfive(schema: str, is_cockroach: bool) -> str:
+    # CockroachDB implements unique constraints as indexes and does not support
+    # ALTER TABLE DROP CONSTRAINT for them; it requires DROP INDEX ... CASCADE.
+    # Postgres rejects DROP INDEX on a constraint-backed index, so we dispatch.
+    drop = (
+        f'DROP INDEX IF EXISTS "{schema}"."uq_workflow_status_queue_name_dedup_id" CASCADE;'
+        if is_cockroach
+        else f'ALTER TABLE "{schema}".workflow_status DROP CONSTRAINT IF EXISTS uq_workflow_status_queue_name_dedup_id;'
+    )
     return f"""
-ALTER TABLE "{schema}".workflow_status DROP CONSTRAINT IF EXISTS uq_workflow_status_queue_name_dedup_id;
+{drop}
 CREATE UNIQUE INDEX "uq_workflow_status_queue_name_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL;
 """
 
@@ -608,7 +616,7 @@ def get_dbos_migrations(
         get_dbos_migration_twentytwo(schema),
         get_dbos_migration_twentythree(schema),
         get_dbos_migration_twentyfour(schema),
-        get_dbos_migration_twentyfive(schema),
+        get_dbos_migration_twentyfive(schema, is_cockroach),
         get_dbos_migration_twentysix(schema),
         get_dbos_migration_twentyseven(schema),
         get_dbos_migration_twentyeight(schema),

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -525,6 +525,12 @@ CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_st
 """
 
 
+def get_dbos_migration_twentyfour(schema: str) -> str:
+    return f"""
+DROP INDEX IF EXISTS "{schema}"."workflow_status_executor_id_index";
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -552,6 +558,7 @@ def get_dbos_migrations(
         get_dbos_migration_twentyone(schema),
         get_dbos_migration_twentytwo(schema),
         get_dbos_migration_twentythree(schema),
+        get_dbos_migration_twentyfour(schema),
     ]
 
 
@@ -767,6 +774,10 @@ DROP INDEX IF EXISTS "idx_workflow_status_parent_workflow_id";
 CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL;
 """
 
+sqlite_migration_twentyfour = """
+DROP INDEX IF EXISTS "workflow_status_executor_id_index";
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -790,4 +801,5 @@ sqlite_migrations = [
     sqlite_migration_twentyone,
     sqlite_migration_twentytwo,
     sqlite_migration_twentythree,
+    sqlite_migration_twentyfour,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -598,7 +598,7 @@ def get_dbos_migration_twentytwo(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_twentythree(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_forked_from" ON "{schema}"."workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_forked_from" ON "{schema}"."workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
 
 
 def get_dbos_migration_twentyfour(schema: str, is_cockroach: bool) -> str:
@@ -610,7 +610,7 @@ def get_dbos_migration_twentyfour(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_twentyfive(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_parent_workflow_id" ON "{schema}"."workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
 
 
 def get_dbos_migration_twentysix(schema: str, is_cockroach: bool) -> str:
@@ -620,13 +620,9 @@ def get_dbos_migration_twentysix(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_twentyseven(schema: str, is_cockroach: bool) -> str:
     # The new partial unique index uses a different name from the original
-    # constraint to avoid a naming collision: Postgres auto-creates an index
-    # with the constraint name, so we can't reuse it until the constraint is
-    # dropped. Creating with a new name first preserves uniqueness throughout
-    # the transition (both the old constraint and new index enforce identical
-    # semantics, since NULLs are SQL-distinct in the old constraint).
+    # constraint to avoid a naming collision
     c = _concurrently(is_cockroach)
-    return f'CREATE UNIQUE INDEX {c} "uq_workflow_status_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
+    return f'CREATE UNIQUE INDEX {c} IF NOT EXISTS "uq_workflow_status_dedup_id" ON "{schema}"."workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
 
 
 def get_dbos_migration_twentyeight(schema: str, is_cockroach: bool) -> str:
@@ -641,12 +637,12 @@ def get_dbos_migration_twentyeight(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_twentynine(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
 
 
 def get_dbos_migration_thirty(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_failed" ON "{schema}"."workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_failed" ON "{schema}"."workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
 
 
 def get_dbos_migration_thirtyone(schema: str, is_cockroach: bool) -> str:
@@ -656,18 +652,17 @@ def get_dbos_migration_thirtyone(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_thirtytwo(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
 
 
 def get_dbos_migration_thirtythree(schema: str) -> str:
-    # ALTER TABLE ADD COLUMN with constant default is fast on Postgres 11+
-    # (catalog-only update via attmissingval); runs in a regular transaction.
-    return f'ALTER TABLE "{schema}"."workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE'
+    # ALTER TABLE ADD COLUMN with constant default is fast (catalog-only update via attmissingval).
+    return f'ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE'
 
 
 def get_dbos_migration_thirtyfour(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} "idx_workflow_status_rate_limited" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_rate_limited" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
 
 
 def get_dbos_migration_thirtyfive(schema: str, is_cockroach: bool) -> str:
@@ -921,33 +916,33 @@ CREATE TABLE queues (
 
 sqlite_migration_twentytwo = 'DROP INDEX IF EXISTS "idx_workflow_status_forked_from"'
 
-sqlite_migration_twentythree = 'CREATE INDEX "idx_workflow_status_forked_from" ON "workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
+sqlite_migration_twentythree = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_forked_from" ON "workflow_status" ("forked_from") WHERE "forked_from" IS NOT NULL'
 
 sqlite_migration_twentyfour = (
     'DROP INDEX IF EXISTS "idx_workflow_status_parent_workflow_id"'
 )
 
-sqlite_migration_twentyfive = 'CREATE INDEX "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
+sqlite_migration_twentyfive = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_parent_workflow_id" ON "workflow_status" ("parent_workflow_id") WHERE "parent_workflow_id" IS NOT NULL'
 
 sqlite_migration_twentysix = 'DROP INDEX IF EXISTS "workflow_status_executor_id_index"'
 
-sqlite_migration_twentyseven = 'CREATE UNIQUE INDEX "uq_workflow_status_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
+sqlite_migration_twentyseven = 'CREATE UNIQUE INDEX IF NOT EXISTS "uq_workflow_status_dedup_id" ON "workflow_status" ("queue_name", "deduplication_id") WHERE "deduplication_id" IS NOT NULL'
 
 sqlite_migration_twentyeight = (
     'DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id"'
 )
 
-sqlite_migration_twentynine = 'CREATE INDEX "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
+sqlite_migration_twentynine = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
 
-sqlite_migration_thirty = 'CREATE INDEX "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
+sqlite_migration_thirty = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
 
 sqlite_migration_thirtyone = 'DROP INDEX IF EXISTS "workflow_status_status_index"'
 
-sqlite_migration_thirtytwo = 'CREATE INDEX "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
+sqlite_migration_thirtytwo = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name", "status", "priority", "created_at") WHERE "status" IN (\'ENQUEUED\', \'PENDING\')'
 
 sqlite_migration_thirtythree = 'ALTER TABLE "workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE'
 
-sqlite_migration_thirtyfour = 'CREATE INDEX "idx_workflow_status_rate_limited" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
+sqlite_migration_thirtyfour = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_rate_limited" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE'
 
 sqlite_migration_thirtyfive = (
     'DROP INDEX IF EXISTS "idx_workflow_status_queue_status_started"'

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -637,7 +637,7 @@ def get_dbos_migration_twentyeight(schema: str, is_cockroach: bool) -> str:
 
 def get_dbos_migration_twentynine(schema: str, is_cockroach: bool) -> str:
     c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_pending" ON "{schema}"."workflow_status" ("created_at") WHERE "status" = \'PENDING\''
 
 
 def get_dbos_migration_thirty(schema: str, is_cockroach: bool) -> str:
@@ -932,7 +932,7 @@ sqlite_migration_twentyeight = (
     'DROP INDEX IF EXISTS "uq_workflow_status_queue_name_dedup_id"'
 )
 
-sqlite_migration_twentynine = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_pending" ON "workflow_status" ("workflow_uuid") WHERE "status" = \'PENDING\''
+sqlite_migration_twentynine = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_pending" ON "workflow_status" ("created_at") WHERE "status" = \'PENDING\''
 
 sqlite_migration_thirty = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_failed" ON "workflow_status" ("status", "created_at") WHERE "status" IN (\'ERROR\', \'CANCELLED\', \'MAX_RECOVERY_ATTEMPTS_EXCEEDED\')'
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -564,11 +564,17 @@ CREATE INDEX "idx_workflow_status_in_flight" ON "{schema}"."workflow_status" ("q
 
 def get_dbos_migration_thirty(schema: str) -> str:
     return f"""
-CREATE INDEX "idx_workflow_status_started" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "started_at_epoch_ms" IS NOT NULL;
+ALTER TABLE "{schema}"."workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE;
 """
 
 
 def get_dbos_migration_thirtyone(schema: str) -> str:
+    return f"""
+CREATE INDEX "idx_workflow_status_rate_limited" ON "{schema}"."workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE;
+"""
+
+
+def get_dbos_migration_thirtytwo(schema: str) -> str:
     return f"""
 DROP INDEX IF EXISTS "{schema}"."idx_workflow_status_queue_status_started";
 """
@@ -609,6 +615,7 @@ def get_dbos_migrations(
         get_dbos_migration_twentynine(schema),
         get_dbos_migration_thirty(schema),
         get_dbos_migration_thirtyone(schema),
+        get_dbos_migration_thirtytwo(schema),
     ]
 
 
@@ -850,10 +857,14 @@ CREATE INDEX "idx_workflow_status_in_flight" ON "workflow_status" ("queue_name",
 """
 
 sqlite_migration_thirty = """
-CREATE INDEX "idx_workflow_status_started" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "started_at_epoch_ms" IS NOT NULL;
+ALTER TABLE "workflow_status" ADD COLUMN "rate_limited" BOOLEAN NOT NULL DEFAULT FALSE;
 """
 
 sqlite_migration_thirtyone = """
+CREATE INDEX "idx_workflow_status_rate_limited" ON "workflow_status" ("queue_name", "started_at_epoch_ms") WHERE "rate_limited" = TRUE;
+"""
+
+sqlite_migration_thirtytwo = """
 DROP INDEX IF EXISTS "idx_workflow_status_queue_status_started";
 """
 
@@ -888,4 +899,5 @@ sqlite_migrations = [
     sqlite_migration_twentynine,
     sqlite_migration_thirty,
     sqlite_migration_thirtyone,
+    sqlite_migration_thirtytwo,
 ]

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -130,7 +130,7 @@ class SystemSchema:
             sqlite_where=text("rate_limited = TRUE"),
         ),
         Index(
-            "uq_workflow_status_queue_name_dedup_id",
+            "uq_workflow_status_dedup_id",
             "queue_name",
             "deduplication_id",
             unique=True,

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -88,6 +88,7 @@ class SystemSchema:
         Column("parent_workflow_id", Text()),
         Column("serialization", Text()),
         Column("delay_until_epoch_ms", BigInteger, nullable=True),
+        Column("rate_limited", Boolean, nullable=False, server_default="false"),
         Index("workflow_status_created_at_index", "created_at"),
         Index(
             "idx_workflow_status_delayed",
@@ -122,11 +123,11 @@ class SystemSchema:
             sqlite_where=text("status IN ('ENQUEUED', 'PENDING')"),
         ),
         Index(
-            "idx_workflow_status_started",
+            "idx_workflow_status_rate_limited",
             "queue_name",
             "started_at_epoch_ms",
-            postgresql_where=text("started_at_epoch_ms IS NOT NULL"),
-            sqlite_where=text("started_at_epoch_ms IS NOT NULL"),
+            postgresql_where=text("rate_limited = TRUE"),
+            sqlite_where=text("rate_limited = TRUE"),
         ),
         Index(
             "uq_workflow_status_queue_name_dedup_id",

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -98,7 +98,7 @@ class SystemSchema:
         ),
         Index(
             "idx_workflow_status_pending",
-            "workflow_uuid",
+            "created_at",
             postgresql_where=text("status = 'PENDING'"),
             sqlite_where=text("status = 'PENDING'"),
         ),

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -15,7 +15,6 @@ from sqlalchemy import (
     String,
     Table,
     Text,
-    UniqueConstraint,
     text,
 )
 
@@ -93,10 +92,13 @@ class SystemSchema:
         Index("idx_workflow_status_delayed", "delay_until_epoch_ms"),
         Index("workflow_status_executor_id_index", "executor_id"),
         Index("workflow_status_status_index", "status"),
-        UniqueConstraint(
+        Index(
+            "uq_workflow_status_queue_name_dedup_id",
             "queue_name",
             "deduplication_id",
-            name="uq_workflow_status_queue_name_dedup_id",
+            unique=True,
+            postgresql_where=text("deduplication_id IS NOT NULL"),
+            sqlite_where=text("deduplication_id IS NOT NULL"),
         ),
     )
 

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -113,6 +113,22 @@ class SystemSchema:
             ),
         ),
         Index(
+            "idx_workflow_status_in_flight",
+            "queue_name",
+            "status",
+            "priority",
+            "created_at",
+            postgresql_where=text("status IN ('ENQUEUED', 'PENDING')"),
+            sqlite_where=text("status IN ('ENQUEUED', 'PENDING')"),
+        ),
+        Index(
+            "idx_workflow_status_started",
+            "queue_name",
+            "started_at_epoch_ms",
+            postgresql_where=text("started_at_epoch_ms IS NOT NULL"),
+            sqlite_where=text("started_at_epoch_ms IS NOT NULL"),
+        ),
+        Index(
             "uq_workflow_status_queue_name_dedup_id",
             "queue_name",
             "deduplication_id",

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -89,9 +89,29 @@ class SystemSchema:
         Column("serialization", Text()),
         Column("delay_until_epoch_ms", BigInteger, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
-        Index("idx_workflow_status_delayed", "delay_until_epoch_ms"),
-        Index("workflow_status_executor_id_index", "executor_id"),
-        Index("workflow_status_status_index", "status"),
+        Index(
+            "idx_workflow_status_delayed",
+            "delay_until_epoch_ms",
+            postgresql_where=text("status = 'DELAYED'"),
+            sqlite_where=text("status = 'DELAYED'"),
+        ),
+        Index(
+            "idx_workflow_status_pending",
+            "workflow_uuid",
+            postgresql_where=text("status = 'PENDING'"),
+            sqlite_where=text("status = 'PENDING'"),
+        ),
+        Index(
+            "idx_workflow_status_failed",
+            "status",
+            "created_at",
+            postgresql_where=text(
+                "status IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED')"
+            ),
+            sqlite_where=text(
+                "status IN ('ERROR', 'CANCELLED', 'MAX_RECOVERY_ATTEMPTS_EXCEEDED')"
+            ),
+        ),
         Index(
             "uq_workflow_status_queue_name_dedup_id",
             "queue_name",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3064,13 +3064,10 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.queue_partition_key
                     == queue_partition_key
                 )
-            if queue._priority_enabled:
-                query = query.order_by(
-                    SystemSchema.workflow_status.c.priority.asc(),
-                    SystemSchema.workflow_status.c.created_at.asc(),
-                )
-            else:
-                query = query.order_by(SystemSchema.workflow_status.c.created_at.asc())
+            query = query.order_by(
+                SystemSchema.workflow_status.c.priority.asc(),
+                SystemSchema.workflow_status.c.created_at.asc(),
+            )
             if max_tasks != sys.maxsize:
                 query = query.limit(int(max_tasks))
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2980,6 +2980,7 @@ class SystemDatabase(ABC):
                     sa.select(sa.func.count())
                     .select_from(SystemSchema.workflow_status)
                     .where(SystemSchema.workflow_status.c.queue_name == queue.name)
+                    .where(SystemSchema.workflow_status.c.rate_limited.is_(True))
                     .where(
                         SystemSchema.workflow_status.c.status.notin_(
                             [
@@ -3103,6 +3104,7 @@ class SystemDatabase(ABC):
                         application_version=app_version,
                         executor_id=executor_id,
                         started_at_epoch_ms=start_time_ms,
+                        rate_limited=queue._limiter is not None,
                         # If a timeout is set, set the deadline on dequeue
                         workflow_deadline_epoch_ms=sa.case(
                             (

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -459,3 +459,71 @@ def test_concurrent_migrations(db_engine: sa.Engine, skip_with_sqlite: None) -> 
         pytest.fail(
             f"{len(errors)}/{num_instances} concurrent migrations failed:\n{error_details}"
         )
+
+
+def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """Simulate a CREATE INDEX CONCURRENTLY that crashed mid-build (leaving an
+    INVALID index) and verify the runner cleans it up and re-runs the
+    migration on the next start."""
+    from dbos._migration import run_dbos_migrations
+
+    engine = dbos._sys_db.engine
+    schema = "dbos"
+    target_index = "idx_workflow_status_in_flight"
+    rewind_to_version = 31  # one before migration 32 which builds target_index
+    final_version = len(get_dbos_migrations(schema, True))
+
+    # Drop the existing valid index, then plant an INVALID index of the same
+    # name. Flipping pg_index.indisvalid mimics what Postgres leaves behind
+    # when CREATE INDEX CONCURRENTLY aborts mid-build.
+    with engine.connect() as raw_conn:
+        conn = raw_conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(sa.text(f'DROP INDEX IF EXISTS "{schema}"."{target_index}"'))
+        conn.execute(
+            sa.text(
+                f'CREATE INDEX "{target_index}" ON "{schema}"."workflow_status" '
+                "(queue_name, status, priority, created_at) "
+                "WHERE status IN ('ENQUEUED', 'PENDING')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "UPDATE pg_index SET indisvalid = false "
+                f"WHERE indexrelid = '{schema}.{target_index}'::regclass"
+            )
+        )
+
+    # Confirm the planted index is INVALID
+    with engine.connect() as conn:
+        valid = conn.execute(
+            sa.text(
+                "SELECT indisvalid FROM pg_index "
+                f"WHERE indexrelid = '{schema}.{target_index}'::regclass"
+            )
+        ).scalar()
+        assert valid is False
+
+    # Rewind the version counter so the runner re-executes migration 32
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :v'),
+            {"v": rewind_to_version},
+        )
+
+    # Re-run migrations: cleanup should drop the invalid index, then 32+ rebuild
+    run_dbos_migrations(engine, schema, use_listen_notify=True)
+
+    # The index now exists and is valid, and the version is back at the latest
+    with engine.connect() as conn:
+        valid = conn.execute(
+            sa.text(
+                "SELECT indisvalid FROM pg_index "
+                f"WHERE indexrelid = '{schema}.{target_index}'::regclass"
+            )
+        ).scalar()
+        assert valid is True
+
+        version = conn.execute(
+            sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+        ).scalar()
+        assert version == final_version

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -461,6 +461,53 @@ def test_concurrent_migrations(db_engine: sa.Engine, skip_with_sqlite: None) -> 
         )
 
 
+def test_version_not_bumped_on_migration_failure(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """If a migration raises mid-flight, the version counter must stay at the
+    prior value so the runner re-attempts it on the next start."""
+    from unittest.mock import patch
+
+    from dbos._migration import run_dbos_migrations
+
+    engine = dbos._sys_db.engine
+    schema = "dbos"
+    rewind_to_version = 31  # one before migration 32
+    final_version = len(get_dbos_migrations(schema, True))
+
+    # Rewind so migration 32 is pending again
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :v'),
+            {"v": rewind_to_version},
+        )
+
+    # Replace migration 32 with invalid SQL. Its execution must raise, and
+    # the runner must not advance the version past 31.
+    with patch(
+        "dbos._migration.get_dbos_migration_thirtytwo",
+        return_value="THIS IS NOT VALID SQL",
+    ):
+        with pytest.raises(Exception):
+            run_dbos_migrations(engine, schema, use_listen_notify=True)
+
+    with engine.connect() as conn:
+        version = conn.execute(
+            sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+        ).scalar()
+        assert version == rewind_to_version
+
+    # Re-run with the real migrations: IF NOT EXISTS guards make 32+ idempotent
+    # given the index still exists from the original fixture migration.
+    run_dbos_migrations(engine, schema, use_listen_notify=True)
+
+    with engine.connect() as conn:
+        version = conn.execute(
+            sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+        ).scalar()
+        assert version == final_version
+
+
 def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) -> None:
     """Simulate a CREATE INDEX CONCURRENTLY that crashed mid-build (leaving an
     INVALID index) and verify the runner cleans it up and re-runs the

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -461,6 +461,32 @@ def test_concurrent_migrations(db_engine: sa.Engine, skip_with_sqlite: None) -> 
         )
 
 
+def test_online_migrations_are_idempotent(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """Re-running every migration from the first online one onward against an
+    already-migrated schema must succeed without error. Guards against
+    missing IF [NOT] EXISTS clauses in any drop/create migration."""
+    from dbos._migration import _ONLINE_MIGRATIONS, run_dbos_migrations
+
+    engine = dbos._sys_db.engine
+    schema = "dbos"
+    rewind_to = min(_ONLINE_MIGRATIONS) - 1
+    final_version = len(get_dbos_migrations(schema, True))
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :v'),
+            {"v": rewind_to},
+        )
+
+    run_dbos_migrations(engine, schema, use_listen_notify=True)
+
+    with engine.connect() as conn:
+        version = conn.execute(
+            sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+        ).scalar()
+        assert version == final_version
+
+
 def test_version_not_bumped_on_migration_failure(
     dbos: DBOS, skip_with_sqlite: None
 ) -> None:


### PR DESCRIPTION
Optimize `workflow_status` table indexes to reduce the cost of maintaining indexes at scale.

- Indexes on `parent_workflow_id`, `forked_from`, and `deduplication_id` are made partial on those fields not being NULL so they're not maintained when not needed.
- The index on `executor_id` is dropped as https://github.com/dbos-inc/dbos-transact-py/pull/644 eliminates the need for it.
- The index on the `status` field is split into two partial indexes: one on `PENDING` workflows for use in recovery; the other on failed workflows (`ERROR`, `CANCELLED`, `MAX_RECOVERY_ATTEMPTS_EXCEEDED`) for rapid troubleshooting. This reduces the number of times the index is updated during a typical workflow lifetime (`ENQUEUED`->`PENDING`->`SUCCESS`).
- The index on `queue_name` and `status` used by the main dequeue query is optimized to index on `("queue_name", "status", "priority", "created_at")`, the exact predicates and sort order of the dequeue query. It is now partial on `ENQUEUED` or `PENDING` workflows as only the dequeue query needs it. 
- A new partial index is created for rate-limited queues to quickly find recent queries in that queue. That index is only maintained for rate-limited queues (using a new `rate_limited` field).
- All migrations use `CREATE INDEX CONCURRENTLY` for safety when running against production workloads.