### PR TITLE
[codex] Fix scheduled and debounced workflow version targeting

### DIFF
--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -156,9 +156,10 @@ def debouncer_workflow(
                         func, *workflow_inputs["args"], **workflow_inputs["kwargs"]
                     )
             else:
-                DBOS.start_workflow(
-                    func, *workflow_inputs["args"], **workflow_inputs["kwargs"]
-                )
+                with SetEnqueueOptions(app_version=ctx["app_version"]):
+                    DBOS.start_workflow(
+                        func, *workflow_inputs["args"], **workflow_inputs["kwargs"]
+                    )
 
 
 class Debouncer(Generic[P, R]):
@@ -240,7 +241,11 @@ class Debouncer(Generic[P, R]):
             ctx.is_within_set_workflow_id_block = False
             ctxOptions: ContextOptions = {
                 "workflow_id": user_workflow_id,
-                "app_version": ctx.app_version,
+                "app_version": (
+                    ctx.app_version
+                    if ctx.app_version is not None
+                    else dbos._sys_db.get_latest_application_version()["version_name"]
+                ),
                 "deduplication_id": ctx.deduplication_id,
                 "priority": ctx.priority,
                 "workflow_timeout_sec": (
@@ -253,7 +258,10 @@ class Debouncer(Generic[P, R]):
             try:
                 # Attempt to enqueue a debouncer for this workflow.
                 deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
-                with SetEnqueueOptions(deduplication_id=deduplication_id):
+                with SetEnqueueOptions(
+                    deduplication_id=deduplication_id,
+                    app_version=ctxOptions["app_version"],
+                ):
                     with SetWorkflowTimeout(None):
                         internal_queue.enqueue(
                             debouncer_workflow,
@@ -340,13 +348,18 @@ class DebouncerClient:
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
 
+        target_app_version = self.workflow_options.get("app_version")
+        if target_app_version is None:
+            target_app_version = self.client.get_latest_application_version()[
+                "version_name"
+            ]
         ctxOptions: ContextOptions = {
             "workflow_id": (
                 self.workflow_options["workflow_id"]
                 if self.workflow_options.get("workflow_id")
                 else generate_uuid()
             ),
-            "app_version": self.workflow_options.get("app_version"),
+            "app_version": target_app_version,
             "deduplication_id": self.workflow_options.get("deduplication_id"),
             "priority": self.workflow_options.get("priority"),
             "workflow_timeout_sec": self.workflow_options.get("workflow_timeout"),
@@ -362,6 +375,7 @@ class DebouncerClient:
                     "workflow_name": DEBOUNCER_WORKFLOW_NAME,
                     "queue_name": INTERNAL_QUEUE_NAME,
                     "deduplication_id": deduplication_id,
+                    "app_version": target_app_version,
                 }
                 self.client.enqueue(
                     debouncer_options,

--- a/dbos/_scheduler_decorator.py
+++ b/dbos/_scheduler_decorator.py
@@ -9,7 +9,7 @@ from ._logger import dbos_logger
 if TYPE_CHECKING:
     from ._dbos import DBOSRegistry
 
-from ._context import SetWorkflowID
+from ._context import SetEnqueueOptions, SetWorkflowID
 from ._croniter import croniter  # type: ignore
 from ._registrations import get_dbos_func_name
 
@@ -48,7 +48,13 @@ def decorator_scheduler_loop(
                 f"sched-{get_dbos_func_name(func)}-{next_exec_time.isoformat()}"
             )
             if not dbos._sys_db.get_workflow_status(workflowID):
-                with SetWorkflowID(workflowID):
+                latest_application_version = (
+                    dbos._sys_db.get_latest_application_version()["version_name"]
+                )
+                with (
+                    SetWorkflowID(workflowID),
+                    SetEnqueueOptions(app_version=latest_application_version),
+                ):
                     scheduler_queue.enqueue(
                         func, next_exec_time, datetime.now(timezone.utc)
                     )

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 
 import pytest
@@ -13,8 +14,39 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
+from dbos._core import DEBOUNCER_WORKFLOW_NAME
 from dbos._queue import Queue
+from dbos._sys_db import WorkflowStatus
 from dbos._utils import GlobalParams
+
+from .conftest import retry_until_success
+
+
+def _create_newer_application_version(dbos: DBOS) -> str:
+    newer_version = f"newer-{uuid.uuid4()}"
+    dbos._sys_db.create_application_version(newer_version)
+    dbos._sys_db.update_application_version_timestamp(
+        newer_version, int(time.time() * 1000) + 1_000_000
+    )
+    return newer_version
+
+
+def _get_debouncer_workflow_for_user_workflow(
+    user_workflow_id: str,
+) -> WorkflowStatus:
+    workflows = DBOS.list_workflows(
+        name=DEBOUNCER_WORKFLOW_NAME,
+        status="ENQUEUED",
+        load_output=False,
+    )
+    matching_workflows = [
+        workflow
+        for workflow in workflows
+        if workflow.input is not None
+        and workflow.input["args"][1]["workflow_id"] == user_workflow_id
+    ]
+    assert len(matching_workflows) == 1
+    return matching_workflows[0]
 
 
 def test_debouncer(dbos: DBOS) -> None:
@@ -68,6 +100,39 @@ def test_debouncer(dbos: DBOS) -> None:
     # Rerun the workflow, verify it looks up by name and still works
     dbos._sys_db.update_workflow_outcome(wfid, "PENDING")
     dbos._execute_workflow_id(wfid).get_result()
+
+
+def test_debouncer_uses_latest_application_version(dbos: DBOS) -> None:
+    original_version = GlobalParams.app_version
+    newer_version = _create_newer_application_version(dbos)
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+    handle = debouncer.debounce(f"key-{uuid.uuid4()}", 0.1, 1)
+
+    try:
+        def check_debouncer_enqueued_on_latest_version() -> None:
+            debouncer_workflow = _get_debouncer_workflow_for_user_workflow(
+                handle.workflow_id
+            )
+            assert debouncer_workflow.app_version == newer_version
+            assert debouncer_workflow.input is not None
+            assert debouncer_workflow.input["args"][1]["app_version"] == newer_version
+
+        retry_until_success(
+            check_debouncer_enqueued_on_latest_version,
+            interval=0.1,
+            max_attempts=20,
+        )
+
+        GlobalParams.app_version = newer_version
+        assert handle.get_result() == 1
+        assert handle.get_status().app_version == newer_version
+    finally:
+        GlobalParams.app_version = original_version
 
 
 def test_debouncer_timeout(dbos: DBOS) -> None:
@@ -179,14 +244,18 @@ def test_debouncer_queue(dbos: DBOS) -> None:
 
     # Test SetEnqueueOptions works
     test_version = "test_version"
-    GlobalParams.app_version = test_version
-    with SetEnqueueOptions(
-        priority=1, deduplication_id="test", app_version=test_version
-    ):
-        handle = debouncer.debounce("key", debounce_period_sec, first_value)
-    assert handle.get_result() == first_value
-    assert handle.get_status().queue_name == queue.name
-    assert handle.get_status().app_version == test_version
+    original_version = GlobalParams.app_version
+    try:
+        GlobalParams.app_version = test_version
+        with SetEnqueueOptions(
+            priority=1, deduplication_id="test", app_version=test_version
+        ):
+            handle = debouncer.debounce("key", debounce_period_sec, first_value)
+        assert handle.get_result() == first_value
+        assert handle.get_status().queue_name == queue.name
+        assert handle.get_status().app_version == test_version
+    finally:
+        GlobalParams.app_version = original_version
 
     # The queue argument also accepts a queue name as a string.
     debouncer_by_name = Debouncer.create(workflow, queue=queue.name)
@@ -275,6 +344,47 @@ def test_debouncer_client(dbos: DBOS, client: DBOSClient) -> None:
     )
     assert handle.workflow_id == wfid
     assert handle.get_result() == first_value
+
+
+def test_debouncer_client_uses_latest_application_version(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    original_version = GlobalParams.app_version
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    DBOS.register_queue("test-queue")
+    newer_version = _create_newer_application_version(dbos)
+
+    options: EnqueueOptions = {
+        "workflow_name": workflow.__qualname__,
+        "queue_name": "test-queue",
+    }
+    debouncer = DebouncerClient(client, options)
+    handle: WorkflowHandle[int] = debouncer.debounce(f"key-{uuid.uuid4()}", 0.1, 1)
+
+    try:
+        def check_debouncer_enqueued_on_latest_version() -> None:
+            debouncer_workflow = _get_debouncer_workflow_for_user_workflow(
+                handle.workflow_id
+            )
+            assert debouncer_workflow.app_version == newer_version
+            assert debouncer_workflow.input is not None
+            assert debouncer_workflow.input["args"][1]["app_version"] == newer_version
+
+        retry_until_success(
+            check_debouncer_enqueued_on_latest_version,
+            interval=0.1,
+            max_attempts=20,
+        )
+
+        GlobalParams.app_version = newer_version
+        assert handle.get_result() == 1
+        assert handle.get_status().app_version == newer_version
+    finally:
+        GlobalParams.app_version = original_version
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler_decorator.py
+++ b/tests/test_scheduler_decorator.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from datetime import datetime
 
 import pytest
@@ -8,6 +9,7 @@ from sqlalchemy.engine import Engine
 # Public API
 from dbos import DBOS
 from dbos._error import DBOSWorkflowFunctionNotFoundError
+from dbos._registrations import get_dbos_func_name
 
 from .conftest import retry_until_success
 
@@ -107,6 +109,32 @@ def test_scheduled_workflow(dbos: DBOS) -> None:
         assert wf_counter >= 2
 
     retry_until_success(check_fired)
+
+
+def test_scheduled_workflow_uses_latest_application_version(dbos: DBOS) -> None:
+    newer_version = f"newer-{uuid.uuid4()}"
+    dbos._sys_db.create_application_version(newer_version)
+    dbos._sys_db.update_application_version_timestamp(
+        newer_version, int(time.time() * 1000) + 1_000_000
+    )
+
+    @DBOS.scheduled("* * * * * *")
+    @DBOS.workflow()
+    def test_workflow(scheduled: datetime, actual: datetime) -> None:
+        pass
+
+    workflow_id_prefix = f"sched-{get_dbos_func_name(test_workflow)}-"
+
+    def check_scheduled_on_latest_version() -> None:
+        workflows = DBOS.list_workflows(
+            workflow_id_prefix=workflow_id_prefix,
+            load_input=False,
+            load_output=False,
+        )
+        assert len(workflows) >= 1
+        assert all(wf.app_version == newer_version for wf in workflows)
+
+    retry_until_success(check_scheduled_on_latest_version)
 
 
 def test_async_scheduled_workflow(dbos: DBOS) -> None:


### PR DESCRIPTION
## Summary
- Route legacy `@DBOS.scheduled` enqueues to the latest registered application version instead of the scheduler process' local version.
- Route new debouncer coordinator workflows to the latest registered application version unless the caller explicitly supplies `app_version`.
- Preserve explicit debouncer `app_version` overrides and pass the resolved version through to the final user workflow.

## Root Cause
Queue workers only dequeue rows whose `application_version` matches the local executor version, or rows with no version. The DB-backed scheduler already stamped scheduled rows with the latest application version, but the legacy scheduler decorator and debouncer paths defaulted to `GlobalParams.app_version` from the process creating the enqueue. During rolling deploys, older executors could therefore create new scheduled/debounced workflow work on older versions.

## Changes
- Wrap legacy scheduled enqueues with `SetEnqueueOptions(app_version=latest_application_version)`.
- Resolve debouncer default app version to `get_latest_application_version()` for both `Debouncer` and `DebouncerClient`.
- Stamp the internal debouncer workflow with that target version so older executors do not pick up new debounce coordinators.
- Apply the resolved app version when the debouncer starts the final user workflow.
- Add regression tests for scheduled workflows, local debouncers, and client debouncers.

## Validation
- `env DBOS_DATABASE=SQLITE uv run --extra otel pytest tests/test_scheduler_decorator.py` -> `9 passed, 2 skipped`
- `env DBOS_DATABASE=SQLITE uv run --extra otel pytest tests/test_debouncer.py` -> `9 passed`