### PR TITLE
Preemptible Async Steps

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1579,6 +1579,14 @@ async def _run_preemptible_step(
                 )
             raise
     finally:
+        # Cancel both tasks so neither leaks if the outer coroutine itself
+        # was cancelled (or the step task is somehow still running).
+        if not step_task.done():
+            step_task.cancel()
+            try:
+                await step_task
+            except BaseException:
+                pass
         if not poller_task.done():
             poller_task.cancel()
             try:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -315,9 +315,8 @@ class StepOptions(TypedDict, total=False):
             only supported for async steps.
 
         preemptible:
-            If True, run the (async) step alongside a poller that watches
-            the workflow's status and cancels the step task if the
-            workflow is cancelled. Only supported for async steps.
+            If True, cancel the (async) step if its workflow is cancelled.
+            Only supported for async steps.
     """
 
     name: Optional[str]

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -313,6 +313,11 @@ class StepOptions(TypedDict, total=False):
             an awaitable resolving to False), the exception is re-raised
             immediately without further retries. Async validators are
             only supported for async steps.
+
+        preemptible:
+            If True, run the (async) step alongside a poller that watches
+            the workflow's status and cancels the step task if the
+            workflow is cancelled. Only supported for async steps.
     """
 
     name: Optional[str]
@@ -321,6 +326,7 @@ class StepOptions(TypedDict, total=False):
     max_attempts: int
     backoff_rate: float
     should_retry: Optional[Callable[[BaseException], Union[bool, Awaitable[bool]]]]
+    preemptible: bool
 
 
 DEFAULT_STEP_OPTIONS: StepOptions = {
@@ -330,7 +336,10 @@ DEFAULT_STEP_OPTIONS: StepOptions = {
     "max_attempts": 3,
     "backoff_rate": 2.0,
     "should_retry": None,
+    "preemptible": False,
 }
+
+PREEMPTION_POLL_INTERVAL_SEC = 1.0
 
 
 def normalize_step_options(opts: Optional[StepOptions]) -> StepOptions:
@@ -1531,6 +1540,57 @@ def decorate_transaction(
     return decorator
 
 
+async def _run_preemptible_step(
+    dbos: "DBOS",
+    workflow_id: str,
+    func: Callable[..., Coroutine[Any, Any, R]],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    poll_interval_sec: float,
+) -> R:
+    step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
+    poller_cancelled_step = False
+
+    async def poller() -> None:
+        nonlocal poller_cancelled_step
+        while True:
+            await asyncio.sleep(poll_interval_sec)
+            try:
+                status = await asyncio.to_thread(
+                    dbos._sys_db.get_workflow_status, workflow_id
+                )
+            except Exception as e:
+                dbos.logger.warning(
+                    f"Error polling status for preemptible step in workflow {workflow_id}: {e}"
+                )
+                continue
+            if (
+                status is not None
+                and status["status"] == WorkflowStatusString.CANCELLED.value
+            ):
+                poller_cancelled_step = True
+                step_task.cancel()
+                return
+
+    poller_task = asyncio.create_task(poller())
+    try:
+        try:
+            return await step_task
+        except asyncio.CancelledError:
+            if poller_cancelled_step:
+                raise DBOSWorkflowCancelledError(
+                    f"Workflow {workflow_id} is cancelled. Aborting preemptible step."
+                )
+            raise
+    finally:
+        if not poller_task.done():
+            poller_task.cancel()
+            try:
+                await poller_task
+            except BaseException:
+                pass
+
+
 def invoke_step(
     dbos: "DBOS",
     step_ctx: DBOSContext,
@@ -1546,6 +1606,7 @@ def invoke_step(
     should_retry: Optional[
         Callable[[BaseException], Union[bool, Awaitable[bool]]]
     ] = None,
+    preemptible: bool = False,
 ) -> R | Coroutine[Any, Any, R]:
     if (
         should_retry is not None
@@ -1555,6 +1616,11 @@ def invoke_step(
         raise DBOSException(
             f"Step {step_name} is sync but should_retry is async. "
             f"Use an async step to pair with an async validator."
+        )
+    if preemptible and not inspect.iscoroutinefunction(func):
+        raise DBOSException(
+            f"Step {step_name} is sync but preemptible=True. "
+            f"Preemption is only supported for async steps."
         )
 
     attributes: TracedAttributes = {
@@ -1600,6 +1666,10 @@ def invoke_step(
 
         try:
             output = func()
+        except DBOSWorkflowCancelledError:
+            # The step was preempted by workflow cancellation. Don't record
+            # an outcome — let the step be re-run on resume.
+            raise
         except Exception as error:
             serialized_e, serialization = serialize_exception(
                 error, None, dbos._serializer
@@ -1647,7 +1717,22 @@ def invoke_step(
             )
             return NoResult()
 
-    stepOutcome = Outcome[R].make(functools.partial(func, *args, **kwargs))
+    if preemptible:
+        async_func = cast(Callable[..., Coroutine[Any, Any, R]], func)
+        step_partial: Callable[[], Union[R, Coroutine[Any, Any, R]]] = (
+            functools.partial(
+                _run_preemptible_step,
+                dbos,
+                step_ctx.workflow_id,
+                async_func,
+                args,
+                kwargs,
+                PREEMPTION_POLL_INTERVAL_SEC,
+            )
+        )
+    else:
+        step_partial = functools.partial(func, *args, **kwargs)
+    stepOutcome = Outcome[R].make(step_partial)
     if retries_allowed:
         stepOutcome = stepOutcome.retry(
             max_attempts,
@@ -1688,6 +1773,7 @@ def run_step(
             max_attempts=options["max_attempts"],
             backoff_rate=options["backoff_rate"],
             should_retry=options["should_retry"],
+            preemptible=options["preemptible"],
         )
         if inspect.iscoroutinefunction(func):
             return dbos._background_event_loop.submit_coroutine(
@@ -1732,6 +1818,7 @@ async def run_step_async(
             max_attempts=options["max_attempts"],
             backoff_rate=options["backoff_rate"],
             should_retry=options["should_retry"],
+            preemptible=options["preemptible"],
         )
         if inspect.iscoroutinefunction(func):
             return await cast(Coroutine[Any, Any, R], outcome)
@@ -1759,8 +1846,14 @@ def decorate_step(
     should_retry: Optional[
         Callable[[BaseException], Union[bool, Awaitable[bool]]]
     ] = None,
+    preemptible: bool = False,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        if preemptible and not inspect.iscoroutinefunction(func):
+            raise DBOSException(
+                f"Step {name or func.__qualname__} is sync but preemptible=True. "
+                f"Preemption is only supported for async steps."
+            )
 
         step_name = name if name is not None else func.__qualname__
 
@@ -1790,6 +1883,7 @@ def decorate_step(
                         max_attempts=max_attempts,
                         backoff_rate=backoff_rate,
                         should_retry=should_retry,
+                        preemptible=preemptible,
                     )
             else:
                 return func(*args, **kwargs)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -338,8 +338,6 @@ DEFAULT_STEP_OPTIONS: StepOptions = {
     "preemptible": False,
 }
 
-PREEMPTION_POLL_INTERVAL_SEC = 1.0
-
 
 def normalize_step_options(opts: Optional[StepOptions]) -> StepOptions:
     return {**DEFAULT_STEP_OPTIONS, **(opts or {})}
@@ -1545,7 +1543,6 @@ async def _run_preemptible_step(
     func: Callable[..., Coroutine[Any, Any, R]],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-    poll_interval_sec: float,
 ) -> R:
     step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
     poller_cancelled_step = False
@@ -1553,7 +1550,7 @@ async def _run_preemptible_step(
     async def poller() -> None:
         nonlocal poller_cancelled_step
         while True:
-            await asyncio.sleep(poll_interval_sec)
+            await asyncio.sleep(1.0)
             try:
                 status = await asyncio.to_thread(
                     dbos._sys_db.get_workflow_status, workflow_id
@@ -1726,7 +1723,6 @@ def invoke_step(
                 async_func,
                 args,
                 kwargs,
-                PREEMPTION_POLL_INTERVAL_SEC,
             )
         )
     else:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1544,13 +1544,14 @@ async def _run_preemptible_step(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> R:
+    PREEMPTIBLE_POLL_INTERVAL_SEC = 1.0
     step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
     poller_cancelled_step = False
 
     async def poller() -> None:
         nonlocal poller_cancelled_step
         while True:
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(PREEMPTIBLE_POLL_INTERVAL_SEC)
             try:
                 status = await asyncio.to_thread(
                     dbos._sys_db.get_workflow_status, workflow_id

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1031,7 +1031,7 @@ class DBOS:
                 step should be retried. If it returns False (or an awaitable resolving
                 to False), the exception is re-raised immediately without further
                 retries. Async validators are only supported for async steps.
-            preemptible(bool): If true, cancel the (async) step if its workflow is cancelled.
+            preemptible(bool): If True, cancel the (async) step if its workflow is cancelled.
                 Only supported for async steps.
 
         """

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1016,6 +1016,7 @@ class DBOS:
         should_retry: Optional[
             Callable[[BaseException], Union[bool, Awaitable[bool]]]
         ] = None,
+        preemptible: bool = False,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """
         Decorate and configure a function for use as a DBOS step.
@@ -1030,6 +1031,8 @@ class DBOS:
                 step should be retried. If it returns False (or an awaitable resolving
                 to False), the exception is re-raised immediately without further
                 retries. Async validators are only supported for async steps.
+            preemptible(bool): If true, cancel the (async) step if its workflow is cancelled.
+                Only supported for async steps.
 
         """
 
@@ -1041,6 +1044,7 @@ class DBOS:
             max_attempts=max_attempts,
             backoff_rate=backoff_rate,
             should_retry=should_retry,
+            preemptible=preemptible,
         )
 
     @classmethod

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 
 from dbos import DBOS, Queue, SetWorkflowID
-from dbos._error import DBOSAwaitedWorkflowCancelledError
+from dbos._error import DBOSAwaitedWorkflowCancelledError, DBOSException
 from dbos._sys_db import StepInfo, WorkflowStatus
 from dbos._utils import INTERNAL_QUEUE_NAME
 from tests.conftest import queue_entries_are_cleaned_up
@@ -310,3 +310,81 @@ async def test_bulk_async_workflow_management(dbos: DBOS) -> None:
         assert await DBOS.get_workflow_status_async(did) is None
 
     assert queue_entries_are_cleaned_up(dbos)
+
+
+@pytest.mark.asyncio
+async def test_preemptible_step_cancels_on_workflow_cancel(dbos: DBOS) -> None:
+    """A preemptible async step is cancelled when the workflow is cancelled."""
+    step_started = asyncio.Event()
+    step_completed = False
+    step_cancelled = False
+
+    @DBOS.step(preemptible=True)
+    async def long_running_step() -> None:
+        nonlocal step_completed, step_cancelled
+        step_started.set()
+        try:
+            await asyncio.sleep(60)
+            step_completed = True
+        except asyncio.CancelledError:
+            step_cancelled = True
+            raise
+
+    @DBOS.workflow()
+    async def wf() -> None:
+        await long_running_step()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(wf)
+
+    await step_started.wait()
+    await DBOS.cancel_workflow_async(wfid)
+
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        await handle.get_result()
+
+    assert step_cancelled
+    assert not step_completed
+
+
+@pytest.mark.asyncio
+async def test_preemptible_step_resumes_after_cancel(dbos: DBOS) -> None:
+    """After preemption cancels a step, resuming the workflow re-runs the step."""
+    invocation_count = 0
+    sleep_event = asyncio.Event()
+
+    @DBOS.step(preemptible=True)
+    async def long_running_step() -> str:
+        nonlocal invocation_count
+        invocation_count += 1
+        if invocation_count == 1:
+            sleep_event.set()
+            await asyncio.sleep(60)
+            return "should-not-reach"
+        return "done"
+
+    @DBOS.workflow()
+    async def wf() -> str:
+        return await long_running_step()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(wf)
+
+    await sleep_event.wait()
+    await DBOS.cancel_workflow_async(wfid)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        await handle.get_result()
+
+    resumed = await DBOS.resume_workflow_async(wfid)
+    assert (await resumed.get_result()) == "done"
+    assert invocation_count == 2
+
+
+def test_preemptible_rejected_for_sync_step(dbos: DBOS) -> None:
+    with pytest.raises(DBOSException):
+
+        @DBOS.step(preemptible=True)
+        def sync_step() -> None:
+            pass

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -313,55 +313,32 @@ async def test_bulk_async_workflow_management(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_preemptible_step_cancels_on_workflow_cancel(dbos: DBOS) -> None:
-    """A preemptible async step is cancelled when the workflow is cancelled."""
-    step_started = asyncio.Event()
-    step_completed = False
-    step_cancelled = False
-
-    @DBOS.step(preemptible=True)
-    async def long_running_step() -> None:
-        nonlocal step_completed, step_cancelled
-        step_started.set()
-        try:
-            await asyncio.sleep(60)
-            step_completed = True
-        except asyncio.CancelledError:
-            step_cancelled = True
-            raise
-
-    @DBOS.workflow()
-    async def wf() -> None:
-        await long_running_step()
-
-    wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        handle = await DBOS.start_workflow_async(wf)
-
-    await step_started.wait()
-    await DBOS.cancel_workflow_async(wfid)
-
-    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
-        await handle.get_result()
-
-    assert step_cancelled
-    assert not step_completed
-
-
-@pytest.mark.asyncio
-async def test_preemptible_step_resumes_after_cancel(dbos: DBOS) -> None:
-    """After preemption cancels a step, resuming the workflow re-runs the step."""
+async def test_preemptible_step_cancellation_and_resume(dbos: DBOS) -> None:
+    """End-to-end preemption: a preemptible step is cancelled mid-flight when
+    the workflow is cancelled (CancelledError observed inside the step, no
+    retry storm even with retries_allowed=True), and on resume the step is
+    re-run from scratch and completes successfully."""
     invocation_count = 0
-    sleep_event = asyncio.Event()
+    step_started = asyncio.Event()
+    first_invocation_cancelled = False
 
-    @DBOS.step(preemptible=True)
+    @DBOS.step(
+        preemptible=True,
+        retries_allowed=True,
+        max_attempts=5,
+        interval_seconds=0.01,
+    )
     async def long_running_step() -> str:
-        nonlocal invocation_count
+        nonlocal invocation_count, first_invocation_cancelled
         invocation_count += 1
         if invocation_count == 1:
-            sleep_event.set()
-            await asyncio.sleep(60)
-            return "should-not-reach"
+            step_started.set()
+            try:
+                await asyncio.sleep(60)
+                return "should-not-reach"
+            except asyncio.CancelledError:
+                first_invocation_cancelled = True
+                raise
         return "done"
 
     @DBOS.workflow()
@@ -372,19 +349,83 @@ async def test_preemptible_step_resumes_after_cancel(dbos: DBOS) -> None:
     with SetWorkflowID(wfid):
         handle = await DBOS.start_workflow_async(wf)
 
-    await sleep_event.wait()
+    await step_started.wait()
     await DBOS.cancel_workflow_async(wfid)
+
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         await handle.get_result()
+    assert first_invocation_cancelled
+    # No retry storm: cancellation must bypass the retry layer.
+    assert invocation_count == 1
 
     resumed = await DBOS.resume_workflow_async(wfid)
     assert (await resumed.get_result()) == "done"
     assert invocation_count == 2
 
 
+@pytest.mark.asyncio
+async def test_preemptible_step_normal_paths(dbos: DBOS) -> None:
+    """preemptible=True doesn't break normal step semantics: normal
+    exceptions still propagate, success returns the value."""
+
+    @DBOS.step(preemptible=True)
+    async def add_one(x: int) -> int:
+        return x + 1
+
+    @DBOS.step(preemptible=True)
+    async def boom() -> None:
+        raise ValueError("boom")
+
+    @DBOS.workflow()
+    async def ok_wf(x: int) -> int:
+        return await add_one(x)
+
+    @DBOS.workflow()
+    async def err_wf() -> None:
+        await boom()
+
+    assert (await ok_wf(41)) == 42
+    with pytest.raises(ValueError, match="boom"):
+        await err_wf()
+
+
 def test_preemptible_rejected_for_sync_step(dbos: DBOS) -> None:
+    """preemptible=True on a sync step is rejected at decoration time."""
     with pytest.raises(DBOSException):
 
         @DBOS.step(preemptible=True)
         def sync_step() -> None:
             pass
+
+
+@pytest.mark.asyncio
+async def test_preemptible_step_no_leak_on_outer_cancel(dbos: DBOS) -> None:
+    """If the outer coroutine running _run_preemptible_step is cancelled,
+    the inner step task is also cancelled (no leak)."""
+    from dbos._core import _run_preemptible_step
+
+    step_started = asyncio.Event()
+    step_cancelled = asyncio.Event()
+
+    async def long_step() -> None:
+        step_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            step_cancelled.set()
+            raise
+
+    # A workflow id that doesn't exist — the poller's status query returns
+    # None each time, so cancellation in this test comes only from the outer
+    # task being cancelled.
+    fake_wfid = "test-no-leak-" + str(uuid.uuid4())
+    outer = asyncio.create_task(
+        _run_preemptible_step(dbos, fake_wfid, long_step, (), {})
+    )
+    await step_started.wait()
+    outer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    # If the step task leaked, this would time out.
+    await asyncio.wait_for(step_cancelled.wait(), timeout=5.0)

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -374,28 +374,48 @@ async def test_preemptible_step_cancellation_and_resume(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_preemptible_step_normal_paths(dbos: DBOS) -> None:
-    """preemptible=True doesn't break normal step semantics: normal
-    exceptions still propagate, success returns the value."""
+    """preemptible=True doesn't break normal step semantics (exceptions
+    propagate), and DBOS.run_step_async with preemptible=True in
+    StepOptions actually triggers preemption when the workflow is
+    cancelled."""
 
-    @DBOS.step(preemptible=True)
-    async def add_one(x: int) -> int:
-        return x + 1
-
+    # Normal exception still propagates.
     @DBOS.step(preemptible=True)
     async def boom() -> None:
         raise ValueError("boom")
 
     @DBOS.workflow()
-    async def ok_wf(x: int) -> int:
-        return await add_one(x)
-
-    @DBOS.workflow()
     async def err_wf() -> None:
         await boom()
 
-    assert (await ok_wf(41)) == 42
     with pytest.raises(ValueError, match="boom"):
         await err_wf()
+
+    # Preemptible passed via StepOptions to run_step_async actually preempts.
+    step_started = asyncio.Event()
+    step_cancelled = False
+
+    async def long_step() -> None:
+        nonlocal step_cancelled
+        step_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            step_cancelled = True
+            raise
+
+    @DBOS.workflow()
+    async def cancel_wf() -> None:
+        await DBOS.run_step_async({"preemptible": True}, long_step)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(cancel_wf)
+    await step_started.wait()
+    await DBOS.cancel_workflow_async(wfid)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        await handle.get_result()
+    assert step_cancelled
 
 
 def test_preemptible_rejected_for_sync_step(dbos: DBOS) -> None:

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -362,6 +362,15 @@ async def test_preemptible_step_cancellation_and_resume(dbos: DBOS) -> None:
     assert (await resumed.get_result()) == "done"
     assert invocation_count == 2
 
+    # After resume, the step should be recorded exactly once with the
+    # successful output — no leftover error checkpoint from the preempted
+    # first invocation.
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    step_entries = [s for s in steps if "long_running_step" in s["function_name"]]
+    assert len(step_entries) == 1
+    assert step_entries[0]["output"] == "done"
+    assert step_entries[0]["error"] is None
+
 
 @pytest.mark.asyncio
 async def test_preemptible_step_normal_paths(dbos: DBOS) -> None:


### PR DESCRIPTION
Support preemption for async steps. By default, if a workflow is cancelled, step execution is not preempted, so the workflow continues running until its current step completes then is preempted at the start of the next step. If the step is preemptible, the step (and thus workflow) is instead cancelled immediately (or after a short polling interval). Closes https://github.com/dbos-inc/dbos-transact-py/issues/660.