### PR TITLE
Improve `datetime` Handling

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -6,10 +6,8 @@ import json
 import sys
 import threading
 import time
-import types
 import uuid
 from concurrent.futures import Future
-from datetime import date, datetime
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -26,12 +24,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_args,
-    get_origin,
-    get_type_hints,
 )
-
-from dateutil.parser import isoparse
 
 from dbos._outcome import NoResult, Outcome, Pending
 from dbos._utils import GlobalParams, retriable_postgres_exception
@@ -64,7 +57,6 @@ from ._error import (
 )
 from ._registrations import (
     DEFAULT_MAX_RECOVERY_ATTEMPTS,
-    DBOSFuncInfo,
     DBOSFuncType,
     ValidateArgsCallable,
     get_config_name,
@@ -81,6 +73,7 @@ from ._serialization import (
     DBOSPortableJSON,
     WorkflowInputs,
     WorkflowSerializationFormat,
+    coerce_portable_args_to_hints,
     deserialize_args,
     deserialize_exception,
     deserialize_value,
@@ -706,69 +699,6 @@ async def _execute_workflow_async(
                     dbos._active_workflows_set.release(status["workflow_uuid"])
 
 
-def _unwrap_optional(hint: Any) -> Any:
-    """Reduce ``Optional[T]`` / ``T | None`` to ``T``; return the hint unchanged otherwise."""
-    if get_origin(hint) in (Union, types.UnionType):
-        non_none = [a for a in get_args(hint) if a is not type(None)]
-        if len(non_none) == 1:
-            return non_none[0]
-    return hint
-
-
-def _coerce_to_hint(value: Any, hint: Any) -> Any:
-    """Best-effort parse an ISO string back into the datetime/date its hint declares."""
-    if hint is None or not isinstance(value, str):
-        return value
-    target = _unwrap_optional(hint)
-    try:
-        if target is datetime:
-            return isoparse(value)
-        if target is date:
-            return isoparse(value).date()
-    except (ValueError, OverflowError, TypeError):
-        return value
-    return value
-
-
-def coerce_portable_args_to_hints(
-    wf_func: Callable[..., Any], fi: DBOSFuncInfo, inputs: WorkflowInputs
-) -> WorkflowInputs:
-    """Restore datetime/date arguments lost to portable JSON serialization.
-
-    The portable serializer encodes datetime/date as ISO strings (see
-    ``_to_rfc3339_utc``) and cannot recover the native type on deserialize. When a
-    workflow parameter is annotated ``datetime``/``date`` but the deserialized value
-    is a string, coerce it back so callers see the declared type regardless of how
-    the workflow was invoked. This makes scheduled workflows (whose first argument
-    is the scheduled time) consistent whether run directly, by cron, or after
-    recovery. Unparseable values are left untouched.
-    """
-    try:
-        hints = get_type_hints(wf_func)
-    except Exception:
-        hints = getattr(wf_func, "__annotations__", {})
-    if not hints:
-        return inputs
-    try:
-        params = list(inspect.signature(wf_func).parameters.values())
-    except (TypeError, ValueError):
-        return inputs
-    # Skip the leading self/cls parameter for class/instance methods: the stored
-    # arguments don't include the bound class argument.
-    if fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance):
-        params = params[1:]
-
-    args = list(inputs["args"])
-    for i, value in enumerate(args):
-        if i < len(params):
-            args[i] = _coerce_to_hint(value, hints.get(params[i].name))
-    kwargs = {
-        key: _coerce_to_hint(val, hints.get(key))
-        for key, val in inputs["kwargs"].items()
-    }
-    return {"args": tuple(args), "kwargs": kwargs}
-
-
 def execute_workflow_by_id(
     dbos: "DBOS", workflow_id: str, is_recovery: bool, is_dequeue: bool
 ) -> "WorkflowHandle[Any]":
@@ -820,7 +750,11 @@ def execute_workflow_by_id(
         and dbos._serializer.name() == DBOSPortableJSON.name()
     )
     if inputs is not None and fi.validate_args is None and used_portable:
-        inputs = coerce_portable_args_to_hints(wf_func, fi, inputs)
+        inputs = coerce_portable_args_to_hints(
+            wf_func,
+            inputs,
+            skip_self=fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance),
+        )
     # Run argument validation if configured on the workflow
     if fi.validate_args is not None and inputs is not None:
         try:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -739,21 +739,18 @@ def execute_workflow_by_id(
             "<NONE>",
             f"{wf_func.__name__} is not a registered workflow function",
         )
-    # The portable serializer encodes datetime/date as ISO strings and can't
-    # recover the native type on deserialize. Restore it against the workflow's
-    # type hints so callers (e.g. scheduled workflows) see the declared type.
-    # Skipped when validate_args is configured, since that already coerces.
-    # The args are portable if explicitly tagged, or if they fell through to a
-    # configured portable serializer (serialization left unset, as the scheduler does).
-    used_portable = status["serialization"] == DBOSPortableJSON.name() or (
+    # Type-coerce arguments whose type is lost to portable JSON serialization.
+    using_portable_serialization = status[
+        "serialization"
+    ] == DBOSPortableJSON.name() or (
         status["serialization"] is None
         and dbos._serializer.name() == DBOSPortableJSON.name()
     )
-    if inputs is not None and fi.validate_args is None and used_portable:
+    if using_portable_serialization and inputs is not None and fi.validate_args is None:
         inputs = coerce_portable_args_to_hints(
             wf_func,
             inputs,
-            skip_self=fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance),
+            has_class_param=fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance),
         )
     # Run argument validation if configured on the workflow
     if fi.validate_args is not None and inputs is not None:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -6,8 +6,10 @@ import json
 import sys
 import threading
 import time
+import types
 import uuid
 from concurrent.futures import Future
+from datetime import date, datetime
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -24,7 +26,12 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
+    get_origin,
+    get_type_hints,
 )
+
+from dateutil.parser import isoparse
 
 from dbos._outcome import NoResult, Outcome, Pending
 from dbos._utils import GlobalParams, retriable_postgres_exception
@@ -57,6 +64,7 @@ from ._error import (
 )
 from ._registrations import (
     DEFAULT_MAX_RECOVERY_ATTEMPTS,
+    DBOSFuncInfo,
     DBOSFuncType,
     ValidateArgsCallable,
     get_config_name,
@@ -698,6 +706,69 @@ async def _execute_workflow_async(
                     dbos._active_workflows_set.release(status["workflow_uuid"])
 
 
+def _unwrap_optional(hint: Any) -> Any:
+    """Reduce ``Optional[T]`` / ``T | None`` to ``T``; return the hint unchanged otherwise."""
+    if get_origin(hint) in (Union, types.UnionType):
+        non_none = [a for a in get_args(hint) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return hint
+
+
+def _coerce_to_hint(value: Any, hint: Any) -> Any:
+    """Best-effort parse an ISO string back into the datetime/date its hint declares."""
+    if hint is None or not isinstance(value, str):
+        return value
+    target = _unwrap_optional(hint)
+    try:
+        if target is datetime:
+            return isoparse(value)
+        if target is date:
+            return isoparse(value).date()
+    except (ValueError, OverflowError, TypeError):
+        return value
+    return value
+
+
+def coerce_portable_args_to_hints(
+    wf_func: Callable[..., Any], fi: DBOSFuncInfo, inputs: WorkflowInputs
+) -> WorkflowInputs:
+    """Restore datetime/date arguments lost to portable JSON serialization.
+
+    The portable serializer encodes datetime/date as ISO strings (see
+    ``_to_rfc3339_utc``) and cannot recover the native type on deserialize. When a
+    workflow parameter is annotated ``datetime``/``date`` but the deserialized value
+    is a string, coerce it back so callers see the declared type regardless of how
+    the workflow was invoked. This makes scheduled workflows (whose first argument
+    is the scheduled time) consistent whether run directly, by cron, or after
+    recovery. Unparseable values are left untouched.
+    """
+    try:
+        hints = get_type_hints(wf_func)
+    except Exception:
+        hints = getattr(wf_func, "__annotations__", {})
+    if not hints:
+        return inputs
+    try:
+        params = list(inspect.signature(wf_func).parameters.values())
+    except (TypeError, ValueError):
+        return inputs
+    # Skip the leading self/cls parameter for class/instance methods: the stored
+    # arguments don't include the bound class argument.
+    if fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance):
+        params = params[1:]
+
+    args = list(inputs["args"])
+    for i, value in enumerate(args):
+        if i < len(params):
+            args[i] = _coerce_to_hint(value, hints.get(params[i].name))
+    kwargs = {
+        key: _coerce_to_hint(val, hints.get(key))
+        for key, val in inputs["kwargs"].items()
+    }
+    return {"args": tuple(args), "kwargs": kwargs}
+
+
 def execute_workflow_by_id(
     dbos: "DBOS", workflow_id: str, is_recovery: bool, is_dequeue: bool
 ) -> "WorkflowHandle[Any]":
@@ -738,6 +809,18 @@ def execute_workflow_by_id(
             "<NONE>",
             f"{wf_func.__name__} is not a registered workflow function",
         )
+    # The portable serializer encodes datetime/date as ISO strings and can't
+    # recover the native type on deserialize. Restore it against the workflow's
+    # type hints so callers (e.g. scheduled workflows) see the declared type.
+    # Skipped when validate_args is configured, since that already coerces.
+    # The args are portable if explicitly tagged, or if they fell through to a
+    # configured portable serializer (serialization left unset, as the scheduler does).
+    used_portable = status["serialization"] == DBOSPortableJSON.name() or (
+        status["serialization"] is None
+        and dbos._serializer.name() == DBOSPortableJSON.name()
+    )
+    if inputs is not None and fi.validate_args is None and used_portable:
+        inputs = coerce_portable_args_to_hints(wf_func, fi, inputs)
     # Run argument validation if configured on the workflow
     if fi.validate_args is not None and inputs is not None:
         try:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -747,11 +747,7 @@ def execute_workflow_by_id(
         and dbos._serializer.name() == DBOSPortableJSON.name()
     )
     if using_portable_serialization and inputs is not None and fi.validate_args is None:
-        inputs = coerce_portable_args_to_hints(
-            wf_func,
-            inputs,
-            has_class_param=fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance),
-        )
+        inputs = coerce_portable_args_to_hints(wf_func, inputs)
     # Run argument validation if configured on the workflow
     if fi.validate_args is not None and inputs is not None:
         try:

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -301,19 +301,13 @@ def deserialize_args(
 def coerce_portable_args_to_hints(
     wf_func: Callable[..., Any],
     inputs: WorkflowInputs,
-    skip_self: bool = False,
+    has_class_param: bool = False,
 ) -> WorkflowInputs:
-    """Restore datetime/date arguments lost to portable JSON serialization.
+    """Type-coerce arguments whose type is lost to portable JSON serialization.
 
-    The portable serializer encodes datetime/date as ISO strings (see
-    ``_to_rfc3339_utc``) and cannot recover the native type on deserialize. When a
-    workflow parameter is annotated ``datetime``/``date`` but the deserialized value
-    is a string, coerce it back so callers see the declared type regardless of how
-    the workflow was invoked. This makes scheduled workflows (whose first argument
-    is the scheduled time) consistent whether run directly, by cron, or after
-    recovery. Unparseable values are left untouched.
+    Currently only supports datetime/date.
 
-    ``skip_self`` drops the leading self/cls parameter for class/instance methods,
+    ``has_class_param`` drops the leading self/cls parameter for class/instance methods,
     whose stored arguments don't include the bound class argument.
     """
 
@@ -339,7 +333,7 @@ def coerce_portable_args_to_hints(
         params = list(inspect.signature(wf_func).parameters.values())
     except (TypeError, ValueError):
         return inputs
-    if skip_self:
+    if has_class_param:
         params = params[1:]
 
     args = list(inputs["args"])

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import inspect
 import json
 import pickle
 from abc import ABC, abstractmethod
@@ -8,7 +9,21 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional, Tuple, TypeAlias, TypedDict, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeAlias,
+    TypedDict,
+    cast,
+    get_type_hints,
+)
+
+from dateutil.parser import isoparse
 
 from ._logger import dbos_logger
 
@@ -281,6 +296,58 @@ def deserialize_args(
     if serialization is not None and serialization != serializer.name():
         raise TypeError(f"Serialization {serialization} is not available")
     return cast(WorkflowInputs, serializer.deserialize(serialized_value))
+
+
+def coerce_portable_args_to_hints(
+    wf_func: Callable[..., Any],
+    inputs: WorkflowInputs,
+    skip_self: bool = False,
+) -> WorkflowInputs:
+    """Restore datetime/date arguments lost to portable JSON serialization.
+
+    The portable serializer encodes datetime/date as ISO strings (see
+    ``_to_rfc3339_utc``) and cannot recover the native type on deserialize. When a
+    workflow parameter is annotated ``datetime``/``date`` but the deserialized value
+    is a string, coerce it back so callers see the declared type regardless of how
+    the workflow was invoked. This makes scheduled workflows (whose first argument
+    is the scheduled time) consistent whether run directly, by cron, or after
+    recovery. Unparseable values are left untouched.
+
+    ``skip_self`` drops the leading self/cls parameter for class/instance methods,
+    whose stored arguments don't include the bound class argument.
+    """
+
+    def coerce(value: Any, hint: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        try:
+            if hint is datetime:
+                return isoparse(value)
+            if hint is date:
+                return isoparse(value).date()
+        except (ValueError, OverflowError, TypeError):
+            return value
+        return value
+
+    try:
+        hints = get_type_hints(wf_func)
+    except Exception:
+        hints = getattr(wf_func, "__annotations__", {})
+    if not hints:
+        return inputs
+    try:
+        params = list(inspect.signature(wf_func).parameters.values())
+    except (TypeError, ValueError):
+        return inputs
+    if skip_self:
+        params = params[1:]
+
+    args = list(inputs["args"])
+    for i, value in enumerate(args):
+        if i < len(params):
+            args[i] = coerce(value, hints.get(params[i].name))
+    kwargs = {key: coerce(val, hints.get(key)) for key, val in inputs["kwargs"].items()}
+    return {"args": tuple(args), "kwargs": kwargs}
 
 
 def _safe_str(x: Any) -> str:

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -23,7 +23,7 @@ from typing import (
     get_type_hints,
 )
 
-from dateutil.parser import isoparse  # type: ignore[import-untyped]
+from dateutil.parser import isoparse
 
 from ._logger import dbos_logger
 

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -301,15 +301,12 @@ def deserialize_args(
 def coerce_portable_args_to_hints(
     wf_func: Callable[..., Any],
     inputs: WorkflowInputs,
-    has_class_param: bool = False,
 ) -> WorkflowInputs:
     """Type-coerce arguments whose type is lost to portable JSON serialization.
 
     Currently only supports datetime/date.
-
-    ``has_class_param`` drops the leading self/cls parameter for class/instance methods,
-    whose stored arguments don't include the bound class argument.
     """
+    from ._registrations import DBOSFuncType, get_func_info
 
     def coerce(value: Any, hint: Any) -> Any:
         if not isinstance(value, str):
@@ -333,7 +330,10 @@ def coerce_portable_args_to_hints(
         params = list(inspect.signature(wf_func).parameters.values())
     except (TypeError, ValueError):
         return inputs
-    if has_class_param:
+    # Drop the leading self/cls parameter for class/instance methods, whose stored
+    # arguments don't include the bound class argument.
+    fi = get_func_info(wf_func)
+    if fi is not None and fi.func_type in (DBOSFuncType.Class, DBOSFuncType.Instance):
         params = params[1:]
 
     args = list(inputs["args"])

--- a/dbos/_serialization.py
+++ b/dbos/_serialization.py
@@ -23,7 +23,7 @@ from typing import (
     get_type_hints,
 )
 
-from dateutil.parser import isoparse
+from dateutil.parser import isoparse  # type: ignore[import-untyped]
 
 from ._logger import dbos_logger
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "otel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:380331cd073e0532ce31757eaafadbf0f8258d1b610b99bc257c2d4a1bc637b8"
+content_hash = "sha256:77e0ccbba299921d897952c2ff53942b8465c3c545964bdeed5c8698e09718e0"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -591,7 +591,6 @@ version = "3.2.4"
 requires_python = ">=3.9"
 summary = "Lightweight in-process concurrent programming"
 groups = ["default", "dev"]
-marker = "platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\""
 files = [
     {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
     {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590"},
@@ -1700,7 +1699,7 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.44"
+version = "2.0.50"
 requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 groups = ["default", "dev"]
@@ -1710,40 +1709,50 @@ dependencies = [
     "typing-extensions>=4.6.0",
 ]
 files = [
-    {file = "sqlalchemy-2.0.44-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c77f3080674fc529b1bd99489378c7f63fcb4ba7f8322b79732e0258f0ea3ce"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c26ef74ba842d61635b0152763d057c8d48215d5be9bb8b7604116a059e9985"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4a172b31785e2f00780eccab00bc240ccdbfdb8345f1e6063175b3ff12ad1b0"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9480c0740aabd8cb29c329b422fb65358049840b34aba0adf63162371d2a96e"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:17835885016b9e4d0135720160db3095dc78c583e7b902b6be799fb21035e749"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cbe4f85f50c656d753890f39468fcd8190c5f08282caf19219f684225bfd5fd2"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-win32.whl", hash = "sha256:2fcc4901a86ed81dc76703f3b93ff881e08761c63263c46991081fd7f034b165"},
-    {file = "sqlalchemy-2.0.44-cp310-cp310-win_amd64.whl", hash = "sha256:9919e77403a483ab81e3423151e8ffc9dd992c20d2603bf17e4a8161111e55f5"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0fe3917059c7ab2ee3f35e77757062b1bea10a0b6ca633c58391e3f3c6c488dd"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:de4387a354ff230bc979b46b2207af841dc8bf29847b6c7dbe60af186d97aefa"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3678a0fb72c8a6a29422b2732fe423db3ce119c34421b5f9955873eb9b62c1e"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3cf6872a23601672d61a68f390e44703442639a12ee9dd5a88bbce52a695e46e"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:329aa42d1be9929603f406186630135be1e7a42569540577ba2c69952b7cf399"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:70e03833faca7166e6a9927fbee7c27e6ecde436774cd0b24bbcc96353bce06b"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-win32.whl", hash = "sha256:253e2f29843fb303eca6b2fc645aca91fa7aa0aa70b38b6950da92d44ff267f3"},
-    {file = "sqlalchemy-2.0.44-cp311-cp311-win_amd64.whl", hash = "sha256:7a8694107eb4308a13b425ca8c0e67112f8134c846b6e1f722698708741215d5"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72fea91746b5890f9e5e0997f16cbf3d53550580d76355ba2d998311b17b2250"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:585c0c852a891450edbb1eaca8648408a3cc125f18cf433941fa6babcc359e29"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b94843a102efa9ac68a7a30cd46df3ff1ed9c658100d30a725d10d9c60a2f44"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:119dc41e7a7defcefc57189cfa0e61b1bf9c228211aba432b53fb71ef367fda1"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0765e318ee9179b3718c4fd7ba35c434f4dd20332fbc6857a5e8df17719c24d7"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2e7b5b079055e02d06a4308d0481658e4f06bc7ef211567edc8f7d5dce52018d"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-win32.whl", hash = "sha256:846541e58b9a81cce7dee8329f352c318de25aa2f2bbe1e31587eb1f057448b4"},
-    {file = "sqlalchemy-2.0.44-cp312-cp312-win_amd64.whl", hash = "sha256:7cbcb47fd66ab294703e1644f78971f6f2f1126424d2b300678f419aa73c7b6e"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ff486e183d151e51b1d694c7aa1695747599bb00b9f5f604092b54b74c64a8e1"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b1af8392eb27b372ddb783b317dea0f650241cea5bd29199b22235299ca2e45"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b61188657e3a2b9ac4e8f04d6cf8e51046e28175f79464c67f2fd35bceb0976"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b87e7b91a5d5973dda5f00cd61ef72ad75a1db73a386b62877d4875a8840959c"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:15f3326f7f0b2bfe406ee562e17f43f36e16167af99c4c0df61db668de20002d"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e77faf6ff919aa8cd63f1c4e561cac1d9a454a191bb864d5dd5e545935e5a40"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-win32.whl", hash = "sha256:ee51625c2d51f8baadf2829fae817ad0b66b140573939dd69284d2ba3553ae73"},
-    {file = "sqlalchemy-2.0.44-cp313-cp313-win_amd64.whl", hash = "sha256:c1c80faaee1a6c3428cecf40d16a2365bcf56c424c92c2b6f0f9ad204b899e9e"},
-    {file = "sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05"},
-    {file = "sqlalchemy-2.0.44.tar.gz", hash = "sha256:0ae7454e1ab1d780aee69fd2aae7d6b8670a581d8847f2d1e0f7ddfbf47e5a22"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7af6eeb84985bf840ba779018ff9424d61ff69b52e66b8789d3c8da7bf5341b2"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fe7822866f3a9fc5f3db21a290ce8961a53050115f05edf9402b6a5feb92a9f"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e1b0f6a4dcd9b4839e2320afb5df37a6981cbc20ff9c423ae11c5537bdbd21"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e195687f1af431c9515416288373b323b6eb599f774409814e89e9d603a56e39"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ea1a8a2db4b2217d456c8d7a873bfc605f06fe3584d315264ea18c2a17585d0b"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-win32.whl", hash = "sha256:68b154b08088b4ec32bb4d2958bfbb50e57549f91a4cd3e7f928e3553ed69031"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-win_amd64.whl", hash = "sha256:66e374271ecb7101273f57af1a62446a953d327eec4f8089147de57c591bbacc"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa6e403663a9c43c8fef7ce4bdb4cf48bcd8d352e91deda2a99f963270bd508"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51b637a84f9fa35ae1f9017e786cb142974a25305085e1b378b3647a67f65ad3"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dab927761d9108550f0cf8e66ff21af56f907a0ce0a689793db615e2b55f62c"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:545eae198d37bcf837a10ede3684e2af32458d6f35c597c35c2de7502dc38fc4"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0fec460e18cdbb4c7773531122ce9a27e96c6ca17af3933941d94da475ad2c86"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-win32.whl", hash = "sha256:e6e814658818fd165e749e3d8490ef16cc7f379a118c37ada8b0589ffbaaac22"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-win_amd64.whl", hash = "sha256:1c5f858fe79c9f5d8fda065c06186356acb7f8df3cd52dbd5ee3f200e4b144f5"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23ae23d8b9d344d30d0a92f06d45825024a5790f1c1dd4cf452636a50d3e58cb"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47b71b933e7b4ebad407c8fdfd70d2c4f08b78b3238bb30eebdd6eb32ca51b89"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:110fdac56ace278949f00de805edacbd6141e382d992f9ba28238b3a0827a600"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5e4ac70e9e757f6b3e87c0491ff034442ecd8dfd36d041a50564c322dafc0e"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724f3dcbe53dd0151e3cb5e7ec4ba4c620bede579caacd16275dc35ce06e8615"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-win32.whl", hash = "sha256:1208050441471d003b7c8cb4054fb084f185cf35ac3f0ea270803865bca9939a"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-win_amd64.whl", hash = "sha256:9d1af51558029a156a70986b7df88f042b3d158d7c8d8fb5072912d4b32d89c7"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:06a9210bdc5f4298cff0781087e2ff45683922252dacc452846373a58761f093"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b53784972ade4f8174b9aa661f31a06f8a936d2cfdd602913ff3c6dd40ae873"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31648fa14460537e768a7303b078e4344d208e0d23e06867c1f376a227ed82db"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03f4323c980ad0e918cc9e5369b015f759f4e534db5bbaf4dc36832c10d05064"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2b9dcc43afef8ac157cd92fce96985d6b8b0cfbd3df4d666f66b4d55a75d202f"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-win32.whl", hash = "sha256:60922d6599065ddca2c6f376b9aa2f41a6b85a271725e0909490bbc50b1998a5"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-win_amd64.whl", hash = "sha256:287086e67275a212c4582d166a6fb03a65ccc5551d80866270ce0dd9f34eccd3"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c966932507a4d7d0a37314927dbfcd89720e3f37d2a1e3352e7ae7939fa8e8a0"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:faffef4bcc20a1892e65e155293d99d60855bbbc79250ab712819cfd56a8e6bb"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c206aec519a2e7bd08abbfb33436e325fd22c632d9c21a9047e376ce241646e"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef4ac756363227ef6402a75fee025a4bc690f92328e825868939b3b3a446a6d"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96fbee6b19c19cd1556c8bf9419447cf2ec149ffcab7ab64348c23e54ef8547f"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-win32.whl", hash = "sha256:8f00e3eb43ba30eb1b238ee03a8a62309486d1321eda3328bb611e0340033ad8"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-win_amd64.whl", hash = "sha256:15708c613cd5005b7dffe1f66ee6a63ee8f5e46799f71c70ebad74178c676a39"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3699dac4be410e97049a1658e9480da9cde956594aa0f3aebc60b88f21c5ba70"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f96233858e3df43932ac11589e22520da6e8aeb624b03fedfeebb0e8ea213086"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4e70c46fad30c3bcc6a4708bc0130a3173e11a5b25f0ea4a9d8911b450f1f52"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1918a3cf564d16d95bca7301005f41ab2ad50b07cd3b9da50d3ed986db148d6a"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b00098cdbdbd38c7be3d568b0c9c3122b8c0ec62b911b57cd5e6e0254d60a76d"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51"},
+    {file = "sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9"},
+    {file = "sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9"},
 ]
 
 [[package]]
@@ -1757,6 +1766,64 @@ dependencies = [
 files = [
     {file = "sqlalchemy_cockroachdb-2.0.3-py3-none-any.whl", hash = "sha256:cd1dca9a8c65ec8564c928ea26d154b7fc02f82948af200d965343894ca0c0f5"},
     {file = "sqlalchemy_cockroachdb-2.0.3.tar.gz", hash = "sha256:48b763ffd8b2a4dc9d56459934a56d7d5ffad415c6e68d114baee5d12cf79c1d"},
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.50"
+extras = ["asyncio"]
+requires_python = ">=3.7"
+summary = "Database Abstraction Library"
+groups = ["default"]
+dependencies = [
+    "greenlet>=1",
+    "sqlalchemy==2.0.50",
+]
+files = [
+    {file = "sqlalchemy-2.0.50-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7af6eeb84985bf840ba779018ff9424d61ff69b52e66b8789d3c8da7bf5341b2"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fe7822866f3a9fc5f3db21a290ce8961a53050115f05edf9402b6a5feb92a9f"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e1b0f6a4dcd9b4839e2320afb5df37a6981cbc20ff9c423ae11c5537bdbd21"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e195687f1af431c9515416288373b323b6eb599f774409814e89e9d603a56e39"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ea1a8a2db4b2217d456c8d7a873bfc605f06fe3584d315264ea18c2a17585d0b"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-win32.whl", hash = "sha256:68b154b08088b4ec32bb4d2958bfbb50e57549f91a4cd3e7f928e3553ed69031"},
+    {file = "sqlalchemy-2.0.50-cp310-cp310-win_amd64.whl", hash = "sha256:66e374271ecb7101273f57af1a62446a953d327eec4f8089147de57c591bbacc"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa6e403663a9c43c8fef7ce4bdb4cf48bcd8d352e91deda2a99f963270bd508"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51b637a84f9fa35ae1f9017e786cb142974a25305085e1b378b3647a67f65ad3"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dab927761d9108550f0cf8e66ff21af56f907a0ce0a689793db615e2b55f62c"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:545eae198d37bcf837a10ede3684e2af32458d6f35c597c35c2de7502dc38fc4"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0fec460e18cdbb4c7773531122ce9a27e96c6ca17af3933941d94da475ad2c86"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-win32.whl", hash = "sha256:e6e814658818fd165e749e3d8490ef16cc7f379a118c37ada8b0589ffbaaac22"},
+    {file = "sqlalchemy-2.0.50-cp311-cp311-win_amd64.whl", hash = "sha256:1c5f858fe79c9f5d8fda065c06186356acb7f8df3cd52dbd5ee3f200e4b144f5"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23ae23d8b9d344d30d0a92f06d45825024a5790f1c1dd4cf452636a50d3e58cb"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47b71b933e7b4ebad407c8fdfd70d2c4f08b78b3238bb30eebdd6eb32ca51b89"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:110fdac56ace278949f00de805edacbd6141e382d992f9ba28238b3a0827a600"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5e4ac70e9e757f6b3e87c0491ff034442ecd8dfd36d041a50564c322dafc0e"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724f3dcbe53dd0151e3cb5e7ec4ba4c620bede579caacd16275dc35ce06e8615"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-win32.whl", hash = "sha256:1208050441471d003b7c8cb4054fb084f185cf35ac3f0ea270803865bca9939a"},
+    {file = "sqlalchemy-2.0.50-cp312-cp312-win_amd64.whl", hash = "sha256:9d1af51558029a156a70986b7df88f042b3d158d7c8d8fb5072912d4b32d89c7"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:06a9210bdc5f4298cff0781087e2ff45683922252dacc452846373a58761f093"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b53784972ade4f8174b9aa661f31a06f8a936d2cfdd602913ff3c6dd40ae873"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31648fa14460537e768a7303b078e4344d208e0d23e06867c1f376a227ed82db"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03f4323c980ad0e918cc9e5369b015f759f4e534db5bbaf4dc36832c10d05064"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2b9dcc43afef8ac157cd92fce96985d6b8b0cfbd3df4d666f66b4d55a75d202f"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-win32.whl", hash = "sha256:60922d6599065ddca2c6f376b9aa2f41a6b85a271725e0909490bbc50b1998a5"},
+    {file = "sqlalchemy-2.0.50-cp313-cp313-win_amd64.whl", hash = "sha256:287086e67275a212c4582d166a6fb03a65ccc5551d80866270ce0dd9f34eccd3"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c966932507a4d7d0a37314927dbfcd89720e3f37d2a1e3352e7ae7939fa8e8a0"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:faffef4bcc20a1892e65e155293d99d60855bbbc79250ab712819cfd56a8e6bb"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c206aec519a2e7bd08abbfb33436e325fd22c632d9c21a9047e376ce241646e"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef4ac756363227ef6402a75fee025a4bc690f92328e825868939b3b3a446a6d"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96fbee6b19c19cd1556c8bf9419447cf2ec149ffcab7ab64348c23e54ef8547f"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-win32.whl", hash = "sha256:8f00e3eb43ba30eb1b238ee03a8a62309486d1321eda3328bb611e0340033ad8"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314-win_amd64.whl", hash = "sha256:15708c613cd5005b7dffe1f66ee6a63ee8f5e46799f71c70ebad74178c676a39"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3699dac4be410e97049a1658e9480da9cde956594aa0f3aebc60b88f21c5ba70"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f96233858e3df43932ac11589e22520da6e8aeb624b03fedfeebb0e8ea213086"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4e70c46fad30c3bcc6a4708bc0130a3173e11a5b25f0ea4a9d8911b450f1f52"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1918a3cf564d16d95bca7301005f41ab2ad50b07cd3b9da50d3ed986db148d6a"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b00098cdbdbd38c7be3d568b0c9c3122b8c0ec62b911b57cd5e6e0254d60a76d"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e"},
+    {file = "sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51"},
+    {file = "sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9"},
+    {file = "sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9"},
 ]
 
 [[package]]
@@ -1870,6 +1937,17 @@ dependencies = [
 files = [
     {file = "types_paramiko-4.0.0.20250822-py3-none-any.whl", hash = "sha256:55bdb14db75ca89039725ec64ae3fa26b8d57b6991cfb476212fa8f83a59753c"},
     {file = "types_paramiko-4.0.0.20250822.tar.gz", hash = "sha256:1b56b0cbd3eec3d2fd123c9eb2704e612b777e15a17705a804279ea6525e0c53"},
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260518"
+requires_python = ">=3.10"
+summary = "Typing stubs for python-dateutil"
+groups = ["dev"]
+files = [
+    {file = "types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8"},
+    {file = "types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,5 @@ dev = [
     "psycopg2-binary>=2.9.11",
     "sqlalchemy-cockroachdb>=2.0.3",
     "aiosqlite>=0.20.0",
+    "types-python-dateutil>=2.9.0.20260518",
 ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1402,6 +1402,8 @@ def test_schedule_with_queue_name(dbos: DBOS) -> None:
     assert sched is not None
     assert sched["queue_name"] is None
 
+    DBOS.delete_schedule("no-queue-schedule")
+
 
 def test_scheduled_workflow_datetime_with_portable_serializer(
     config: DBOSConfig, cleanup_test_databases: None
@@ -1446,4 +1448,3 @@ def test_scheduled_workflow_datetime_with_portable_serializer(
         DBOS.delete_schedule("portable-schedule")
     finally:
         DBOS.destroy(destroy_registry=True)
-    DBOS.delete_schedule("no-queue-schedule")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@ import pytest
 
 from dbos import DBOS, DBOSClient, DBOSConfig, DBOSConfiguredInstance, Queue
 from dbos._error import DBOSException
+from dbos._serialization import DBOSPortableJSONSerializer
 from dbos._utils import INTERNAL_QUEUE_NAME
 
 from .conftest import default_config, retry_until_success
@@ -1400,4 +1401,49 @@ def test_schedule_with_queue_name(dbos: DBOS) -> None:
     sched = DBOS.get_schedule("no-queue-schedule")
     assert sched is not None
     assert sched["queue_name"] is None
+
+
+def test_scheduled_workflow_datetime_with_portable_serializer(
+    config: DBOSConfig, cleanup_test_databases: None
+) -> None:
+    """Reproduces https://github.com/dbos-inc/dbos-transact-py/issues/697.
+
+    With the portable JSON serializer, the scheduled-time first argument of a
+    scheduled workflow is round-tripped through serialization when the workflow
+    is enqueued (by cron, trigger, or recovery). Because the portable serializer
+    encodes datetimes as RFC3339 strings, the workflow receives a `str` instead
+    of the `datetime` it gets when invoked directly in-process.
+    """
+    config["serializer"] = DBOSPortableJSONSerializer()
+    DBOS.destroy(destroy_registry=True)
+    DBOS(config=config)
+    DBOS.launch()
+    try:
+        received: list[tuple[Any, Any]] = []
+
+        @DBOS.workflow()
+        def scheduled_workflow(scheduled_at: datetime, ctx: Any) -> None:
+            received.append((scheduled_at, ctx))
+
+        DBOS.create_schedule(
+            schedule_name="portable-schedule",
+            workflow_fn=scheduled_workflow,
+            schedule="0 0 * * *",  # daily, won't fire during the test
+            context={"env": "test"},
+        )
+
+        handle = DBOS.trigger_schedule("portable-schedule")
+        handle.get_result()
+
+        assert len(received) == 1
+        scheduled_at, ctx = received[0]
+        assert ctx == {"env": "test"}
+        # BUG: with the portable serializer this is a `str`, not a `datetime`.
+        assert isinstance(
+            scheduled_at, datetime
+        ), f"expected datetime, got {type(scheduled_at).__name__}: {scheduled_at!r}"
+
+        DBOS.delete_schedule("portable-schedule")
+    finally:
+        DBOS.destroy(destroy_registry=True)
     DBOS.delete_schedule("no-queue-schedule")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1441,10 +1441,36 @@ def test_scheduled_workflow_datetime_with_portable_serializer(
         scheduled_at, ctx = received[0]
         assert ctx == {"env": "test"}
         # BUG: with the portable serializer this is a `str`, not a `datetime`.
-        assert isinstance(
-            scheduled_at, datetime
-        ), f"expected datetime, got {type(scheduled_at).__name__}: {scheduled_at!r}"
+        assert isinstance(scheduled_at, datetime)
 
         DBOS.delete_schedule("portable-schedule")
+
+        # Also exercise a class-method scheduled workflow: the leading `cls`
+        # parameter must be skipped so the scheduled-time hint still aligns.
+        cls_received: list[tuple[Any, Any]] = []
+
+        @DBOS.dbos_class()
+        class ScheduledClass:
+            @classmethod
+            @DBOS.workflow()
+            def scheduled_wf(cls, scheduled_at: datetime, ctx: Any) -> None:
+                cls_received.append((scheduled_at, ctx))
+
+        DBOS.create_schedule(
+            schedule_name="portable-class-schedule",
+            workflow_fn=ScheduledClass.scheduled_wf,
+            schedule="0 0 * * *",  # daily, won't fire during the test
+            context={"env": "cls"},
+        )
+
+        cls_handle = DBOS.trigger_schedule("portable-class-schedule")
+        cls_handle.get_result()
+
+        assert len(cls_received) == 1
+        cls_scheduled_at, cls_ctx = cls_received[0]
+        assert cls_ctx == {"env": "cls"}
+        assert isinstance(cls_scheduled_at, datetime)
+
+        DBOS.delete_schedule("portable-class-schedule")
     finally:
         DBOS.destroy(destroy_registry=True)


### PR DESCRIPTION
When using portable serialization, automatically parse `datetime` (and `date`) arguments from their string representation into the appropriate Python type. This requires those types to be annotated. This allows scheduled workflows (which must use `datetime`) to work well with portable serialization.

Closes https://github.com/dbos-inc/dbos-transact-py/issues/697