### PR TITLE
Migration Early Exit

### DIFF
--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -65,6 +65,43 @@ def _bump_migration_version(
             )
 
 
+def should_migrate(engine: sa.Engine, schema: str, use_listen_notify: bool) -> bool:
+    """Return True if the schema or dbos_migrations table is missing, or if
+    the recorded migration version is behind the latest. Postgres-only."""
+    with engine.begin() as conn:
+        schema_exists = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = :schema"
+            ),
+            {"schema": schema},
+        ).fetchone()
+        if schema_exists is None:
+            return True
+
+        table_exists = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = :schema AND table_name = 'dbos_migrations'"
+            ),
+            {"schema": schema},
+        ).fetchone()
+        if table_exists is None:
+            return True
+
+        current_version_row = conn.execute(
+            sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+        ).fetchone()
+        current_version = current_version_row[0] if current_version_row else 0
+
+        version_str = conn.execute(sa.text("SELECT version()")).scalar() or ""
+        is_cockroach = "cockroachdb" in version_str.lower()
+
+        latest_version = len(
+            get_dbos_migrations(schema, use_listen_notify, is_cockroach)
+        )
+        return current_version < latest_version
+
+
 def ensure_dbos_schema(engine: sa.Engine, schema: str) -> None:
     """
     True if using DBOS migrations (DBOS schema and migrations table already exist or were created)

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -5,7 +5,7 @@ import psycopg
 import sqlalchemy as sa
 from sqlalchemy.exc import DBAPIError
 
-from dbos._migration import ensure_dbos_schema, run_dbos_migrations
+from dbos._migration import ensure_dbos_schema, run_dbos_migrations, should_migrate
 
 from ._logger import dbos_logger
 from ._sys_db import SystemDatabase
@@ -52,6 +52,11 @@ class PostgresSystemDatabase(SystemDatabase):
                 conn.execute(sa.text("SELECT 1"))
 
         assert self.schema
+        # Skip the advisory lock and migration work entirely if the schema
+        # and dbos_migrations table already exist and are at the latest version.
+        if not should_migrate(self.engine, self.schema, self.use_listen_notify):
+            return
+
         # Use an advisory lock to serialize concurrent migrations.
         # Try to acquire the lock for up to 30 seconds. If we can't, log a
         # warning and proceed to run migrations without it, rather than

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -534,6 +534,46 @@ def test_version_not_bumped_on_migration_failure(
         assert version == final_version
 
 
+def test_should_migrate(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """should_migrate must return True when the schema is missing, the
+    dbos_migrations table is missing, or the recorded version is behind the
+    latest; and False once the schema is fully migrated."""
+    from dbos._migration import should_migrate
+
+    engine = dbos._sys_db.engine
+    schema = "dbos"
+    latest_version = len(get_dbos_migrations(schema, True))
+
+    # A freshly-migrated dbos fixture should be up to date
+    assert should_migrate(engine, schema, use_listen_notify=True) is False
+
+    # Rewinding the version makes migrations pending again
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :v'),
+            {"v": latest_version - 1},
+        )
+    assert should_migrate(engine, schema, use_listen_notify=True) is True
+
+    # Restore version, then drop the migrations table to simulate a partially
+    # initialized schema. should_migrate must report True.
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(f'UPDATE "{schema}".dbos_migrations SET version = :v'),
+            {"v": latest_version},
+        )
+    assert should_migrate(engine, schema, use_listen_notify=True) is False
+
+    with engine.begin() as conn:
+        conn.execute(sa.text(f'DROP TABLE "{schema}".dbos_migrations'))
+    assert should_migrate(engine, schema, use_listen_notify=True) is True
+
+    # A schema name that does not exist at all must also report True
+    assert (
+        should_migrate(engine, "nonexistent_schema_xyz", use_listen_notify=True) is True
+    )
+
+
 def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) -> None:
     """Simulate a CREATE INDEX CONCURRENTLY that crashed mid-build (leaving an
     INVALID index) and verify the runner cleans it up and re-runs the


### PR DESCRIPTION
Early exit from `run_migrations` (and do not take the advisory lock) if migrations do not need to be run.