### PR TITLE
Fix list schedules context desez

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -44,6 +44,7 @@ from dbos._serialization import (
     DefaultSerializer,
     Serializer,
     WorkflowSerializationFormat,
+    deserialize_schedule_context,
     serialize_args,
 )
 from dbos._sys_db import (
@@ -1157,15 +1158,17 @@ class DBOSClient:
             schedule_name_prefix=schedule_name_prefix,
         )
         for s in schedules:
-            s["context"] = self._sys_db.serializer.deserialize(s["context"])
+            s["context"] = deserialize_schedule_context(
+                self._sys_db.serializer, s["context"]
+            )
         return schedules
 
     def get_schedule(self, name: str) -> Optional[WorkflowSchedule]:
         """Return the schedule with the given name, or ``None`` if it does not exist."""
         schedule = self._sys_db.get_schedule(name)
         if schedule is not None:
-            schedule["context"] = self._sys_db.serializer.deserialize(
-                schedule["context"]
+            schedule["context"] = deserialize_schedule_context(
+                self._sys_db.serializer, schedule["context"]
             )
         return schedule
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -44,7 +44,7 @@ from dbos._serialization import (
     DefaultSerializer,
     Serializer,
     WorkflowSerializationFormat,
-    deserialize_schedule_context,
+    safe_deserialize_schedule_context,
     serialize_args,
 )
 from dbos._sys_db import (
@@ -1158,8 +1158,10 @@ class DBOSClient:
             schedule_name_prefix=schedule_name_prefix,
         )
         for s in schedules:
-            s["context"] = deserialize_schedule_context(
-                self._sys_db.serializer, s["context"]
+            s["context"] = safe_deserialize_schedule_context(
+                self._sys_db.serializer,
+                s["schedule_name"],
+                serialized_context=s["context"],
             )
         return schedules
 
@@ -1167,8 +1169,10 @@ class DBOSClient:
         """Return the schedule with the given name, or ``None`` if it does not exist."""
         schedule = self._sys_db.get_schedule(name)
         if schedule is not None:
-            schedule["context"] = deserialize_schedule_context(
-                self._sys_db.serializer, schedule["context"]
+            schedule["context"] = safe_deserialize_schedule_context(
+                self._sys_db.serializer,
+                schedule["schedule_name"],
+                serialized_context=schedule["context"],
             )
         return schedule
 

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypedDict, TypeVar, Union
 
-from dbos._serialization import Serializer
+from dbos._serialization import Serializer, deserialize_schedule_context
 from dbos._sys_db import (
     NotificationInfo,
     StepInfo,
@@ -546,8 +546,10 @@ class ScheduleOutput:
         *,
         load_context: bool = True,
     ) -> "ScheduleOutput":
-        context_str = (
-            str(serializer.deserialize(s["context"])) if load_context else None
+        context_str: Optional[str] = (
+            str(deserialize_schedule_context(serializer, s["context"]))
+            if load_context
+            else None
         )
         return cls(
             schedule_id=s["schedule_id"],

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypedDict, TypeVar, Union
 
-from dbos._serialization import Serializer, deserialize_schedule_context
+from dbos._serialization import Serializer, safe_deserialize_schedule_context
 from dbos._sys_db import (
     NotificationInfo,
     StepInfo,
@@ -547,7 +547,13 @@ class ScheduleOutput:
         load_context: bool = True,
     ) -> "ScheduleOutput":
         context_str: Optional[str] = (
-            str(deserialize_schedule_context(serializer, s["context"]))
+            str(
+                safe_deserialize_schedule_context(
+                    serializer,
+                    s["schedule_name"],
+                    serialized_context=s["context"],
+                )
+            )
             if load_context
             else None
         )

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -42,8 +42,8 @@ from dbos._serialization import (
     DefaultSerializer,
     Serializer,
     WorkflowSerializationFormat,
-    deserialize_schedule_context,
     deserialize_value,
+    safe_deserialize_schedule_context,
     serialize_value,
 )
 from dbos._sys_db import SystemDatabase, WorkflowStatus
@@ -2642,8 +2642,10 @@ class DBOS:
                 schedule_name_prefix=schedule_name_prefix,
             )
         for s in schedules:
-            s["context"] = deserialize_schedule_context(
-                dbos._sys_db.serializer, s["context"]
+            s["context"] = safe_deserialize_schedule_context(
+                dbos._sys_db.serializer,
+                s["schedule_name"],
+                serialized_context=s["context"],
             )
         return schedules
 
@@ -2663,8 +2665,10 @@ class DBOS:
         else:
             schedule = dbos._sys_db.get_schedule(name)
         if schedule is not None:
-            schedule["context"] = deserialize_schedule_context(
-                dbos._sys_db.serializer, schedule["context"]
+            schedule["context"] = safe_deserialize_schedule_context(
+                dbos._sys_db.serializer,
+                schedule["schedule_name"],
+                serialized_context=schedule["context"],
             )
         return schedule
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -42,6 +42,7 @@ from dbos._serialization import (
     DefaultSerializer,
     Serializer,
     WorkflowSerializationFormat,
+    deserialize_schedule_context,
     deserialize_value,
     serialize_value,
 )
@@ -2641,7 +2642,9 @@ class DBOS:
                 schedule_name_prefix=schedule_name_prefix,
             )
         for s in schedules:
-            s["context"] = dbos._sys_db.serializer.deserialize(s["context"])
+            s["context"] = deserialize_schedule_context(
+                dbos._sys_db.serializer, s["context"]
+            )
         return schedules
 
     @classmethod
@@ -2660,8 +2663,8 @@ class DBOS:
         else:
             schedule = dbos._sys_db.get_schedule(name)
         if schedule is not None:
-            schedule["context"] = dbos._sys_db.serializer.deserialize(
-                schedule["context"]
+            schedule["context"] = deserialize_schedule_context(
+                dbos._sys_db.serializer, schedule["context"]
             )
         return schedule
 

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -90,6 +90,13 @@ class Serializer(ABC):
         return "custom_serializer"
 
 
+def deserialize_schedule_context(serializer: "Serializer", context: str) -> Any:
+    try:
+        return serializer.deserialize(context)
+    except Exception as e:
+        return f"<error deserializing context: {e}>"
+
+
 class DefaultSerializer(Serializer):
 
     def serialize(self, data: Any) -> str:

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -90,13 +90,6 @@ class Serializer(ABC):
         return "custom_serializer"
 
 
-def deserialize_schedule_context(serializer: "Serializer", context: str) -> Any:
-    try:
-        return serializer.deserialize(context)
-    except Exception as e:
-        return f"<error deserializing context: {e}>"
-
-
 class DefaultSerializer(Serializer):
 
     def serialize(self, data: Any) -> str:
@@ -442,3 +435,25 @@ def safe_deserialize(
         )
         exception = serialized_exception  # type: ignore
     return input, output, exception
+
+
+def safe_deserialize_schedule_context(
+    serializer: Serializer,
+    schedule_name: str,
+    *,
+    serialized_context: str,
+) -> Any:
+    """
+    This function safely deserializes a schedule's recorded context.
+    If it is not deserializable, it logs a warning and returns a string instead of throwing an exception.
+
+    This function is used in schedule introspection methods (list_schedules and get_schedule)
+    to ensure errors related to nondeserializable objects are observable.
+    """
+    try:
+        return serializer.deserialize(serialized_context)
+    except Exception as e:
+        dbos_logger.warning(
+            f"Warning: context object could not be deserialized for schedule {schedule_name}, returning as string: {e}"
+        )
+        return serialized_context

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -130,8 +130,8 @@ def test_list_schedules_undeserializable_context(
     # Regression: a schedule's context is serialized application data. If the
     # application code changes so the context can no longer be deserialized (e.g. a
     # class it was pickled against is removed/renamed), listing schedules must not
-    # fail for *all* schedules. The bad one carries an error marker; others come
-    # through intact.
+    # fail for *all* schedules. The bad one comes back as its raw serialized string
+    # (and logs a warning); others come through intact.
     @DBOS.workflow()
     def my_workflow(scheduled_at: datetime, ctx: Any) -> None:
         pass
@@ -153,6 +153,10 @@ def test_list_schedules_undeserializable_context(
         ]
     )
 
+    # The raw serialized form we expect the bad context to fall back to (captured
+    # before the class is removed, since we can no longer construct it afterward).
+    expected_raw = dbos._sys_db.serializer.serialize(_StaleContext(region="us"))
+
     # Simulate the application code changing: the class the context was pickled
     # against no longer exists in its module, so pickle.loads can't resolve it.
     monkeypatch.delattr(sys.modules[__name__], "_StaleContext")
@@ -161,9 +165,10 @@ def test_list_schedules_undeserializable_context(
     assert len(schedules) == 2
     by_name = {s["schedule_name"]: s for s in schedules}
     assert by_name["good-schedule"]["context"] == {"env": "test"}
-    assert str(by_name["bad-schedule"]["context"]).startswith(
-        "<error deserializing context:"
-    )
+    # The undeserializable context falls back to its raw serialized string.
+    bad_context = by_name["bad-schedule"]["context"]
+    assert isinstance(bad_context, str)
+    assert bad_context == expected_raw
 
 
 def test_apply_schedules(dbos: DBOS) -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -113,6 +114,57 @@ def test_schedule_crud(dbos: DBOS) -> None:
     DBOS.delete_schedule("test-schedule")
     assert DBOS.get_schedule("test-schedule") is None
     assert len(DBOS.list_schedules()) == 0
+
+
+class _StaleContext:
+    """Module-level so it can be pickled into a schedule's context, then removed
+    to simulate the application class no longer existing at deserialization time."""
+
+    def __init__(self, region: str) -> None:
+        self.region = region
+
+
+def test_list_schedules_undeserializable_context(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: a schedule's context is serialized application data. If the
+    # application code changes so the context can no longer be deserialized (e.g. a
+    # class it was pickled against is removed/renamed), listing schedules must not
+    # fail for *all* schedules. The bad one carries an error marker; others come
+    # through intact.
+    @DBOS.workflow()
+    def my_workflow(scheduled_at: datetime, ctx: Any) -> None:
+        pass
+
+    DBOS.apply_schedules(
+        [
+            {
+                "schedule_name": "good-schedule",
+                "workflow_fn": my_workflow,
+                "schedule": "* * * * *",
+                "context": {"env": "test"},
+            },
+            {
+                "schedule_name": "bad-schedule",
+                "workflow_fn": my_workflow,
+                "schedule": "* * * * *",
+                "context": _StaleContext(region="us"),
+            },
+        ]
+    )
+
+    # Simulate the application code changing: the class the context was pickled
+    # against no longer exists in its module, so pickle.loads can't resolve it.
+    monkeypatch.delattr(sys.modules[__name__], "_StaleContext")
+
+    schedules = DBOS.list_schedules()
+    print(schedules)
+    assert len(schedules) == 2
+    by_name = {s["schedule_name"]: s for s in schedules}
+    assert by_name["good-schedule"]["context"] == {"env": "test"}
+    assert str(by_name["bad-schedule"]["context"]).startswith(
+        "<error deserializing context:"
+    )
 
 
 def test_apply_schedules(dbos: DBOS) -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -158,7 +158,6 @@ def test_list_schedules_undeserializable_context(
     monkeypatch.delattr(sys.modules[__name__], "_StaleContext")
 
     schedules = DBOS.list_schedules()
-    print(schedules)
     assert len(schedules) == 2
     by_name = {s["schedule_name"]: s for s in schedules}
     assert by_name["good-schedule"]["context"] == {"env": "test"}

--- a/tests/ts_client/package-lock.json
+++ b/tests/ts_client/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
If a schedule's context stores data that refers to objects that disappeared, deserialize fail. This produces a poor UX for the list schedules path, which is entirely denied if a single schedule context is rotten:
<img width="782" height="574" alt="Screenshot 2026-05-29 at 17 51 02" src="https://github.com/user-attachments/assets/344aa3b4-d840-4e7e-9693-3813c704bc63" />

Reproducible with the test:

<img width="844" height="417" alt="Screenshot 2026-05-29 at 18 06 33" src="https://github.com/user-attachments/assets/32deee48-6a87-4ea3-beac-0281aabb48cb" />
