### PR TITLE
DBOS.listen_queues: use Sequence instead of List to avoid type checker error

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -26,6 +26,7 @@ from typing import (
     Literal,
     Optional,
     Protocol,
+    Sequence,
     Tuple,
     Type,
     TypedDict,
@@ -3092,7 +3093,7 @@ class DBOS:
         return dbos_tracer
 
     @classmethod
-    def listen_queues(cls, queues: List[Union[Queue, str]]) -> None:
+    def listen_queues(cls, queues: Sequence[Union[Queue, str]]) -> None:
         """
         Configure this DBOS process to only listen to (dequeue workflows from) specific queues.
 


### PR DESCRIPTION
`queues` parameter should be annotated with `Sequence[Union[Queue, str]]` instead of `List[Union[Queue, str]]` to avoid type checker error.