### PR TITLE
Bulk Send

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -28,6 +28,7 @@ from ._serialization import (
 )
 from ._sys_db import (
     ClientScheduleInput,
+    SendMessage,
     StepInfo,
     VersionInfo,
     WorkflowSchedule,
@@ -52,6 +53,7 @@ __all__ = [
     "SetWorkflowID",
     "SetWorkflowTimeout",
     "SetEnqueueOptions",
+    "SendMessage",
     "StepInfo",
     "StepOptions",
     "WorkflowHandle",

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -497,12 +497,10 @@ class DBOSClient:
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
     ) -> None:
-        self._sys_db.send_direct(
-            destination_id,
-            message,
-            topic,
-            message_uuid=idempotency_key,
+        self._sys_db.send_bulk(
+            [SendMessage(destination_id, message, topic, idempotency_key)],
             serialization_type=serialization_type,
+            function_name="DBOS.send",
         )
 
     async def send_async(

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -500,7 +500,7 @@ class DBOSClient:
         self._sys_db.send_bulk(
             [SendMessage(destination_id, message, topic, idempotency_key)],
             serialization_type=serialization_type,
-            workflow_uuid=None,
+            workflow_id=None,
             function_id=None,
             function_name="DBOS.send",
         )
@@ -537,7 +537,7 @@ class DBOSClient:
         self._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
-            workflow_uuid=None,
+            workflow_id=None,
             function_id=None,
             function_name="DBOS.send_bulk",
         )

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -48,6 +48,7 @@ from dbos._serialization import (
 )
 from dbos._sys_db import (
     ClientScheduleInput,
+    SendMessage,
     StepInfo,
     SystemDatabase,
     VersionInfo,
@@ -521,6 +522,35 @@ class DBOSClient:
             message,
             topic,
             idempotency_key,
+            serialization_type=serialization_type,
+        )
+
+    def send_bulk(
+        self,
+        messages: List[SendMessage],
+        *,
+        serialization_type: Optional[
+            WorkflowSerializationFormat
+        ] = WorkflowSerializationFormat.DEFAULT,
+    ) -> None:
+        """Send many messages to workflow executions in a single transaction."""
+        self._sys_db.send_bulk(
+            messages,
+            serialization_type=serialization_type,
+        )
+
+    async def send_bulk_async(
+        self,
+        messages: List[SendMessage],
+        *,
+        serialization_type: Optional[
+            WorkflowSerializationFormat
+        ] = WorkflowSerializationFormat.DEFAULT,
+    ) -> None:
+        """Send many messages to workflow executions in a single transaction."""
+        return await asyncio.to_thread(
+            self.send_bulk,
+            messages,
             serialization_type=serialization_type,
         )
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -496,6 +496,7 @@ class DBOSClient:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
         self._sys_db.send_bulk(
             [SendMessage(destination_id, message, topic, idempotency_key)],
@@ -503,6 +504,7 @@ class DBOSClient:
             workflow_id=None,
             function_id=None,
             function_name="DBOS.send",
+            send_to_forks=send_to_forks,
         )
 
     async def send_async(
@@ -515,6 +517,7 @@ class DBOSClient:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
         return await asyncio.to_thread(
             self.send,
@@ -523,6 +526,7 @@ class DBOSClient:
             topic,
             idempotency_key,
             serialization_type=serialization_type,
+            send_to_forks=send_to_forks,
         )
 
     def send_bulk(
@@ -532,14 +536,20 @@ class DBOSClient:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send many messages to workflow executions in a single transaction."""
+        """Send many messages to workflow executions in a single transaction.
+
+        If `send_to_forks` is set, every message is also delivered to all
+        workflows recursively forked from its destination.
+        """
         self._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
             workflow_id=None,
             function_id=None,
             function_name="DBOS.send_bulk",
+            send_to_forks=send_to_forks,
         )
 
     async def send_bulk_async(
@@ -549,12 +559,18 @@ class DBOSClient:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send many messages to workflow executions in a single transaction."""
+        """Send many messages to workflow executions in a single transaction.
+
+        If `send_to_forks` is set, every message is also delivered to all
+        workflows recursively forked from its destination.
+        """
         return await asyncio.to_thread(
             self.send_bulk,
             messages,
             serialization_type=serialization_type,
+            send_to_forks=send_to_forks,
         )
 
     def get_event(self, workflow_id: str, key: str, timeout_seconds: float = 60) -> Any:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -500,6 +500,8 @@ class DBOSClient:
         self._sys_db.send_bulk(
             [SendMessage(destination_id, message, topic, idempotency_key)],
             serialization_type=serialization_type,
+            workflow_uuid=None,
+            function_id=None,
             function_name="DBOS.send",
         )
 
@@ -535,6 +537,9 @@ class DBOSClient:
         self._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
+            workflow_uuid=None,
+            function_id=None,
+            function_name="DBOS.send_bulk",
         )
 
     async def send_bulk_async(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1929,11 +1929,14 @@ def send_bulk(
     serialization_type: Optional[WorkflowSerializationFormat],
     function_name: str,
     span_name: str,
+    send_to_forks: bool,
 ) -> None:
     """Send one or more messages, optionally as a step within a workflow.
 
     Underlies both `DBOS.send` (a single message) and `DBOS.send_bulk` (many),
-    which differ only in the `function_name`/`span_name` they record.
+    which differ only in the `function_name`/`span_name` they record. When
+    `send_to_forks` is set, each message also reaches every workflow recursively
+    forked from its destination.
     """
     if (
         serialization_type is None
@@ -1957,6 +1960,7 @@ def send_bulk(
                 workflow_id=ctx.workflow_id,
                 function_id=ctx.curr_step_function_id,
                 function_name=function_name,
+                send_to_forks=send_to_forks,
             )
     else:
         dbos._sys_db.send_bulk(
@@ -1965,6 +1969,7 @@ def send_bulk(
             workflow_id=None,
             function_id=None,
             function_name=function_name,
+            send_to_forks=send_to_forks,
         )
 
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1954,7 +1954,7 @@ def send_bulk(
             dbos._sys_db.send_bulk(
                 messages,
                 serialization_type=serialization_type,
-                workflow_uuid=ctx.workflow_id,
+                workflow_id=ctx.workflow_id,
                 function_id=ctx.curr_step_function_id,
                 function_name=function_name,
             )
@@ -1962,7 +1962,7 @@ def send_bulk(
         dbos._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
-            workflow_uuid=None,
+            workflow_id=None,
             function_id=None,
             function_name=function_name,
         )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -84,6 +84,7 @@ from ._serialization import (
 from ._sys_db import (
     EnqueueOptionsInternal,
     OperationResultInternal,
+    SendMessage,
     WorkflowStatus,
     WorkflowStatusInternal,
     WorkflowStatusString,
@@ -1964,6 +1965,42 @@ def send(
             message,
             topic,
             message_uuid=idempotency_key,
+            serialization_type=serialization_type,
+        )
+
+
+def send_bulk(
+    dbos: "DBOS",
+    cur_ctx: Optional["DBOSContext"],
+    messages: List[SendMessage],
+    *,
+    serialization_type: Optional[WorkflowSerializationFormat],
+) -> None:
+    if (
+        serialization_type is None
+        or serialization_type == WorkflowSerializationFormat.DEFAULT
+    ):
+        serialization_type = (
+            cur_ctx.serialization_type
+            if cur_ctx is not None
+            else WorkflowSerializationFormat.DEFAULT
+        )
+
+    if cur_ctx and cur_ctx.is_workflow():
+        # Inside a workflow, the entire bulk send is recorded as a single step.
+        attributes: TracedAttributes = {
+            "name": "send_bulk",
+        }
+        with EnterDBOSStepCtx(attributes, cur_ctx) as ctx:
+            dbos._sys_db.send_bulk(
+                messages,
+                serialization_type=serialization_type,
+                workflow_uuid=ctx.workflow_id,
+                function_id=ctx.curr_step_function_id,
+            )
+    else:
+        dbos._sys_db.send_bulk(
+            messages,
             serialization_type=serialization_type,
         )
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1921,61 +1921,20 @@ def decorate_step(
     return decorator
 
 
-def send(
-    dbos: "DBOS",
-    cur_ctx: Optional["DBOSContext"],
-    destination_id: str,
-    message: Any,
-    topic: Optional[str] = None,
-    *,
-    serialization_type: Optional[WorkflowSerializationFormat],
-    idempotency_key: Optional[str] = None,
-) -> None:
-    if (
-        serialization_type is None
-        or serialization_type == WorkflowSerializationFormat.DEFAULT
-    ):
-        serialization_type = (
-            cur_ctx.serialization_type
-            if cur_ctx is not None
-            else WorkflowSerializationFormat.DEFAULT
-        )
-
-    def do_send(destination_id: str, message: Any, topic: Optional[str]) -> None:
-        assert cur_ctx is not None
-        attributes: TracedAttributes = {
-            "name": "send",
-        }
-        with EnterDBOSStepCtx(attributes, cur_ctx) as ctx:
-            dbos._sys_db.send(
-                ctx.workflow_id,
-                ctx.curr_step_function_id,
-                destination_id,
-                message,
-                topic,
-                serialization_type=serialization_type,
-                message_uuid=idempotency_key,
-            )
-
-    if cur_ctx and cur_ctx.is_workflow():
-        return do_send(destination_id, message, topic)
-    else:
-        dbos._sys_db.send_direct(
-            destination_id,
-            message,
-            topic,
-            message_uuid=idempotency_key,
-            serialization_type=serialization_type,
-        )
-
-
 def send_bulk(
     dbos: "DBOS",
     cur_ctx: Optional["DBOSContext"],
     messages: List[SendMessage],
     *,
     serialization_type: Optional[WorkflowSerializationFormat],
+    function_name: str = "DBOS.send_bulk",
+    span_name: str = "send_bulk",
 ) -> None:
+    """Send one or more messages, optionally as a step within a workflow.
+
+    Underlies both `DBOS.send` (a single message) and `DBOS.send_bulk` (many),
+    which differ only in the `function_name`/`span_name` they record.
+    """
     if (
         serialization_type is None
         or serialization_type == WorkflowSerializationFormat.DEFAULT
@@ -1987,9 +1946,9 @@ def send_bulk(
         )
 
     if cur_ctx and cur_ctx.is_workflow():
-        # Inside a workflow, the entire bulk send is recorded as a single step.
+        # Inside a workflow, the entire send is recorded as a single step.
         attributes: TracedAttributes = {
-            "name": "send_bulk",
+            "name": span_name,
         }
         with EnterDBOSStepCtx(attributes, cur_ctx) as ctx:
             dbos._sys_db.send_bulk(
@@ -1997,11 +1956,13 @@ def send_bulk(
                 serialization_type=serialization_type,
                 workflow_uuid=ctx.workflow_id,
                 function_id=ctx.curr_step_function_id,
+                function_name=function_name,
             )
     else:
         dbos._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
+            function_name=function_name,
         )
 
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1927,8 +1927,8 @@ def send_bulk(
     messages: List[SendMessage],
     *,
     serialization_type: Optional[WorkflowSerializationFormat],
-    function_name: str = "DBOS.send_bulk",
-    span_name: str = "send_bulk",
+    function_name: str,
+    span_name: str,
 ) -> None:
     """Send one or more messages, optionally as a step within a workflow.
 
@@ -1962,6 +1962,8 @@ def send_bulk(
         dbos._sys_db.send_bulk(
             messages,
             serialization_type=serialization_type,
+            workflow_uuid=None,
+            function_id=None,
             function_name=function_name,
         )
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1483,6 +1483,8 @@ class DBOS:
             snapshot_step_context(),
             messages,
             serialization_type=serialization_type,
+            function_name="DBOS.send_bulk",
+            span_name="send_bulk",
         )
 
     @classmethod
@@ -1503,6 +1505,8 @@ class DBOS:
             ctx,
             messages,
             serialization_type=serialization_type,
+            function_name="DBOS.send_bulk",
+            span_name="send_bulk",
         )
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -66,7 +66,6 @@ from ._core import (
     record_sleep,
     run_step,
     run_step_async,
-    send,
     send_bulk,
     set_event,
     start_workflow,
@@ -1434,14 +1433,13 @@ class DBOS:
     ) -> None:
         """Send a message to a workflow execution."""
         check_async("send")
-        return send(
+        return send_bulk(
             _get_dbos_instance(),
             snapshot_step_context(),
-            destination_id,
-            message,
-            topic,
+            [SendMessage(destination_id, message, topic, idempotency_key)],
             serialization_type=serialization_type,
-            idempotency_key=idempotency_key,
+            function_name="DBOS.send",
+            span_name="send",
         )
 
     @classmethod
@@ -1460,14 +1458,13 @@ class DBOS:
         ctx = snapshot_step_context()
         await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(
-            send,
+            send_bulk,
             _get_dbos_instance(),
             ctx,
-            destination_id,
-            message,
-            topic,
+            [SendMessage(destination_id, message, topic, idempotency_key)],
             serialization_type=serialization_type,
-            idempotency_key=idempotency_key,
+            function_name="DBOS.send",
+            span_name="send",
         )
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1430,8 +1430,13 @@ class DBOS:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send a message to a workflow execution."""
+        """Send a message to a workflow execution.
+
+        If `send_to_forks` is set, the message is also delivered to all workflows
+        recursively forked from `destination_id`.
+        """
         check_async("send")
         return send_bulk(
             _get_dbos_instance(),
@@ -1440,6 +1445,7 @@ class DBOS:
             serialization_type=serialization_type,
             function_name="DBOS.send",
             span_name="send",
+            send_to_forks=send_to_forks,
         )
 
     @classmethod
@@ -1453,8 +1459,13 @@ class DBOS:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send a message to a workflow execution."""
+        """Send a message to a workflow execution.
+
+        If `send_to_forks` is set, the message is also delivered to all workflows
+        recursively forked from `destination_id`.
+        """
         ctx = snapshot_step_context()
         await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(
@@ -1465,6 +1476,7 @@ class DBOS:
             serialization_type=serialization_type,
             function_name="DBOS.send",
             span_name="send",
+            send_to_forks=send_to_forks,
         )
 
     @classmethod
@@ -1475,8 +1487,13 @@ class DBOS:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send many messages to workflow executions in a single transaction."""
+        """Send many messages to workflow executions in a single transaction.
+
+        If `send_to_forks` is set, every message is also delivered to all
+        workflows recursively forked from its destination.
+        """
         check_async("send_bulk")
         return send_bulk(
             _get_dbos_instance(),
@@ -1485,6 +1502,7 @@ class DBOS:
             serialization_type=serialization_type,
             function_name="DBOS.send_bulk",
             span_name="send_bulk",
+            send_to_forks=send_to_forks,
         )
 
     @classmethod
@@ -1495,8 +1513,13 @@ class DBOS:
         serialization_type: Optional[
             WorkflowSerializationFormat
         ] = WorkflowSerializationFormat.DEFAULT,
+        send_to_forks: bool = False,
     ) -> None:
-        """Send many messages to workflow executions in a single transaction."""
+        """Send many messages to workflow executions in a single transaction.
+
+        If `send_to_forks` is set, every message is also delivered to all
+        workflows recursively forked from its destination.
+        """
         ctx = snapshot_step_context()
         await cls._configure_asyncio_thread_pool()
         await asyncio.to_thread(
@@ -1507,6 +1530,7 @@ class DBOS:
             serialization_type=serialization_type,
             function_name="DBOS.send_bulk",
             span_name="send_bulk",
+            send_to_forks=send_to_forks,
         )
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -67,6 +67,7 @@ from ._core import (
     run_step,
     run_step_async,
     send,
+    send_bulk,
     set_event,
     start_workflow,
     start_workflow_async,
@@ -101,6 +102,7 @@ from ._scheduler import (
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
     GetEventWorkflowContext,
+    SendMessage,
     StepInfo,
     SystemDatabase,
     VersionInfo,
@@ -1466,6 +1468,44 @@ class DBOS:
             topic,
             serialization_type=serialization_type,
             idempotency_key=idempotency_key,
+        )
+
+    @classmethod
+    def send_bulk(
+        cls,
+        messages: List[SendMessage],
+        *,
+        serialization_type: Optional[
+            WorkflowSerializationFormat
+        ] = WorkflowSerializationFormat.DEFAULT,
+    ) -> None:
+        """Send many messages to workflow executions in a single transaction."""
+        check_async("send_bulk")
+        return send_bulk(
+            _get_dbos_instance(),
+            snapshot_step_context(),
+            messages,
+            serialization_type=serialization_type,
+        )
+
+    @classmethod
+    async def send_bulk_async(
+        cls,
+        messages: List[SendMessage],
+        *,
+        serialization_type: Optional[
+            WorkflowSerializationFormat
+        ] = WorkflowSerializationFormat.DEFAULT,
+    ) -> None:
+        """Send many messages to workflow executions in a single transaction."""
+        ctx = snapshot_step_context()
+        await cls._configure_asyncio_thread_pool()
+        await asyncio.to_thread(
+            send_bulk,
+            _get_dbos_instance(),
+            ctx,
+            messages,
+            serialization_type=serialization_type,
         )
 
     @classmethod

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2495,13 +2495,14 @@ class SystemDatabase(ABC):
                 for dest in destinations:
                     if m.idempotency_key is None:
                         message_uuid = str(generate_uuid())
-                    elif send_to_forks:
-                        # One key fans out to many recipients; derive a distinct,
-                        # deterministic message_uuid per destination so each gets
-                        # the message while replays stay idempotent.
-                        message_uuid = f"{m.idempotency_key}::{dest}"
                     else:
-                        message_uuid = m.idempotency_key
+                        # An idempotency key is scoped per destination: suffix it
+                        # with the recipient's workflow ID. This gives each recipient
+                        # a distinct, deterministic message_uuid (so a single key can
+                        # fan out across forks) while replays stay idempotent, and
+                        # makes the message_uuid independent of whether the send fanned
+                        # out to forks.
+                        message_uuid = f"{m.idempotency_key}::{dest}"
                     rows.append(
                         {
                             "destination_uuid": dest,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2381,13 +2381,23 @@ class SystemDatabase(ABC):
 
         This is the single implementation underlying both `DBOS.send`/`send_bulk`
         (inside and outside a workflow) and `DBOSClient.send`/`send_bulk`. When
-        called from a workflow, `workflow_uuid` and `function_id` identify the
+        called from a workflow, `workflow_id` and `function_id` identify the
         single step recording the operation, which makes it idempotent on replay;
         `function_name` is the name recorded for that step. Each message also
         provides its own idempotency via the primary key constraint on
         `message_uuid`.
         """
         start_time = int(time.time() * 1000)
+
+        # Reject duplicate idempotency keys
+        provided_keys = [m.idempotency_key for m in messages if m.idempotency_key]
+        if len(provided_keys) != len(set(provided_keys)):
+            duplicates = sorted(
+                {k for k in provided_keys if provided_keys.count(k) > 1}
+            )
+            raise DBOSException(
+                f"send_bulk received duplicate idempotency keys: {', '.join(duplicates)}"
+            )
 
         rows = []
         for m in messages:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -355,6 +356,16 @@ class NotificationInfo(TypedDict):
 
 _dbos_null_topic = "__null__topic__"
 _dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
+
+
+@dataclass
+class SendMessage:
+    """A single message to send as part of a bulk send operation."""
+
+    destination_id: str
+    message: Any
+    topic: Optional[str] = None
+    idempotency_key: Optional[str] = None
 
 
 class EventCount(TypedDict):
@@ -2472,6 +2483,98 @@ class SystemDatabase(ABC):
                     "`send` destination", destination_uuid
                 )
             raise
+
+    @db_retry()
+    def send_bulk(
+        self,
+        messages: List[SendMessage],
+        *,
+        serialization_type: Optional["WorkflowSerializationFormat"],
+        workflow_uuid: Optional[str] = None,
+        function_id: Optional[int] = None,
+    ) -> None:
+        """Send many messages in a single transaction.
+
+        Shared by `DBOS.send_bulk` (both inside and outside a workflow) and
+        `DBOSClient.send_bulk`. When called from a workflow, `workflow_uuid` and
+        `function_id` identify the single step recording the bulk send, which
+        makes the whole operation idempotent on replay. Each message provides
+        its own idempotency via the primary key constraint on `message_uuid`.
+        """
+        function_name = "DBOS.send_bulk"
+        start_time = int(time.time() * 1000)
+
+        rows = []
+        for m in messages:
+            message_uuid = (
+                m.idempotency_key
+                if m.idempotency_key is not None
+                else str(generate_uuid())
+            )
+            serval, serialization = serialize_value(
+                m.message,
+                serialization_type,
+                self.serializer,
+            )
+            rows.append(
+                {
+                    "destination_uuid": m.destination_id,
+                    "topic": m.topic if m.topic is not None else _dbos_null_topic,
+                    "message": serval,
+                    "message_uuid": message_uuid,
+                    "serialization": serialization,
+                }
+            )
+
+        with self.engine.begin() as c:
+            if workflow_uuid is not None:
+                assert function_id is not None
+                recorded_output = self._check_operation_execution_txn(
+                    workflow_uuid, function_id, function_name, conn=c
+                )
+                if recorded_output is not None:
+                    dbos_logger.debug(
+                        f"Replaying send_bulk, id: {function_id}, messages: {len(rows)}"
+                    )
+                    return  # Already sent before
+                else:
+                    dbos_logger.debug(
+                        f"Running send_bulk, id: {function_id}, messages: {len(rows)}"
+                    )
+
+            try:
+                if rows:
+                    c.execute(
+                        self.dialect.insert(SystemSchema.notifications)
+                        .values(rows)
+                        .on_conflict_do_nothing(
+                            index_elements=[
+                                SystemSchema.notifications.c.message_uuid,
+                            ]
+                        )
+                    )
+            except DBAPIError as dbapi_error:
+                if self._is_foreign_key_violation(dbapi_error):
+                    raise DBOSNonExistentWorkflowError(
+                        "`send_bulk` destination",
+                        ", ".join(sorted({m.destination_id for m in messages})),
+                    )
+                raise
+
+            if workflow_uuid is not None:
+                assert function_id is not None
+                output: OperationResultInternal = {
+                    "workflow_uuid": workflow_uuid,
+                    "function_id": function_id,
+                    "function_name": function_name,
+                    "started_at_epoch_ms": start_time,
+                    "output": None,
+                    "error": None,
+                    "serialization": None,
+                }
+                self._record_operation_result_txn(
+                    output, int(time.time() * 1000), conn=c
+                )
 
     @db_retry()
     def recv_setup(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2369,29 +2369,51 @@ class SystemDatabase(ABC):
             )
 
     def _find_fork_descendants_txn(
-        self, workflow_id: str, conn: sa.Connection
-    ) -> Set[str]:
-        """Return every workflow recursively forked from `workflow_id`.
+        self, workflow_ids: List[str], conn: sa.Connection
+    ) -> Dict[str, Set[str]]:
+        """Return every workflow recursively forked from each of `workflow_ids`.
 
-        Walks the `forked_from` chain breadth-first, so it includes direct forks,
-        forks of those forks, and so on. The starting workflow itself is not
-        included. Self-references and cycles (which should not occur) are ignored.
+        Resolves all of the given roots together: one query per level of the fork
+        forest covers every root at once, rather than a separate traversal per
+        root. The `forked_from` edges discovered are accumulated into an adjacency
+        map, then each root's descendant set (direct forks, forks of forks, ...,
+        excluding the root itself) is computed in memory. Self-references and
+        cycles (which should not occur) are ignored.
         """
-        descendants: Set[str] = set()
-        frontier = [workflow_id]
+        # Bulk breadth-first walk over the union of all roots, recording the
+        # parent -> children edges of every reachable fork.
+        children: Dict[str, List[str]] = {}
+        seen: Set[str] = set(workflow_ids)
+        frontier = list(dict.fromkeys(workflow_ids))
         while frontier:
             rows = conn.execute(
-                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
-                    SystemSchema.workflow_status.c.forked_from.in_(frontier)
-                )
+                sa.select(
+                    SystemSchema.workflow_status.c.workflow_uuid,
+                    SystemSchema.workflow_status.c.forked_from,
+                ).where(SystemSchema.workflow_status.c.forked_from.in_(frontier))
             ).all()
             next_frontier = []
-            for (forked_id,) in rows:
-                if forked_id != workflow_id and forked_id not in descendants:
-                    descendants.add(forked_id)
+            for forked_id, forked_from in rows:
+                children.setdefault(forked_from, []).append(forked_id)
+                if forked_id not in seen:
+                    seen.add(forked_id)
                     next_frontier.append(forked_id)
             frontier = next_frontier
-        return descendants
+
+        # Compute each root's descendants in memory from the adjacency map.
+        result: Dict[str, Set[str]] = {}
+        for root in workflow_ids:
+            if root in result:
+                continue
+            descendants: Set[str] = set()
+            stack = list(children.get(root, []))
+            while stack:
+                node = stack.pop()
+                if node != root and node not in descendants:
+                    descendants.add(node)
+                    stack.extend(children.get(node, []))
+            result[root] = descendants
+        return result
 
     @db_retry()
     def send_bulk(
@@ -2454,15 +2476,21 @@ class SystemDatabase(ABC):
                     )
 
             # Expand each message to its destination set (the workflow itself plus,
-            # if requested, every workflow recursively forked from it). Fork
-            # resolution happens inside the transaction so the recipient set is
-            # consistent with the insert.
+            # if requested, every workflow recursively forked from it). Forks for
+            # all destinations are resolved in a single bulk walk, inside the
+            # transaction so the recipient set is consistent with the insert.
+            fork_descendants: Dict[str, Set[str]] = {}
+            if send_to_forks:
+                fork_descendants = self._find_fork_descendants_txn(
+                    [m.destination_id for m, _, _ in prepared], c
+                )
+
             rows = []
             for m, serval, serialization in prepared:
                 destinations = [m.destination_id]
                 if send_to_forks:
                     destinations.extend(
-                        sorted(self._find_fork_descendants_txn(m.destination_id, c))
+                        sorted(fork_descendants.get(m.destination_id, set()))
                     )
                 for dest in destinations:
                     if m.idempotency_key is None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2368,123 +2368,6 @@ class SystemDatabase(ABC):
             )
 
     @db_retry()
-    def send(
-        self,
-        workflow_uuid: str,
-        function_id: int,
-        destination_uuid: str,
-        message: Any,
-        topic: Optional[str],
-        *,
-        serialization_type: Optional["WorkflowSerializationFormat"],
-        message_uuid: Optional[str],
-    ) -> None:
-        function_name = "DBOS.send"
-        start_time = int(time.time() * 1000)
-        topic = topic if topic is not None else _dbos_null_topic
-        if message_uuid is None:
-            message_uuid = str(generate_uuid())
-        serval, serialization = serialize_value(
-            message,
-            serialization_type,
-            self.serializer,
-        )
-        with self.engine.begin() as c:
-            recorded_output = self._check_operation_execution_txn(
-                workflow_uuid, function_id, function_name, conn=c
-            )
-            if recorded_output is not None:
-                dbos_logger.debug(
-                    f"Replaying send, id: {function_id}, destination_uuid: {destination_uuid}, topic: {topic}"
-                )
-                return  # Already sent before
-            else:
-                dbos_logger.debug(
-                    f"Running send, id: {function_id}, destination_uuid: {destination_uuid}, topic: {topic}"
-                )
-
-            try:
-                c.execute(
-                    self.dialect.insert(SystemSchema.notifications)
-                    .values(
-                        destination_uuid=destination_uuid,
-                        topic=topic,
-                        message=serval,
-                        message_uuid=message_uuid,
-                        serialization=serialization,
-                    )
-                    .on_conflict_do_nothing(
-                        index_elements=[
-                            SystemSchema.notifications.c.message_uuid,
-                        ]
-                    )
-                )
-            except DBAPIError as dbapi_error:
-                if self._is_foreign_key_violation(dbapi_error):
-                    raise DBOSNonExistentWorkflowError(
-                        "`send` destination", destination_uuid
-                    )
-                raise
-            output: OperationResultInternal = {
-                "workflow_uuid": workflow_uuid,
-                "function_id": function_id,
-                "function_name": function_name,
-                "started_at_epoch_ms": start_time,
-                "output": None,
-                "error": None,
-                "serialization": None,
-            }
-            self._record_operation_result_txn(output, int(time.time() * 1000), conn=c)
-
-    @db_retry()
-    def send_direct(
-        self,
-        destination_uuid: str,
-        message: Any,
-        topic: Optional[str] = None,
-        message_uuid: Optional[str] = None,
-        *,
-        serialization_type: Optional["WorkflowSerializationFormat"] = None,
-    ) -> None:
-        """Send a message without requiring a workflow context.
-
-        Idempotency is provided by the primary key constraint on message_uuid.
-        On duplicate message_uuid, silently returns (idempotent replay).
-        """
-
-        topic = topic if topic is not None else _dbos_null_topic
-        if message_uuid is None:
-            message_uuid = str(generate_uuid())
-        serval, serialization = serialize_value(
-            message,
-            serialization_type,
-            self.serializer,
-        )
-        try:
-            with self.engine.begin() as c:
-                c.execute(
-                    self.dialect.insert(SystemSchema.notifications)
-                    .values(
-                        destination_uuid=destination_uuid,
-                        topic=topic,
-                        message=serval,
-                        message_uuid=message_uuid,
-                        serialization=serialization,
-                    )
-                    .on_conflict_do_nothing(
-                        index_elements=[
-                            SystemSchema.notifications.c.message_uuid,
-                        ]
-                    )
-                )
-        except DBAPIError as dbapi_error:
-            if self._is_foreign_key_violation(dbapi_error):
-                raise DBOSNonExistentWorkflowError(
-                    "`send` destination", destination_uuid
-                )
-            raise
-
-    @db_retry()
     def send_bulk(
         self,
         messages: List[SendMessage],
@@ -2492,16 +2375,18 @@ class SystemDatabase(ABC):
         serialization_type: Optional["WorkflowSerializationFormat"],
         workflow_uuid: Optional[str] = None,
         function_id: Optional[int] = None,
+        function_name: str = "DBOS.send_bulk",
     ) -> None:
-        """Send many messages in a single transaction.
+        """Send one or more messages in a single transaction.
 
-        Shared by `DBOS.send_bulk` (both inside and outside a workflow) and
-        `DBOSClient.send_bulk`. When called from a workflow, `workflow_uuid` and
-        `function_id` identify the single step recording the bulk send, which
-        makes the whole operation idempotent on replay. Each message provides
-        its own idempotency via the primary key constraint on `message_uuid`.
+        This is the single implementation underlying both `DBOS.send`/`send_bulk`
+        (inside and outside a workflow) and `DBOSClient.send`/`send_bulk`. When
+        called from a workflow, `workflow_uuid` and `function_id` identify the
+        single step recording the operation, which makes it idempotent on replay;
+        `function_name` is the name recorded for that step. Each message also
+        provides its own idempotency via the primary key constraint on
+        `message_uuid`.
         """
-        function_name = "DBOS.send_bulk"
         start_time = int(time.time() * 1000)
 
         rows = []
@@ -2534,12 +2419,12 @@ class SystemDatabase(ABC):
                 )
                 if recorded_output is not None:
                     dbos_logger.debug(
-                        f"Replaying send_bulk, id: {function_id}, messages: {len(rows)}"
+                        f"Replaying {function_name}, id: {function_id}, messages: {len(rows)}"
                     )
                     return  # Already sent before
                 else:
                     dbos_logger.debug(
-                        f"Running send_bulk, id: {function_id}, messages: {len(rows)}"
+                        f"Running {function_name}, id: {function_id}, messages: {len(rows)}"
                     )
 
             try:
@@ -2556,7 +2441,7 @@ class SystemDatabase(ABC):
             except DBAPIError as dbapi_error:
                 if self._is_foreign_key_violation(dbapi_error):
                     raise DBOSNonExistentWorkflowError(
-                        "`send_bulk` destination",
+                        "`send` destination",
                         ", ".join(sorted({m.destination_id for m in messages})),
                     )
                 raise

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2373,7 +2373,7 @@ class SystemDatabase(ABC):
         messages: List[SendMessage],
         *,
         serialization_type: Optional["WorkflowSerializationFormat"],
-        workflow_uuid: Optional[str],
+        workflow_id: Optional[str],
         function_id: Optional[int],
         function_name: str,
     ) -> None:
@@ -2412,10 +2412,10 @@ class SystemDatabase(ABC):
             )
 
         with self.engine.begin() as c:
-            if workflow_uuid is not None:
+            if workflow_id is not None:
                 assert function_id is not None
                 recorded_output = self._check_operation_execution_txn(
-                    workflow_uuid, function_id, function_name, conn=c
+                    workflow_id, function_id, function_name, conn=c
                 )
                 if recorded_output is not None:
                     dbos_logger.debug(
@@ -2446,10 +2446,10 @@ class SystemDatabase(ABC):
                     )
                 raise
 
-            if workflow_uuid is not None:
+            if workflow_id is not None:
                 assert function_id is not None
                 output: OperationResultInternal = {
-                    "workflow_uuid": workflow_uuid,
+                    "workflow_uuid": workflow_id,
                     "function_id": function_id,
                     "function_name": function_name,
                     "started_at_epoch_ms": start_time,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2373,9 +2373,9 @@ class SystemDatabase(ABC):
         messages: List[SendMessage],
         *,
         serialization_type: Optional["WorkflowSerializationFormat"],
-        workflow_uuid: Optional[str] = None,
-        function_id: Optional[int] = None,
-        function_name: str = "DBOS.send_bulk",
+        workflow_uuid: Optional[str],
+        function_id: Optional[int],
+        function_name: str,
     ) -> None:
         """Send one or more messages in a single transaction.
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     TypedDict,
     TypeVar,
@@ -2367,6 +2368,31 @@ class SystemDatabase(ABC):
                 workflow_id, function_id, function_name, c
             )
 
+    def _find_fork_descendants_txn(
+        self, workflow_id: str, conn: sa.Connection
+    ) -> Set[str]:
+        """Return every workflow recursively forked from `workflow_id`.
+
+        Walks the `forked_from` chain breadth-first, so it includes direct forks,
+        forks of those forks, and so on. The starting workflow itself is not
+        included. Self-references and cycles (which should not occur) are ignored.
+        """
+        descendants: Set[str] = set()
+        frontier = [workflow_id]
+        while frontier:
+            rows = conn.execute(
+                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                    SystemSchema.workflow_status.c.forked_from.in_(frontier)
+                )
+            ).all()
+            next_frontier = []
+            for (forked_id,) in rows:
+                if forked_id != workflow_id and forked_id not in descendants:
+                    descendants.add(forked_id)
+                    next_frontier.append(forked_id)
+            frontier = next_frontier
+        return descendants
+
     @db_retry()
     def send_bulk(
         self,
@@ -2376,6 +2402,7 @@ class SystemDatabase(ABC):
         workflow_id: Optional[str],
         function_id: Optional[int],
         function_name: str,
+        send_to_forks: bool,
     ) -> None:
         """Send one or more messages in a single transaction.
 
@@ -2386,6 +2413,10 @@ class SystemDatabase(ABC):
         `function_name` is the name recorded for that step. Each message also
         provides its own idempotency via the primary key constraint on
         `message_uuid`.
+
+        When `send_to_forks` is set, every message is delivered not only to its
+        `destination_id` but also to every workflow recursively forked from it
+        (forks, forks of forks, ...) that exists at send time.
         """
         start_time = int(time.time() * 1000)
 
@@ -2399,27 +2430,12 @@ class SystemDatabase(ABC):
                 f"send_bulk received duplicate idempotency keys: {', '.join(duplicates)}"
             )
 
-        rows = []
-        for m in messages:
-            message_uuid = (
-                m.idempotency_key
-                if m.idempotency_key is not None
-                else str(generate_uuid())
-            )
-            serval, serialization = serialize_value(
-                m.message,
-                serialization_type,
-                self.serializer,
-            )
-            rows.append(
-                {
-                    "destination_uuid": m.destination_id,
-                    "topic": m.topic if m.topic is not None else _dbos_null_topic,
-                    "message": serval,
-                    "message_uuid": message_uuid,
-                    "serialization": serialization,
-                }
-            )
+        # Serialize each message once (independent of how many destinations it
+        # fans out to once forks are resolved).
+        prepared = [
+            (m, *serialize_value(m.message, serialization_type, self.serializer))
+            for m in messages
+        ]
 
         with self.engine.begin() as c:
             if workflow_id is not None:
@@ -2429,12 +2445,45 @@ class SystemDatabase(ABC):
                 )
                 if recorded_output is not None:
                     dbos_logger.debug(
-                        f"Replaying {function_name}, id: {function_id}, messages: {len(rows)}"
+                        f"Replaying {function_name}, id: {function_id}, messages: {len(messages)}"
                     )
                     return  # Already sent before
                 else:
                     dbos_logger.debug(
-                        f"Running {function_name}, id: {function_id}, messages: {len(rows)}"
+                        f"Running {function_name}, id: {function_id}, messages: {len(messages)}"
+                    )
+
+            # Expand each message to its destination set (the workflow itself plus,
+            # if requested, every workflow recursively forked from it). Fork
+            # resolution happens inside the transaction so the recipient set is
+            # consistent with the insert.
+            rows = []
+            for m, serval, serialization in prepared:
+                destinations = [m.destination_id]
+                if send_to_forks:
+                    destinations.extend(
+                        sorted(self._find_fork_descendants_txn(m.destination_id, c))
+                    )
+                for dest in destinations:
+                    if m.idempotency_key is None:
+                        message_uuid = str(generate_uuid())
+                    elif send_to_forks:
+                        # One key fans out to many recipients; derive a distinct,
+                        # deterministic message_uuid per destination so each gets
+                        # the message while replays stay idempotent.
+                        message_uuid = f"{m.idempotency_key}::{dest}"
+                    else:
+                        message_uuid = m.idempotency_key
+                    rows.append(
+                        {
+                            "destination_uuid": dest,
+                            "topic": (
+                                m.topic if m.topic is not None else _dbos_null_topic
+                            ),
+                            "message": serval,
+                            "message_uuid": message_uuid,
+                            "serialization": serialization,
+                        }
                     )
 
             try:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -11,6 +11,7 @@ from dbos import (
     DBOS,
     DBOSConfig,
     Queue,
+    SendMessage,
     SetWorkflowID,
     SetWorkflowTimeout,
     WorkflowHandleAsync,
@@ -225,6 +226,45 @@ async def test_send_recv_async(dbos: DBOS) -> None:
     with pytest.raises(Exception) as exc_info:
         await dbos.recv_async("test1")
     assert "recv() must be called from within a workflow" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_send_bulk_async(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    async def recv_two() -> str:
+        msg1 = await dbos.recv_async(timeout_seconds=10)
+        msg2 = await dbos.recv_async(timeout_seconds=10)
+        return f"{msg1}-{msg2}"
+
+    # Bulk send from outside a workflow.
+    dest_uuid = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid):
+        handle = await dbos.start_workflow_async(recv_two)
+
+    await DBOS.send_bulk_async(
+        [
+            SendMessage(dest_uuid, "a"),
+            SendMessage(dest_uuid, "b"),
+        ]
+    )
+    assert (await handle.get_result()) == "a-b"
+
+    # Bulk send from within a workflow, recorded as a single step.
+    dest_uuid2 = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid2):
+        handle2 = await dbos.start_workflow_async(recv_two)
+
+    @DBOS.workflow()
+    async def send_bulk_wf(dest: str) -> None:
+        await DBOS.send_bulk_async(
+            [
+                SendMessage(dest, "c"),
+                SendMessage(dest, "d"),
+            ]
+        )
+
+    await send_bulk_wf(dest_uuid2)
+    assert (await handle2.get_result()) == "c-d"
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,14 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import DBAPIError
 
-from dbos import DBOS, DBOSClient, DBOSConfig, EnqueueOptions, SetWorkflowID
+from dbos import (
+    DBOS,
+    DBOSClient,
+    DBOSConfig,
+    EnqueueOptions,
+    SendMessage,
+    SetWorkflowID,
+)
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
 from tests import client_collateral
 from tests.client_collateral import event_test, retrieve_test, send_test
@@ -244,6 +251,33 @@ def test_client_send_no_topic(client: DBOSClient, dbos: DBOS) -> None:
 
     result = handle.get_result()
     assert result == message
+
+
+def test_client_send_bulk(client: DBOSClient, dbos: DBOS) -> None:
+
+    from tests.client_collateral import send_test
+
+    run_client_collateral()
+
+    now = time.time_ns()
+    topic = f"test-topic-{now}"
+
+    wfid_a = str(uuid.uuid4())
+    wfid_b = str(uuid.uuid4())
+    with SetWorkflowID(wfid_a):
+        handle_a = DBOS.start_workflow(send_test, topic)
+    with SetWorkflowID(wfid_b):
+        handle_b = DBOS.start_workflow(send_test, topic)
+
+    client.send_bulk(
+        [
+            SendMessage(wfid_a, f"to_a {now}", topic),
+            SendMessage(wfid_b, f"to_b {now}", topic),
+        ]
+    )
+
+    assert handle_a.get_result() == f"to_a {now}"
+    assert handle_b.get_result() == f"to_b {now}"
 
 
 def run_send_worker(wfid: str, topic: Optional[str], app_ver: str) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1224,6 +1224,44 @@ def test_send_bulk_idempotency_key(dbos: DBOS) -> None:
     assert handle.get_result() == "hello-None"
 
 
+def test_send_bulk_duplicate_key_within_batch(dbos: DBOS) -> None:
+    """Two messages sharing an idempotency key in a single bulk call is rejected
+    before the transaction starts, so nothing is delivered."""
+
+    @DBOS.workflow()
+    def recv_one() -> str:
+        return str(DBOS.recv(timeout_seconds=3))
+
+    dest_uuid = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid):
+        handle = dbos.start_workflow(recv_one)
+
+    key = str(uuid.uuid4())
+    with pytest.raises(Exception) as exc_info:
+        DBOS.send_bulk(
+            [
+                SendMessage(dest_uuid, "first", idempotency_key=key),
+                SendMessage(dest_uuid, "second", idempotency_key=key),
+            ]
+        )
+    assert "duplicate idempotency keys" in str(exc_info.value)
+    assert key in str(exc_info.value)
+    # Nothing was sent: the recv times out and returns None.
+    assert handle.get_result() == "None"
+
+
+def test_send_bulk_empty(dbos: DBOS) -> None:
+    """An empty bulk send is a no-op and must not raise, in or out of a workflow."""
+    DBOS.send_bulk([])
+
+    @DBOS.workflow()
+    def send_empty_wf() -> str:
+        DBOS.send_bulk([])
+        return "ok"
+
+    assert send_empty_wf() == "ok"
+
+
 def test_set_get_events(
     dbos: DBOS, config: DBOSConfig, skip_with_sqlite_imprecise_time: None
 ) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1273,53 +1273,9 @@ def _notification_destinations(dbos: DBOS, message_uuids: bool = False) -> Set[s
 
 
 def test_send_bulk_send_to_forks(dbos: DBOS) -> None:
-    """send_to_forks fans a message out to the workflow and all of its forks,
-    recursively (forks of forks included)."""
-
-    @DBOS.step()
-    def step_a() -> int:
-        return 1
-
-    @DBOS.step()
-    def step_b() -> int:
-        return 2
-
-    @DBOS.workflow()
-    def forkable() -> int:
-        return step_a() + step_b()
-
-    # Original workflow.
-    wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        assert forkable() == 3
-
-    # A fork of the original, and a fork of that fork.
-    fork1 = DBOS.fork_workflow(wfid, 1)
-    fork1_id = fork1.workflow_id
-    assert fork1.get_result() == 3
-    assert fork1.get_status().forked_from == wfid
-
-    fork2 = DBOS.fork_workflow(fork1_id, 1)
-    fork2_id = fork2.workflow_id
-    assert fork2.get_result() == 3
-    assert fork2.get_status().forked_from == fork1_id
-
-    # An unrelated workflow that must not receive the message.
-    other_id = str(uuid.uuid4())
-    with SetWorkflowID(other_id):
-        assert forkable() == 3
-
-    DBOS.send_bulk([SendMessage(wfid, "hello")], send_to_forks=True)
-
-    dests = _notification_destinations(dbos)
-    assert wfid in dests
-    assert fork1_id in dests  # direct fork
-    assert fork2_id in dests  # fork of a fork (recursive)
-    assert other_id not in dests
-
-
-def test_send_bulk_send_to_forks_disabled(dbos: DBOS) -> None:
-    """Without send_to_forks, only the named destination receives the message."""
+    """send_to_forks fans each message out to its destination plus every workflow
+    recursively forked from it. A single bulk send resolves all destinations at
+    once, each reaching only its own fork subtree."""
 
     @DBOS.step()
     def step_a() -> int:
@@ -1329,93 +1285,56 @@ def test_send_bulk_send_to_forks_disabled(dbos: DBOS) -> None:
     def forkable() -> int:
         return step_a()
 
-    wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        assert forkable() == 1
-    fork = DBOS.fork_workflow(wfid, 1)
-    fork_id = fork.workflow_id
-    assert fork.get_result() == 1
-
-    DBOS.send_bulk([SendMessage(wfid, "hello")])
-
-    dests = _notification_destinations(dbos)
-    assert wfid in dests
-    assert fork_id not in dests
-
-
-def test_send_bulk_send_to_forks_idempotency_key(dbos: DBOS) -> None:
-    """With an idempotency key, fanning out to forks derives a distinct
-    message_uuid per recipient, and the whole send stays idempotent on repeat."""
-
-    @DBOS.step()
-    def step_a() -> int:
-        return 1
-
-    @DBOS.workflow()
-    def forkable() -> int:
-        return step_a()
-
-    wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        assert forkable() == 1
-    fork = DBOS.fork_workflow(wfid, 1)
-    fork_id = fork.workflow_id
-    assert fork.get_result() == 1
-
-    key = str(uuid.uuid4())
-
-    def do_send() -> None:
-        DBOS.send_bulk(
-            [SendMessage(wfid, "hello", idempotency_key=key)],
-            send_to_forks=True,
-        )
-
-    do_send()
-    uuids_after_first = _notification_destinations(dbos, message_uuids=True)
-    # One distinct message_uuid per recipient (original + fork).
-    assert f"{key}::{wfid}" in uuids_after_first
-    assert f"{key}::{fork_id}" in uuids_after_first
-
-    # Re-sending with the same key delivers nothing new (idempotent).
-    do_send()
-    assert _notification_destinations(dbos, message_uuids=True) == uuids_after_first
-
-
-def test_send_bulk_send_to_forks_multiple_destinations(dbos: DBOS) -> None:
-    """A single bulk send to several destinations resolves all of their forks in
-    one go, and each destination only fans out to its own fork subtree."""
-
-    @DBOS.step()
-    def step_a() -> int:
-        return 1
-
-    @DBOS.workflow()
-    def forkable() -> int:
-        return step_a()
-
-    def make_workflow_with_fork() -> tuple[str, str]:
+    def run_root() -> str:
         wfid = str(uuid.uuid4())
         with SetWorkflowID(wfid):
             assert forkable() == 1
-        fork = DBOS.fork_workflow(wfid, 1)
-        assert fork.get_result() == 1
-        return wfid, fork.workflow_id
+        return wfid
 
-    wf_a, fork_a = make_workflow_with_fork()
-    wf_b, fork_b = make_workflow_with_fork()
-    # An unrelated workflow (and its fork) that is not a send target.
-    wf_c, fork_c = make_workflow_with_fork()
+    def fork(wfid: str) -> str:
+        handle = DBOS.fork_workflow(wfid, 1)
+        assert handle.get_result() == 1
+        assert handle.get_status().forked_from == wfid
+        return handle.workflow_id
 
+    # Destination A: a fork and a fork-of-a-fork (recursive).
+    a = run_root()
+    a_fork = fork(a)
+    a_fork_fork = fork(a_fork)
+    # Destination B: a single fork.
+    b = run_root()
+    b_fork = fork(b)
+    # Unrelated workflow C with a fork: never a send target.
+    c = run_root()
+    c_fork = fork(c)
+
+    # One bulk send to A and B, with an idempotency key on A.
+    key = str(uuid.uuid4())
     DBOS.send_bulk(
-        [SendMessage(wf_a, "to_a"), SendMessage(wf_b, "to_b")],
+        [SendMessage(a, "to_a", idempotency_key=key), SendMessage(b, "to_b")],
         send_to_forks=True,
     )
 
     dests = _notification_destinations(dbos)
-    assert {wf_a, fork_a, wf_b, fork_b} <= dests
-    # wf_c's subtree is untouched - each destination only reaches its own forks.
-    assert wf_c not in dests
-    assert fork_c not in dests
+    # A and B each reach their full (recursive) fork subtree...
+    assert {a, a_fork, a_fork_fork, b, b_fork} <= dests
+    # ...while C's subtree is untouched: each destination only reaches its own forks.
+    assert c not in dests and c_fork not in dests
+
+    # A's idempotency key derives one distinct message_uuid per recipient.
+    uuids = _notification_destinations(dbos, message_uuids=True)
+    assert {f"{key}::{a}", f"{key}::{a_fork}", f"{key}::{a_fork_fork}"} <= uuids
+
+    # Re-sending A with the same key is idempotent: nothing new appears.
+    DBOS.send_bulk([SendMessage(a, "x", idempotency_key=key)], send_to_forks=True)
+    assert _notification_destinations(dbos, message_uuids=True) == uuids
+
+    # Without send_to_forks, only the named destination is reached.
+    d = run_root()
+    d_fork = fork(d)
+    DBOS.send_bulk([SendMessage(d, "to_d")])
+    dests = _notification_destinations(dbos)
+    assert d in dests and d_fork not in dests
 
 
 def test_set_get_events(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 import uuid
-from typing import Any, Optional
+from typing import Any, Optional, Set
 
 import pytest
 import sqlalchemy as sa
@@ -1260,6 +1260,125 @@ def test_send_bulk_empty(dbos: DBOS) -> None:
         return "ok"
 
     assert send_empty_wf() == "ok"
+
+
+def _notification_destinations(dbos: DBOS, message_uuids: bool = False) -> Set[str]:
+    col = (
+        SystemSchema.notifications.c.message_uuid
+        if message_uuids
+        else SystemSchema.notifications.c.destination_uuid
+    )
+    with dbos._sys_db.engine.begin() as c:
+        return {r[0] for r in c.execute(sa.select(col)).all()}
+
+
+def test_send_bulk_send_to_forks(dbos: DBOS) -> None:
+    """send_to_forks fans a message out to the workflow and all of its forks,
+    recursively (forks of forks included)."""
+
+    @DBOS.step()
+    def step_a() -> int:
+        return 1
+
+    @DBOS.step()
+    def step_b() -> int:
+        return 2
+
+    @DBOS.workflow()
+    def forkable() -> int:
+        return step_a() + step_b()
+
+    # Original workflow.
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert forkable() == 3
+
+    # A fork of the original, and a fork of that fork.
+    fork1 = DBOS.fork_workflow(wfid, 1)
+    fork1_id = fork1.workflow_id
+    assert fork1.get_result() == 3
+    assert fork1.get_status().forked_from == wfid
+
+    fork2 = DBOS.fork_workflow(fork1_id, 1)
+    fork2_id = fork2.workflow_id
+    assert fork2.get_result() == 3
+    assert fork2.get_status().forked_from == fork1_id
+
+    # An unrelated workflow that must not receive the message.
+    other_id = str(uuid.uuid4())
+    with SetWorkflowID(other_id):
+        assert forkable() == 3
+
+    DBOS.send_bulk([SendMessage(wfid, "hello")], send_to_forks=True)
+
+    dests = _notification_destinations(dbos)
+    assert wfid in dests
+    assert fork1_id in dests  # direct fork
+    assert fork2_id in dests  # fork of a fork (recursive)
+    assert other_id not in dests
+
+
+def test_send_bulk_send_to_forks_disabled(dbos: DBOS) -> None:
+    """Without send_to_forks, only the named destination receives the message."""
+
+    @DBOS.step()
+    def step_a() -> int:
+        return 1
+
+    @DBOS.workflow()
+    def forkable() -> int:
+        return step_a()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert forkable() == 1
+    fork = DBOS.fork_workflow(wfid, 1)
+    fork_id = fork.workflow_id
+    assert fork.get_result() == 1
+
+    DBOS.send_bulk([SendMessage(wfid, "hello")])
+
+    dests = _notification_destinations(dbos)
+    assert wfid in dests
+    assert fork_id not in dests
+
+
+def test_send_bulk_send_to_forks_idempotency_key(dbos: DBOS) -> None:
+    """With an idempotency key, fanning out to forks derives a distinct
+    message_uuid per recipient, and the whole send stays idempotent on repeat."""
+
+    @DBOS.step()
+    def step_a() -> int:
+        return 1
+
+    @DBOS.workflow()
+    def forkable() -> int:
+        return step_a()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert forkable() == 1
+    fork = DBOS.fork_workflow(wfid, 1)
+    fork_id = fork.workflow_id
+    assert fork.get_result() == 1
+
+    key = str(uuid.uuid4())
+
+    def do_send() -> None:
+        DBOS.send_bulk(
+            [SendMessage(wfid, "hello", idempotency_key=key)],
+            send_to_forks=True,
+        )
+
+    do_send()
+    uuids_after_first = _notification_destinations(dbos, message_uuids=True)
+    # One distinct message_uuid per recipient (original + fork).
+    assert f"{key}::{wfid}" in uuids_after_first
+    assert f"{key}::{fork_id}" in uuids_after_first
+
+    # Re-sending with the same key delivers nothing new (idempotent).
+    do_send()
+    assert _notification_destinations(dbos, message_uuids=True) == uuids_after_first
 
 
 def test_set_get_events(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1621,7 +1621,7 @@ def test_debug_logging(
     )
     assert "Running sleep" in caplog.text
     assert "Running set_event" in caplog.text
-    assert "Running send" in caplog.text
+    assert "Running DBOS.send" in caplog.text
 
     result2 = dest_handle.get_result()
     assert result2 == "event_value, test_message"

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import OperationalError
 from dbos import (
     DBOS,
     DBOSConfig,
+    SendMessage,
     SetWorkflowID,
     SetWorkflowTimeout,
     WorkflowHandle,
@@ -1099,6 +1100,128 @@ def test_send_idempotency_key(dbos: DBOS) -> None:
     send_from_step_idem_wf()
     # The second recv times out (returns None), proving only one message was delivered.
     assert handle4.get_result() == "hello_step-None"
+
+
+def test_send_bulk(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def recv_three() -> str:
+        msg1 = DBOS.recv("t", timeout_seconds=10)
+        msg2 = DBOS.recv("t", timeout_seconds=10)
+        msg3 = DBOS.recv(timeout_seconds=10)
+        return f"{msg1}-{msg2}-{msg3}"
+
+    # Test 1: Bulk send to a single destination across topics, from outside a workflow.
+    dest_uuid = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid):
+        handle = dbos.start_workflow(recv_three)
+
+    DBOS.send_bulk(
+        [
+            SendMessage(dest_uuid, "a", "t"),
+            SendMessage(dest_uuid, "b", "t"),
+            SendMessage(dest_uuid, "c"),
+        ]
+    )
+    assert handle.get_result() == "a-b-c"
+
+    # Test 2: Bulk send to multiple destinations in one transaction.
+    dest_a = str(uuid.uuid4())
+    dest_b = str(uuid.uuid4())
+
+    @DBOS.workflow()
+    def recv_one() -> str:
+        return str(DBOS.recv(timeout_seconds=10))
+
+    with SetWorkflowID(dest_a):
+        handle_a = dbos.start_workflow(recv_one)
+    with SetWorkflowID(dest_b):
+        handle_b = dbos.start_workflow(recv_one)
+
+    DBOS.send_bulk(
+        [
+            SendMessage(dest_a, "to_a"),
+            SendMessage(dest_b, "to_b"),
+        ]
+    )
+    assert handle_a.get_result() == "to_a"
+    assert handle_b.get_result() == "to_b"
+
+    # Test 3: A bulk send including a non-existent destination is atomic - nothing is sent.
+    dest_real = str(uuid.uuid4())
+    with SetWorkflowID(dest_real):
+        handle_real = dbos.start_workflow(recv_one)
+    dest_fake = str(uuid.uuid4())
+
+    with pytest.raises(Exception) as exc_info:
+        DBOS.send_bulk(
+            [
+                SendMessage(dest_real, "should_not_arrive"),
+                SendMessage(dest_fake, "to_nowhere"),
+            ]
+        )
+    assert "Non-existent `send_bulk` destination" in str(exc_info.value)
+    # Because the transaction rolled back, no message was delivered: the recv
+    # times out and returns None (stringified by recv_one).
+    assert handle_real.get_result() == "None"
+
+
+def test_send_bulk_from_workflow(dbos: DBOS) -> None:
+    send_counter = 0
+
+    @DBOS.workflow()
+    def recv_two() -> str:
+        msg1 = DBOS.recv(timeout_seconds=10)
+        msg2 = DBOS.recv(timeout_seconds=10)
+        return f"{msg1}-{msg2}"
+
+    dest_uuid = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid):
+        handle = dbos.start_workflow(recv_two)
+
+    @DBOS.workflow()
+    def send_bulk_wf(dest: str) -> None:
+        nonlocal send_counter
+        send_counter += 1
+        DBOS.send_bulk(
+            [
+                SendMessage(dest, "one"),
+                SendMessage(dest, "two"),
+            ]
+        )
+
+    send_uuid = str(uuid.uuid4())
+    with SetWorkflowID(send_uuid):
+        send_bulk_wf(dest_uuid)
+    assert handle.get_result() == "one-two"
+    assert send_counter == 1
+
+    # Re-invoking with the same workflow ID replays the recorded result without
+    # re-running the body, so the bulk send is not executed a second time.
+    with SetWorkflowID(send_uuid):
+        send_bulk_wf(dest_uuid)
+    assert send_counter == 1
+
+
+def test_send_bulk_idempotency_key(dbos: DBOS) -> None:
+    recv_event = threading.Event()
+
+    @DBOS.workflow()
+    def recv_two() -> str:
+        msg1 = DBOS.recv(timeout_seconds=10)
+        recv_event.set()
+        msg2 = DBOS.recv(timeout_seconds=2)
+        return f"{msg1}-{msg2}"
+
+    dest_uuid = str(uuid.uuid4())
+    with SetWorkflowID(dest_uuid):
+        handle = dbos.start_workflow(recv_two)
+
+    idem_key = str(uuid.uuid4())
+    DBOS.send_bulk([SendMessage(dest_uuid, "hello", idempotency_key=idem_key)])
+    recv_event.wait()
+    # A later bulk send reusing a message's idempotency key is silently deduplicated.
+    DBOS.send_bulk([SendMessage(dest_uuid, "duplicate", idempotency_key=idem_key)])
+    assert handle.get_result() == "hello-None"
 
 
 def test_set_get_events(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1159,7 +1159,7 @@ def test_send_bulk(dbos: DBOS) -> None:
                 SendMessage(dest_fake, "to_nowhere"),
             ]
         )
-    assert "Non-existent `send_bulk` destination" in str(exc_info.value)
+    assert "Non-existent `send` destination" in str(exc_info.value)
     # Because the transaction rolled back, no message was delivered: the recv
     # times out and returns None (stringified by recv_one).
     assert handle_real.get_result() == "None"

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1381,6 +1381,43 @@ def test_send_bulk_send_to_forks_idempotency_key(dbos: DBOS) -> None:
     assert _notification_destinations(dbos, message_uuids=True) == uuids_after_first
 
 
+def test_send_bulk_send_to_forks_multiple_destinations(dbos: DBOS) -> None:
+    """A single bulk send to several destinations resolves all of their forks in
+    one go, and each destination only fans out to its own fork subtree."""
+
+    @DBOS.step()
+    def step_a() -> int:
+        return 1
+
+    @DBOS.workflow()
+    def forkable() -> int:
+        return step_a()
+
+    def make_workflow_with_fork() -> tuple[str, str]:
+        wfid = str(uuid.uuid4())
+        with SetWorkflowID(wfid):
+            assert forkable() == 1
+        fork = DBOS.fork_workflow(wfid, 1)
+        assert fork.get_result() == 1
+        return wfid, fork.workflow_id
+
+    wf_a, fork_a = make_workflow_with_fork()
+    wf_b, fork_b = make_workflow_with_fork()
+    # An unrelated workflow (and its fork) that is not a send target.
+    wf_c, fork_c = make_workflow_with_fork()
+
+    DBOS.send_bulk(
+        [SendMessage(wf_a, "to_a"), SendMessage(wf_b, "to_b")],
+        send_to_forks=True,
+    )
+
+    dests = _notification_destinations(dbos)
+    assert {wf_a, fork_a, wf_b, fork_b} <= dests
+    # wf_c's subtree is untouched - each destination only reaches its own forks.
+    assert wf_c not in dests
+    assert fork_c not in dests
+
+
 def test_set_get_events(
     dbos: DBOS, config: DBOSConfig, skip_with_sqlite_imprecise_time: None
 ) -> None:


### PR DESCRIPTION
Also add a `send_to_forks` flag which also sends a message to a workflow's forks (and their forks, recursively).