### PR TITLE
Log schema when connecting to system database

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -487,13 +487,13 @@ class SystemDatabase(ABC):
 
         # Log system database connection information
         if engine:
-            dbos_logger.info("Initializing DBOS system database with custom engine")
+            dbos_logger.info(f"Initializing DBOS system database with custom engine: {engine.url} (schema: {schema})")
         else:
             printable_sys_db_url = sa.make_url(system_database_url).render_as_string(
                 hide_password=True
             )
             dbos_logger.info(
-                f"Initializing DBOS system database with URL: {printable_sys_db_url}"
+                f"Initializing DBOS system database with URL: {printable_sys_db_url} (schema: {schema})"
             )
             if system_database_url.startswith("sqlite"):
                 dbos_logger.info(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -487,7 +487,8 @@ class SystemDatabase(ABC):
 
         # Log system database connection information
         if engine:
-            dbos_logger.info(f"Initializing DBOS system database with custom engine: {engine.url} (schema: {schema})")
+            printable_sys_db_url = engine.url.render_as_string(hide_password=True)
+            dbos_logger.info(f"Initializing DBOS system database with custom engine: {printable_sys_db_url} (schema: {schema})")
         else:
             printable_sys_db_url = sa.make_url(system_database_url).render_as_string(
                 hide_password=True


### PR DESCRIPTION
This logs the custom engine URL and also the schema when connecting to the system database, which helps ensure you know what you are connected to.

I used f-string formatting, since that was the convention in the repository. However, wanted to note that in general using %-formatting with parameters (e.g. `log("%s", var)`) does have less performance impact if the log level isn't hit due to the avoided string interpolation.