### PR TITLE
Datasources

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -8,6 +8,7 @@ from ._context import (
     SetWorkflowTimeout,
 )
 from ._core import StepOptions
+from ._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
 from ._dbos import (
     DBOS,
     DBOSConfiguredInstance,
@@ -69,4 +70,6 @@ __all__ = [
     "pydantic_args_validator",
     "make_pydantic_args_validator",
     "run_dbos_database_migrations",
+    "SQLAlchemyDatasource",
+    "AsyncSQLAlchemyDatasource",
 ]

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -15,6 +15,7 @@ from dbos._serialization import WorkflowSerializationFormat
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from dbos._utils import GlobalParams, generate_uuid
@@ -105,6 +106,8 @@ class DBOSContext:
         self.curr_step_function_id: int = -1
         self.curr_tx_function_id: int = -1
         self.sql_session: Optional[Session] = None
+        self.sync_ds_session: Optional[Session] = None
+        self.async_ds_session: Optional[AsyncSession] = None
         self.context_spans: list[ContextSpan] = []
 
         self.authenticated_user: Optional[str] = None
@@ -268,6 +271,18 @@ class DBOSContext:
         self.sql_session = None
         self.curr_tx_function_id = -1
         self._end_span(exc_value)
+
+    def start_sync_ds_transaction(self, ses: Session) -> None:
+        self.sync_ds_session = ses
+
+    def end_sync_ds_transaction(self) -> None:
+        self.sync_ds_session = None
+
+    def start_async_ds_transaction(self, ses: AsyncSession) -> None:
+        self.async_ds_session = ses
+
+    def end_async_ds_transaction(self) -> None:
+        self.async_ds_session = None
 
     def start_handler(self, attributes: TracedAttributes) -> None:
         self._start_span(attributes)

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -10,6 +10,7 @@ from typing import (
     ParamSpec,
     TypedDict,
     TypeVar,
+    Union,
     cast,
 )
 
@@ -209,7 +210,7 @@ class AsyncDatasource(ABC):
 
     async def _record_result(
         self,
-        conn: AsyncConnection,
+        conn: Union[AsyncConnection, AsyncSession],
         workflow_id: str,
         step_id: int,
         output: Optional[str],
@@ -241,55 +242,72 @@ class AsyncDatasource(ABC):
             )
 
         ctx = get_local_dbos_context()
-        in_workflow = ctx is not None and ctx.is_within_workflow()
+        in_wf = ctx is not None and ctx.is_workflow()
 
-        workflow_id: str = ""
-        step_id: int = -1
+        async def _body() -> R:
+            workflow_id: str = ""
+            step_id: int = -1
 
-        if in_workflow:
-            step_ctx = ctx.snapshot_step_ctx()
-            workflow_id = step_ctx.workflow_id
-            step_id = step_ctx.function_id
-            recorded = await self._check_execution(workflow_id, step_id)
-            if recorded is not None:
-                return cast(R, _replay_recorded(recorded, self.serializer))
+            if in_wf:
+                inner_ctx = get_local_dbos_context()
+                assert inner_ctx is not None
+                workflow_id = inner_ctx.workflow_id
+                step_id = inner_ctx.curr_step_function_id
+                recorded = await self._check_execution(workflow_id, step_id)
+                if recorded is not None:
+                    return cast(R, _replay_recorded(recorded, self.serializer))
 
-        output: R
-        with DBOSContextEnsure() as exec_ctx:
-            async with self.sessionmaker() as session:
-                exec_ctx.start_async_ds_transaction(session)
-                try:
-                    async with session.begin():
-                        await session.connection(
-                            execution_options={"isolation_level": isolation_level}
-                        )
-                        output = await func(*args, **kwargs)
-                    if in_workflow:
-                        serialized, serialization = serialize_value(
-                            output, None, self.serializer
-                        )
-                        async with self.engine.begin() as conn:
-                            await self._record_result(
-                                conn,
-                                workflow_id,
-                                step_id,
-                                serialized,
-                                None,
-                                serialization,
+            output: R
+            with DBOSContextEnsure() as exec_ctx:
+                async with self.sessionmaker() as session:
+                    exec_ctx.start_async_ds_transaction(session)
+                    try:
+                        async with session.begin():
+                            await session.connection(
+                                execution_options={"isolation_level": isolation_level}
                             )
-                except Exception as e:
-                    if in_workflow:
-                        serialized_e, serialization = serialize_exception(
-                            e, None, self.serializer
-                        )
-                        await self._record_error(
-                            workflow_id, step_id, serialized_e, serialization
-                        )
-                    raise
-                finally:
-                    exec_ctx.end_async_ds_transaction()
+                            output = await func(*args, **kwargs)
+                            if in_wf:
+                                serialized, serialization = serialize_value(
+                                    output, None, self.serializer
+                                )
+                                await self._record_result(
+                                    session,
+                                    workflow_id,
+                                    step_id,
+                                    serialized,
+                                    None,
+                                    serialization,
+                                )
+                    except Exception as e:
+                        if in_wf:
+                            serialized_e, serialization = serialize_exception(
+                                e, None, self.serializer
+                            )
+                            await self._record_error(
+                                workflow_id, step_id, serialized_e, serialization
+                            )
+                        raise
+                    finally:
+                        exec_ctx.end_async_ds_transaction()
 
-        return output
+            return output
+
+        if in_wf:
+            from dbos._core import StepOptions, run_step_async
+            from dbos._dbos import _get_dbos_instance
+
+            assert ctx is not None
+            step_options: StepOptions = {"name": name}
+            return await run_step_async(
+                _get_dbos_instance(),
+                ctx.snapshot_step_ctx(),
+                _body,
+                step_options,
+                (),
+                {},
+            )
+        return await _body()
 
     def transaction(
         self,
@@ -431,7 +449,7 @@ class SyncDatasource(ABC):
 
     def _record_result(
         self,
-        conn: sa.Connection,
+        conn: Union[sa.Connection, Session],
         workflow_id: str,
         step_id: int,
         output: Optional[str],
@@ -463,55 +481,64 @@ class SyncDatasource(ABC):
             )
 
         ctx = get_local_dbos_context()
-        in_workflow = ctx is not None and ctx.is_within_workflow()
+        in_wf = ctx is not None and ctx.is_workflow()
 
-        workflow_id: str = ""
-        step_id: int = -1
+        def _body() -> R:
+            workflow_id: str = ""
+            step_id: int = -1
 
-        if in_workflow:
-            step_ctx = ctx.snapshot_step_ctx()
-            workflow_id = step_ctx.workflow_id
-            step_id = step_ctx.function_id
-            recorded = self._check_execution(workflow_id, step_id)
-            if recorded is not None:
-                return cast(R, _replay_recorded(recorded, self.serializer))
+            if in_wf:
+                inner_ctx = get_local_dbos_context()
+                assert inner_ctx is not None
+                workflow_id = inner_ctx.workflow_id
+                step_id = inner_ctx.curr_step_function_id
+                recorded = self._check_execution(workflow_id, step_id)
+                if recorded is not None:
+                    return cast(R, _replay_recorded(recorded, self.serializer))
 
-        output: R
-        with DBOSContextEnsure() as exec_ctx:
-            with self.sessionmaker() as session:
-                exec_ctx.start_sync_ds_transaction(session)
-                try:
-                    with session.begin():
-                        session.connection(
-                            execution_options={"isolation_level": isolation_level}
-                        )
-                        output = func(*args, **kwargs)
-                    if in_workflow:
-                        serialized, serialization = serialize_value(
-                            output, None, self.serializer
-                        )
-                        with self.engine.begin() as conn:
-                            self._record_result(
-                                conn,
-                                workflow_id,
-                                step_id,
-                                serialized,
-                                None,
-                                serialization,
+            output: R
+            with DBOSContextEnsure() as exec_ctx:
+                with self.sessionmaker() as session:
+                    exec_ctx.start_sync_ds_transaction(session)
+                    try:
+                        with session.begin():
+                            session.connection(
+                                execution_options={"isolation_level": isolation_level}
                             )
-                except Exception as e:
-                    if in_workflow:
-                        serialized_e, serialization = serialize_exception(
-                            e, None, self.serializer
-                        )
-                        self._record_error(
-                            workflow_id, step_id, serialized_e, serialization
-                        )
-                    raise
-                finally:
-                    exec_ctx.end_sync_ds_transaction()
+                            output = func(*args, **kwargs)
+                            if in_wf:
+                                serialized, serialization = serialize_value(
+                                    output, None, self.serializer
+                                )
+                                self._record_result(
+                                    session,
+                                    workflow_id,
+                                    step_id,
+                                    serialized,
+                                    None,
+                                    serialization,
+                                )
+                    except Exception as e:
+                        if in_wf:
+                            serialized_e, serialization = serialize_exception(
+                                e, None, self.serializer
+                            )
+                            self._record_error(
+                                workflow_id, step_id, serialized_e, serialization
+                            )
+                        raise
+                    finally:
+                        exec_ctx.end_sync_ds_transaction()
 
-        return output
+            return output
+
+        if in_wf:
+            from dbos._core import StepOptions, run_step
+            from dbos._dbos import _get_dbos_instance
+
+            step_options: StepOptions = {"name": name}
+            return run_step(_get_dbos_instance(), _body, step_options, (), {})
+        return _body()
 
     def transaction(
         self,

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC, abstractmethod
 from typing import (
     Any,
@@ -12,10 +13,13 @@ from typing import (
 )
 
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from dbos._core import StepOptions
 from dbos._dbos import DBOS, IsolationLevel, check_async
+from dbos._error import DBOSException
+from dbos._schemas.datasource_database import DatasourceSchema
 
 from ._logger import dbos_logger
 from ._serialization import Serializer
@@ -72,29 +76,25 @@ class AsyncDatasource(ABC):
         import sqlalchemy.dialects.sqlite as sq
 
         if engine:
-            dbos_logger.info("Initializing AsyncDatasource with custom engine")
+            dbos_logger.info("Initializing SyncDatasource with custom engine")
         else:
-            printable_db_url = sa.make_url(database_url).render_as_string(
+            printable_url = sa.make_url(database_url).render_as_string(
                 hide_password=True
             )
             dbos_logger.info(
-                f"Initializing DBOS AsyncDatasource with URL: {printable_db_url}"
+                f"Initializing DBOS SyncDatasource with URL: {printable_url}"
             )
-            if database_url.startswith("sqlite"):
+            if not database_url.startswith("sqlite"):
                 dbos_logger.info(
-                    f"Using SQLite as a AsyncDatasource. The SQLite AsyncDatasource is for development and testing. PostgreSQL is recommended for production use."
-                )
-            else:
-                dbos_logger.info(
-                    f"DBOS AsyncDatasource engine parameters: {engine_kwargs}"
+                    f"DBOS SyncDatasource engine parameters: {engine_kwargs}"
                 )
         self.dialect = sq if database_url.startswith("sqlite") else pg
-        self.serializer = serializer
         self.schema = (
             None
             if database_url.startswith("sqlite")
             else (schema if schema else "dbos")
         )
+        DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
             self.engine = engine
             self.created_engine = False
@@ -102,6 +102,8 @@ class AsyncDatasource(ABC):
             self.engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
         self._engine_kwargs = engine_kwargs
+        self.sessionmaker = async_sessionmaker(bind=self.engine)
+        self.serializer = serializer
 
     @abstractmethod
     def _create_engine(
@@ -114,6 +116,9 @@ class AsyncDatasource(ABC):
     async def run_migrations(self) -> None:
         """Run database migrations specific to the database type."""
         pass
+
+    def sql_session(cls) -> AsyncSession:
+        raise NotImplementedError()
 
     @overload
     async def run_tx_async(
@@ -140,6 +145,17 @@ class AsyncDatasource(ABC):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R:
+        name = ds_options.name if ds_options.name is not None else func.__qualname__
+        isolation_level = (
+            ds_options.isolation_level
+            if ds_options.isolation_level is not None
+            else "SERIALIZABLE"
+        )
+        if inspect.iscoroutinefunction(func) == False:
+            raise DBOSException(
+                f"Function {name} is not a coroutine function, but AsyncDatasource.run_tx_async requires a coroutine functions"
+            )
+
         raise NotImplementedError()
 
 
@@ -188,27 +204,23 @@ class SyncDatasource(ABC):
         if engine:
             dbos_logger.info("Initializing SyncDatasource with custom engine")
         else:
-            printable_db_url = sa.make_url(database_url).render_as_string(
+            printable_url = sa.make_url(database_url).render_as_string(
                 hide_password=True
             )
             dbos_logger.info(
-                f"Initializing DBOS SyncDatasource with URL: {printable_db_url}"
+                f"Initializing DBOS SyncDatasource with URL: {printable_url}"
             )
-            if database_url.startswith("sqlite"):
-                dbos_logger.info(
-                    f"Using SQLite as a SyncDatasource. The SQLite SyncDatasource is for development and testing. PostgreSQL is recommended for production use."
-                )
-            else:
+            if not database_url.startswith("sqlite"):
                 dbos_logger.info(
                     f"DBOS SyncDatasource engine parameters: {engine_kwargs}"
                 )
         self.dialect = sq if database_url.startswith("sqlite") else pg
-        self.serializer = serializer
         self.schema = (
             None
             if database_url.startswith("sqlite")
             else (schema if schema else "dbos")
         )
+        DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
             self.engine = engine
             self.created_engine = False
@@ -216,6 +228,8 @@ class SyncDatasource(ABC):
             self.engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
         self._engine_kwargs = engine_kwargs
+        self.sessionmaker = sessionmaker(bind=self.engine)
+        self.serializer = serializer
 
     @abstractmethod
     def _create_engine(
@@ -228,6 +242,9 @@ class SyncDatasource(ABC):
     def run_migrations(self) -> None:
         """Run database migrations specific to the database type."""
         pass
+
+    def sql_session(cls) -> Session:
+        raise NotImplementedError()
 
     @overload
     def run_tx(

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from dbos._core import StepOptions
-from dbos._dbos import DBOS, IsolationLevel
+from dbos._dbos import DBOS, IsolationLevel, check_async
 
 from ._logger import dbos_logger
 from ._serialization import Serializer
@@ -115,6 +115,33 @@ class AsyncDatasource(ABC):
         """Run database migrations specific to the database type."""
         pass
 
+    @overload
+    async def run_tx_async(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, Coroutine[Any, Any, R]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R: ...
+
+    @overload
+    async def run_tx_async(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R: ...
+
+    async def run_tx_async(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, Coroutine[Any, Any, R]] | Callable[P, R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
+        raise NotImplementedError()
+
 
 class SyncDatasource(ABC):
     @staticmethod
@@ -201,3 +228,33 @@ class SyncDatasource(ABC):
     def run_migrations(self) -> None:
         """Run database migrations specific to the database type."""
         pass
+
+    @overload
+    def run_tx(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, Coroutine[Any, Any, R]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R: ...
+
+    @overload
+    def run_tx(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R: ...
+
+    def run_tx(
+        self,
+        ds_options: Optional[DatasourceOptions],
+        func: Callable[P, Coroutine[Any, Any, R]] | Callable[P, R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
+        """Invoke a step function and checkpoint its result."""
+        check_async("run_step")
+
+        raise NotImplementedError()

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -99,7 +99,7 @@ class DatasourceOptions(TypedDict, total=False):
     isolation_level: Optional[IsolationLevel]
 
 
-class AsyncDatasource(ABC):
+class AsyncSQLAlchemyDatasource(ABC):
 
     def __init__(
         self,
@@ -136,7 +136,7 @@ class AsyncDatasource(ABC):
         engine: Optional[AsyncEngine] = None,
         schema: Optional[str] = None,
         serializer: Optional[Serializer] = None,
-    ) -> "AsyncDatasource":
+    ) -> "AsyncSQLAlchemyDatasource ":
         if serializer is None:
             serializer = DBOSDefaultSerializer
         if engine_kwargs is None:
@@ -144,7 +144,7 @@ class AsyncDatasource(ABC):
         if database_url.startswith("sqlite"):
             from ._datasource_sqlite import SqliteAsyncDatasource
 
-            instance: AsyncDatasource = SqliteAsyncDatasource(
+            instance: AsyncSQLAlchemyDatasource = SqliteAsyncDatasource(
                 database_url=database_url,
                 engine_kwargs=engine_kwargs,
                 engine=engine,
@@ -356,7 +356,7 @@ class AsyncDatasource(ABC):
         return decorator
 
 
-class SyncDatasource(ABC):
+class SQLAlchemyDatasource(ABC):
 
     def __init__(
         self,
@@ -393,7 +393,7 @@ class SyncDatasource(ABC):
         engine: Optional[sa.Engine] = None,
         schema: Optional[str] = None,
         serializer: Optional[Serializer] = None,
-    ) -> "SyncDatasource":
+    ) -> "SQLAlchemyDatasource ":
         if serializer is None:
             serializer = DBOSDefaultSerializer
         if engine_kwargs is None:
@@ -401,7 +401,7 @@ class SyncDatasource(ABC):
         if database_url.startswith("sqlite"):
             from ._datasource_sqlite import SqliteSyncDatasource
 
-            instance: SyncDatasource = SqliteSyncDatasource(
+            instance: SQLAlchemyDatasource = SqliteSyncDatasource(
                 database_url=database_url,
                 engine_kwargs=engine_kwargs,
                 engine=engine,

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -13,9 +13,15 @@ from typing import (
 )
 
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+)
 from sqlalchemy.orm import Session, sessionmaker
 
+from dbos._app_db import RecordedResult
 from dbos._core import StepOptions
 from dbos._dbos import DBOS, IsolationLevel, check_async
 from dbos._error import DBOSException
@@ -120,6 +126,58 @@ class AsyncDatasource(ABC):
     def sql_session(cls) -> AsyncSession:
         raise NotImplementedError()
 
+    async def _check_execution(
+        self, workflow_id: str, step_id: int
+    ) -> None | RecordedResult:
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                sa.select(
+                    DatasourceSchema.datasource_outputs.c.output,
+                    DatasourceSchema.datasource_outputs.c.error,
+                    DatasourceSchema.datasource_outputs.c.serialization,
+                ).where(
+                    DatasourceSchema.datasource_outputs.c.workflow_id == workflow_id,
+                    DatasourceSchema.datasource_outputs.c.step_id == step_id,
+                )
+            )
+            row = result.first()
+            return (
+                None
+                if row is None
+                else {"output": row[0], "error": row[1], "serialization": row[2]}
+            )
+
+    async def _record_error(
+        self,
+        workflow_id: str,
+        step_id: int,
+        error: str,
+        serialization: str | None,
+    ):
+        async with self.engine.begin() as conn:
+            await self._record_result(
+                conn, workflow_id, step_id, None, error, serialization
+            )
+
+    async def _record_result(
+        self,
+        conn: AsyncConnection,
+        workflow_id: str,
+        step_id: int,
+        output: str | None,
+        error: str | None,
+        serialization: str | None,
+    ):
+        await conn.execute(
+            sa.insert(DatasourceSchema.datasource_outputs).values(
+                workflow_id=workflow_id,
+                step_id=step_id,
+                output=output,
+                error=error,
+                serialization=serialization,
+            )
+        )
+
     @overload
     async def run_tx_async(
         self,
@@ -145,13 +203,17 @@ class AsyncDatasource(ABC):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R:
-        name = ds_options.name if ds_options.name is not None else func.__qualname__
+        name = (
+            ds_options["name"]
+            if ds_options and ds_options.get("name") is not None
+            else func.__qualname__
+        )
         isolation_level = (
-            ds_options.isolation_level
-            if ds_options.isolation_level is not None
+            ds_options["isolation_level"]
+            if ds_options and ds_options.get("isolation_level") is not None
             else "SERIALIZABLE"
         )
-        if inspect.iscoroutinefunction(func) == False:
+        if not inspect.iscoroutinefunction(func):
             raise DBOSException(
                 f"Function {name} is not a coroutine function, but AsyncDatasource.run_tx_async requires a coroutine functions"
             )

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -12,6 +12,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import sqlalchemy as sa
@@ -44,7 +45,7 @@ R = TypeVar("R")
 
 
 def _parse_ds_options(
-    ds_options: Optional["DatasourceOptions"], func: Callable
+    ds_options: Optional["DatasourceOptions"], func: Callable[..., Any]
 ) -> "tuple[str, str]":
     name = (ds_options.get("name") if ds_options else None) or func.__qualname__
     isolation_level: str = (
@@ -309,12 +310,28 @@ class AsyncDatasource(ABC):
             )
         return await _body()
 
+    @overload
+    def transaction(
+        self, func: Callable[P, Coroutine[Any, Any, R]]
+    ) -> Callable[P, Coroutine[Any, Any, R]]: ...
+
+    @overload
     def transaction(
         self,
-        func: Optional[Callable] = None,
+        func: None = None,
         *,
         name: Optional[str] = None,
-        isolation_level: str = "SERIALIZABLE",
+        isolation_level: IsolationLevel = "SERIALIZABLE",
+    ) -> Callable[
+        [Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]
+    ]: ...
+
+    def transaction(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        *,
+        name: Optional[str] = None,
+        isolation_level: IsolationLevel = "SERIALIZABLE",
     ) -> Any:
         def decorator(
             f: Callable[..., Coroutine[Any, Any, Any]],
@@ -540,12 +557,24 @@ class SyncDatasource(ABC):
             return run_step(_get_dbos_instance(), _body, step_options, (), {})
         return _body()
 
+    @overload
+    def transaction(self, func: Callable[P, R]) -> Callable[P, R]: ...
+
+    @overload
     def transaction(
         self,
-        func: Optional[Callable] = None,
+        func: None = None,
         *,
         name: Optional[str] = None,
-        isolation_level: str = "SERIALIZABLE",
+        isolation_level: IsolationLevel = "SERIALIZABLE",
+    ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+
+    def transaction(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        *,
+        name: Optional[str] = None,
+        isolation_level: IsolationLevel = "SERIALIZABLE",
     ) -> Any:
         def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
             if inspect.iscoroutinefunction(f):

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -1,5 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
+from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -9,7 +10,7 @@ from typing import (
     ParamSpec,
     TypedDict,
     TypeVar,
-    overload,
+    cast,
 )
 
 import sqlalchemy as sa
@@ -22,16 +23,23 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import Session, sessionmaker
 
 from dbos._app_db import RecordedResult
-from dbos._core import StepOptions
-from dbos._dbos import DBOS, IsolationLevel, check_async
+from dbos._context import DBOSContextEnsure, get_local_dbos_context
+from dbos._dbos import IsolationLevel
 from dbos._error import DBOSException
 from dbos._schemas.datasource_database import DatasourceSchema
+from dbos._serialization import (
+    DBOSDefaultSerializer,
+    Serializer,
+    deserialize_exception,
+    deserialize_value,
+    serialize_exception,
+    serialize_value,
+)
 
 from ._logger import dbos_logger
-from ._serialization import Serializer
 
-P = ParamSpec("P")  # A generic type for workflow parameters
-R = TypeVar("R", covariant=True)  # A generic type for workflow return values
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class DatasourceOptions(TypedDict, total=False):
@@ -40,34 +48,6 @@ class DatasourceOptions(TypedDict, total=False):
 
 
 class AsyncDatasource(ABC):
-    @staticmethod
-    def create(
-        database_url: str,
-        engine_kwargs: Dict[str, Any],
-        engine: Optional[AsyncEngine],
-        schema: Optional[str],
-        serializer: Serializer,
-    ) -> "AsyncDatasource":
-        if database_url.startswith("sqlite"):
-            from ._datasource_sqlite import SqliteAsyncDatasource
-
-            return SqliteAsyncDatasource(
-                database_url=database_url,
-                engine_kwargs=engine_kwargs,
-                engine=engine,
-                schema=schema,
-                serializer=serializer,
-            )
-        else:
-            from ._datasource_postgres import PostgresAsyncDatasource
-
-            return PostgresAsyncDatasource(
-                database_url=database_url,
-                engine_kwargs=engine_kwargs,
-                engine=engine,
-                schema=schema,
-                serializer=serializer,
-            )
 
     def __init__(
         self,
@@ -82,17 +62,17 @@ class AsyncDatasource(ABC):
         import sqlalchemy.dialects.sqlite as sq
 
         if engine:
-            dbos_logger.info("Initializing SyncDatasource with custom engine")
+            dbos_logger.info("Initializing AsyncDatasource with custom engine")
         else:
             printable_url = sa.make_url(database_url).render_as_string(
                 hide_password=True
             )
             dbos_logger.info(
-                f"Initializing DBOS SyncDatasource with URL: {printable_url}"
+                f"Initializing DBOS AsyncDatasource with URL: {printable_url}"
             )
             if not database_url.startswith("sqlite"):
                 dbos_logger.info(
-                    f"DBOS SyncDatasource engine parameters: {engine_kwargs}"
+                    f"DBOS AsyncDatasource engine parameters: {engine_kwargs}"
                 )
         self.dialect = sq if database_url.startswith("sqlite") else pg
         self.schema = (
@@ -111,24 +91,61 @@ class AsyncDatasource(ABC):
         self.sessionmaker = async_sessionmaker(bind=self.engine)
         self.serializer = serializer
 
+    @staticmethod
+    async def create(
+        database_url: str,
+        engine_kwargs: Optional[Dict[str, Any]] = None,
+        engine: Optional[AsyncEngine] = None,
+        schema: Optional[str] = None,
+        serializer: Optional[Serializer] = None,
+    ) -> "AsyncDatasource":
+        if serializer is None:
+            serializer = DBOSDefaultSerializer
+        if engine_kwargs is None:
+            engine_kwargs = {}
+        if database_url.startswith("sqlite"):
+            from ._datasource_sqlite import SqliteAsyncDatasource
+
+            instance: AsyncDatasource = SqliteAsyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        else:
+            from ._datasource_postgres import PostgresAsyncDatasource
+
+            instance = PostgresAsyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        await instance.run_migrations()
+        return instance
+
     @abstractmethod
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
-        """Create a database engine specific to the database type."""
         pass
 
     @abstractmethod
     async def run_migrations(self) -> None:
-        """Run database migrations specific to the database type."""
         pass
 
-    def sql_session(cls) -> AsyncSession:
-        raise NotImplementedError()
+    def sql_session(self) -> AsyncSession:
+        ctx = get_local_dbos_context()
+        assert (
+            ctx is not None and ctx.async_ds_session is not None
+        ), "sql_session() must be called within an async datasource transaction"
+        return ctx.async_ds_session
 
     async def _check_execution(
         self, workflow_id: str, step_id: int
-    ) -> None | RecordedResult:
+    ) -> Optional[RecordedResult]:
         async with self.engine.connect() as conn:
             result = await conn.execute(
                 sa.select(
@@ -152,8 +169,8 @@ class AsyncDatasource(ABC):
         workflow_id: str,
         step_id: int,
         error: str,
-        serialization: str | None,
-    ):
+        serialization: Optional[str],
+    ) -> None:
         async with self.engine.begin() as conn:
             await self._record_result(
                 conn, workflow_id, step_id, None, error, serialization
@@ -164,10 +181,10 @@ class AsyncDatasource(ABC):
         conn: AsyncConnection,
         workflow_id: str,
         step_id: int,
-        output: str | None,
-        error: str | None,
-        serialization: str | None,
-    ):
+        output: Optional[str],
+        error: Optional[str],
+        serialization: Optional[str],
+    ) -> None:
         await conn.execute(
             sa.insert(DatasourceSchema.datasource_outputs).values(
                 workflow_id=workflow_id,
@@ -178,78 +195,121 @@ class AsyncDatasource(ABC):
             )
         )
 
-    @overload
-    async def run_tx_async(
+    async def run_tx_step_async(
         self,
         ds_options: Optional[DatasourceOptions],
         func: Callable[P, Coroutine[Any, Any, R]],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> R: ...
-
-    @overload
-    async def run_tx_async(
-        self,
-        ds_options: Optional[DatasourceOptions],
-        func: Callable[P, R],
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> R: ...
-
-    async def run_tx_async(
-        self,
-        ds_options: Optional[DatasourceOptions],
-        func: Callable[P, Coroutine[Any, Any, R]] | Callable[P, R],
-        *args: P.args,
-        **kwargs: P.kwargs,
     ) -> R:
-        name = (
-            ds_options["name"]
-            if ds_options and ds_options.get("name") is not None
-            else func.__qualname__
-        )
-        isolation_level = (
-            ds_options["isolation_level"]
-            if ds_options and ds_options.get("isolation_level") is not None
-            else "SERIALIZABLE"
-        )
+        name = (ds_options.get("name") if ds_options else None) or func.__qualname__
+        isolation_level: str = (
+            ds_options.get("isolation_level") if ds_options else None
+        ) or "SERIALIZABLE"
+
         if not inspect.iscoroutinefunction(func):
             raise DBOSException(
-                f"Function {name} is not a coroutine function, but AsyncDatasource.run_tx_async requires a coroutine functions"
+                f"Function {name} must be a coroutine function for AsyncDatasource"
             )
 
-        raise NotImplementedError()
+        ctx = get_local_dbos_context()
+        in_workflow = ctx is not None and ctx.is_within_workflow()
+
+        workflow_id: str = ""
+        step_id: int = -1
+
+        if in_workflow:
+            step_ctx = ctx.snapshot_step_ctx()
+            workflow_id = step_ctx.workflow_id
+            step_id = step_ctx.function_id
+            recorded = await self._check_execution(workflow_id, step_id)
+            if recorded is not None:
+                if recorded["error"]:
+                    raise deserialize_exception(
+                        recorded["error"], recorded["serialization"], self.serializer
+                    )
+                elif recorded["output"] is not None:
+                    return cast(
+                        R,
+                        deserialize_value(
+                            recorded["output"],
+                            recorded["serialization"],
+                            self.serializer,
+                        ),
+                    )
+                else:
+                    raise DBOSException(
+                        "Datasource recorded output and error are both None"
+                    )
+
+        output: R
+        with DBOSContextEnsure() as exec_ctx:
+            async with self.sessionmaker() as session:
+                exec_ctx.start_async_ds_transaction(session)
+                try:
+                    async with session.begin():
+                        await session.connection(
+                            execution_options={"isolation_level": isolation_level}
+                        )
+                        output = await func(*args, **kwargs)
+                    if in_workflow:
+                        serialized, serialization = serialize_value(
+                            output, None, self.serializer
+                        )
+                        async with self.engine.begin() as conn:
+                            await self._record_result(
+                                conn,
+                                workflow_id,
+                                step_id,
+                                serialized,
+                                None,
+                                serialization,
+                            )
+                except Exception as e:
+                    if in_workflow:
+                        serialized_e, serialization = serialize_exception(
+                            e, None, self.serializer
+                        )
+                        await self._record_error(
+                            workflow_id, step_id, serialized_e, serialization
+                        )
+                    raise
+                finally:
+                    exec_ctx.end_async_ds_transaction()
+
+        return output
+
+    def transaction(
+        self,
+        func: Optional[Callable] = None,
+        *,
+        name: Optional[str] = None,
+        isolation_level: str = "SERIALIZABLE",
+    ) -> Any:
+        def decorator(
+            f: Callable[..., Coroutine[Any, Any, Any]],
+        ) -> Callable[..., Coroutine[Any, Any, Any]]:
+            if not inspect.iscoroutinefunction(f):
+                raise DBOSException(
+                    f"AsyncDatasource.transaction requires a coroutine function, "
+                    f"but {f.__qualname__} is not"
+                )
+            ds_options: DatasourceOptions = {"isolation_level": isolation_level}
+            if name is not None:
+                ds_options["name"] = name
+
+            @wraps(f)
+            async def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await self.run_tx_step_async(ds_options, f, *args, **kwargs)
+
+            return wrapper
+
+        if func is not None:
+            return decorator(func)
+        return decorator
 
 
 class SyncDatasource(ABC):
-    @staticmethod
-    def create(
-        database_url: str,
-        engine_kwargs: Dict[str, Any],
-        engine: Optional[sa.Engine],
-        schema: Optional[str],
-        serializer: Serializer,
-    ) -> "SyncDatasource":
-        if database_url.startswith("sqlite"):
-            from ._datasource_sqlite import SqliteSyncDatasource
-
-            return SqliteSyncDatasource(
-                database_url=database_url,
-                engine_kwargs=engine_kwargs,
-                engine=engine,
-                schema=schema,
-                serializer=serializer,
-            )
-        else:
-            from ._datasource_postgres import PostgresSyncDatasource
-
-            return PostgresSyncDatasource(
-                database_url=database_url,
-                engine_kwargs=engine_kwargs,
-                engine=engine,
-                schema=schema,
-                serializer=serializer,
-            )
 
     def __init__(
         self,
@@ -293,47 +353,215 @@ class SyncDatasource(ABC):
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.serializer = serializer
 
+    @staticmethod
+    def create(
+        database_url: str,
+        engine_kwargs: Optional[Dict[str, Any]] = None,
+        engine: Optional[sa.Engine] = None,
+        schema: Optional[str] = None,
+        serializer: Optional[Serializer] = None,
+    ) -> "SyncDatasource":
+        if serializer is None:
+            serializer = DBOSDefaultSerializer
+        if engine_kwargs is None:
+            engine_kwargs = {}
+        if database_url.startswith("sqlite"):
+            from ._datasource_sqlite import SqliteSyncDatasource
+
+            instance: SyncDatasource = SqliteSyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        else:
+            from ._datasource_postgres import PostgresSyncDatasource
+
+            instance = PostgresSyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        instance.run_migrations()
+        return instance
+
     @abstractmethod
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
-        """Create a database engine specific to the database type."""
         pass
 
     @abstractmethod
     def run_migrations(self) -> None:
-        """Run database migrations specific to the database type."""
         pass
 
-    def sql_session(cls) -> Session:
-        raise NotImplementedError()
+    def sql_session(self) -> Session:
+        ctx = get_local_dbos_context()
+        assert (
+            ctx is not None and ctx.sync_ds_session is not None
+        ), "sql_session() must be called within a sync datasource transaction"
+        return ctx.sync_ds_session
 
-    @overload
-    def run_tx(
+    def _check_execution(
+        self, workflow_id: str, step_id: int
+    ) -> Optional[RecordedResult]:
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                sa.select(
+                    DatasourceSchema.datasource_outputs.c.output,
+                    DatasourceSchema.datasource_outputs.c.error,
+                    DatasourceSchema.datasource_outputs.c.serialization,
+                ).where(
+                    DatasourceSchema.datasource_outputs.c.workflow_id == workflow_id,
+                    DatasourceSchema.datasource_outputs.c.step_id == step_id,
+                )
+            )
+            row = result.first()
+            return (
+                None
+                if row is None
+                else {"output": row[0], "error": row[1], "serialization": row[2]}
+            )
+
+    def _record_error(
         self,
-        ds_options: Optional[DatasourceOptions],
-        func: Callable[P, Coroutine[Any, Any, R]],
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> R: ...
+        workflow_id: str,
+        step_id: int,
+        error: str,
+        serialization: Optional[str],
+    ) -> None:
+        with self.engine.begin() as conn:
+            self._record_result(conn, workflow_id, step_id, None, error, serialization)
 
-    @overload
-    def run_tx(
+    def _record_result(
+        self,
+        conn: sa.Connection,
+        workflow_id: str,
+        step_id: int,
+        output: Optional[str],
+        error: Optional[str],
+        serialization: Optional[str],
+    ) -> None:
+        conn.execute(
+            sa.insert(DatasourceSchema.datasource_outputs).values(
+                workflow_id=workflow_id,
+                step_id=step_id,
+                output=output,
+                error=error,
+                serialization=serialization,
+            )
+        )
+
+    def run_tx_step(
         self,
         ds_options: Optional[DatasourceOptions],
         func: Callable[P, R],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> R: ...
-
-    def run_tx(
-        self,
-        ds_options: Optional[DatasourceOptions],
-        func: Callable[P, Coroutine[Any, Any, R]] | Callable[P, R],
-        *args: P.args,
-        **kwargs: P.kwargs,
     ) -> R:
-        """Invoke a step function and checkpoint its result."""
-        check_async("run_step")
+        name = (ds_options.get("name") if ds_options else None) or func.__qualname__
+        isolation_level: str = (
+            ds_options.get("isolation_level") if ds_options else None
+        ) or "SERIALIZABLE"
 
-        raise NotImplementedError()
+        if inspect.iscoroutinefunction(func):
+            raise DBOSException(
+                f"Function {name} is a coroutine; use AsyncDatasource.run_tx_step_async instead"
+            )
+
+        ctx = get_local_dbos_context()
+        in_workflow = ctx is not None and ctx.is_within_workflow()
+
+        workflow_id: str = ""
+        step_id: int = -1
+
+        if in_workflow:
+            step_ctx = ctx.snapshot_step_ctx()
+            workflow_id = step_ctx.workflow_id
+            step_id = step_ctx.function_id
+            recorded = self._check_execution(workflow_id, step_id)
+            if recorded is not None:
+                if recorded["error"]:
+                    raise deserialize_exception(
+                        recorded["error"], recorded["serialization"], self.serializer
+                    )
+                elif recorded["output"] is not None:
+                    return cast(
+                        R,
+                        deserialize_value(
+                            recorded["output"],
+                            recorded["serialization"],
+                            self.serializer,
+                        ),
+                    )
+                else:
+                    raise DBOSException(
+                        "Datasource recorded output and error are both None"
+                    )
+
+        output: R
+        with DBOSContextEnsure() as exec_ctx:
+            with self.sessionmaker() as session:
+                exec_ctx.start_sync_ds_transaction(session)
+                try:
+                    with session.begin():
+                        session.connection(
+                            execution_options={"isolation_level": isolation_level}
+                        )
+                        output = func(*args, **kwargs)
+                    if in_workflow:
+                        serialized, serialization = serialize_value(
+                            output, None, self.serializer
+                        )
+                        with self.engine.begin() as conn:
+                            self._record_result(
+                                conn,
+                                workflow_id,
+                                step_id,
+                                serialized,
+                                None,
+                                serialization,
+                            )
+                except Exception as e:
+                    if in_workflow:
+                        serialized_e, serialization = serialize_exception(
+                            e, None, self.serializer
+                        )
+                        self._record_error(
+                            workflow_id, step_id, serialized_e, serialization
+                        )
+                    raise
+                finally:
+                    exec_ctx.end_sync_ds_transaction()
+
+        return output
+
+    def transaction(
+        self,
+        func: Optional[Callable] = None,
+        *,
+        name: Optional[str] = None,
+        isolation_level: str = "SERIALIZABLE",
+    ) -> Any:
+        def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+            if inspect.iscoroutinefunction(f):
+                raise DBOSException(
+                    f"SyncDatasource.transaction requires a non-coroutine function, "
+                    f"but {f.__qualname__} is a coroutine"
+                )
+            ds_options: DatasourceOptions = {"isolation_level": isolation_level}
+            if name is not None:
+                ds_options["name"] = name
+
+            @wraps(f)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return self.run_tx_step(ds_options, f, *args, **kwargs)
+
+            return wrapper
+
+        if func is not None:
+            return decorator(func)
+        return decorator

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -42,6 +42,29 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def _parse_ds_options(
+    ds_options: Optional["DatasourceOptions"], func: Callable
+) -> "tuple[str, str]":
+    name = (ds_options.get("name") if ds_options else None) or func.__qualname__
+    isolation_level: str = (
+        ds_options.get("isolation_level") if ds_options else None
+    ) or "SERIALIZABLE"
+    return name, isolation_level
+
+
+def _replay_recorded(recorded: "RecordedResult", serializer: "Serializer") -> Any:
+    if recorded["error"]:
+        raise deserialize_exception(
+            recorded["error"], recorded["serialization"], serializer
+        )
+    elif recorded["output"] is not None:
+        return deserialize_value(
+            recorded["output"], recorded["serialization"], serializer
+        )
+    else:
+        raise DBOSException("Datasource recorded output and error are both None")
+
+
 class DatasourceOptions(TypedDict, total=False):
     name: Optional[str]
     isolation_level: Optional[IsolationLevel]
@@ -202,10 +225,7 @@ class AsyncDatasource(ABC):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R:
-        name = (ds_options.get("name") if ds_options else None) or func.__qualname__
-        isolation_level: str = (
-            ds_options.get("isolation_level") if ds_options else None
-        ) or "SERIALIZABLE"
+        name, isolation_level = _parse_ds_options(ds_options, func)
 
         if not inspect.iscoroutinefunction(func):
             raise DBOSException(
@@ -224,23 +244,7 @@ class AsyncDatasource(ABC):
             step_id = step_ctx.function_id
             recorded = await self._check_execution(workflow_id, step_id)
             if recorded is not None:
-                if recorded["error"]:
-                    raise deserialize_exception(
-                        recorded["error"], recorded["serialization"], self.serializer
-                    )
-                elif recorded["output"] is not None:
-                    return cast(
-                        R,
-                        deserialize_value(
-                            recorded["output"],
-                            recorded["serialization"],
-                            self.serializer,
-                        ),
-                    )
-                else:
-                    raise DBOSException(
-                        "Datasource recorded output and error are both None"
-                    )
+                return cast(R, _replay_recorded(recorded, self.serializer))
 
         output: R
         with DBOSContextEnsure() as exec_ctx:
@@ -462,10 +466,7 @@ class SyncDatasource(ABC):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R:
-        name = (ds_options.get("name") if ds_options else None) or func.__qualname__
-        isolation_level: str = (
-            ds_options.get("isolation_level") if ds_options else None
-        ) or "SERIALIZABLE"
+        name, isolation_level = _parse_ds_options(ds_options, func)
 
         if inspect.iscoroutinefunction(func):
             raise DBOSException(
@@ -484,23 +485,7 @@ class SyncDatasource(ABC):
             step_id = step_ctx.function_id
             recorded = self._check_execution(workflow_id, step_id)
             if recorded is not None:
-                if recorded["error"]:
-                    raise deserialize_exception(
-                        recorded["error"], recorded["serialization"], self.serializer
-                    )
-                elif recorded["output"] is not None:
-                    return cast(
-                        R,
-                        deserialize_value(
-                            recorded["output"],
-                            recorded["serialization"],
-                            self.serializer,
-                        ),
-                    )
-                else:
-                    raise DBOSException(
-                        "Datasource recorded output and error are both None"
-                    )
+                return cast(R, _replay_recorded(recorded, self.serializer))
 
         output: R
         with DBOSContextEnsure() as exec_ctx:

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -1,0 +1,203 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Optional,
+    ParamSpec,
+    TypedDict,
+    TypeVar,
+    overload,
+)
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from dbos._core import StepOptions
+from dbos._dbos import DBOS, IsolationLevel
+
+from ._logger import dbos_logger
+from ._serialization import Serializer
+
+P = ParamSpec("P")  # A generic type for workflow parameters
+R = TypeVar("R", covariant=True)  # A generic type for workflow return values
+
+
+class DatasourceOptions(TypedDict, total=False):
+    name: Optional[str]
+    isolation_level: Optional[IsolationLevel]
+
+
+class AsyncDatasource(ABC):
+    @staticmethod
+    def create(
+        database_url: str,
+        engine_kwargs: Dict[str, Any],
+        engine: Optional[AsyncEngine],
+        schema: Optional[str],
+        serializer: Serializer,
+    ) -> "AsyncDatasource":
+        if database_url.startswith("sqlite"):
+            from ._datasource_sqlite import SqliteAsyncDatasource
+
+            return SqliteAsyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        else:
+            from ._datasource_postgres import PostgresAsyncDatasource
+
+            return PostgresAsyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+
+    def __init__(
+        self,
+        *,
+        database_url: str,
+        engine_kwargs: Dict[str, Any],
+        engine: Optional[AsyncEngine],
+        schema: Optional[str],
+        serializer: Serializer,
+    ):
+        import sqlalchemy.dialects.postgresql as pg
+        import sqlalchemy.dialects.sqlite as sq
+
+        if engine:
+            dbos_logger.info("Initializing AsyncDatasource with custom engine")
+        else:
+            printable_db_url = sa.make_url(database_url).render_as_string(
+                hide_password=True
+            )
+            dbos_logger.info(
+                f"Initializing DBOS AsyncDatasource with URL: {printable_db_url}"
+            )
+            if database_url.startswith("sqlite"):
+                dbos_logger.info(
+                    f"Using SQLite as a AsyncDatasource. The SQLite AsyncDatasource is for development and testing. PostgreSQL is recommended for production use."
+                )
+            else:
+                dbos_logger.info(
+                    f"DBOS AsyncDatasource engine parameters: {engine_kwargs}"
+                )
+        self.dialect = sq if database_url.startswith("sqlite") else pg
+        self.serializer = serializer
+        self.schema = (
+            None
+            if database_url.startswith("sqlite")
+            else (schema if schema else "dbos")
+        )
+        if engine:
+            self.engine = engine
+            self.created_engine = False
+        else:
+            self.engine = self._create_engine(database_url, engine_kwargs)
+            self.created_engine = True
+        self._engine_kwargs = engine_kwargs
+
+    @abstractmethod
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> AsyncEngine:
+        """Create a database engine specific to the database type."""
+        pass
+
+    @abstractmethod
+    async def run_migrations(self) -> None:
+        """Run database migrations specific to the database type."""
+        pass
+
+
+class SyncDatasource(ABC):
+    @staticmethod
+    def create(
+        database_url: str,
+        engine_kwargs: Dict[str, Any],
+        engine: Optional[sa.Engine],
+        schema: Optional[str],
+        serializer: Serializer,
+    ) -> "SyncDatasource":
+        if database_url.startswith("sqlite"):
+            from ._datasource_sqlite import SqliteSyncDatasource
+
+            return SqliteSyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+        else:
+            from ._datasource_postgres import PostgresSyncDatasource
+
+            return PostgresSyncDatasource(
+                database_url=database_url,
+                engine_kwargs=engine_kwargs,
+                engine=engine,
+                schema=schema,
+                serializer=serializer,
+            )
+
+    def __init__(
+        self,
+        *,
+        database_url: str,
+        engine_kwargs: Dict[str, Any],
+        engine: Optional[sa.Engine],
+        schema: Optional[str],
+        serializer: Serializer,
+    ):
+        import sqlalchemy.dialects.postgresql as pg
+        import sqlalchemy.dialects.sqlite as sq
+
+        if engine:
+            dbos_logger.info("Initializing SyncDatasource with custom engine")
+        else:
+            printable_db_url = sa.make_url(database_url).render_as_string(
+                hide_password=True
+            )
+            dbos_logger.info(
+                f"Initializing DBOS SyncDatasource with URL: {printable_db_url}"
+            )
+            if database_url.startswith("sqlite"):
+                dbos_logger.info(
+                    f"Using SQLite as a SyncDatasource. The SQLite SyncDatasource is for development and testing. PostgreSQL is recommended for production use."
+                )
+            else:
+                dbos_logger.info(
+                    f"DBOS SyncDatasource engine parameters: {engine_kwargs}"
+                )
+        self.dialect = sq if database_url.startswith("sqlite") else pg
+        self.serializer = serializer
+        self.schema = (
+            None
+            if database_url.startswith("sqlite")
+            else (schema if schema else "dbos")
+        )
+        if engine:
+            self.engine = engine
+            self.created_engine = False
+        else:
+            self.engine = self._create_engine(database_url, engine_kwargs)
+            self.created_engine = True
+        self._engine_kwargs = engine_kwargs
+
+    @abstractmethod
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> sa.Engine:
+        """Create a database engine specific to the database type."""
+        pass
+
+    @abstractmethod
+    def run_migrations(self) -> None:
+        """Run database migrations specific to the database type."""
+        pass

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -65,6 +65,33 @@ def _replay_recorded(recorded: "RecordedResult", serializer: "Serializer") -> An
         raise DBOSException("Datasource recorded output and error are both None")
 
 
+def _row_to_result(row: Any) -> Optional[RecordedResult]:
+    return (
+        None
+        if row is None
+        else {"output": row[0], "error": row[1], "serialization": row[2]}
+    )
+
+
+def _log_datasource_init(
+    name: str,
+    database_url: str,
+    engine_kwargs: Dict[str, Any],
+    has_engine: bool,
+) -> None:
+    if has_engine:
+        dbos_logger.info(f"Initializing {name} with custom engine")
+    else:
+        printable_url = sa.make_url(database_url).render_as_string(hide_password=True)
+        dbos_logger.info(f"Initializing DBOS {name} with URL: {printable_url}")
+        if not database_url.startswith("sqlite"):
+            dbos_logger.info(f"DBOS {name} engine parameters: {engine_kwargs}")
+
+
+def _resolve_schema(database_url: str, schema: Optional[str]) -> Optional[str]:
+    return None if database_url.startswith("sqlite") else (schema or "dbos")
+
+
 class DatasourceOptions(TypedDict, total=False):
     name: Optional[str]
     isolation_level: Optional[IsolationLevel]
@@ -84,25 +111,11 @@ class AsyncDatasource(ABC):
         import sqlalchemy.dialects.postgresql as pg
         import sqlalchemy.dialects.sqlite as sq
 
-        if engine:
-            dbos_logger.info("Initializing AsyncDatasource with custom engine")
-        else:
-            printable_url = sa.make_url(database_url).render_as_string(
-                hide_password=True
-            )
-            dbos_logger.info(
-                f"Initializing DBOS AsyncDatasource with URL: {printable_url}"
-            )
-            if not database_url.startswith("sqlite"):
-                dbos_logger.info(
-                    f"DBOS AsyncDatasource engine parameters: {engine_kwargs}"
-                )
-        self.dialect = sq if database_url.startswith("sqlite") else pg
-        self.schema = (
-            None
-            if database_url.startswith("sqlite")
-            else (schema if schema else "dbos")
+        _log_datasource_init(
+            "AsyncDatasource", database_url, engine_kwargs, bool(engine)
         )
+        self.dialect = sq if database_url.startswith("sqlite") else pg
+        self.schema = _resolve_schema(database_url, schema)
         DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
             self.engine = engine
@@ -180,12 +193,7 @@ class AsyncDatasource(ABC):
                     DatasourceSchema.datasource_outputs.c.step_id == step_id,
                 )
             )
-            row = result.first()
-            return (
-                None
-                if row is None
-                else {"output": row[0], "error": row[1], "serialization": row[2]}
-            )
+            return _row_to_result(result.first())
 
     async def _record_error(
         self,
@@ -327,25 +335,11 @@ class SyncDatasource(ABC):
         import sqlalchemy.dialects.postgresql as pg
         import sqlalchemy.dialects.sqlite as sq
 
-        if engine:
-            dbos_logger.info("Initializing SyncDatasource with custom engine")
-        else:
-            printable_url = sa.make_url(database_url).render_as_string(
-                hide_password=True
-            )
-            dbos_logger.info(
-                f"Initializing DBOS SyncDatasource with URL: {printable_url}"
-            )
-            if not database_url.startswith("sqlite"):
-                dbos_logger.info(
-                    f"DBOS SyncDatasource engine parameters: {engine_kwargs}"
-                )
-        self.dialect = sq if database_url.startswith("sqlite") else pg
-        self.schema = (
-            None
-            if database_url.startswith("sqlite")
-            else (schema if schema else "dbos")
+        _log_datasource_init(
+            "SyncDatasource", database_url, engine_kwargs, bool(engine)
         )
+        self.dialect = sq if database_url.startswith("sqlite") else pg
+        self.schema = _resolve_schema(database_url, schema)
         DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
             self.engine = engine
@@ -423,12 +417,7 @@ class SyncDatasource(ABC):
                     DatasourceSchema.datasource_outputs.c.step_id == step_id,
                 )
             )
-            row = result.first()
-            return (
-                None
-                if row is None
-                else {"output": row[0], "error": row[1], "serialization": row[2]}
-            )
+            return _row_to_result(result.first())
 
     def _record_error(
         self,

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -45,11 +45,11 @@ class PostgresAsyncDatasource(AsyncDatasource):
             await pg_ds_engine.dispose()
 
         async with self.engine.begin() as conn:
-            await conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))
+            await conn.execute(sa.text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema}"'))
             await conn.execute(
                 sa.text(
                     f"""
-                    CREATE TABLE IF NOT EXISTS {self.schema}".datasource_outputs (
+                    CREATE TABLE IF NOT EXISTS "{self.schema}".datasource_outputs (
                         workflow_id TEXT NOT NULL,
                         step_id INT NOT NULL,
                         output TEXT,
@@ -74,11 +74,11 @@ class PostgresSyncDatasource(SyncDatasource):
     def run_migrations(self) -> None:
         """Run database migrations specific to the database type."""
         with self.engine.begin() as conn:
-            conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))
+            conn.execute(sa.text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema}"'))
             conn.execute(
                 sa.text(
                     f"""
-                    CREATE TABLE IF NOT EXISTS {self.schema}".datasource_outputs (
+                    CREATE TABLE IF NOT EXISTS "{self.schema}".datasource_outputs (
                         workflow_id TEXT NOT NULL,
                         step_id INT NOT NULL,
                         output TEXT,

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 import sqlalchemy as sa
-from sqlalchemy import URL, event
+from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from dbos._datasource import AsyncDatasource, SyncDatasource
@@ -13,79 +13,48 @@ def _make_url(database_url: str) -> URL:
     return sa.make_url(database_url).set(drivername="postgresql+psycopg")
 
 
+def _schema_sql(schema: str) -> sa.TextClause:
+    return sa.text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+
+
+def _table_sql(schema: str) -> sa.TextClause:
+    return sa.text(
+        f"""
+        CREATE TABLE IF NOT EXISTS "{schema}".datasource_outputs (
+            workflow_id TEXT NOT NULL,
+            step_id INT NOT NULL,
+            output TEXT,
+            error TEXT,
+            serialization TEXT,
+            created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint,
+            PRIMARY KEY (workflow_id, step_id)
+        )"""
+    )
+
+
 class PostgresAsyncDatasource(AsyncDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
-        url = _make_url(database_url)
         if engine_kwargs is None:
             engine_kwargs = {}
-        return create_async_engine(url, **engine_kwargs)
+        return create_async_engine(_make_url(database_url), **engine_kwargs)
 
     async def run_migrations(self) -> None:
-        ds_db_url = self.engine.url
-        try:
-            pg_ds_engine = create_async_engine(
-                ds_db_url.set(database="postgres"), **self._engine_kwargs
-            )
-            async with pg_ds_engine.connect() as conn:
-                await conn.execution_options(isolation_level="AUTOCOMMIT")
-                if not (
-                    await conn.execute(
-                        sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
-                        parameters={"db_name": ds_db_url.database},
-                    )
-                ).scalar():
-                    await conn.execute(sa.text(f"CREATE DATABASE {ds_db_url.database}"))
-        except Exception:
-            dbos_logger.warning(
-                f"Could not connect to postgres database to verify existence of {ds_db_url.database}. Continuing..."
-            )
-        finally:
-            await pg_ds_engine.dispose()
-
         async with self.engine.begin() as conn:
-            await conn.execute(sa.text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema}"'))
-            await conn.execute(
-                sa.text(
-                    f"""
-                    CREATE TABLE IF NOT EXISTS "{self.schema}".datasource_outputs (
-                        workflow_id TEXT NOT NULL,
-                        step_id INT NOT NULL,
-                        output TEXT,
-                        error TEXT,
-                        serialization TEXT,
-                        created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint,
-                        PRIMARY KEY (workflow_id, step_id)
-                    )"""
-                )
-            )
+            await conn.execute(_schema_sql(self.schema))
+            await conn.execute(_table_sql(self.schema))
 
 
 class PostgresSyncDatasource(SyncDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
-        url = _make_url(database_url)
         if engine_kwargs is None:
             engine_kwargs = {}
-        return sa.create_engine(url, **engine_kwargs)
+        return sa.create_engine(_make_url(database_url), **engine_kwargs)
 
     def run_migrations(self) -> None:
-        """Run database migrations specific to the database type."""
         with self.engine.begin() as conn:
-            conn.execute(sa.text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema}"'))
-            conn.execute(
-                sa.text(
-                    f"""
-                    CREATE TABLE IF NOT EXISTS "{self.schema}".datasource_outputs (
-                        workflow_id TEXT NOT NULL,
-                        step_id INT NOT NULL,
-                        output TEXT,
-                        error TEXT,
-                        serialization TEXT,
-                        created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint,
-                        PRIMARY KEY (workflow_id, step_id)
-                    )"""
-                )
-            )
+            conn.execute(_schema_sql(self.schema))
+            conn.execute(_table_sql(self.schema))

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -41,6 +41,7 @@ class PostgresAsyncDatasource(AsyncDatasource):
         return create_async_engine(_make_url(database_url), **engine_kwargs)
 
     async def run_migrations(self) -> None:
+        assert self.schema is not None
         async with self.engine.begin() as conn:
             await conn.execute(_schema_sql(self.schema))
             await conn.execute(_table_sql(self.schema))
@@ -55,6 +56,7 @@ class PostgresSyncDatasource(SyncDatasource):
         return sa.create_engine(_make_url(database_url), **engine_kwargs)
 
     def run_migrations(self) -> None:
+        assert self.schema is not None
         with self.engine.begin() as conn:
             conn.execute(_schema_sql(self.schema))
             conn.execute(_table_sql(self.schema))

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from dbos._datasource import AsyncDatasource, SyncDatasource
+from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
 
 from ._logger import dbos_logger
 
@@ -32,7 +32,7 @@ def _table_sql(schema: str) -> sa.TextClause:
     )
 
 
-class PostgresAsyncDatasource(AsyncDatasource):
+class PostgresAsyncDatasource(AsyncSQLAlchemyDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
@@ -47,7 +47,7 @@ class PostgresAsyncDatasource(AsyncDatasource):
             await conn.execute(_table_sql(self.schema))
 
 
-class PostgresSyncDatasource(SyncDatasource):
+class PostgresSyncDatasource(SQLAlchemyDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict
+
+import sqlalchemy as sa
+from sqlalchemy import URL, event
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dbos._datasource import AsyncDatasource, SyncDatasource
+
+from ._logger import dbos_logger
+
+
+def _make_url(database_url: str) -> URL:
+    return sa.make_url(database_url).set(drivername="postgresql+psycopg")
+
+
+class PostgresAsyncDatasource(AsyncDatasource):
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> AsyncEngine:
+        url = _make_url(database_url)
+        return create_async_engine(url, **engine_kwargs)
+
+    async def run_migrations(self) -> None:
+        async with self.engine.begin() as conn:
+            await conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))
+            await conn.execute(
+                sa.text(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {self.schema}".datasource_outputs (
+                        workflow_id TEXT NOT NULL,
+                        step_id INT NOT NULL,
+                        output TEXT,
+                        error TEXT,
+                        serialization TEXT,
+                        created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint,
+                        PRIMARY KEY (workflow_id, step_id)
+                    )"""
+                )
+            )
+
+
+class PostgresSyncDatasource(SyncDatasource):
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> sa.Engine:
+        url = _make_url(database_url)
+        return sa.create_engine(url, **engine_kwargs)
+
+    def run_migrations(self) -> None:
+        """Run database migrations specific to the database type."""
+        with self.engine.begin() as conn:
+            conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))
+            conn.execute(
+                sa.text(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {self.schema}".datasource_outputs (
+                        workflow_id TEXT NOT NULL,
+                        step_id INT NOT NULL,
+                        output TEXT,
+                        error TEXT,
+                        serialization TEXT,
+                        created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint,
+                        PRIMARY KEY (workflow_id, step_id)
+                    )"""
+                )
+            )

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -29,7 +29,7 @@ class PostgresAsyncDatasource(AsyncDatasource):
                 ds_db_url.set(database="postgres"), **self._engine_kwargs
             )
             async with pg_ds_engine.connect() as conn:
-                conn.execution_options(isolation_level="AUTOCOMMIT")
+                await conn.execution_options(isolation_level="AUTOCOMMIT")
                 if not (
                     await conn.execute(
                         sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
@@ -42,7 +42,7 @@ class PostgresAsyncDatasource(AsyncDatasource):
                 f"Could not connect to postgres database to verify existence of {ds_db_url.database}. Continuing..."
             )
         finally:
-            pg_ds_engine.dispose()
+            await pg_ds_engine.dispose()
 
         async with self.engine.begin() as conn:
             await conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -18,9 +18,32 @@ class PostgresAsyncDatasource(AsyncDatasource):
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
         url = _make_url(database_url)
+        if engine_kwargs is None:
+            engine_kwargs = {}
         return create_async_engine(url, **engine_kwargs)
 
     async def run_migrations(self) -> None:
+        ds_db_url = self.engine.url
+        try:
+            pg_ds_engine = create_async_engine(
+                ds_db_url.set(database="postgres"), **self._engine_kwargs
+            )
+            async with pg_ds_engine.connect() as conn:
+                conn.execution_options(isolation_level="AUTOCOMMIT")
+                if not (
+                    await conn.execute(
+                        sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
+                        parameters={"db_name": ds_db_url.database},
+                    )
+                ).scalar():
+                    await conn.execute(sa.text(f"CREATE DATABASE {ds_db_url.database}"))
+        except Exception:
+            dbos_logger.warning(
+                f"Could not connect to postgres database to verify existence of {ds_db_url.database}. Continuing..."
+            )
+        finally:
+            pg_ds_engine.dispose()
+
         async with self.engine.begin() as conn:
             await conn.execute(sa.text(f'CREATE SCHEMA "{self.schema}"'))
             await conn.execute(
@@ -44,6 +67,8 @@ class PostgresSyncDatasource(SyncDatasource):
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
         url = _make_url(database_url)
+        if engine_kwargs is None:
+            engine_kwargs = {}
         return sa.create_engine(url, **engine_kwargs)
 
     def run_migrations(self) -> None:

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -10,29 +10,48 @@ from dbos._schemas.datasource_database import DatasourceSchema
 
 from ._logger import dbos_logger
 
+_PG_ONLY_CONNECT_ARGS = frozenset(("application_name", "connect_timeout"))
+
+_CHECK_TABLE_SQL = sa.text(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='datasource_outputs'"
+)
+
+_CREATE_TABLE_SQL = sa.text(
+    f"""
+    CREATE TABLE datasource_outputs (
+        workflow_id TEXT NOT NULL,
+        step_id INTEGER NOT NULL,
+        output TEXT,
+        error TEXT,
+        serialization TEXT,
+        created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+        PRIMARY KEY (workflow_id, step_id)
+    )"""
+)
+
+
+def _filter_sqlite_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    kwargs = engine_kwargs.copy()
+    connect_args = kwargs.get("connect_args", {})
+    if connect_args:
+        filtered_keys = [k for k in connect_args if k in _PG_ONLY_CONNECT_ARGS]
+        if filtered_keys:
+            dbos_logger.debug(
+                f"Ignoring PostgreSQL-specific connect_args for SQLite: {filtered_keys}"
+            )
+        kwargs["connect_args"] = {
+            k: v for k, v in connect_args.items() if k not in _PG_ONLY_CONNECT_ARGS
+        }
+    return kwargs
+
 
 class SqliteAsyncDatasource(AsyncDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
-        """Create a SQLite engine."""
-        sqlite_kwargs = engine_kwargs.copy()
-        connect_args = sqlite_kwargs.get("connect_args", {})
-        if connect_args:
-            filtered_keys = [
-                k for k in connect_args if k in ("application_name", "connect_timeout")
-            ]
-            if filtered_keys:
-                dbos_logger.debug(
-                    f"Ignoring PostgreSQL-specific connect_args for SQLite: {filtered_keys}"
-                )
-            sqlite_connect_args = {
-                k: v
-                for k, v in connect_args.items()
-                if k not in ("application_name", "connect_timeout")
-            }
-            sqlite_kwargs["connect_args"] = sqlite_connect_args
-        engine = create_async_engine(database_url, **sqlite_kwargs)
+        engine = create_async_engine(
+            database_url, **_filter_sqlite_kwargs(engine_kwargs)
+        )
 
         # Use IMMEDIATE transactions to serialize writers and prevent race conditions
         @event.listens_for(engine, "connect")
@@ -45,27 +64,9 @@ class SqliteAsyncDatasource(AsyncDatasource):
     async def run_migrations(self) -> None:
         async with self.engine.begin() as conn:
             await conn.execute(sa.text("PRAGMA foreign_keys = ON"))
-            result = await conn.execute(
-                sa.text(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
-                )
-            )
-
+            result = await conn.execute(_CHECK_TABLE_SQL)
             if result.fetchone() is None:
-                await conn.execute(
-                    sa.text(
-                        f"""
-                        CREATE TABLE datasource_outputs (
-                            workflow_id TEXT NOT NULL,
-                            step_id INTEGER NOT NULL,
-                            output TEXT,
-                            error TEXT,
-                            serialization TEXT,
-                            created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
-                            PRIMARY KEY (workflow_id, step_id)
-                        )"""
-                    )
-                )
+                await conn.execute(_CREATE_TABLE_SQL)
 
 
 class SqliteSyncDatasource(SyncDatasource):
@@ -73,44 +74,11 @@ class SqliteSyncDatasource(SyncDatasource):
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
         DatasourceSchema.datasource_outputs.schema = None
-        sqlite_kwargs = engine_kwargs.copy()
-        connect_args = sqlite_kwargs.get("connect_args", {})
-        if connect_args:
-            filtered_keys = [
-                k for k in connect_args if k in ("application_name", "connect_timeout")
-            ]
-            if filtered_keys:
-                dbos_logger.debug(
-                    f"Ignoring PostgreSQL-specific connect_args for SQLite: {filtered_keys}"
-                )
-            sqlite_connect_args = {
-                k: v
-                for k, v in connect_args.items()
-                if k not in ("application_name", "connect_timeout")
-            }
-            sqlite_kwargs["connect_args"] = sqlite_connect_args
-        return sa.create_engine(database_url, **sqlite_kwargs)
+        return sa.create_engine(database_url, **_filter_sqlite_kwargs(engine_kwargs))
 
     def run_migrations(self) -> None:
         with self.engine.begin() as conn:
             conn.execute(sa.text("PRAGMA foreign_keys = ON"))
-            result = conn.execute(
-                sa.text(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='datasource_outputs'"
-                )
-            )
+            result = conn.execute(_CHECK_TABLE_SQL)
             if result.fetchone() is None:
-                conn.execute(
-                    sa.text(
-                        f"""
-                        CREATE TABLE datasource_outputs (
-                            workflow_id TEXT NOT NULL,
-                            step_id INTEGER NOT NULL,
-                            output TEXT,
-                            error TEXT,
-                            serialization TEXT,
-                            created_at BIGINT NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
-                            PRIMARY KEY (workflow_id, step_id)
-                        )"""
-                    )
-                )
+                conn.execute(_CREATE_TABLE_SQL)

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -44,14 +44,13 @@ class SqliteAsyncDatasource(AsyncDatasource):
     async def run_migrations(self) -> None:
         async with self.engine.begin() as conn:
             await conn.execute(sa.text("PRAGMA foreign_keys = ON"))
-            result = (
-                await conn.execute(
-                    sa.text(
-                        "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
-                    )
+            result = await conn.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
                 )
-            ).fetchone()
-            if result is None:
+            )
+
+            if result.fetchone() is None:
                 await conn.execute(
                     sa.text(
                         f"""
@@ -106,8 +105,8 @@ class SqliteSyncDatasource(SyncDatasource):
                 sa.text(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
                 )
-            ).fetchone()
-            if result is None:
+            )
+            if result.fetchone() is None:
                 conn.execute(
                     sa.text(
                         f"""

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -55,14 +55,14 @@ class SqliteAsyncDatasource(AsyncDatasource):
                 await conn.execute(
                     sa.text(
                         f"""
-                        CREATE TABLE dbos_datasource_outputs (
+                        CREATE TABLE datasource_outputs (
                             workflow_id TEXT NOT NULL,
                             step_id INTEGER NOT NULL,
                             output TEXT,
                             error TEXT,
                             serialization TEXT,
                             created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
-                            PRIMARY KEY (workflow_uuid, function_id),
+                            PRIMARY KEY (workflow_id, step_id)
                         )"""
                     )
                 )
@@ -110,6 +110,7 @@ class SqliteSyncDatasource(SyncDatasource):
                             error TEXT,
                             serialization TEXT,
                             created_at BIGINT NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+                            PRIMARY KEY (workflow_id, step_id)
                         )"""
                     )
                 )

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -1,0 +1,123 @@
+from typing import Any, Dict
+
+import sqlalchemy as sa
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dbos._datasource import AsyncDatasource, SyncDatasource
+from dbos._migration import get_sqlite_timestamp_expr
+
+from ._logger import dbos_logger
+
+
+class SqliteAsyncDatasource(AsyncDatasource):
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> AsyncEngine:
+        """Create a SQLite engine."""
+        sqlite_kwargs = engine_kwargs.copy()
+        connect_args = sqlite_kwargs.get("connect_args", {})
+        if connect_args:
+            filtered_keys = [
+                k for k in connect_args if k in ("application_name", "connect_timeout")
+            ]
+            if filtered_keys:
+                dbos_logger.debug(
+                    f"Ignoring PostgreSQL-specific connect_args for SQLite: {filtered_keys}"
+                )
+            sqlite_connect_args = {
+                k: v
+                for k, v in connect_args.items()
+                if k not in ("application_name", "connect_timeout")
+            }
+            sqlite_kwargs["connect_args"] = sqlite_connect_args
+        engine = create_async_engine(database_url, **sqlite_kwargs)
+
+        # Use IMMEDIATE transactions to serialize writers and prevent race conditions
+        @event.listens_for(engine, "connect")
+        def set_sqlite_immediate(dbapi_conn: Any, connection_record: Any) -> None:
+            dbapi_conn.isolation_level = "IMMEDIATE"
+            dbapi_conn.execute("PRAGMA foreign_keys=ON")
+
+        return engine
+
+    async def run_migrations(self) -> None:
+        async with self.engine.begin() as conn:
+            await conn.execute(sa.text("PRAGMA foreign_keys = ON"))
+            result = (
+                await conn.execute(
+                    sa.text(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
+                    )
+                )
+            ).fetchone()
+            if result is None:
+                await conn.execute(
+                    sa.text(
+                        f"""
+                        CREATE TABLE dbos_datasource_outputs (
+                            workflow_id TEXT NOT NULL,
+                            step_id INTEGER NOT NULL,
+                            output TEXT,
+                            error TEXT,
+                            serialization TEXT,
+                            created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+                            PRIMARY KEY (workflow_uuid, function_id),
+                        )"""
+                    )
+                )
+
+
+class SqliteSyncDatasource(SyncDatasource):
+    def _create_engine(
+        self, database_url: str, engine_kwargs: Dict[str, Any]
+    ) -> sa.Engine:
+        """Create a SQLite engine."""
+        sqlite_kwargs = engine_kwargs.copy()
+        connect_args = sqlite_kwargs.get("connect_args", {})
+        if connect_args:
+            filtered_keys = [
+                k for k in connect_args if k in ("application_name", "connect_timeout")
+            ]
+            if filtered_keys:
+                dbos_logger.debug(
+                    f"Ignoring PostgreSQL-specific connect_args for SQLite: {filtered_keys}"
+                )
+            sqlite_connect_args = {
+                k: v
+                for k, v in connect_args.items()
+                if k not in ("application_name", "connect_timeout")
+            }
+            sqlite_kwargs["connect_args"] = sqlite_connect_args
+        engine = sa.create_engine(database_url, **sqlite_kwargs)
+
+        # Use IMMEDIATE transactions to serialize writers and prevent race conditions
+        @event.listens_for(engine, "connect")
+        def set_sqlite_immediate(dbapi_conn: Any, connection_record: Any) -> None:
+            dbapi_conn.isolation_level = "IMMEDIATE"
+            dbapi_conn.execute("PRAGMA foreign_keys=ON")
+
+        return engine
+
+    def run_migrations(self) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(sa.text("PRAGMA foreign_keys = ON"))
+            result = conn.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
+                )
+            ).fetchone()
+            if result is None:
+                conn.execute(
+                    sa.text(
+                        f"""
+                        CREATE TABLE dbos_datasource_outputs (
+                            workflow_id TEXT NOT NULL,
+                            step_id INTEGER NOT NULL,
+                            output TEXT,
+                            error TEXT,
+                            serialization TEXT,
+                            created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+                        )"""
+                    )
+                )

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from dbos._datasource import AsyncDatasource, SyncDatasource
 from dbos._migration import get_sqlite_timestamp_expr
+from dbos._schemas.datasource_database import DatasourceSchema
 
 from ._logger import dbos_logger
 
@@ -71,7 +72,7 @@ class SqliteSyncDatasource(SyncDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
-        """Create a SQLite engine."""
+        DatasourceSchema.datasource_outputs.schema = None
         sqlite_kwargs = engine_kwargs.copy()
         connect_args = sqlite_kwargs.get("connect_args", {})
         if connect_args:
@@ -88,35 +89,27 @@ class SqliteSyncDatasource(SyncDatasource):
                 if k not in ("application_name", "connect_timeout")
             }
             sqlite_kwargs["connect_args"] = sqlite_connect_args
-        engine = sa.create_engine(database_url, **sqlite_kwargs)
-
-        # Use IMMEDIATE transactions to serialize writers and prevent race conditions
-        @event.listens_for(engine, "connect")
-        def set_sqlite_immediate(dbapi_conn: Any, connection_record: Any) -> None:
-            dbapi_conn.isolation_level = "IMMEDIATE"
-            dbapi_conn.execute("PRAGMA foreign_keys=ON")
-
-        return engine
+        return sa.create_engine(database_url, **sqlite_kwargs)
 
     def run_migrations(self) -> None:
         with self.engine.begin() as conn:
             conn.execute(sa.text("PRAGMA foreign_keys = ON"))
             result = conn.execute(
                 sa.text(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='dbos_datasource_outputs'"
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='datasource_outputs'"
                 )
             )
             if result.fetchone() is None:
                 conn.execute(
                     sa.text(
                         f"""
-                        CREATE TABLE dbos_datasource_outputs (
+                        CREATE TABLE datasource_outputs (
                             workflow_id TEXT NOT NULL,
                             step_id INTEGER NOT NULL,
                             output TEXT,
                             error TEXT,
                             serialization TEXT,
-                            created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+                            created_at BIGINT NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
                         )"""
                     )
                 )

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -54,7 +54,8 @@ class SqliteAsyncDatasource(AsyncDatasource):
         )
 
         # Use IMMEDIATE transactions to serialize writers and prevent race conditions
-        @event.listens_for(engine, "connect")
+        # AsyncEngine events must be attached to the underlying sync engine
+        @event.listens_for(engine.sync_engine, "connect")
         def set_sqlite_immediate(dbapi_conn: Any, connection_record: Any) -> None:
             dbapi_conn.isolation_level = "IMMEDIATE"
             dbapi_conn.execute("PRAGMA foreign_keys=ON")

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from dbos._datasource import AsyncDatasource, SyncDatasource
+from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
 from dbos._migration import get_sqlite_timestamp_expr
 from dbos._schemas.datasource_database import DatasourceSchema
 
@@ -45,7 +45,7 @@ def _filter_sqlite_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return kwargs
 
 
-class SqliteAsyncDatasource(AsyncDatasource):
+class SqliteAsyncDatasource(AsyncSQLAlchemyDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> AsyncEngine:
@@ -70,7 +70,7 @@ class SqliteAsyncDatasource(AsyncDatasource):
                 await conn.execute(_CREATE_TABLE_SQL)
 
 
-class SqliteSyncDatasource(SyncDatasource):
+class SqliteSyncDatasource(SQLAlchemyDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:

--- a/dbos/_schemas/datasource_database.py
+++ b/dbos/_schemas/datasource_database.py
@@ -1,0 +1,32 @@
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Index,
+    Integer,
+    MetaData,
+    PrimaryKeyConstraint,
+    Table,
+    Text,
+    text,
+)
+
+
+class DatasourceSchema:
+    schema = "dbos"
+    metadata_obj = MetaData(schema=schema)
+
+    datasource_outputs = Table(
+        "datasource_outputs",
+        metadata_obj,
+        Column("workflow_id", Text),
+        Column("step_id", Integer),
+        Column("output", Text, nullable=True),
+        Column("error", Text, nullable=True),
+        Column("serialization", Text, nullable=True),
+        Column(
+            "created_at",
+            BigInteger,
+            nullable=False,
+        ),
+        PrimaryKeyConstraint("workflow_id", "step_id"),
+    )

--- a/dbos/_schemas/datasource_database.py
+++ b/dbos/_schemas/datasource_database.py
@@ -1,13 +1,11 @@
 from sqlalchemy import (
     BigInteger,
     Column,
-    Index,
     Integer,
     MetaData,
     PrimaryKeyConstraint,
     Table,
     Text,
-    text,
 )
 
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "otel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:01ba4172411311a47994f47e73972d1fb9aa439301b51aeea75a316d8a448060"
+content_hash = "sha256:8ba2399351bc4d424bf6c2ed7a766ddee2abd85bbf9d4f81f9327bd8ddf5050d"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,21 @@
 groups = ["default", "dev", "otel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8ba2399351bc4d424bf6c2ed7a766ddee2abd85bbf9d4f81f9327bd8ddf5050d"
+content_hash = "sha256:b2351a4ae6288093a96401acdb35f0ae230d813b9aeb1004438bbb76c9a7c0f7"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+requires_python = ">=3.9"
+summary = "asyncio bridge to the standard sqlite3 module"
+groups = ["dev"]
+files = [
+    {file = "aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"},
+    {file = "aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650"},
+]
 
 [[package]]
 name = "annotated-doc"
@@ -1192,71 +1203,6 @@ files = [
     {file = "psycopg_binary-3.2.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:7130effd0517881f3a852eff98729d51034128f0737f64f0d1c7ea8343d77bd7"},
     {file = "psycopg_binary-3.2.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89b3c5201ca616d69ca0c3c0003ca18f7170a679c445c7e386ebfb4f29aa738e"},
     {file = "psycopg_binary-3.2.12-cp314-cp314-win_amd64.whl", hash = "sha256:48a8e29f3e38fcf8d393b8fe460d83e39c107ad7e5e61cd3858a7569e0554a39"},
-]
-
-[[package]]
-name = "psycopg2-binary"
-version = "2.9.11"
-requires_python = ">=3.9"
-summary = "psycopg2 - Python-PostgreSQL Database Adapter"
-groups = ["dev"]
-files = [
-    {file = "psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d6fe6b47d0b42ce1c9f1fa3e35bb365011ca22e39db37074458f27921dca40f2"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6c0e4262e089516603a09474ee13eabf09cb65c332277e39af68f6233911087"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c47676e5b485393f069b4d7a811267d3168ce46f988fa602658b8bb901e9e64d"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a28d8c01a7b27a1e3265b11250ba7557e5f72b5ee9e5f3a2fa8d2949c29bf5d2"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f3f2732cf504a1aa9e9609d02f79bea1067d99edf844ab92c247bbca143303b"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:865f9945ed1b3950d968ec4690ce68c55019d79e4497366d36e090327ce7db14"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:91537a8df2bde69b1c1db01d6d944c831ca793952e4f57892600e96cee95f2cd"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4dca1f356a67ecb68c81a7bc7809f1569ad9e152ce7fd02c2f2036862ca9f66b"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0da4de5c1ac69d94ed4364b6cbe7190c1a70d325f112ba783d83f8440285f152"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37d8412565a7267f7d79e29ab66876e55cb5e8e7b3bbf94f8206f6795f8f7e7e"},
-    {file = "psycopg2_binary-2.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:c665f01ec8ab273a61c62beeb8cce3014c214429ced8a308ca1fc410ecac3a39"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0e8480afd62362d0a6a27dd09e4ca2def6fa50ed3a4e7c09165266106b2ffa10"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:763c93ef1df3da6d1a90f86ea7f3f806dc06b21c198fa87c3c25504abec9404a"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e164359396576a3cc701ba8af4751ae68a07235d7a380c631184a611220d9a4"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d57c9c387660b8893093459738b6abddbb30a7eab058b77b0d0d1c7d521ddfd7"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c226ef95eb2250974bf6fa7a842082b31f68385c4f3268370e3f3870e7859ee"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a311f1edc9967723d3511ea7d2708e2c3592e3405677bf53d5c7246753591fbb"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ebb415404821b6d1c47353ebe9c8645967a5235e6d88f914147e7fd411419e6f"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f07c9c4a5093258a03b28fab9b4f151aa376989e7f35f855088234e656ee6a94"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:00ce1830d971f43b667abe4a56e42c1e2d594b32da4802e44a73bacacb25535f"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cffe9d7697ae7456649617e8bb8d7a45afb71cd13f7ab22af3e5c61f04840908"},
-    {file = "psycopg2_binary-2.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:304fd7b7f97eef30e91b8f7e720b3db75fee010b520e434ea35ed1ff22501d03"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:be9b840ac0525a283a96b556616f5b4820e0526addb8dcf6525a0fa162730be4"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f090b7ddd13ca842ebfe301cd587a76a4cf0913b1e429eb92c1be5dbeb1a19bc"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ab8905b5dcb05bf3fb22e0cf90e10f469563486ffb6a96569e51f897c750a76a"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf940cd7e7fec19181fdbc29d76911741153d51cab52e5c21165f3262125685e"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a1cf393f1cdaf6a9b57c0a719a1068ba1069f022a59b8b1fe44b006745b59757"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7a6beb4beaa62f88592ccc65df20328029d721db309cb3250b0aae0fa146c3"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:31b32c457a6025e74d233957cc9736742ac5a6cb196c6b68499f6bb51390bd6a"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d"},
-    {file = "psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1"},
-    {file = "psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d"},
-    {file = "psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "otel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:b2351a4ae6288093a96401acdb35f0ae230d813b9aeb1004438bbb76c9a7c0f7"
+content_hash = "sha256:380331cd073e0532ce31757eaafadbf0f8258d1b610b99bc257c2d4a1bc637b8"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1203,6 +1203,71 @@ files = [
     {file = "psycopg_binary-3.2.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:7130effd0517881f3a852eff98729d51034128f0737f64f0d1c7ea8343d77bd7"},
     {file = "psycopg_binary-3.2.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89b3c5201ca616d69ca0c3c0003ca18f7170a679c445c7e386ebfb4f29aa738e"},
     {file = "psycopg_binary-3.2.12-cp314-cp314-win_amd64.whl", hash = "sha256:48a8e29f3e38fcf8d393b8fe460d83e39c107ad7e5e61cd3858a7569e0554a39"},
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+requires_python = ">=3.9"
+summary = "psycopg2 - Python-PostgreSQL Database Adapter"
+groups = ["dev"]
+files = [
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1"},
+    {file = "psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be"},
+    {file = "psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b"},
+    {file = "psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290"},
+    {file = "psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd"},
+    {file = "psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980"},
+    {file = "psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
     "uvicorn>=0.35.0",
     "fastapi>=0.121.0",
     "httpx>=0.28.1",
-
-    "aiosqlite>=0.20.0",
+    "psycopg2-binary>=2.9.11",
     "sqlalchemy-cockroachdb>=2.0.3",
+    "aiosqlite>=0.20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "websockets>=14.0",
     "typer-slim>=0.17.4",
     "sqlalchemy>=2.0.43",
-    "aiosqlite>=0.20.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"
@@ -48,6 +47,9 @@ otel = [
 ]
 validation = [
     "pydantic>=2.0",
+]
+asyncsqlite = [
+    "aiosqlite>=0.20.0",
 ]
 [build-system]
 requires = ["pdm-backend"]
@@ -105,5 +107,6 @@ dev = [
     "fastapi>=0.121.0",
     "httpx>=0.28.1",
     "psycopg2-binary>=2.9.11",
+    "aiosqlite>=0.20.0",
     "sqlalchemy-cockroachdb>=2.0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "websockets>=14.0",
     "typer-slim>=0.17.4",
     "sqlalchemy>=2.0.43",
+    "aiosqlite>=0.20.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
     "uvicorn>=0.35.0",
     "fastapi>=0.121.0",
     "httpx>=0.28.1",
-    "psycopg2-binary>=2.9.11",
+
     "aiosqlite>=0.20.0",
     "sqlalchemy-cockroachdb>=2.0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ otel = [
 validation = [
     "pydantic>=2.0",
 ]
-asyncsqlite = [
+aiosqlite = [
     "aiosqlite>=0.20.0",
 ]
 [build-system]

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,0 +1,446 @@
+"""Tests for SyncDatasource and AsyncDatasource."""
+
+import uuid
+from typing import Any, Generator
+from urllib.parse import quote
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from dbos import DBOS, SetWorkflowID
+from dbos._datasource import AsyncDatasource, DatasourceOptions, SyncDatasource
+from dbos._error import DBOSException
+from tests.conftest import default_config, using_sqlite
+
+# ---------------------------------------------------------------------------
+# Sync SQLite fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sync_ds(tmp_path: Any) -> Generator[SyncDatasource, None, None]:
+    db_url = f"sqlite:///{tmp_path}/ds_test.sqlite"
+    ds = SyncDatasource.create(db_url)
+    yield ds
+    if ds.created_engine:
+        ds.engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Async PG fixture (skipped when using SQLite)
+# ---------------------------------------------------------------------------
+
+
+def _pg_ds_url() -> str:
+    cfg = default_config()
+    assert cfg["application_database_url"] is not None
+    # Use the same PG host/port/credentials but the same database (schema isolates data)
+    return (
+        cfg["application_database_url"]
+        .replace("postgresql://", "postgresql+psycopg://")
+        .replace("sqlite:///", "")  # No-op if already PG
+    )
+
+
+@pytest.fixture()
+def require_pg() -> str:
+    """Skip the test if SQLite mode or PG is not reachable. Use as first fixture arg
+    in tests that need PG so the skip fires before heavier fixtures (e.g. dbos) run."""
+    cfg = default_config()
+    assert cfg["application_database_url"] is not None
+    url = cfg["application_database_url"]
+    if not url.startswith("postgresql"):
+        pytest.skip("Skipping test when testing SQLite")
+    try:
+        engine = sa.create_engine(
+            sa.make_url(url).set(drivername="postgresql+psycopg2"),
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        engine.dispose()
+    except Exception:
+        pytest.skip("PostgreSQL not reachable")
+    return url
+
+
+@pytest.fixture()
+def pg_ds_url(require_pg: str) -> str:
+    """PostgreSQL URL for datasource tests (skips when SQLite or PG unavailable)."""
+    return require_pg
+
+
+@pytest.fixture()
+def async_ds_schema() -> str:
+    return f"ds_test_{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Sync bare-run tests (no DBOS workflow needed)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_ds_bare_run(sync_ds: SyncDatasource) -> None:
+    """run_tx_step outside a workflow executes the function transactionally."""
+    counter = {"n": 0}
+
+    def increment(amount: int) -> int:
+        session = sync_ds.sql_session()
+        session.execute(text("SELECT 1"))  # touch the session
+        counter["n"] += amount
+        return counter["n"]
+
+    result = sync_ds.run_tx_step(None, increment, 5)
+    assert result == 5
+    result = sync_ds.run_tx_step(None, increment, 3)
+    assert result == 8
+
+
+def test_sync_ds_decorator_bare_run(sync_ds: SyncDatasource) -> None:
+    """@ds.transaction outside a workflow executes the function transactionally."""
+    counter = {"n": 0}
+
+    @sync_ds.transaction
+    def increment(amount: int) -> int:
+        session = sync_ds.sql_session()
+        session.execute(text("SELECT 1"))
+        counter["n"] += amount
+        return counter["n"]
+
+    assert increment(10) == 10
+    assert increment(5) == 15
+
+
+def test_sync_ds_decorator_with_options(sync_ds: SyncDatasource) -> None:
+    """@ds.transaction accepts isolation_level and name options."""
+    counter = {"n": 0}
+
+    @sync_ds.transaction(isolation_level="SERIALIZABLE", name="my_step")
+    def increment(amount: int) -> int:
+        counter["n"] += amount
+        return counter["n"]
+
+    assert increment(7) == 7
+
+
+def test_sync_ds_sql_session_outside_tx_raises(sync_ds: SyncDatasource) -> None:
+    """sql_session() outside a datasource transaction must raise."""
+    with pytest.raises(AssertionError):
+        sync_ds.sql_session()
+
+
+def test_sync_ds_rejects_coroutine(sync_ds: SyncDatasource) -> None:
+    """run_tx_step with a coroutine function must raise immediately."""
+
+    async def my_async_func() -> str:
+        return "oops"
+
+    with pytest.raises(DBOSException, match="coroutine"):
+        sync_ds.run_tx_step(None, my_async_func)  # type: ignore
+
+
+def test_sync_ds_transaction_decorator_rejects_coroutine(
+    sync_ds: SyncDatasource,
+) -> None:
+    """@ds.transaction on a coroutine must raise at decoration time."""
+    with pytest.raises(DBOSException, match="coroutine"):
+
+        @sync_ds.transaction
+        async def bad() -> str:
+            return "nope"
+
+
+# ---------------------------------------------------------------------------
+# Sync OAOO tests (inside a DBOS workflow)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_ds_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+    """run_tx_step inside a workflow records the result and replays on retry."""
+    call_count = {"n": 0}
+
+    @DBOS.workflow()
+    def my_workflow(value: str) -> str:
+        return sync_ds.run_tx_step(None, expensive_step, value)
+
+    def expensive_step(value: str) -> str:
+        call_count["n"] += 1
+        return f"result:{value}"
+
+    wfid = str(uuid.uuid4())
+
+    with SetWorkflowID(wfid):
+        result = my_workflow("hello")
+    assert result == "result:hello"
+    assert call_count["n"] == 1
+
+    # Second run with same wfid must replay from datasource_outputs
+    with SetWorkflowID(wfid):
+        result = my_workflow("hello")
+    assert result == "result:hello"
+    assert call_count["n"] == 1  # Not called again
+
+
+def test_sync_ds_decorator_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+    """@ds.transaction inside a workflow records and replays the result."""
+    call_count = {"n": 0}
+
+    @sync_ds.transaction
+    def decorated_step(value: str) -> str:
+        call_count["n"] += 1
+        return f"decorated:{value}"
+
+    @DBOS.workflow()
+    def my_workflow(value: str) -> str:
+        return decorated_step(value)
+
+    wfid = str(uuid.uuid4())
+
+    with SetWorkflowID(wfid):
+        result = my_workflow("world")
+    assert result == "decorated:world"
+    assert call_count["n"] == 1
+
+    with SetWorkflowID(wfid):
+        result = my_workflow("world")
+    assert result == "decorated:world"
+    assert call_count["n"] == 1
+
+
+def test_sync_ds_error_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+    """When a datasource step raises, the error is recorded and replayed."""
+    call_count = {"n": 0}
+
+    def failing_step() -> str:
+        call_count["n"] += 1
+        raise ValueError("ds step failed")
+
+    @DBOS.workflow()
+    def my_workflow() -> str:
+        return sync_ds.run_tx_step(None, failing_step)
+
+    wfid = str(uuid.uuid4())
+
+    with SetWorkflowID(wfid):
+        with pytest.raises(ValueError, match="ds step failed"):
+            my_workflow()
+    assert call_count["n"] == 1
+
+    # Second run: error replayed without calling the function again
+    with SetWorkflowID(wfid):
+        with pytest.raises(Exception, match="ds step failed"):
+            my_workflow()
+    assert call_count["n"] == 1
+
+
+def test_sync_ds_multiple_steps_in_workflow(
+    dbos: DBOS, sync_ds: SyncDatasource
+) -> None:
+    """Multiple datasource steps in one workflow each get their own step_id."""
+    call_counts = {"a": 0, "b": 0}
+
+    def step_a() -> str:
+        call_counts["a"] += 1
+        return "A"
+
+    def step_b() -> str:
+        call_counts["b"] += 1
+        return "B"
+
+    @DBOS.workflow()
+    def my_workflow() -> str:
+        r1 = sync_ds.run_tx_step(None, step_a)
+        r2 = sync_ds.run_tx_step(None, step_b)
+        return r1 + r2
+
+    wfid = str(uuid.uuid4())
+
+    with SetWorkflowID(wfid):
+        result = my_workflow()
+    assert result == "AB"
+
+    with SetWorkflowID(wfid):
+        result = my_workflow()
+    assert result == "AB"
+    # Each step called exactly once
+    assert call_counts["a"] == 1
+    assert call_counts["b"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Async bare-run tests (PG only — aiosqlite not installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_ds_bare_run(pg_ds_url: str, async_ds_schema: str) -> None:
+    """run_tx_step_async outside a workflow executes the function transactionally."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+
+    counter = {"n": 0}
+
+    async def increment(amount: int) -> int:
+        session = ds.sql_session()
+        await session.execute(text("SELECT 1"))
+        counter["n"] += amount
+        return counter["n"]
+
+    try:
+        result = await ds.run_tx_step_async(None, increment, 5)
+        assert result == 5
+        result = await ds.run_tx_step_async(None, increment, 3)
+        assert result == 8
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_decorator_bare_run(
+    pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """@ds.transaction on an async function works outside a workflow."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+
+    counter = {"n": 0}
+
+    @ds.transaction
+    async def increment(amount: int) -> int:
+        session = ds.sql_session()
+        await session.execute(text("SELECT 1"))
+        counter["n"] += amount
+        return counter["n"]
+
+    try:
+        assert await increment(10) == 10
+        assert await increment(5) == 15
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_rejects_sync_func(pg_ds_url: str, async_ds_schema: str) -> None:
+    """run_tx_step_async with a non-coroutine must raise."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+
+    def sync_func() -> str:
+        return "oops"
+
+    try:
+        with pytest.raises(DBOSException, match="coroutine"):
+            await ds.run_tx_step_async(None, sync_func)  # type: ignore
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_transaction_decorator_rejects_sync(
+    pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """@ds.transaction on a sync function must raise at decoration time."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+
+    try:
+        with pytest.raises(DBOSException, match="coroutine"):
+
+            @ds.transaction
+            def bad() -> str:
+                return "nope"
+
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Async OAOO tests (PG only, inside a DBOS workflow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_ds_oaoo(
+    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """run_tx_step_async inside a workflow records the result and replays on retry."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    call_count = {"n": 0}
+
+    async def expensive_step(value: str) -> str:
+        call_count["n"] += 1
+        session = ds.sql_session()
+        await session.execute(text("SELECT 1"))
+        return f"async:{value}"
+
+    @DBOS.workflow()
+    async def my_workflow(value: str) -> str:
+        return await ds.run_tx_step_async(None, expensive_step, value)
+
+    wfid = str(uuid.uuid4())
+
+    try:
+        with SetWorkflowID(wfid):
+            result = await my_workflow("hello")
+        assert result == "async:hello"
+        assert call_count["n"] == 1
+
+        with SetWorkflowID(wfid):
+            result = await my_workflow("hello")
+        assert result == "async:hello"
+        assert call_count["n"] == 1  # Not called again
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_error_oaoo(
+    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """Async datasource step error is recorded and replayed without re-executing."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    call_count = {"n": 0}
+
+    async def failing_step() -> str:
+        call_count["n"] += 1
+        raise ValueError("async ds step failed")
+
+    @DBOS.workflow()
+    async def my_workflow() -> str:
+        return await ds.run_tx_step_async(None, failing_step)
+
+    wfid = str(uuid.uuid4())
+
+    try:
+        with SetWorkflowID(wfid):
+            with pytest.raises(Exception, match="async ds step failed"):
+                await my_workflow()
+        assert call_count["n"] == 1
+
+        with SetWorkflowID(wfid):
+            with pytest.raises(Exception, match="async ds step failed"):
+                await my_workflow()
+        assert call_count["n"] == 1  # Not called again
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -469,7 +469,7 @@ async def test_async_ds_transaction_decorator_rejects_sync(
     """@ds.transaction on a sync function must raise at decoration time."""
     with pytest.raises(DBOSException, match="coroutine"):
 
-        @async_ds.transaction
+        @async_ds.transaction  # type: ignore[arg-type]
         def bad() -> str:
             return "nope"
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,5 +1,7 @@
 """Tests for SyncDatasource and AsyncDatasource."""
 
+import base64
+import pickle
 import uuid
 from typing import Any, AsyncGenerator, Generator
 
@@ -8,8 +10,7 @@ import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy import text
 
-from dbos import DBOS, SetWorkflowID
-from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
+from dbos import DBOS, AsyncSQLAlchemyDatasource, SetWorkflowID, SQLAlchemyDatasource
 from dbos._error import DBOSException
 from dbos._schemas.datasource_database import DatasourceSchema
 from dbos._schemas.system_database import SystemSchema
@@ -350,6 +351,68 @@ def test_sync_ds_writes_both_tables(dbos: DBOS, sync_ds: SQLAlchemyDatasource) -
     _check_both_tables(sync_ds, dbos, wfid)
 
 
+def test_sync_ds_step_recorded_with_name(
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
+) -> None:
+    """Datasource step appears in list_workflow_steps with the right name and output."""
+
+    def my_step() -> str:
+        return "run_tx_result"
+
+    @sync_ds.transaction
+    def unnamed_step() -> str:
+        return "unnamed_result"
+
+    @sync_ds.transaction(name="my_named_step")
+    def named_step() -> str:
+        return "named_result"
+
+    @DBOS.workflow()
+    def my_workflow() -> tuple[str, str, str]:
+        r1 = sync_ds.run_tx_step(None, my_step)
+        r2 = unnamed_step()
+        r3 = named_step()
+        return r1, r2, r3
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert my_workflow() == ("run_tx_result", "unnamed_result", "named_result")
+
+    steps = DBOS.list_workflow_steps(wfid)
+    assert len(steps) == 3
+    assert steps[0]["function_id"] == 1
+    assert steps[0]["function_name"].endswith("my_step")
+    assert steps[0]["output"] == "run_tx_result"
+    assert steps[1]["function_id"] == 2
+    assert steps[1]["function_name"].endswith("unnamed_step")
+    assert steps[1]["output"] == "unnamed_result"
+    assert steps[2]["function_id"] == 3
+    assert steps[2]["function_name"] == "my_named_step"
+    assert steps[2]["output"] == "named_result"
+
+    with sync_ds.engine.connect() as conn:
+        ds_rows = conn.execute(
+            sa.select(
+                DatasourceSchema.datasource_outputs.c.step_id,
+                DatasourceSchema.datasource_outputs.c.output,
+                DatasourceSchema.datasource_outputs.c.error,
+                DatasourceSchema.datasource_outputs.c.serialization,
+            )
+            .where(DatasourceSchema.datasource_outputs.c.workflow_id == wfid)
+            .order_by(DatasourceSchema.datasource_outputs.c.step_id)
+        ).fetchall()
+    assert len(ds_rows) == 3
+    for row in ds_rows:
+        assert row.error is None
+        assert row.serialization == "py_pickle"
+    assert ds_rows[0].step_id == 1
+    assert pickle.loads(base64.b64decode(ds_rows[0].output)) == "run_tx_result"
+    assert ds_rows[1].step_id == 2
+    assert pickle.loads(base64.b64decode(ds_rows[1].output)) == "unnamed_result"
+    assert ds_rows[2].step_id == 3
+    assert pickle.loads(base64.b64decode(ds_rows[2].output)) == "named_result"
+
+
 def test_sync_ds_recovers_from_sysdb_loss(
     dbos: DBOS, sync_ds: SQLAlchemyDatasource
 ) -> None:
@@ -622,6 +685,75 @@ async def test_async_ds_writes_both_tables(
         assert await my_workflow() == "world"
 
     await _async_check_both_tables(async_ds, dbos, wfid)
+
+
+@pytest.mark.asyncio
+async def test_async_ds_step_recorded_with_name(
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
+) -> None:
+    """Async datasource step appears in list_workflow_steps with the right name and output."""
+
+    async def my_step() -> str:
+        return "run_tx_result"
+
+    @async_ds.transaction
+    async def unnamed_step() -> str:
+        return "unnamed_result"
+
+    @async_ds.transaction(name="my_named_async_step")
+    async def named_step() -> str:
+        return "named_result"
+
+    @DBOS.workflow()
+    async def my_workflow() -> tuple[str, str, str]:
+        r1 = await async_ds.run_tx_step_async(None, my_step)
+        r2 = await unnamed_step()
+        r3 = await named_step()
+        return r1, r2, r3
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert await my_workflow() == (
+            "run_tx_result",
+            "unnamed_result",
+            "named_result",
+        )
+
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    assert len(steps) == 3
+    assert steps[0]["function_id"] == 1
+    assert steps[0]["function_name"].endswith("my_step")
+    assert steps[0]["output"] == "run_tx_result"
+    assert steps[1]["function_id"] == 2
+    assert steps[1]["function_name"].endswith("unnamed_step")
+    assert steps[1]["output"] == "unnamed_result"
+    assert steps[2]["function_id"] == 3
+    assert steps[2]["function_name"] == "my_named_async_step"
+    assert steps[2]["output"] == "named_result"
+
+    async with async_ds.engine.connect() as conn:
+        ds_rows = (
+            await conn.execute(
+                sa.select(
+                    DatasourceSchema.datasource_outputs.c.step_id,
+                    DatasourceSchema.datasource_outputs.c.output,
+                    DatasourceSchema.datasource_outputs.c.error,
+                    DatasourceSchema.datasource_outputs.c.serialization,
+                )
+                .where(DatasourceSchema.datasource_outputs.c.workflow_id == wfid)
+                .order_by(DatasourceSchema.datasource_outputs.c.step_id)
+            )
+        ).fetchall()
+    assert len(ds_rows) == 3
+    for row in ds_rows:
+        assert row.error is None
+        assert row.serialization == "py_pickle"
+    assert ds_rows[0].step_id == 1
+    assert pickle.loads(base64.b64decode(ds_rows[0].output)) == "run_tx_result"
+    assert ds_rows[1].step_id == 2
+    assert pickle.loads(base64.b64decode(ds_rows[1].output)) == "unnamed_result"
+    assert ds_rows[2].step_id == 3
+    assert pickle.loads(base64.b64decode(ds_rows[2].output)) == "named_result"
 
 
 @pytest.mark.asyncio

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -327,6 +327,46 @@ async def test_async_ds_decorator_bare_run(
 
 
 @pytest.mark.asyncio
+async def test_async_ds_decorator_with_options(
+    pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """@ds.transaction accepts isolation_level and name options."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    counter = {"n": 0}
+
+    @ds.transaction(isolation_level="SERIALIZABLE", name="my_step")
+    async def increment(amount: int) -> int:
+        counter["n"] += amount
+        return counter["n"]
+
+    try:
+        assert await increment(7) == 7
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_sql_session_outside_tx_raises(
+    pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """sql_session() outside an async datasource transaction must raise."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    try:
+        with pytest.raises(AssertionError):
+            ds.sql_session()
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_async_ds_rejects_sync_func(pg_ds_url: str, async_ds_schema: str) -> None:
     """run_tx_step_async with a non-coroutine must raise."""
     ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
@@ -411,6 +451,43 @@ async def test_async_ds_oaoo(
 
 
 @pytest.mark.asyncio
+async def test_async_ds_decorator_oaoo(
+    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """@ds.transaction inside a workflow records and replays the result."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    call_count = {"n": 0}
+
+    @ds.transaction
+    async def decorated_step(value: str) -> str:
+        call_count["n"] += 1
+        return f"decorated:{value}"
+
+    @DBOS.workflow()
+    async def my_workflow(value: str) -> str:
+        return await decorated_step(value)
+
+    wfid = str(uuid.uuid4())
+
+    try:
+        with SetWorkflowID(wfid):
+            result = await my_workflow("world")
+        assert result == "decorated:world"
+        assert call_count["n"] == 1
+
+        with SetWorkflowID(wfid):
+            result = await my_workflow("world")
+        assert result == "decorated:world"
+        assert call_count["n"] == 1
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_async_ds_error_oaoo(
     require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
 ) -> None:
@@ -438,6 +515,48 @@ async def test_async_ds_error_oaoo(
             with pytest.raises(Exception, match="async ds step failed"):
                 await my_workflow()
         assert call_count["n"] == 1  # Not called again
+    finally:
+        async with ds.engine.begin() as conn:
+            await conn.execute(
+                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+            )
+        await ds.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_ds_multiple_steps_in_workflow(
+    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
+) -> None:
+    """Multiple async datasource steps in one workflow each get their own step_id."""
+    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    call_counts = {"a": 0, "b": 0}
+
+    async def step_a() -> str:
+        call_counts["a"] += 1
+        return "A"
+
+    async def step_b() -> str:
+        call_counts["b"] += 1
+        return "B"
+
+    @DBOS.workflow()
+    async def my_workflow() -> str:
+        r1 = await ds.run_tx_step_async(None, step_a)
+        r2 = await ds.run_tx_step_async(None, step_b)
+        return r1 + r2
+
+    wfid = str(uuid.uuid4())
+
+    try:
+        with SetWorkflowID(wfid):
+            result = await my_workflow()
+        assert result == "AB"
+
+        with SetWorkflowID(wfid):
+            result = await my_workflow()
+        assert result == "AB"
+        assert call_counts["a"] == 1
+        assert call_counts["b"] == 1
     finally:
         async with ds.engine.begin() as conn:
             await conn.execute(

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -23,7 +23,7 @@ from tests.conftest import default_config
 def _skip_if_pg_unreachable(raw_pg_url: str) -> None:
     try:
         engine = sa.create_engine(
-            sa.make_url(raw_pg_url).set(drivername="postgresql+psycopg2"),
+            sa.make_url(raw_pg_url).set(drivername="postgresql+psycopg"),
             connect_args={"connect_timeout": 3},
         )
         with engine.connect():

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy import text
 
 from dbos import DBOS, SetWorkflowID
-from dbos._datasource import AsyncDatasource, SyncDatasource
+from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
 from dbos._error import DBOSException
 from dbos._schemas.datasource_database import DatasourceSchema
 from dbos._schemas.system_database import SystemSchema
@@ -33,7 +33,9 @@ def _skip_if_pg_unreachable(raw_pg_url: str) -> None:
         pytest.skip("PostgreSQL not reachable")
 
 
-def _check_both_tables(ds: SyncDatasource, dbos_instance: DBOS, wfid: str) -> None:
+def _check_both_tables(
+    ds: SQLAlchemyDatasource, dbos_instance: DBOS, wfid: str
+) -> None:
     with ds.engine.connect() as conn:
         ds_row = conn.execute(
             sa.select(
@@ -58,7 +60,7 @@ def _check_both_tables(ds: SyncDatasource, dbos_instance: DBOS, wfid: str) -> No
 
 
 async def _async_check_both_tables(
-    ds: AsyncDatasource, dbos_instance: DBOS, wfid: str
+    ds: AsyncSQLAlchemyDatasource, dbos_instance: DBOS, wfid: str
 ) -> None:
     async with ds.engine.connect() as conn:
         ds_row = (
@@ -93,9 +95,9 @@ async def _async_check_both_tables(
 @pytest.fixture(params=["sqlite", "pg"])
 def sync_ds(
     request: pytest.FixtureRequest, tmp_path: Any
-) -> Generator[SyncDatasource, None, None]:
+) -> Generator[SQLAlchemyDatasource, None, None]:
     if request.param == "sqlite":
-        ds = SyncDatasource.create(f"sqlite:///{tmp_path}/ds_test.sqlite")
+        ds = SQLAlchemyDatasource.create(f"sqlite:///{tmp_path}/ds_test.sqlite")
         yield ds
         if ds.created_engine:
             ds.engine.dispose()
@@ -106,7 +108,7 @@ def sync_ds(
             pytest.skip("not a PostgreSQL environment")
         _skip_if_pg_unreachable(url)
         schema = f"ds_test_{uuid.uuid4().hex[:8]}"
-        ds = SyncDatasource.create(
+        ds = SQLAlchemyDatasource.create(
             url.replace("postgresql://", "postgresql+psycopg://"), schema=schema
         )
         yield ds
@@ -119,9 +121,9 @@ def sync_ds(
 @pytest_asyncio.fixture(params=["sqlite", "pg"])
 async def async_ds(
     request: pytest.FixtureRequest, tmp_path: Any
-) -> AsyncGenerator[AsyncDatasource, None]:
+) -> AsyncGenerator[AsyncSQLAlchemyDatasource, None]:
     if request.param == "sqlite":
-        ds = await AsyncDatasource.create(
+        ds = await AsyncSQLAlchemyDatasource.create(
             f"sqlite+aiosqlite:///{tmp_path}/async_ds_test.sqlite"
         )
         yield ds
@@ -133,7 +135,7 @@ async def async_ds(
             pytest.skip("not a PostgreSQL environment")
         _skip_if_pg_unreachable(url)
         schema = f"ds_test_{uuid.uuid4().hex[:8]}"
-        ds = await AsyncDatasource.create(
+        ds = await AsyncSQLAlchemyDatasource.create(
             url.replace("postgresql://", "postgresql+psycopg://"), schema=schema
         )
         yield ds
@@ -147,7 +149,7 @@ async def async_ds(
 # ---------------------------------------------------------------------------
 
 
-def test_sync_ds_bare_run(sync_ds: SyncDatasource) -> None:
+def test_sync_ds_bare_run(sync_ds: SQLAlchemyDatasource) -> None:
     """run_tx_step outside a workflow executes the function transactionally."""
     counter = {"n": 0}
 
@@ -163,7 +165,7 @@ def test_sync_ds_bare_run(sync_ds: SyncDatasource) -> None:
     assert result == 8
 
 
-def test_sync_ds_decorator_bare_run(sync_ds: SyncDatasource) -> None:
+def test_sync_ds_decorator_bare_run(sync_ds: SQLAlchemyDatasource) -> None:
     """@ds.transaction outside a workflow executes the function transactionally."""
     counter = {"n": 0}
 
@@ -178,7 +180,7 @@ def test_sync_ds_decorator_bare_run(sync_ds: SyncDatasource) -> None:
     assert increment(5) == 15
 
 
-def test_sync_ds_decorator_with_options(sync_ds: SyncDatasource) -> None:
+def test_sync_ds_decorator_with_options(sync_ds: SQLAlchemyDatasource) -> None:
     """@ds.transaction accepts isolation_level and name options."""
     counter = {"n": 0}
 
@@ -190,13 +192,13 @@ def test_sync_ds_decorator_with_options(sync_ds: SyncDatasource) -> None:
     assert increment(7) == 7
 
 
-def test_sync_ds_sql_session_outside_tx_raises(sync_ds: SyncDatasource) -> None:
+def test_sync_ds_sql_session_outside_tx_raises(sync_ds: SQLAlchemyDatasource) -> None:
     """sql_session() outside a datasource transaction must raise."""
     with pytest.raises(AssertionError):
         sync_ds.sql_session()
 
 
-def test_sync_ds_rejects_coroutine(sync_ds: SyncDatasource) -> None:
+def test_sync_ds_rejects_coroutine(sync_ds: SQLAlchemyDatasource) -> None:
     """run_tx_step with a coroutine function must raise immediately."""
 
     async def my_async_func() -> str:
@@ -207,7 +209,7 @@ def test_sync_ds_rejects_coroutine(sync_ds: SyncDatasource) -> None:
 
 
 def test_sync_ds_transaction_decorator_rejects_coroutine(
-    sync_ds: SyncDatasource,
+    sync_ds: SQLAlchemyDatasource,
 ) -> None:
     """@ds.transaction on a coroutine must raise at decoration time."""
     with pytest.raises(DBOSException, match="coroutine"):
@@ -222,7 +224,7 @@ def test_sync_ds_transaction_decorator_rejects_coroutine(
 # ---------------------------------------------------------------------------
 
 
-def test_sync_ds_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+def test_sync_ds_oaoo(dbos: DBOS, sync_ds: SQLAlchemyDatasource) -> None:
     """run_tx_step inside a workflow records the result and replays on retry."""
     call_count = {"n": 0}
 
@@ -247,7 +249,7 @@ def test_sync_ds_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
     assert call_count["n"] == 1
 
 
-def test_sync_ds_decorator_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+def test_sync_ds_decorator_oaoo(dbos: DBOS, sync_ds: SQLAlchemyDatasource) -> None:
     """@ds.transaction inside a workflow records and replays the result."""
     call_count = {"n": 0}
 
@@ -273,7 +275,7 @@ def test_sync_ds_decorator_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
     assert call_count["n"] == 1
 
 
-def test_sync_ds_error_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+def test_sync_ds_error_oaoo(dbos: DBOS, sync_ds: SQLAlchemyDatasource) -> None:
     """When a datasource step raises, the error is recorded and replayed."""
     call_count = {"n": 0}
 
@@ -299,7 +301,7 @@ def test_sync_ds_error_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
 
 
 def test_sync_ds_multiple_steps_in_workflow(
-    dbos: DBOS, sync_ds: SyncDatasource
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
 ) -> None:
     """Multiple datasource steps in one workflow each get their own step_id."""
     call_counts = {"a": 0, "b": 0}
@@ -331,7 +333,7 @@ def test_sync_ds_multiple_steps_in_workflow(
     assert call_counts["b"] == 1
 
 
-def test_sync_ds_writes_both_tables(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+def test_sync_ds_writes_both_tables(dbos: DBOS, sync_ds: SQLAlchemyDatasource) -> None:
     """Datasource step writes to both datasource_outputs and operation_outputs."""
 
     def step_fn() -> str:
@@ -348,7 +350,9 @@ def test_sync_ds_writes_both_tables(dbos: DBOS, sync_ds: SyncDatasource) -> None
     _check_both_tables(sync_ds, dbos, wfid)
 
 
-def test_sync_ds_recovers_from_sysdb_loss(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+def test_sync_ds_recovers_from_sysdb_loss(
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
+) -> None:
     """datasource_outputs is the source of truth when the sysdb step record is lost.
 
     Simulates the crash window: datasource_outputs was written atomically inside
@@ -397,7 +401,7 @@ def test_sync_ds_recovers_from_sysdb_loss(dbos: DBOS, sync_ds: SyncDatasource) -
 
 
 @pytest.mark.asyncio
-async def test_async_ds_bare_run(async_ds: AsyncDatasource) -> None:
+async def test_async_ds_bare_run(async_ds: AsyncSQLAlchemyDatasource) -> None:
     """run_tx_step_async outside a workflow executes the function transactionally."""
     counter = {"n": 0}
 
@@ -414,7 +418,7 @@ async def test_async_ds_bare_run(async_ds: AsyncDatasource) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_bare_run(async_ds: AsyncDatasource) -> None:
+async def test_async_ds_decorator_bare_run(async_ds: AsyncSQLAlchemyDatasource) -> None:
     """@ds.transaction on an async function works outside a workflow."""
     counter = {"n": 0}
 
@@ -430,7 +434,9 @@ async def test_async_ds_decorator_bare_run(async_ds: AsyncDatasource) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_with_options(async_ds: AsyncDatasource) -> None:
+async def test_async_ds_decorator_with_options(
+    async_ds: AsyncSQLAlchemyDatasource,
+) -> None:
     """@ds.transaction accepts isolation_level and name options."""
     counter = {"n": 0}
 
@@ -444,7 +450,7 @@ async def test_async_ds_decorator_with_options(async_ds: AsyncDatasource) -> Non
 
 @pytest.mark.asyncio
 async def test_async_ds_sql_session_outside_tx_raises(
-    async_ds: AsyncDatasource,
+    async_ds: AsyncSQLAlchemyDatasource,
 ) -> None:
     """sql_session() outside an async datasource transaction must raise."""
     with pytest.raises(AssertionError):
@@ -452,7 +458,7 @@ async def test_async_ds_sql_session_outside_tx_raises(
 
 
 @pytest.mark.asyncio
-async def test_async_ds_rejects_sync_func(async_ds: AsyncDatasource) -> None:
+async def test_async_ds_rejects_sync_func(async_ds: AsyncSQLAlchemyDatasource) -> None:
     """run_tx_step_async with a non-coroutine must raise."""
 
     def sync_func() -> str:
@@ -464,7 +470,7 @@ async def test_async_ds_rejects_sync_func(async_ds: AsyncDatasource) -> None:
 
 @pytest.mark.asyncio
 async def test_async_ds_transaction_decorator_rejects_sync(
-    async_ds: AsyncDatasource,
+    async_ds: AsyncSQLAlchemyDatasource,
 ) -> None:
     """@ds.transaction on a sync function must raise at decoration time."""
     with pytest.raises(DBOSException, match="coroutine"):
@@ -480,7 +486,7 @@ async def test_async_ds_transaction_decorator_rejects_sync(
 
 
 @pytest.mark.asyncio
-async def test_async_ds_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
+async def test_async_ds_oaoo(dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource) -> None:
     """run_tx_step_async inside a workflow records the result and replays on retry."""
     call_count = {"n": 0}
 
@@ -508,7 +514,9 @@ async def test_async_ds_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
+async def test_async_ds_decorator_oaoo(
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
+) -> None:
     """@ds.transaction inside a workflow records and replays the result."""
     call_count = {"n": 0}
 
@@ -535,7 +543,9 @@ async def test_async_ds_decorator_oaoo(dbos: DBOS, async_ds: AsyncDatasource) ->
 
 
 @pytest.mark.asyncio
-async def test_async_ds_error_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
+async def test_async_ds_error_oaoo(
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
+) -> None:
     """Async datasource step error is recorded and replayed without re-executing."""
     call_count = {"n": 0}
 
@@ -562,7 +572,7 @@ async def test_async_ds_error_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> Non
 
 @pytest.mark.asyncio
 async def test_async_ds_multiple_steps_in_workflow(
-    dbos: DBOS, async_ds: AsyncDatasource
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
 ) -> None:
     """Multiple async datasource steps in one workflow each get their own step_id."""
     call_counts = {"a": 0, "b": 0}
@@ -596,7 +606,7 @@ async def test_async_ds_multiple_steps_in_workflow(
 
 @pytest.mark.asyncio
 async def test_async_ds_writes_both_tables(
-    dbos: DBOS, async_ds: AsyncDatasource
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
 ) -> None:
     """Async datasource step writes to both datasource_outputs and operation_outputs."""
 
@@ -616,7 +626,7 @@ async def test_async_ds_writes_both_tables(
 
 @pytest.mark.asyncio
 async def test_async_ds_recovers_from_sysdb_loss(
-    dbos: DBOS, async_ds: AsyncDatasource
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
 ) -> None:
     """datasource_outputs is the source of truth when the sysdb step record is lost.
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,60 +1,29 @@
 """Tests for SyncDatasource and AsyncDatasource."""
 
 import uuid
-from typing import Any, Generator
-from urllib.parse import quote
+from typing import Any, AsyncGenerator, Generator
 
 import pytest
+import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy import text
 
 from dbos import DBOS, SetWorkflowID
-from dbos._datasource import AsyncDatasource, DatasourceOptions, SyncDatasource
+from dbos._datasource import AsyncDatasource, SyncDatasource
 from dbos._error import DBOSException
-from tests.conftest import default_config, using_sqlite
+from dbos._schemas.datasource_database import DatasourceSchema
+from dbos._schemas.system_database import SystemSchema
+from tests.conftest import default_config
 
 # ---------------------------------------------------------------------------
-# Sync SQLite fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def sync_ds(tmp_path: Any) -> Generator[SyncDatasource, None, None]:
-    db_url = f"sqlite:///{tmp_path}/ds_test.sqlite"
-    ds = SyncDatasource.create(db_url)
-    yield ds
-    if ds.created_engine:
-        ds.engine.dispose()
-
-
-# ---------------------------------------------------------------------------
-# Async PG fixture (skipped when using SQLite)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-def _pg_ds_url() -> str:
-    cfg = default_config()
-    assert cfg["application_database_url"] is not None
-    # Use the same PG host/port/credentials but the same database (schema isolates data)
-    return (
-        cfg["application_database_url"]
-        .replace("postgresql://", "postgresql+psycopg://")
-        .replace("sqlite:///", "")  # No-op if already PG
-    )
-
-
-@pytest.fixture()
-def require_pg() -> str:
-    """Skip the test if SQLite mode or PG is not reachable. Use as first fixture arg
-    in tests that need PG so the skip fires before heavier fixtures (e.g. dbos) run."""
-    cfg = default_config()
-    assert cfg["application_database_url"] is not None
-    url = cfg["application_database_url"]
-    if not url.startswith("postgresql"):
-        pytest.skip("Skipping test when testing SQLite")
+def _skip_if_pg_unreachable(raw_pg_url: str) -> None:
     try:
         engine = sa.create_engine(
-            sa.make_url(url).set(drivername="postgresql+psycopg2"),
+            sa.make_url(raw_pg_url).set(drivername="postgresql+psycopg2"),
             connect_args={"connect_timeout": 3},
         )
         with engine.connect():
@@ -62,18 +31,115 @@ def require_pg() -> str:
         engine.dispose()
     except Exception:
         pytest.skip("PostgreSQL not reachable")
-    return url
 
 
-@pytest.fixture()
-def pg_ds_url(require_pg: str) -> str:
-    """PostgreSQL URL for datasource tests (skips when SQLite or PG unavailable)."""
-    return require_pg
+def _check_both_tables(ds: SyncDatasource, dbos_instance: DBOS, wfid: str) -> None:
+    with ds.engine.connect() as conn:
+        ds_row = conn.execute(
+            sa.select(
+                DatasourceSchema.datasource_outputs.c.step_id,
+                DatasourceSchema.datasource_outputs.c.output,
+            ).where(DatasourceSchema.datasource_outputs.c.workflow_id == wfid)
+        ).first()
+    assert ds_row is not None, "datasource_outputs row missing"
+    assert ds_row.step_id == 1
+    assert ds_row.output is not None
+
+    with dbos_instance._sys_db.engine.connect() as conn:
+        sys_row = conn.execute(
+            sa.select(
+                SystemSchema.operation_outputs.c.function_id,
+                SystemSchema.operation_outputs.c.output,
+            ).where(SystemSchema.operation_outputs.c.workflow_uuid == wfid)
+        ).first()
+    assert sys_row is not None, "operation_outputs row missing"
+    assert sys_row.function_id == 1
+    assert sys_row.output is not None
 
 
-@pytest.fixture()
-def async_ds_schema() -> str:
-    return f"ds_test_{uuid.uuid4().hex[:8]}"
+async def _async_check_both_tables(
+    ds: AsyncDatasource, dbos_instance: DBOS, wfid: str
+) -> None:
+    async with ds.engine.connect() as conn:
+        ds_row = (
+            await conn.execute(
+                sa.select(
+                    DatasourceSchema.datasource_outputs.c.step_id,
+                    DatasourceSchema.datasource_outputs.c.output,
+                ).where(DatasourceSchema.datasource_outputs.c.workflow_id == wfid)
+            )
+        ).first()
+    assert ds_row is not None, "datasource_outputs row missing"
+    assert ds_row.step_id == 1
+    assert ds_row.output is not None
+
+    with dbos_instance._sys_db.engine.connect() as conn:
+        sys_row = conn.execute(
+            sa.select(
+                SystemSchema.operation_outputs.c.function_id,
+                SystemSchema.operation_outputs.c.output,
+            ).where(SystemSchema.operation_outputs.c.workflow_uuid == wfid)
+        ).first()
+    assert sys_row is not None, "operation_outputs row missing"
+    assert sys_row.function_id == 1
+    assert sys_row.output is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["sqlite", "pg"])
+def sync_ds(
+    request: pytest.FixtureRequest, tmp_path: Any
+) -> Generator[SyncDatasource, None, None]:
+    if request.param == "sqlite":
+        ds = SyncDatasource.create(f"sqlite:///{tmp_path}/ds_test.sqlite")
+        yield ds
+        if ds.created_engine:
+            ds.engine.dispose()
+    else:
+        cfg = default_config()
+        url = cfg.get("application_database_url") or ""
+        if not url.startswith("postgresql"):
+            pytest.skip("not a PostgreSQL environment")
+        _skip_if_pg_unreachable(url)
+        schema = f"ds_test_{uuid.uuid4().hex[:8]}"
+        ds = SyncDatasource.create(
+            url.replace("postgresql://", "postgresql+psycopg://"), schema=schema
+        )
+        yield ds
+        with ds.engine.begin() as conn:
+            conn.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        if ds.created_engine:
+            ds.engine.dispose()
+
+
+@pytest_asyncio.fixture(params=["sqlite", "pg"])
+async def async_ds(
+    request: pytest.FixtureRequest, tmp_path: Any
+) -> AsyncGenerator[AsyncDatasource, None]:
+    if request.param == "sqlite":
+        ds = await AsyncDatasource.create(
+            f"sqlite+aiosqlite:///{tmp_path}/async_ds_test.sqlite"
+        )
+        yield ds
+        await ds.engine.dispose()
+    else:
+        cfg = default_config()
+        url = cfg.get("application_database_url") or ""
+        if not url.startswith("postgresql"):
+            pytest.skip("not a PostgreSQL environment")
+        _skip_if_pg_unreachable(url)
+        schema = f"ds_test_{uuid.uuid4().hex[:8]}"
+        ds = await AsyncDatasource.create(
+            url.replace("postgresql://", "postgresql+psycopg://"), schema=schema
+        )
+        yield ds
+        async with ds.engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await ds.engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +153,7 @@ def test_sync_ds_bare_run(sync_ds: SyncDatasource) -> None:
 
     def increment(amount: int) -> int:
         session = sync_ds.sql_session()
-        session.execute(text("SELECT 1"))  # touch the session
+        session.execute(text("SELECT 1"))
         counter["n"] += amount
         return counter["n"]
 
@@ -175,11 +241,10 @@ def test_sync_ds_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
     assert result == "result:hello"
     assert call_count["n"] == 1
 
-    # Second run with same wfid must replay from datasource_outputs
     with SetWorkflowID(wfid):
         result = my_workflow("hello")
     assert result == "result:hello"
-    assert call_count["n"] == 1  # Not called again
+    assert call_count["n"] == 1
 
 
 def test_sync_ds_decorator_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
@@ -227,7 +292,6 @@ def test_sync_ds_error_oaoo(dbos: DBOS, sync_ds: SyncDatasource) -> None:
             my_workflow()
     assert call_count["n"] == 1
 
-    # Second run: error replayed without calling the function again
     with SetWorkflowID(wfid):
         with pytest.raises(Exception, match="ds step failed"):
             my_workflow()
@@ -263,202 +327,192 @@ def test_sync_ds_multiple_steps_in_workflow(
     with SetWorkflowID(wfid):
         result = my_workflow()
     assert result == "AB"
-    # Each step called exactly once
     assert call_counts["a"] == 1
     assert call_counts["b"] == 1
 
 
+def test_sync_ds_writes_both_tables(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+    """Datasource step writes to both datasource_outputs and operation_outputs."""
+
+    def step_fn() -> str:
+        return "hello"
+
+    @DBOS.workflow()
+    def my_workflow() -> str:
+        return sync_ds.run_tx_step(None, step_fn)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert my_workflow() == "hello"
+
+    _check_both_tables(sync_ds, dbos, wfid)
+
+
+def test_sync_ds_recovers_from_sysdb_loss(dbos: DBOS, sync_ds: SyncDatasource) -> None:
+    """datasource_outputs is the source of truth when the sysdb step record is lost.
+
+    Simulates the crash window: datasource_outputs was written atomically inside
+    the user transaction, but the system crashed before operation_outputs was
+    persisted. On re-run, the step result must be recovered from datasource_outputs
+    without re-executing the step function.
+    """
+    call_count = {"n": 0}
+
+    def step_fn() -> str:
+        call_count["n"] += 1
+        return "recovered"
+
+    @DBOS.workflow()
+    def my_workflow() -> str:
+        return sync_ds.run_tx_step(None, step_fn)
+
+    wfid = str(uuid.uuid4())
+
+    # First run: writes both tables.
+    with SetWorkflowID(wfid):
+        assert my_workflow() == "recovered"
+    assert call_count["n"] == 1
+
+    # Simulate crash: remove the workflow record from the system DB.
+    # The CASCADE on operation_outputs.workflow_uuid wipes the step record too,
+    # while datasource_outputs (in the app DB) is unaffected.
+    with dbos._sys_db.engine.begin() as conn:
+        conn.execute(
+            sa.delete(SystemSchema.workflow_status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == wfid
+            )
+        )
+
+    # Re-run: DBOS treats this as a new workflow (no workflow_status row).
+    # run_step finds no operation_outputs entry, so it calls _body().
+    # _body() finds the datasource_outputs row and replays — step_fn not called.
+    with SetWorkflowID(wfid):
+        assert my_workflow() == "recovered"
+    assert call_count["n"] == 1
+
+
 # ---------------------------------------------------------------------------
-# Async bare-run tests (PG only — aiosqlite not installed)
+# Async bare-run tests (no DBOS workflow needed)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_async_ds_bare_run(pg_ds_url: str, async_ds_schema: str) -> None:
+async def test_async_ds_bare_run(async_ds: AsyncDatasource) -> None:
     """run_tx_step_async outside a workflow executes the function transactionally."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
-
     counter = {"n": 0}
 
     async def increment(amount: int) -> int:
-        session = ds.sql_session()
+        session = async_ds.sql_session()
         await session.execute(text("SELECT 1"))
         counter["n"] += amount
         return counter["n"]
 
-    try:
-        result = await ds.run_tx_step_async(None, increment, 5)
-        assert result == 5
-        result = await ds.run_tx_step_async(None, increment, 3)
-        assert result == 8
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    result = await async_ds.run_tx_step_async(None, increment, 5)
+    assert result == 5
+    result = await async_ds.run_tx_step_async(None, increment, 3)
+    assert result == 8
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_bare_run(
-    pg_ds_url: str, async_ds_schema: str
-) -> None:
+async def test_async_ds_decorator_bare_run(async_ds: AsyncDatasource) -> None:
     """@ds.transaction on an async function works outside a workflow."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
-
     counter = {"n": 0}
 
-    @ds.transaction
+    @async_ds.transaction
     async def increment(amount: int) -> int:
-        session = ds.sql_session()
+        session = async_ds.sql_session()
         await session.execute(text("SELECT 1"))
         counter["n"] += amount
         return counter["n"]
 
-    try:
-        assert await increment(10) == 10
-        assert await increment(5) == 15
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    assert await increment(10) == 10
+    assert await increment(5) == 15
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_with_options(
-    pg_ds_url: str, async_ds_schema: str
-) -> None:
+async def test_async_ds_decorator_with_options(async_ds: AsyncDatasource) -> None:
     """@ds.transaction accepts isolation_level and name options."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
     counter = {"n": 0}
 
-    @ds.transaction(isolation_level="SERIALIZABLE", name="my_step")
+    @async_ds.transaction(isolation_level="SERIALIZABLE", name="my_step")
     async def increment(amount: int) -> int:
         counter["n"] += amount
         return counter["n"]
 
-    try:
-        assert await increment(7) == 7
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    assert await increment(7) == 7
 
 
 @pytest.mark.asyncio
 async def test_async_ds_sql_session_outside_tx_raises(
-    pg_ds_url: str, async_ds_schema: str
+    async_ds: AsyncDatasource,
 ) -> None:
     """sql_session() outside an async datasource transaction must raise."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
-    try:
-        with pytest.raises(AssertionError):
-            ds.sql_session()
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    with pytest.raises(AssertionError):
+        async_ds.sql_session()
 
 
 @pytest.mark.asyncio
-async def test_async_ds_rejects_sync_func(pg_ds_url: str, async_ds_schema: str) -> None:
+async def test_async_ds_rejects_sync_func(async_ds: AsyncDatasource) -> None:
     """run_tx_step_async with a non-coroutine must raise."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
 
     def sync_func() -> str:
         return "oops"
 
-    try:
-        with pytest.raises(DBOSException, match="coroutine"):
-            await ds.run_tx_step_async(None, sync_func)  # type: ignore
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    with pytest.raises(DBOSException, match="coroutine"):
+        await async_ds.run_tx_step_async(None, sync_func)  # type: ignore
 
 
 @pytest.mark.asyncio
 async def test_async_ds_transaction_decorator_rejects_sync(
-    pg_ds_url: str, async_ds_schema: str
+    async_ds: AsyncDatasource,
 ) -> None:
     """@ds.transaction on a sync function must raise at decoration time."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
+    with pytest.raises(DBOSException, match="coroutine"):
 
-    try:
-        with pytest.raises(DBOSException, match="coroutine"):
-
-            @ds.transaction
-            def bad() -> str:
-                return "nope"
-
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+        @async_ds.transaction
+        def bad() -> str:
+            return "nope"
 
 
 # ---------------------------------------------------------------------------
-# Async OAOO tests (PG only, inside a DBOS workflow)
+# Async OAOO tests (inside a DBOS workflow)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_async_ds_oaoo(
-    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
-) -> None:
+async def test_async_ds_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
     """run_tx_step_async inside a workflow records the result and replays on retry."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
     call_count = {"n": 0}
 
     async def expensive_step(value: str) -> str:
         call_count["n"] += 1
-        session = ds.sql_session()
+        session = async_ds.sql_session()
         await session.execute(text("SELECT 1"))
         return f"async:{value}"
 
     @DBOS.workflow()
     async def my_workflow(value: str) -> str:
-        return await ds.run_tx_step_async(None, expensive_step, value)
+        return await async_ds.run_tx_step_async(None, expensive_step, value)
 
     wfid = str(uuid.uuid4())
 
-    try:
-        with SetWorkflowID(wfid):
-            result = await my_workflow("hello")
-        assert result == "async:hello"
-        assert call_count["n"] == 1
+    with SetWorkflowID(wfid):
+        result = await my_workflow("hello")
+    assert result == "async:hello"
+    assert call_count["n"] == 1
 
-        with SetWorkflowID(wfid):
-            result = await my_workflow("hello")
-        assert result == "async:hello"
-        assert call_count["n"] == 1  # Not called again
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    with SetWorkflowID(wfid):
+        result = await my_workflow("hello")
+    assert result == "async:hello"
+    assert call_count["n"] == 1
 
 
 @pytest.mark.asyncio
-async def test_async_ds_decorator_oaoo(
-    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
-) -> None:
+async def test_async_ds_decorator_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
     """@ds.transaction inside a workflow records and replays the result."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
     call_count = {"n": 0}
 
-    @ds.transaction
+    @async_ds.transaction
     async def decorated_step(value: str) -> str:
         call_count["n"] += 1
         return f"decorated:{value}"
@@ -469,30 +523,20 @@ async def test_async_ds_decorator_oaoo(
 
     wfid = str(uuid.uuid4())
 
-    try:
-        with SetWorkflowID(wfid):
-            result = await my_workflow("world")
-        assert result == "decorated:world"
-        assert call_count["n"] == 1
+    with SetWorkflowID(wfid):
+        result = await my_workflow("world")
+    assert result == "decorated:world"
+    assert call_count["n"] == 1
 
-        with SetWorkflowID(wfid):
-            result = await my_workflow("world")
-        assert result == "decorated:world"
-        assert call_count["n"] == 1
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    with SetWorkflowID(wfid):
+        result = await my_workflow("world")
+    assert result == "decorated:world"
+    assert call_count["n"] == 1
 
 
 @pytest.mark.asyncio
-async def test_async_ds_error_oaoo(
-    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
-) -> None:
+async def test_async_ds_error_oaoo(dbos: DBOS, async_ds: AsyncDatasource) -> None:
     """Async datasource step error is recorded and replayed without re-executing."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
     call_count = {"n": 0}
 
     async def failing_step() -> str:
@@ -501,34 +545,26 @@ async def test_async_ds_error_oaoo(
 
     @DBOS.workflow()
     async def my_workflow() -> str:
-        return await ds.run_tx_step_async(None, failing_step)
+        return await async_ds.run_tx_step_async(None, failing_step)
 
     wfid = str(uuid.uuid4())
 
-    try:
-        with SetWorkflowID(wfid):
-            with pytest.raises(Exception, match="async ds step failed"):
-                await my_workflow()
-        assert call_count["n"] == 1
+    with SetWorkflowID(wfid):
+        with pytest.raises(Exception, match="async ds step failed"):
+            await my_workflow()
+    assert call_count["n"] == 1
 
-        with SetWorkflowID(wfid):
-            with pytest.raises(Exception, match="async ds step failed"):
-                await my_workflow()
-        assert call_count["n"] == 1  # Not called again
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
-            )
-        await ds.engine.dispose()
+    with SetWorkflowID(wfid):
+        with pytest.raises(Exception, match="async ds step failed"):
+            await my_workflow()
+    assert call_count["n"] == 1
 
 
 @pytest.mark.asyncio
 async def test_async_ds_multiple_steps_in_workflow(
-    require_pg: str, dbos: DBOS, pg_ds_url: str, async_ds_schema: str
+    dbos: DBOS, async_ds: AsyncDatasource
 ) -> None:
     """Multiple async datasource steps in one workflow each get their own step_id."""
-    ds = await AsyncDatasource.create(pg_ds_url, schema=async_ds_schema)
     call_counts = {"a": 0, "b": 0}
 
     async def step_a() -> str:
@@ -541,25 +577,84 @@ async def test_async_ds_multiple_steps_in_workflow(
 
     @DBOS.workflow()
     async def my_workflow() -> str:
-        r1 = await ds.run_tx_step_async(None, step_a)
-        r2 = await ds.run_tx_step_async(None, step_b)
+        r1 = await async_ds.run_tx_step_async(None, step_a)
+        r2 = await async_ds.run_tx_step_async(None, step_b)
         return r1 + r2
 
     wfid = str(uuid.uuid4())
 
-    try:
-        with SetWorkflowID(wfid):
-            result = await my_workflow()
-        assert result == "AB"
+    with SetWorkflowID(wfid):
+        result = await my_workflow()
+    assert result == "AB"
 
-        with SetWorkflowID(wfid):
-            result = await my_workflow()
-        assert result == "AB"
-        assert call_counts["a"] == 1
-        assert call_counts["b"] == 1
-    finally:
-        async with ds.engine.begin() as conn:
-            await conn.execute(
-                text(f'DROP SCHEMA IF EXISTS "{async_ds_schema}" CASCADE')
+    with SetWorkflowID(wfid):
+        result = await my_workflow()
+    assert result == "AB"
+    assert call_counts["a"] == 1
+    assert call_counts["b"] == 1
+
+
+@pytest.mark.asyncio
+async def test_async_ds_writes_both_tables(
+    dbos: DBOS, async_ds: AsyncDatasource
+) -> None:
+    """Async datasource step writes to both datasource_outputs and operation_outputs."""
+
+    async def step_fn() -> str:
+        return "world"
+
+    @DBOS.workflow()
+    async def my_workflow() -> str:
+        return await async_ds.run_tx_step_async(None, step_fn)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert await my_workflow() == "world"
+
+    await _async_check_both_tables(async_ds, dbos, wfid)
+
+
+@pytest.mark.asyncio
+async def test_async_ds_recovers_from_sysdb_loss(
+    dbos: DBOS, async_ds: AsyncDatasource
+) -> None:
+    """datasource_outputs is the source of truth when the sysdb step record is lost.
+
+    Simulates the crash window: datasource_outputs was written atomically inside
+    the user transaction, but the system crashed before operation_outputs was
+    persisted. On re-run, the step result must be recovered from datasource_outputs
+    without re-executing the step function.
+    """
+    call_count = {"n": 0}
+
+    async def step_fn() -> str:
+        call_count["n"] += 1
+        return "recovered"
+
+    @DBOS.workflow()
+    async def my_workflow() -> str:
+        return await async_ds.run_tx_step_async(None, step_fn)
+
+    wfid = str(uuid.uuid4())
+
+    # First run: writes both tables.
+    with SetWorkflowID(wfid):
+        assert await my_workflow() == "recovered"
+    assert call_count["n"] == 1
+
+    # Simulate crash: remove the workflow record from the system DB.
+    # The CASCADE on operation_outputs.workflow_uuid wipes the step record too,
+    # while datasource_outputs (in the app DB) is unaffected.
+    with dbos._sys_db.engine.begin() as conn:
+        conn.execute(
+            sa.delete(SystemSchema.workflow_status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == wfid
             )
-        await ds.engine.dispose()
+        )
+
+    # Re-run: DBOS treats this as a new workflow (no workflow_status row).
+    # run_step finds no operation_outputs entry, so it calls _body().
+    # _body() finds the datasource_outputs row and replays — step_fn not called.
+    with SetWorkflowID(wfid):
+        assert await my_workflow() == "recovered"
+    assert call_count["n"] == 1


### PR DESCRIPTION
Introduces datasources, similar to [TS datasources](https://docs.dbos.dev/typescript/tutorials/transaction-tutorial)

Note:
* Unlike built in DBOS transactions, running a datasource transaction outside of a workflow does *NOT* create a temporary workflow. A DS transaction simply executes as is w/o durable execution bookkeeping when run outside of a workflow
* PG Datasources do not attempt to create the associated database on startup. This is in contrast to "vanilla" DBOS which does attempt to create the app db on startup if it doesn't exist. PG Datasources only ensure the `datasource_outputs` table exists

fixes #563