### PR TITLE
LISTEN/NOTIFY in Streams

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -966,13 +966,17 @@ class DBOSClient:
                     offset += 1
                 except ValueError:
                     # No value yet: stop if the workflow is done, else wait for a
-                    # notification (with a fallback timeout to catch dropped ones).
+                    # notification. A stream write wakes us immediately via
+                    # LISTEN/NOTIFY, but a workflow finishing without writing or
+                    # closing the stream fires none, so poll to notice termination.
                     status = get_workflow(self._sys_db, workflow_id)
                     if status is None:
                         break
                     if not workflow_is_active(status.status):
                         break
-                    event.wait(timeout=self._sys_db._stream_poll_timeout)
+                    event.wait(
+                        timeout=self._sys_db._notification_listener_polling_interval_sec
+                    )
         finally:
             self._sys_db.unregister_stream_listener(payload)
 
@@ -1017,7 +1021,10 @@ class DBOSClient:
                         break
                     if not workflow_is_active(status.status):
                         break
-                    deadline = time.time() + self._sys_db._stream_poll_timeout
+                    deadline = (
+                        time.time()
+                        + self._sys_db._notification_listener_polling_interval_sec
+                    )
                     while not event.is_set():
                         remaining = deadline - time.time()
                         if remaining <= 0:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -185,6 +185,9 @@ class DBOSClient:
             schema=dbos_system_schema,
             serializer=serializer,
             executor_id=None,
+            # The client does not run a notification listener thread, so stream
+            # reads cannot be woken by LISTEN/NOTIFY and instead poll the offset.
+            use_listen_notify=False,
         )
         self._sys_db.check_connection()
 
@@ -969,9 +972,7 @@ class DBOSClient:
                         break
                     if not workflow_is_active(status.status):
                         break
-                    event.wait(
-                        timeout=self._sys_db._notification_fallback_polling_interval
-                    )
+                    event.wait(timeout=self._sys_db._stream_poll_timeout)
         finally:
             self._sys_db.unregister_stream_listener(payload)
 
@@ -1016,10 +1017,7 @@ class DBOSClient:
                         break
                     if not workflow_is_active(status.status):
                         break
-                    deadline = (
-                        time.time()
-                        + self._sys_db._notification_fallback_polling_interval
-                    )
+                    deadline = time.time() + self._sys_db._stream_poll_timeout
                     while not event.is_set():
                         remaining = deadline - time.time()
                         if remaining <= 0:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -966,9 +966,8 @@ class DBOSClient:
                     offset += 1
                 except ValueError:
                     # No value yet: stop if the workflow is done, else wait for a
-                    # notification. A stream write wakes us immediately via
-                    # LISTEN/NOTIFY, but a workflow finishing without writing or
-                    # closing the stream fires none, so poll to notice termination.
+                    # notification. Workflow completion fires none, so the wait
+                    # is bounded by the polling interval to notice termination.
                     status = get_workflow(self._sys_db, workflow_id)
                     if status is None:
                         break

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -949,22 +949,31 @@ class DBOSClient:
             The values written to the stream in order
         """
         offset = 0
-        while True:
-            try:
-                value = self._sys_db.read_stream(workflow_id, key, offset)
-                if value == _dbos_stream_closed_sentinel:
-                    break
-                yield value
-                offset += 1
-            except ValueError:
-                # Poll the offset until a value arrives or the workflow terminates
-                status = get_workflow(self._sys_db, workflow_id)
-                if status is None:
-                    break
-                if not workflow_is_active(status.status):
-                    break
-                time.sleep(1.0)
-                continue
+        event, payload = self._sys_db.register_stream_listener(workflow_id, key)
+        try:
+            while True:
+                # Clear before reading so a notification arriving after the read
+                # leaves the event set and the wait below returns immediately.
+                event.clear()
+                try:
+                    value = self._sys_db.read_stream(workflow_id, key, offset)
+                    if value == _dbos_stream_closed_sentinel:
+                        break
+                    yield value
+                    offset += 1
+                except ValueError:
+                    # No value yet: stop if the workflow is done, else wait for a
+                    # notification (with a fallback timeout to catch dropped ones).
+                    status = get_workflow(self._sys_db, workflow_id)
+                    if status is None:
+                        break
+                    if not workflow_is_active(status.status):
+                        break
+                    event.wait(
+                        timeout=self._sys_db._notification_fallback_polling_interval
+                    )
+        finally:
+            self._sys_db.unregister_stream_listener(payload)
 
     async def read_stream_async(
         self, workflow_id: str, key: str
@@ -982,26 +991,42 @@ class DBOSClient:
             The values written to the stream in order
         """
         offset = 0
-        while True:
-            try:
-                value = await asyncio.to_thread(
-                    self._sys_db.read_stream, workflow_id, key, offset
-                )
-                if value == _dbos_stream_closed_sentinel:
-                    break
-                yield value
-                offset += 1
-            except ValueError:
-                # Poll the offset until a value arrives or the workflow terminates
-                status = await asyncio.to_thread(
-                    get_workflow, self._sys_db, workflow_id
-                )
-                if status is None:
-                    break
-                if not workflow_is_active(status.status):
-                    break
-                await asyncio.sleep(1.0)
-                continue
+        event, payload = self._sys_db.register_stream_listener(workflow_id, key)
+        try:
+            while True:
+                # Clear before reading so a notification arriving after the read
+                # leaves the event set and the wait below returns immediately.
+                event.clear()
+                try:
+                    value = await asyncio.to_thread(
+                        self._sys_db.read_stream, workflow_id, key, offset
+                    )
+                    if value == _dbos_stream_closed_sentinel:
+                        break
+                    yield value
+                    offset += 1
+                except ValueError:
+                    # No value yet: stop if the workflow is done, else wait for a
+                    # notification. Poll the event with short asyncio sleeps (no
+                    # held thread), bounded by the fallback re-check interval.
+                    status = await asyncio.to_thread(
+                        get_workflow, self._sys_db, workflow_id
+                    )
+                    if status is None:
+                        break
+                    if not workflow_is_active(status.status):
+                        break
+                    deadline = (
+                        time.time()
+                        + self._sys_db._notification_fallback_polling_interval
+                    )
+                    while not event.is_set():
+                        remaining = deadline - time.time()
+                        if remaining <= 0:
+                            break
+                        await asyncio.sleep(min(remaining, 0.1))
+        finally:
+            self._sys_db.unregister_stream_listener(payload)
 
     # ── Schedule API ──────────────────────────────────────────────
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3115,7 +3115,7 @@ class DBOS:
         polling_interval = (
             polling_interval_sec
             if polling_interval_sec is not None
-            else dbos_instance._notification_listener_polling_interval_sec
+            else sys_db._stream_poll_timeout
         )
 
         event, payload = sys_db.register_stream_listener(workflow_id, key)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3025,20 +3025,27 @@ class DBOS:
         offset = 0
         sys_db = _get_dbos_instance()._sys_db
 
-        while True:
-            try:
-                value = sys_db.read_stream(workflow_id, key, offset)
-                if value == _dbos_stream_closed_sentinel:
-                    break
-                yield value
-                offset += 1
-            except ValueError:
-                # Poll the offset until a value arrives or the workflow terminates
-                status = cls.retrieve_workflow(workflow_id).get_status().status
-                if not workflow_is_active(status):
-                    break
-                time.sleep(1.0)
-                continue
+        event, payload = sys_db.register_stream_listener(workflow_id, key)
+        try:
+            while True:
+                # Clear before reading so a notification arriving after the read
+                # leaves the event set and the wait below returns immediately.
+                event.clear()
+                try:
+                    value = sys_db.read_stream(workflow_id, key, offset)
+                    if value == _dbos_stream_closed_sentinel:
+                        break
+                    yield value
+                    offset += 1
+                except ValueError:
+                    # No value yet: stop if the workflow is done, else wait for a
+                    # notification (with a fallback timeout to catch dropped ones).
+                    status = cls.retrieve_workflow(workflow_id).get_status().status
+                    if not workflow_is_active(status):
+                        break
+                    event.wait(timeout=sys_db._notification_fallback_polling_interval)
+        finally:
+            sys_db.unregister_stream_listener(payload)
 
     @classmethod
     async def write_stream_async(
@@ -3094,7 +3101,7 @@ class DBOS:
         Args:
             workflow_id(str): The workflow instance ID that owns the stream
             key(str): The stream key / name within the workflow
-            polling_interval_sec(float, optional): Polling interval in seconds when waiting for new values.
+            polling_interval_sec(float, optional): Polling interval in seconds when waiting for new values when not using LISTEN/NOTIFY.
                 Defaults to the configured notification_listener_polling_interval_sec (1.0 if not configured).
 
         Yields:
@@ -3111,25 +3118,38 @@ class DBOS:
             else dbos_instance._notification_listener_polling_interval_sec
         )
 
-        while True:
-            try:
-                value = await asyncio.to_thread(
-                    sys_db.read_stream, workflow_id, key, offset
-                )
-                if value == _dbos_stream_closed_sentinel:
-                    break
-                yield value
-                offset += 1
-            except ValueError:
-                # Poll the offset until a value arrives or the workflow terminates
-                handle: WorkflowHandleAsync[Any] = await cls.retrieve_workflow_async(
-                    workflow_id
-                )
-                status = await handle.get_status()
-                if not workflow_is_active(status.status):
-                    break
-                await asyncio.sleep(polling_interval)
-                continue
+        event, payload = sys_db.register_stream_listener(workflow_id, key)
+        try:
+            while True:
+                # Clear before reading so a notification arriving after the read
+                # leaves the event set and the wait below returns immediately.
+                event.clear()
+                try:
+                    value = await asyncio.to_thread(
+                        sys_db.read_stream, workflow_id, key, offset
+                    )
+                    if value == _dbos_stream_closed_sentinel:
+                        break
+                    yield value
+                    offset += 1
+                except ValueError:
+                    # No value yet: stop if the workflow is done, else wait for a
+                    # notification. Poll the event with short asyncio sleeps (no
+                    # held thread), bounded by the fallback re-check interval.
+                    handle: WorkflowHandleAsync[Any] = (
+                        await cls.retrieve_workflow_async(workflow_id)
+                    )
+                    status = await handle.get_status()
+                    if not workflow_is_active(status.status):
+                        break
+                    deadline = time.time() + polling_interval
+                    while not event.is_set():
+                        remaining = deadline - time.time()
+                        if remaining <= 0:
+                            break
+                        await asyncio.sleep(min(remaining, 0.1))
+        finally:
+            sys_db.unregister_stream_listener(payload)
 
     @classmethod
     def patch(cls, patch_name: str) -> bool:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3039,11 +3039,15 @@ class DBOS:
                     offset += 1
                 except ValueError:
                     # No value yet: stop if the workflow is done, else wait for a
-                    # notification (with a fallback timeout to catch dropped ones).
+                    # notification. A stream write wakes us immediately via
+                    # LISTEN/NOTIFY, but a workflow finishing without writing or
+                    # closing the stream fires none, so poll to notice termination.
                     status = cls.retrieve_workflow(workflow_id).get_status().status
                     if not workflow_is_active(status):
                         break
-                    event.wait(timeout=sys_db._stream_poll_timeout)
+                    event.wait(
+                        timeout=sys_db._notification_listener_polling_interval_sec
+                    )
         finally:
             sys_db.unregister_stream_listener(payload)
 
@@ -3115,7 +3119,7 @@ class DBOS:
         polling_interval = (
             polling_interval_sec
             if polling_interval_sec is not None
-            else sys_db._stream_poll_timeout
+            else sys_db._notification_listener_polling_interval_sec
         )
 
         event, payload = sys_db.register_stream_listener(workflow_id, key)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3043,7 +3043,7 @@ class DBOS:
                     status = cls.retrieve_workflow(workflow_id).get_status().status
                     if not workflow_is_active(status):
                         break
-                    event.wait(timeout=sys_db._notification_fallback_polling_interval)
+                    event.wait(timeout=sys_db._stream_poll_timeout)
         finally:
             sys_db.unregister_stream_listener(payload)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3039,9 +3039,8 @@ class DBOS:
                     offset += 1
                 except ValueError:
                     # No value yet: stop if the workflow is done, else wait for a
-                    # notification. A stream write wakes us immediately via
-                    # LISTEN/NOTIFY, but a workflow finishing without writing or
-                    # closing the stream fires none, so poll to notice termination.
+                    # notification. Workflow completion fires none, so the wait
+                    # is bounded by the polling interval to notice termination.
                     status = cls.retrieve_workflow(workflow_id).get_status().status
                     if not workflow_is_active(status):
                         break

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -826,9 +826,10 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
     return migration
 
 
-def get_dbos_migration_thirtynine(
-    schema: str, use_listen_notify: bool, is_cockroach: bool
-) -> str:
+def get_dbos_migration_thirtynine(schema: str, use_listen_notify: bool) -> str:
+    # Gated on use_listen_notify only, matching the notifications/workflow_events
+    # triggers in migration one. Deployments without LISTEN/NOTIFY (e.g.
+    # CockroachDB) set use_listen_notify=False and use the polling fallback.
     if not use_listen_notify:
         return ""
     return f"""
@@ -894,7 +895,7 @@ def get_dbos_migrations(
         get_dbos_migration_thirtysix(schema),
         get_dbos_migration_thirtyseven(schema, is_cockroach),
         get_dbos_migration_thirtyeight(schema, is_cockroach),
-        get_dbos_migration_thirtynine(schema, use_listen_notify, is_cockroach),
+        get_dbos_migration_thirtynine(schema, use_listen_notify),
     ]
 
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -826,6 +826,34 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
     return migration
 
 
+def get_dbos_migration_thirtynine(
+    schema: str, use_listen_notify: bool, is_cockroach: bool
+) -> str:
+    # CockroachDB does not support LISTEN/NOTIFY, so it always uses the polling
+    # fallback and never installs this trigger.
+    if not use_listen_notify:
+        return ""
+    return f"""
+-- Create streams notification function
+CREATE OR REPLACE FUNCTION "{schema}".streams_function() RETURNS TRIGGER AS $$
+DECLARE
+    payload text := NEW.workflow_uuid || '::' || NEW.key;
+BEGIN
+    PERFORM pg_notify('dbos_streams_channel', payload);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER FUNCTION "{schema}".streams_function() SET search_path = pg_catalog, pg_temp;
+
+-- Create streams trigger
+DROP TRIGGER IF EXISTS dbos_streams_trigger ON "{schema}".streams;
+CREATE TRIGGER dbos_streams_trigger
+AFTER INSERT ON "{schema}".streams
+FOR EACH ROW EXECUTE FUNCTION "{schema}".streams_function();
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -868,6 +896,7 @@ def get_dbos_migrations(
         get_dbos_migration_thirtysix(schema),
         get_dbos_migration_thirtyseven(schema, is_cockroach),
         get_dbos_migration_thirtyeight(schema, is_cockroach),
+        get_dbos_migration_thirtynine(schema, use_listen_notify, is_cockroach),
     ]
 
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -829,8 +829,6 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
 def get_dbos_migration_thirtynine(
     schema: str, use_listen_notify: bool, is_cockroach: bool
 ) -> str:
-    # CockroachDB does not support LISTEN/NOTIFY, so it always uses the polling
-    # fallback and never installs this trigger.
     if not use_listen_notify:
         return ""
     return f"""

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2627,6 +2627,20 @@ class SystemDatabase(ABC):
     # The interval that recv and get_event poll on as a fallback to catch dropped notifications
     _notification_fallback_polling_interval: float = 60.0
 
+    @property
+    def _stream_poll_timeout(self) -> float:
+        """How long a blocked stream reader waits before re-reading its offset.
+
+        With LISTEN/NOTIFY a notification wakes the reader sooner and this is
+        only the fallback for dropped notifications. Without a listener (e.g. the
+        client), the wait itself is the poll, so use the shorter polling interval.
+        """
+        return (
+            self._notification_fallback_polling_interval
+            if self.use_listen_notify
+            else self._notification_listener_polling_interval_sec
+        )
+
     def recv(
         self,
         workflow_uuid: str,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2627,20 +2627,6 @@ class SystemDatabase(ABC):
     # The interval that recv and get_event poll on as a fallback to catch dropped notifications
     _notification_fallback_polling_interval: float = 60.0
 
-    @property
-    def _stream_poll_timeout(self) -> float:
-        """How long a blocked stream reader waits before re-reading its offset.
-
-        With LISTEN/NOTIFY a notification wakes the reader sooner and this is
-        only the fallback for dropped notifications. Without a listener (e.g. the
-        client), the wait itself is the poll, so use the shorter polling interval.
-        """
-        return (
-            self._notification_fallback_polling_interval
-            if self.use_listen_notify
-            else self._notification_listener_polling_interval_sec
-        )
-
     def recv(
         self,
         workflow_uuid: str,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -553,6 +553,7 @@ class SystemDatabase(ABC):
 
         self.notifications_map = ThreadSafeEventDict()
         self.workflow_events_map = ThreadSafeEventDict()
+        self.streams_map = ThreadSafeEventDict()
         self.executor_id = executor_id
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
@@ -2755,6 +2756,27 @@ class SystemDatabase(ABC):
                             event.set()
                             dbos_logger.debug(f"Signaled event for {payload}")
 
+                # Check all entries in the streams_map. A stream reader re-reads
+                # at its own offset on wakeup, so any row for (workflow_uuid, key)
+                # is a sufficient hint to re-check.
+                for (
+                    payload,
+                    (workflow_uuid, key),
+                    event,
+                ) in self.streams_map.snapshot():
+                    with self.engine.begin() as conn:
+                        result = conn.execute(
+                            sa.select(sa.literal(1))
+                            .where(
+                                SystemSchema.streams.c.workflow_uuid == workflow_uuid,
+                                SystemSchema.streams.c.key == key,
+                            )
+                            .limit(1)
+                        )
+                        if result.fetchone():
+                            event.set()
+                            dbos_logger.debug(f"Signaled event for {payload}")
+
             except Exception as e:
                 if self._run_background_processes:
                     dbos_logger.warning(f"Notification poller error: {e}")
@@ -3742,6 +3764,25 @@ class SystemDatabase(ABC):
             _dbos_stream_closed_sentinel,
             serialization_type=WorkflowSerializationFormat.PORTABLE,
         )
+
+    def register_stream_listener(
+        self, workflow_uuid: str, key: str
+    ) -> Tuple[threading.Event, str]:
+        """Register an event for the listener to signal when the stream is written.
+
+        Returns the event to wait on and the payload key to unregister later.
+        Must be called before reading so a notification arriving between a read
+        and the wait is not lost.
+        """
+        payload = f"{workflow_uuid}::{key}"
+        _, event = self.streams_map.set(
+            payload, threading.Event(), (workflow_uuid, key)
+        )
+        return event, payload
+
+    def unregister_stream_listener(self, payload: str) -> None:
+        """Drop a previously registered stream listener event."""
+        self.streams_map.pop(payload)
 
     @db_retry()
     def read_stream(self, workflow_uuid: str, key: str, offset: int) -> Any:

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -156,6 +156,7 @@ class PostgresSystemDatabase(SystemDatabase):
 
                     psycopg_conn.execute("LISTEN dbos_notifications_channel")
                     psycopg_conn.execute("LISTEN dbos_workflow_events_channel")
+                    psycopg_conn.execute("LISTEN dbos_streams_channel")
                 while self._run_background_processes:
                     gen = psycopg_conn.notifies()
                     for notify in gen:
@@ -180,6 +181,15 @@ class PostgresSystemDatabase(SystemDatabase):
                                 event.set()
                                 dbos_logger.debug(
                                     f"Signaled workflow_events event for {notify.payload}"
+                                )
+                        elif channel == "dbos_streams_channel":
+                            if notify.payload:
+                                event = self.streams_map.get(notify.payload)
+                                if event is None:
+                                    continue
+                                event.set()
+                                dbos_logger.debug(
+                                    f"Signaled streams event for {notify.payload}"
                                 )
                         else:
                             dbos_logger.error(f"Unknown channel: {channel}")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -113,6 +113,41 @@ def test_stream_concurrent_write_read(dbos: DBOS) -> None:
     assert read_values == expected_values
 
 
+def test_stream_low_latency_delivery(dbos: DBOS) -> None:
+    """Values should reach a blocked reader promptly via LISTEN/NOTIFY rather
+    than after a fixed polling interval. Each value carries the wall-clock time
+    it was written; the reader asserts it received the value shortly after."""
+    stream_key = "latency_stream"
+    num_values = 5
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for _ in range(num_values):
+            # Capture the write time as close to the write as possible, then
+            # pause so the reader is genuinely blocked waiting for the next one.
+            DBOS.write_stream(stream_key, time.time())
+            DBOS.sleep(1.0)
+        DBOS.close_stream(stream_key)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(writer_workflow)
+
+    max_latency = 0.0
+    count = 0
+    for written_at in DBOS.read_stream(wfid, stream_key):
+        latency = time.time() - written_at
+        max_latency = max(max_latency, latency)
+        count += 1
+
+    handle.get_result()
+
+    assert count == num_values
+    # NOTIFY delivery is single-digit milliseconds; a 1s polling fallback would
+    # average ~0.5s and frequently exceed this across several values.
+    assert max_latency < 0.5, f"max delivery latency {max_latency:.3f}s too high"
+
+
 def test_stream_multiple_keys(dbos: DBOS) -> None:
     """Test multiple streams with different keys in the same workflow."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -180,10 +180,11 @@ def test_stream_low_latency_delivery(
     assert count == num_values
     assert max_latency < 0.5, f"DBOS delivery latency {max_latency:.3f}s too high"
 
-    # Out-of-process client: no notification listener thread, so it polls the
-    # offset at ~1s. Verify it still delivers every value, bounded well under
-    # the 60s dropped-notification fallback (i.e. it is actually polling, not
-    # stuck waiting on a notification that never arrives).
+    # Out-of-process client: no notification listener thread, so its event is
+    # never signaled and each read falls back to re-reading the offset once
+    # event.wait times out (notification_listener_polling_interval_sec, ~1s by
+    # default). Verify it still delivers every value, confirming it actually
+    # polls rather than blocking forever on a notification that never arrives.
     client_wfid = str(uuid.uuid4())
     with SetWorkflowID(client_wfid):
         client_handle = DBOS.start_workflow(writer_workflow)
@@ -252,10 +253,11 @@ async def test_stream_low_latency_delivery_async(
     assert count == num_values
     assert max_latency < 0.5, f"DBOS delivery latency {max_latency:.3f}s too high"
 
-    # Out-of-process client: no notification listener thread, so it polls the
-    # offset at ~1s. Verify it still delivers every value, bounded well under
-    # the 60s dropped-notification fallback (i.e. it is actually polling, not
-    # stuck waiting on a notification that never arrives).
+    # Out-of-process client: no notification listener thread, so its event is
+    # never signaled and each read falls back to re-reading the offset once
+    # event.wait times out (notification_listener_polling_interval_sec, ~1s by
+    # default). Verify it still delivers every value, confirming it actually
+    # polls rather than blocking forever on a notification that never arrives.
     client_wfid = str(uuid.uuid4())
     with SetWorkflowID(client_wfid):
         client_handle = await DBOS.start_workflow_async(writer_workflow)
@@ -721,7 +723,9 @@ async def test_stream_termination_while_reader_blocked_async(dbos: DBOS) -> None
 
     await handle.get_result()
     assert read_values == ["only_value"]
-    # Far below the 60s fallback the buggy implementation waited out.
+    # Termination fires no notification, so the reader only notices once its
+    # event.wait times out and re-checks the workflow status (one polling
+    # interval, ~1s by default); comfortably under the 10s bound.
     assert elapsed < 10.0, f"reader took {elapsed:.1f}s to notice termination"
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -123,7 +123,7 @@ def test_stream_low_latency_delivery(
     out-of-process (client) reader (polling), and an in-process reader with
     LISTEN/NOTIFY disabled (polling)."""
     stream_key = "latency_stream"
-    num_values = 5
+    num_values = 3
 
     @DBOS.workflow()
     def writer_workflow() -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -185,6 +185,80 @@ def test_stream_low_latency_delivery(
     ), f"polling DBOS delivery latency {max_latency:.3f}s too high"
 
 
+@pytest.mark.asyncio
+async def test_stream_low_latency_delivery_async(
+    config: DBOSConfig, dbos: DBOS, client: DBOSClient
+) -> None:
+    """Async counterpart of test_stream_low_latency_delivery, exercising the
+    read_stream_async paths for the in-process (DBOS) reader with LISTEN/NOTIFY,
+    the out-of-process (client) reader (polling), and an in-process reader with
+    LISTEN/NOTIFY disabled (polling)."""
+    stream_key = "latency_stream_async"
+    num_values = 3
+
+    @DBOS.workflow()
+    async def writer_workflow() -> None:
+        for _ in range(num_values):
+            # Capture the write time as close to the write as possible, then
+            # pause so the reader is genuinely blocked waiting for the next one.
+            await DBOS.write_stream_async(stream_key, time.time())
+            await DBOS.sleep_async(1.0)
+        await DBOS.close_stream_async(stream_key)
+
+    async def measure(read_aiter: Any) -> tuple[int, float]:
+        max_latency = 0.0
+        count = 0
+        async for written_at in read_aiter:
+            max_latency = max(max_latency, time.time() - written_at)
+            count += 1
+        return count, max_latency
+
+    # In-process DBOS reader woken by LISTEN/NOTIFY. Force a long polling
+    # interval so low latency can only come from a notification, not the poll.
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(writer_workflow)
+    count, max_latency = await measure(
+        DBOS.read_stream_async(wfid, stream_key, polling_interval_sec=60.0)
+    )
+    await handle.get_result()
+    assert count == num_values
+    assert max_latency < 0.5, f"DBOS delivery latency {max_latency:.3f}s too high"
+
+    # Out-of-process client: no notification listener thread, so it polls the
+    # offset at ~1s. Verify it still delivers every value, bounded well under
+    # the 60s dropped-notification fallback (i.e. it is actually polling, not
+    # stuck waiting on a notification that never arrives).
+    client_wfid = str(uuid.uuid4())
+    with SetWorkflowID(client_wfid):
+        client_handle = await DBOS.start_workflow_async(writer_workflow)
+    count, max_latency = await measure(
+        client.read_stream_async(client_wfid, stream_key)
+    )
+    await client_handle.get_result()
+    assert count == num_values
+    assert max_latency < 2.0, f"client delivery latency {max_latency:.3f}s too high"
+
+    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
+    # reader still receives every value via the polling fallback. The trigger
+    # installed earlier harmlessly fires notifications that nobody listens for;
+    # the reader is woken by the polling listener thread instead.
+    DBOS.destroy(destroy_registry=False)
+    config["use_listen_notify"] = False
+    DBOS(config=config)
+    DBOS.launch()
+
+    poll_wfid = str(uuid.uuid4())
+    with SetWorkflowID(poll_wfid):
+        poll_handle = await DBOS.start_workflow_async(writer_workflow)
+    count, max_latency = await measure(DBOS.read_stream_async(poll_wfid, stream_key))
+    await poll_handle.get_result()
+    assert count == num_values
+    assert (
+        max_latency < 2.0
+    ), f"polling DBOS delivery latency {max_latency:.3f}s too high"
+
+
 def test_stream_multiple_keys(dbos: DBOS) -> None:
     """Test multiple streams with different keys in the same workflow."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 # Public API
-from dbos import DBOS, SetWorkflowID
+from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._client import DBOSClient
 
 
@@ -113,11 +113,15 @@ def test_stream_concurrent_write_read(dbos: DBOS) -> None:
     assert read_values == expected_values
 
 
-def test_stream_low_latency_delivery(dbos: DBOS, client: DBOSClient) -> None:
+def test_stream_low_latency_delivery(
+    config: DBOSConfig, dbos: DBOS, client: DBOSClient
+) -> None:
     """Values should reach a blocked reader promptly via LISTEN/NOTIFY rather
     than after a fixed polling interval. Each value carries the wall-clock time
     it was written; the reader asserts it received the value shortly after.
-    Verified for both the in-process (DBOS) and out-of-process (client) readers."""
+    Verified for the in-process (DBOS) reader with LISTEN/NOTIFY, the
+    out-of-process (client) reader (polling), and an in-process reader with
+    LISTEN/NOTIFY disabled (polling)."""
     stream_key = "latency_stream"
     num_values = 5
 
@@ -160,6 +164,25 @@ def test_stream_low_latency_delivery(dbos: DBOS, client: DBOSClient) -> None:
     client_handle.get_result()
     assert count == num_values
     assert max_latency < 2.0, f"client delivery latency {max_latency:.3f}s too high"
+
+    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
+    # reader still receives every value via the polling fallback. The trigger
+    # installed earlier harmlessly fires notifications that nobody listens for;
+    # the reader is woken by the polling listener thread instead.
+    DBOS.destroy(destroy_registry=False)
+    config["use_listen_notify"] = False
+    DBOS(config=config)
+    DBOS.launch()
+
+    poll_wfid = str(uuid.uuid4())
+    with SetWorkflowID(poll_wfid):
+        poll_handle = DBOS.start_workflow(writer_workflow)
+    count, max_latency = measure(DBOS.read_stream(poll_wfid, stream_key))
+    poll_handle.get_result()
+    assert count == num_values
+    assert (
+        max_latency < 2.0
+    ), f"polling DBOS delivery latency {max_latency:.3f}s too high"
 
 
 def test_stream_multiple_keys(dbos: DBOS) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -113,10 +113,11 @@ def test_stream_concurrent_write_read(dbos: DBOS) -> None:
     assert read_values == expected_values
 
 
-def test_stream_low_latency_delivery(dbos: DBOS) -> None:
+def test_stream_low_latency_delivery(dbos: DBOS, client: DBOSClient) -> None:
     """Values should reach a blocked reader promptly via LISTEN/NOTIFY rather
     than after a fixed polling interval. Each value carries the wall-clock time
-    it was written; the reader asserts it received the value shortly after."""
+    it was written; the reader asserts it received the value shortly after.
+    Verified for both the in-process (DBOS) and out-of-process (client) readers."""
     stream_key = "latency_stream"
     num_values = 5
 
@@ -129,23 +130,36 @@ def test_stream_low_latency_delivery(dbos: DBOS) -> None:
             DBOS.sleep(1.0)
         DBOS.close_stream(stream_key)
 
+    def measure(read_iter: Any) -> tuple[int, float]:
+        max_latency = 0.0
+        count = 0
+        for written_at in read_iter:
+            max_latency = max(max_latency, time.time() - written_at)
+            count += 1
+        return count, max_latency
+
+    # In-process DBOS reader: woken by LISTEN/NOTIFY, so delivery is single-digit
+    # milliseconds. A 1s polling fallback would average ~0.5s and frequently
+    # exceed this across several values.
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         handle = DBOS.start_workflow(writer_workflow)
-
-    max_latency = 0.0
-    count = 0
-    for written_at in DBOS.read_stream(wfid, stream_key):
-        latency = time.time() - written_at
-        max_latency = max(max_latency, latency)
-        count += 1
-
+    count, max_latency = measure(DBOS.read_stream(wfid, stream_key))
     handle.get_result()
-
     assert count == num_values
-    # NOTIFY delivery is single-digit milliseconds; a 1s polling fallback would
-    # average ~0.5s and frequently exceed this across several values.
-    assert max_latency < 0.5, f"max delivery latency {max_latency:.3f}s too high"
+    assert max_latency < 0.5, f"DBOS delivery latency {max_latency:.3f}s too high"
+
+    # Out-of-process client: no notification listener thread, so it polls the
+    # offset at ~1s. Verify it still delivers every value, bounded well under
+    # the 60s dropped-notification fallback (i.e. it is actually polling, not
+    # stuck waiting on a notification that never arrives).
+    client_wfid = str(uuid.uuid4())
+    with SetWorkflowID(client_wfid):
+        client_handle = DBOS.start_workflow(writer_workflow)
+    count, max_latency = measure(client.read_stream(client_wfid, stream_key))
+    client_handle.get_result()
+    assert count == num_values
+    assert max_latency < 2.0, f"client delivery latency {max_latency:.3f}s too high"
 
 
 def test_stream_multiple_keys(dbos: DBOS) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -78,6 +78,33 @@ def test_unclosed_stream(dbos: DBOS) -> None:
     assert read_values == test_values
 
 
+def test_stream_termination_while_reader_blocked(dbos: DBOS) -> None:
+    """A reader that catches up to an open stream while the writer is still
+    running must terminate promptly once the workflow completes, even though no
+    value or close marker wakes it. Unlike the other unclosed-stream tests, which
+    read only after the workflow finished, this forces the blocking wait path."""
+    stream_key = "termination_latency_stream"
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        # Write once, then stay alive without writing or closing, so the reader
+        # catches up and blocks waiting for the workflow to terminate.
+        DBOS.write_stream(stream_key, "only_value")
+        DBOS.sleep(2.0)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(writer_workflow)
+
+    start = time.time()
+    read_values = list(DBOS.read_stream(wfid, stream_key))
+    elapsed = time.time() - start
+
+    handle.get_result()
+    assert read_values == ["only_value"]
+    assert elapsed < 10.0, f"reader took {elapsed:.1f}s to notice termination"
+
+
 def test_stream_concurrent_write_read(dbos: DBOS) -> None:
     """Test reading from a stream while it's being written to."""
     stream_key = "concurrent_stream"
@@ -667,6 +694,35 @@ async def test_unclosed_stream_async(dbos: DBOS) -> None:
         read_values.append(value)
 
     assert read_values == test_values
+
+
+@pytest.mark.asyncio
+async def test_stream_termination_while_reader_blocked_async(dbos: DBOS) -> None:
+    """Async counterpart of test_stream_termination_while_reader_blocked,
+    exercising the read_stream_async termination path."""
+    stream_key = "termination_latency_stream_async"
+
+    @DBOS.workflow()
+    async def writer_workflow() -> None:
+        # Write once, then stay alive without writing or closing, so the reader
+        # catches up and blocks waiting for the workflow to terminate.
+        await DBOS.write_stream_async(stream_key, "only_value")
+        await DBOS.sleep_async(2.0)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(writer_workflow)
+
+    start = time.time()
+    read_values = []
+    async for value in DBOS.read_stream_async(wfid, stream_key):
+        read_values.append(value)
+    elapsed = time.time() - start
+
+    await handle.get_result()
+    assert read_values == ["only_value"]
+    # Far below the 60s fallback the buggy implementation waited out.
+    assert elapsed < 10.0, f"reader took {elapsed:.1f}s to notice termination"
 
 
 def test_client_read_stream(dbos: DBOS, client: DBOSClient) -> None:


### PR DESCRIPTION
`DBOS.read_stream` now uses LISTEN/NOTIFY to receive new stream messages with lower latency. Polling remains as a fallback.

Closes https://github.com/dbos-inc/dbos-transact-py/issues/686