### PR TITLE
Add otel_attribute_format config for OTel-semconv span attributes (#665)

### DIFF
--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -337,9 +337,12 @@ class DBOSContext:
         self.authenticated_user = user
         self.authenticated_roles = roles
         if user is not None and len(self.context_spans) > 0:
-            self.context_spans[-1].span.set_attribute("authenticatedUser", user)
             self.context_spans[-1].span.set_attribute(
-                "authenticatedUserRoles", json.dumps(roles) if roles is not None else ""
+                dbos_tracer._resolve_attribute_name("authenticatedUser"), user
+            )
+            self.context_spans[-1].span.set_attribute(
+                dbos_tracer._resolve_attribute_name("authenticatedUserRoles"),
+                json.dumps(roles) if roles is not None else "",
             )
 
 

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -1,7 +1,7 @@
 import os
 import re
 from importlib import resources
-from typing import Any, Dict, List, Optional, TypedDict, cast
+from typing import Any, Dict, List, Literal, Optional, TypedDict, cast
 
 import sqlalchemy as sa
 import yaml
@@ -47,6 +47,11 @@ class DBOSConfig(TypedDict, total=False):
         use_listen_notify (bool): Whether to use LISTEN/NOTIFY or polling to listen for notifications and events.  Defaults to True. As this affects migrations, may not be changed after the system database is first created.
         notification_listener_polling_interval_sec (float): Polling interval in seconds for the notification listener background process. Defaults to 1.0. Minimum value is 0.001. Lower values can speed up test execution.
         scheduler_polling_interval_sec (float): Polling interval in seconds for the scheduler thread to detect new workflow schedules. Defaults to 30.0.
+        otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
+            "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward
+            compatibility with existing dashboards and the TypeScript Transact SDK. "semconv" emits the
+            OpenTelemetry-style equivalents under the dbos.* namespace (e.g. dbos.operation.uuid,
+            dbos.application.id), per https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/.
     """
 
     name: str
@@ -77,6 +82,7 @@ class DBOSConfig(TypedDict, total=False):
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
+    otel_attribute_format: Optional[Literal["legacy", "semconv"]]
 
 
 class RuntimeConfig(TypedDict, total=False):
@@ -112,6 +118,7 @@ class TelemetryConfig(TypedDict, total=False):
     OTLPExporter: Optional[OTLPExporterConfig]
     otlp_attributes: Optional[dict[str, str]]
     disable_otlp: bool
+    otel_attribute_format: Optional[Literal["legacy", "semconv"]]
 
 
 class ConfigFile(TypedDict, total=False):
@@ -194,6 +201,7 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         "OTLPExporter": {"tracesEndpoint": [], "logsEndpoint": []},
         "otlp_attributes": config.get("otlp_attributes", {}),
         "disable_otlp": disable_otlp,
+        "otel_attribute_format": config.get("otel_attribute_format", "legacy"),
     }
     # For mypy
     assert telemetry["OTLPExporter"] is not None

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -50,7 +50,7 @@ class DBOSConfig(TypedDict, total=False):
         otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
             "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward
             compatibility with existing dashboards and the TypeScript Transact SDK. "semconv" emits the
-            OpenTelemetry-style equivalents under the dbos.* namespace (e.g. dbos.operation.uuid,
+            OpenTelemetry-style equivalents under the dbos.* namespace (e.g. dbos.operation.workflow_id,
             dbos.application.id), per https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/.
     """
 

--- a/dbos/_fastapi.py
+++ b/dbos/_fastapi.py
@@ -8,6 +8,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from . import DBOS
 from ._context import EnterDBOSHandler, OperationType, SetWorkflowID, TracedAttributes
 from ._error import DBOSException
+from ._tracer import dbos_tracer
 from ._utils import generate_uuid, request_id_header
 
 
@@ -88,5 +89,8 @@ def setup_fastapi_middleware(app: FastAPI, dbos: DBOS) -> None:
                 and hasattr(response, "status_code")
             ):
                 if DBOS.span is not None:
-                    DBOS.span.set_attribute("responseCode", response.status_code)
+                    DBOS.span.set_attribute(
+                        dbos_tracer._resolve_attribute_name("responseCode"),
+                        response.status_code,
+                    )
         return response

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -14,6 +14,42 @@ if TYPE_CHECKING:
     from ._context import TracedAttributes
 
 
+# How span attribute names are emitted to OTLP.
+#
+# - "legacy"  : original DBOS names (e.g. operationUUID, applicationID).
+#               Default for backward compatibility with existing dashboards
+#               and the TypeScript Transact SDK.
+# - "semconv" : OpenTelemetry-style names under the dbos.* namespace
+#               (e.g. dbos.operation.uuid, dbos.application.id). Follows
+#               https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
+OtelAttributeFormat = Literal["legacy", "semconv"]
+
+
+# Legacy DBOS attribute name -> OpenTelemetry semconv-style equivalent.
+# Keys MUST match the field names in `TracedAttributes` in `_context.py`,
+# plus the few attributes set ad-hoc (`responseCode`,
+# `authenticatedUser*`).
+_LEGACY_TO_SEMCONV: dict[str, str] = {
+    "operationUUID": "dbos.operation.uuid",
+    "operationType": "dbos.operation.type",
+    "applicationID": "dbos.application.id",
+    "applicationVersion": "dbos.application.version",
+    "executorID": "dbos.executor.id",
+    "queueName": "dbos.queue.name",
+    "authenticatedUser": "dbos.user.name",
+    "authenticatedUserRoles": "dbos.user.roles",
+    "authenticatedUserAssumedRole": "dbos.user.assumed_role",
+    "requestID": "dbos.request.id",
+    "requestIP": "dbos.request.ip",
+    "requestURL": "dbos.request.url",
+    "requestMethod": "dbos.request.method",
+    "responseCode": "dbos.response.status_code",
+}
+
+
+_DEFAULT_OTEL_ATTRIBUTE_FORMAT: OtelAttributeFormat = "legacy"
+
+
 class DBOSTracer:
 
     otlp_attributes: dict[str, str] = {}
@@ -22,10 +58,16 @@ class DBOSTracer:
         self.app_id = os.environ.get("DBOS__APPID", None)
         self.provider: Optional[TracerProvider] = None
         self.disable_otlp: bool = False
+        self.otel_attribute_format: OtelAttributeFormat = (
+            _DEFAULT_OTEL_ATTRIBUTE_FORMAT
+        )
 
     def config(self, config: ConfigFile) -> None:
         self.otlp_attributes = config.get("telemetry", {}).get("otlp_attributes", {})  # type: ignore
         self.disable_otlp = config.get("telemetry", {}).get("disable_otlp", False)  # type: ignore
+        self.otel_attribute_format = config.get("telemetry", {}).get(  # type: ignore
+            "otel_attribute_format", _DEFAULT_OTEL_ATTRIBUTE_FORMAT
+        )
         otlp_traces_endpoints = (
             config.get("telemetry", {}).get("OTLPExporter", {}).get("tracesEndpoint")  # type: ignore
         )
@@ -73,6 +115,14 @@ class DBOSTracer:
     def set_provider(self, provider: "Optional[TracerProvider]") -> None:
         self.provider = provider
 
+    def _resolve_attribute_name(self, key: str) -> str:
+        """Map a legacy DBOS attribute name to the name that should be
+        emitted on the span, per `otel_attribute_format`. Returns the
+        original key for unknown attributes."""
+        if self.otel_attribute_format == "semconv":
+            return _LEGACY_TO_SEMCONV.get(key, key)
+        return key
+
     def start_span(
         self, attributes: "TracedAttributes", parent: "Optional[Span]" = None
     ) -> "Span":
@@ -90,8 +140,10 @@ class DBOSTracer:
         attributes["executorID"] = GlobalParams.executor_id
         for k, v in attributes.items():
             if k != "name" and v is not None and isinstance(v, (str, bool, int, float)):
-                span.set_attribute(k, v)
+                span.set_attribute(self._resolve_attribute_name(k), v)
         for k, v in self.otlp_attributes.items():
+            # User-provided custom attributes are passed through verbatim;
+            # they don't go through the legacy/semconv mapping.
             span.set_attribute(k, v)
         return span
 

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -30,7 +30,7 @@ OtelAttributeFormat = Literal["legacy", "semconv"]
 # plus the few attributes set ad-hoc (`responseCode`,
 # `authenticatedUser*`).
 _LEGACY_TO_SEMCONV: dict[str, str] = {
-    "operationUUID": "dbos.operation.uuid",
+    "operationUUID": "dbos.operation.workflow_id",
     "operationType": "dbos.operation.type",
     "applicationID": "dbos.application.id",
     "applicationVersion": "dbos.application.version",
@@ -58,9 +58,7 @@ class DBOSTracer:
         self.app_id = os.environ.get("DBOS__APPID", None)
         self.provider: Optional[TracerProvider] = None
         self.disable_otlp: bool = False
-        self.otel_attribute_format: OtelAttributeFormat = (
-            _DEFAULT_OTEL_ATTRIBUTE_FORMAT
-        )
+        self.otel_attribute_format: OtelAttributeFormat = _DEFAULT_OTEL_ATTRIBUTE_FORMAT
 
     def config(self, config: ConfigFile) -> None:
         self.otlp_attributes = config.get("telemetry", {}).get("otlp_attributes", {})  # type: ignore

--- a/dbos/_tracer.py
+++ b/dbos/_tracer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 #               Default for backward compatibility with existing dashboards
 #               and the TypeScript Transact SDK.
 # - "semconv" : OpenTelemetry-style names under the dbos.* namespace
-#               (e.g. dbos.operation.uuid, dbos.application.id). Follows
+#               (e.g. dbos.operation.workflow_id, dbos.application.id). Follows
 #               https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
 OtelAttributeFormat = Literal["legacy", "semconv"]
 

--- a/tests/test_otel_attribute_format.py
+++ b/tests/test_otel_attribute_format.py
@@ -1,0 +1,91 @@
+"""Tests for the `otel_attribute_format` configuration flag.
+
+When `otel_attribute_format="legacy"` (the default), DBOS span attributes
+use their original camelCase names. When `otel_attribute_format="semconv"`,
+they're emitted under the OTel-style `dbos.*` namespace.
+"""
+
+from dbos import DBOS, DBOSConfig
+from dbos._tracer import _LEGACY_TO_SEMCONV, DBOSTracer
+from tests.conftest import TestOtelType
+
+
+def test_resolve_attribute_name_legacy_passthrough() -> None:
+    tracer = DBOSTracer()
+    tracer.otel_attribute_format = "legacy"
+    for legacy_name in _LEGACY_TO_SEMCONV:
+        assert tracer._resolve_attribute_name(legacy_name) == legacy_name
+
+
+def test_resolve_attribute_name_semconv_remap() -> None:
+    tracer = DBOSTracer()
+    tracer.otel_attribute_format = "semconv"
+    for legacy_name, semconv_name in _LEGACY_TO_SEMCONV.items():
+        assert tracer._resolve_attribute_name(legacy_name) == semconv_name
+
+
+def test_resolve_attribute_name_unknown_passes_through() -> None:
+    """Unknown attribute names are unaffected by the format flag."""
+    for fmt in ("legacy", "semconv"):
+        tracer = DBOSTracer()
+        tracer.otel_attribute_format = fmt  # type: ignore[assignment]
+        assert tracer._resolve_attribute_name("custom.user.attribute") == (
+            "custom.user.attribute"
+        )
+
+
+def test_legacy_attributes_default_emitted_on_span(
+    config: DBOSConfig, setup_in_memory_otlp_collector: TestOtelType
+) -> None:
+    """With no override, spans carry the legacy attribute names."""
+    exporter, _, _ = setup_in_memory_otlp_collector
+
+    DBOS.destroy(destroy_registry=True)
+    config["enable_otlp"] = True
+    DBOS(config=config)
+    DBOS.launch()
+
+    @DBOS.workflow()
+    def w() -> None:
+        pass
+
+    exporter.clear()
+    w()
+
+    spans = exporter.get_finished_spans()
+    assert spans, "expected at least one span"
+    attrs = spans[-1].attributes or {}
+    assert "applicationVersion" in attrs
+    assert "executorID" in attrs
+    assert "dbos.application.version" not in attrs
+    assert "dbos.executor.id" not in attrs
+
+
+def test_semconv_attributes_emitted_on_span(
+    config: DBOSConfig, setup_in_memory_otlp_collector: TestOtelType
+) -> None:
+    """With `otel_attribute_format="semconv"`, spans carry the dbos.* names
+    in place of the legacy ones."""
+    exporter, _, _ = setup_in_memory_otlp_collector
+
+    DBOS.destroy(destroy_registry=True)
+    config["enable_otlp"] = True
+    config["otel_attribute_format"] = "semconv"
+    DBOS(config=config)
+    DBOS.launch()
+
+    @DBOS.workflow()
+    def w() -> None:
+        pass
+
+    exporter.clear()
+    w()
+
+    spans = exporter.get_finished_spans()
+    assert spans, "expected at least one span"
+    attrs = spans[-1].attributes or {}
+    assert "dbos.application.version" in attrs
+    assert "dbos.executor.id" in attrs
+    # Legacy names must not also appear when semconv is selected.
+    assert "applicationVersion" not in attrs
+    assert "executorID" not in attrs

--- a/tests/test_otel_attribute_format.py
+++ b/tests/test_otel_attribute_format.py
@@ -5,7 +5,10 @@ use their original camelCase names. When `otel_attribute_format="semconv"`,
 they're emitted under the OTel-style `dbos.*` namespace.
 """
 
+import uuid
+
 from dbos import DBOS, DBOSConfig
+from dbos._context import SetWorkflowID
 from dbos._tracer import _LEGACY_TO_SEMCONV, DBOSTracer
 from tests.conftest import TestOtelType
 
@@ -28,7 +31,7 @@ def test_resolve_attribute_name_unknown_passes_through() -> None:
     """Unknown attribute names are unaffected by the format flag."""
     for fmt in ("legacy", "semconv"):
         tracer = DBOSTracer()
-        tracer.otel_attribute_format = fmt  # type: ignore[assignment]
+        tracer.otel_attribute_format = fmt
         assert tracer._resolve_attribute_name("custom.user.attribute") == (
             "custom.user.attribute"
         )
@@ -79,11 +82,15 @@ def test_semconv_attributes_emitted_on_span(
         pass
 
     exporter.clear()
-    w()
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        w()
 
     spans = exporter.get_finished_spans()
     assert spans, "expected at least one span"
     attrs = spans[-1].attributes or {}
+    assert "dbos.operation.workflow_id" in attrs
+    assert attrs["dbos.operation.workflow_id"] == wfid
     assert "dbos.application.version" in attrs
     assert "dbos.executor.id" in attrs
     # Legacy names must not also appear when semconv is selected.

--- a/tests/test_otel_attribute_format.py
+++ b/tests/test_otel_attribute_format.py
@@ -62,6 +62,7 @@ def test_legacy_attributes_default_emitted_on_span(
     assert "executorID" in attrs
     assert "dbos.application.version" not in attrs
     assert "dbos.executor.id" not in attrs
+    DBOS.destroy(destroy_registry=True)
 
 
 def test_semconv_attributes_emitted_on_span(
@@ -96,3 +97,4 @@ def test_semconv_attributes_emitted_on_span(
     # Legacy names must not also appear when semconv is selected.
     assert "applicationVersion" not in attrs
     assert "executorID" not in attrs
+    DBOS.destroy(destroy_registry=True)


### PR DESCRIPTION
Closes [#665](https://github.com/dbos-inc/dbos-transact-py/issues/665).

Parallel TypeScript PR: [dbos-transact-ts#1242](https://github.com/dbos-inc/dbos-transact-ts/pull/1242).

## Description

DBOS currently emits span attributes using flat camelCase names without a vendor namespace (`operationUUID`, `applicationID`, `responseCode`, …). These don't follow [OTel's attribute naming spec](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/), which calls for:

1. A vendor prefix (e.g. `dbos.*`) — without one, generic names like `responseCode` and `requestID` collide with attributes set by other instrumentation in the same process.
2. Dot-separated namespaces (`dbos.operation.uuid`).
3. Lowercase snake_case on the final segment.

This makes it hard for downstream consumers (SQL commenters, sampling rules, log/trace filters, dashboard glob filters) to say "give me everything DBOS-related" — they have to enumerate every legacy attribute name and risk missing future ones.

## Implementation

Adds an opt-in `otel_attribute_format` config flag to `DBOSConfig`:

```python
DBOS(config={..., "otel_attribute_format": "semconv"})
```

| Value | Behavior |
|---|---|
| `"legacy"` | (default) Emit original DBOS names. No change for existing users. |
| `"semconv"` | Emit OTel-style names under the `dbos.*` namespace. |

A new `DBOSTracer._resolve_attribute_name(key)` translates legacy names through a static mapping table when `semconv` is selected, and is invoked at the three places DBOS sets attributes on spans:

- `_tracer.py:start_span` — primary path, covers the `TracedAttributes` TypedDict
- `_fastapi.py` — `responseCode` set on the request span
- `_context.py` — `authenticatedUser` / `authenticatedUserRoles` set when auth is established

User-supplied `otlp_attributes` are passed through verbatim and **not** affected by the format flag — the mapping only applies to DBOS's own internal attribute names.

### Mapping

```
operationUUID                -> dbos.operation.workflow_id
operationType                -> dbos.operation.type
applicationID                -> dbos.application.id
applicationVersion           -> dbos.application.version
executorID                   -> dbos.executor.id
queueName                    -> dbos.queue.name
authenticatedUser            -> dbos.user.name
authenticatedUserRoles       -> dbos.user.roles
authenticatedUserAssumedRole -> dbos.user.assumed_role
requestID                    -> dbos.request.id
requestIP                    -> dbos.request.ip
requestURL                   -> dbos.request.url
requestMethod                -> dbos.request.method
responseCode                 -> dbos.response.status_code
```

## Backward compatibility

- `"legacy"` is the default, so this is fully non-breaking. Existing dashboards, alerts, and log queries continue to work unchanged.
- TypeScript Transact SDK compatibility (per the comment on `TracedAttributes`) is preserved by default.
- The flag is process-wide, so a single deploy can flip an entire service to the new names atomically.

## Cross-SDK consistency

The `# Keys must be the same as in TypeScript Transact` comment on `TracedAttributes` ([_context.py:41](https://github.com/dbos-inc/dbos-transact-py/blob/main/dbos/_context.py#L41)) flags that these names are shared with [`dbos-transact-ts`](https://github.com/dbos-inc/dbos-transact-ts).

The mapping in this PR was chosen to converge with the parallel TS PR ([dbos-transact-ts#1242](https://github.com/dbos-inc/dbos-transact-ts/pull/1242)) so users running both SDKs see the same `dbos.*` attribute schema once both flip to `semconv`.

The current legacy names already drift in two places: Python's `authenticatedUserRoles` / `authenticatedUserAssumedRole` vs TS's `authenticatedRoles` / `assumedRole`. Both sides map their respective name to the same `dbos.user.roles` / `dbos.user.assumed_role`, so opting into `semconv` converges them. The aspirational `# Keys must be the same` comment could probably be updated separately.

## Migration path (suggested)

1. Now: ship `legacy` (default) + `semconv` (opt-in).
2. Future minor: encourage users to test `semconv`. Optionally add a deprecation log for the `legacy` mode.
3. Future major (or at maintainer discretion): flip the default to `semconv`.

I deliberately did **not** add a `"both"` mode (emit both names simultaneously). Happy to add it if maintainers think it's needed for migration; left out for now to keep the surface area small.

## Testing

New file `tests/test_otel_attribute_format.py`:

- `test_resolve_attribute_name_legacy_passthrough` — every legacy key resolves to itself in legacy mode.
- `test_resolve_attribute_name_semconv_remap` — every legacy key maps to its `dbos.*` equivalent in semconv mode.
- `test_resolve_attribute_name_unknown_passes_through` — unknown attribute names are unaffected by the format flag in either mode.
- `test_legacy_attributes_default_emitted_on_span` — end-to-end: with the default config, finished spans carry `applicationVersion` / `executorID` and not the `dbos.*` equivalents.
- `test_semconv_attributes_emitted_on_span` — end-to-end: with `otel_attribute_format="semconv"`, finished spans carry `dbos.application.version` / `dbos.executor.id` and not the legacy names.

The integration tests use the existing `setup_in_memory_otlp_collector` fixture from `tests/conftest.py`.

## Notes for reviewers

- I matched the existing `# type: ignore` comments on chained `.get()` calls in `DBOSTracer.config()` rather than refactoring; happy to clean those up in a separate PR if desired.
- Open to feedback on naming — `otel_attribute_format` could equally be `attribute_format` or `attribute_naming`. I picked `otel_attribute_format` because it makes clear that the values are about OTel-semconv compliance, not DBOS-internal serialization.
