### PR TITLE
Improve Cancellation Semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<div align="center">
+<div align="center"> 
 
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/dbos-inc/dbos-transact-py/unit-test.yml?query=branch%3Amain)](https://github.com/dbos-inc/dbos-transact-py/actions/workflows/unit-test.yml)
 [![PyPI release (latest SemVer)](https://img.shields.io/pypi/v/dbos.svg)](https://pypi.python.org/pypi/dbos)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<div align="center"> 
+<div align="center">
 
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/dbos-inc/dbos-transact-py/unit-test.yml?query=branch%3Amain)](https://github.com/dbos-inc/dbos-transact-py/actions/workflows/unit-test.yml)
 [![PyPI release (latest SemVer)](https://img.shields.io/pypi/v/dbos.svg)](https://pypi.python.org/pypi/dbos)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -782,6 +782,9 @@ class SystemDatabase(ABC):
     ) -> None:
         with self.engine.begin() as c:
             now_ms = self._now_ms_sql()
+            # Record the outcome, but never overwrite the terminal CANCELLED
+            # status: a workflow can be cancelled during its final step, and if so
+            # it must not be able to subsequently complete.
             c.execute(
                 sa.update(SystemSchema.workflow_status)
                 .values(
@@ -794,7 +797,22 @@ class SystemDatabase(ABC):
                     completed_at=now_ms,
                 )
                 .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
+                .where(
+                    SystemSchema.workflow_status.c.status
+                    != WorkflowStatusString.CANCELLED.value
+                )
             )
+            # If the workflow is cancelled, abort the function so it does not
+            # complete. This mirrors the cancellation check done before each step.
+            current_status = c.execute(
+                sa.select(SystemSchema.workflow_status.c.status).where(
+                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+                )
+            ).scalar_one_or_none()
+            if current_status == WorkflowStatusString.CANCELLED.value:
+                raise DBOSWorkflowCancelledError(
+                    f"Workflow {workflow_id} is cancelled. Aborting function."
+                )
 
     def cancel_workflows(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -785,7 +785,7 @@ class SystemDatabase(ABC):
             # Record the outcome, but never overwrite the terminal CANCELLED
             # status: a workflow can be cancelled during its final step, and if so
             # it must not be able to subsequently complete.
-            c.execute(
+            result = c.execute(
                 sa.update(SystemSchema.workflow_status)
                 .values(
                     status=status,
@@ -803,16 +803,19 @@ class SystemDatabase(ABC):
                 )
             )
             # update_workflow_outcome is only called to finalize a workflow. If
-            # the workflow has been cancelled, the guarded UPDATE above was a
-            # no-op: the workflow must not complete, so raise so it ends as
-            # cancelled rather than succeeding or erroring.
-            current_status = c.execute(
-                sa.select(SystemSchema.workflow_status.c.status).where(
-                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
-                )
-            ).scalar_one_or_none()
-            if current_status == WorkflowStatusString.CANCELLED.value:
-                raise DBOSAwaitedWorkflowCancelledError(workflow_id)
+            # the guarded UPDATE above matched no rows, the workflow may have
+            # been cancelled: a cancelled workflow must not complete, so re-read
+            # the status and raise so it ends as cancelled rather than succeeding
+            # or erroring. The re-read only happens on this rare no-op path, not
+            # on every completion.
+            if result.rowcount == 0:
+                current_status = c.execute(
+                    sa.select(SystemSchema.workflow_status.c.status).where(
+                        SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+                    )
+                ).scalar_one_or_none()
+                if current_status == WorkflowStatusString.CANCELLED.value:
+                    raise DBOSAwaitedWorkflowCancelledError(workflow_id)
 
     def cancel_workflows(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -802,17 +802,17 @@ class SystemDatabase(ABC):
                     != WorkflowStatusString.CANCELLED.value
                 )
             )
-            # If the workflow is cancelled, abort the function so it does not
-            # complete. This mirrors the cancellation check done before each step.
+            # update_workflow_outcome is only called to finalize a workflow. If
+            # the workflow has been cancelled, the guarded UPDATE above was a
+            # no-op: the workflow must not complete, so raise so it ends as
+            # cancelled rather than succeeding or erroring.
             current_status = c.execute(
                 sa.select(SystemSchema.workflow_status.c.status).where(
                     SystemSchema.workflow_status.c.workflow_uuid == workflow_id
                 )
             ).scalar_one_or_none()
             if current_status == WorkflowStatusString.CANCELLED.value:
-                raise DBOSWorkflowCancelledError(
-                    f"Workflow {workflow_id} is cancelled. Aborting function."
-                )
+                raise DBOSAwaitedWorkflowCancelledError(workflow_id)
 
     def cancel_workflows(
         self,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1386,15 +1386,13 @@ def test_cancelling_queued_workflows(dbos: DBOS) -> None:
     assert blocked_handle.get_status().status == WorkflowStatusString.CANCELLED.value
     assert regular_handle.get_result() == None
 
-    # Complete the blocked workflow. After cancellation, the workflow body
-    # may either observe the cancel signal (raising
-    # DBOSAwaitedWorkflowCancelledError) or complete normally and overwrite
-    # the CANCELLED status with SUCCESS — both outcomes are acceptable.
+    # Unblock the cancelled workflow's body. Even though it now runs to
+    # completion, CANCELLED is terminal: it must not overwrite CANCELLED with
+    # SUCCESS, and awaiting its result must raise.
     blocking_event.set()
-    try:
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         blocked_handle.get_result()
-    except DBOSAwaitedWorkflowCancelledError:
-        pass
+    assert blocked_handle.get_status().status == WorkflowStatusString.CANCELLED.value
 
     # Verify all queue entries eventually get cleaned up.
     assert queue_entries_are_cleaned_up(dbos)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2230,8 +2230,19 @@ def test_timeout_queue_recovery(dbos: DBOS) -> None:
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         original_handle.get_result()
 
+    # Reset the workflow to PENDING so it can be recovered. (update_workflow_outcome
+    # cannot be used here: it will not move a workflow out of the terminal
+    # CANCELLED state.)
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.update(SystemSchema.workflow_status)
+            .values({"status": "PENDING"})
+            .where(
+                SystemSchema.workflow_status.c.workflow_uuid
+                == original_handle.workflow_id
+            )
+        )
     # Recover the workflow. Verify its deadline remains the same
-    dbos._sys_db.update_workflow_outcome(original_handle.workflow_id, "PENDING")
     handles = DBOS._recover_pending_workflows()
     assert len(handles) == 1
     recovered_handle = handles[0]

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -71,6 +71,50 @@ def test_cancel_resume(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_cancel_after_final_step(dbos: DBOS) -> None:
+    # A workflow cancelled after its final step completes (but before it
+    # finishes) must not be able to complete successfully. CANCELLED is terminal.
+    steps_completed = 0
+    workflow_event = threading.Event()
+    main_thread_event = threading.Event()
+    input = 5
+
+    @DBOS.step()
+    def step_one() -> None:
+        nonlocal steps_completed
+        steps_completed += 1
+
+    @DBOS.workflow()
+    def simple_workflow(x: int) -> int:
+        # The only step runs and records its output...
+        step_one()
+        # ...then the workflow is cancelled before it returns.
+        main_thread_event.set()
+        workflow_event.wait()
+        return x
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        cancelled_handle = DBOS.start_workflow(simple_workflow, input)
+    main_thread_event.wait()
+    DBOS.cancel_workflow(wfid)
+    workflow_event.set()
+
+    # The workflow must not complete successfully.
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        cancelled_handle.get_result()
+    assert steps_completed == 1
+    assert DBOS.get_workflow_status(wfid).status == "CANCELLED"  # type: ignore[union-attr]
+
+    # Resuming it should let it complete successfully.
+    handle = DBOS.resume_workflow(wfid)
+    assert handle.get_result() == input
+    assert DBOS.get_workflow_status(wfid).status == "SUCCESS"  # type: ignore[union-attr]
+    assert steps_completed == 1  # step_one was already recorded, not re-run
+
+    assert queue_entries_are_cleaned_up(dbos)
+
+
 def test_delete_workflow(dbos: DBOS) -> None:
     @DBOS.transaction()
     def txn(x: int) -> int:

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -986,8 +986,9 @@ def test_resume_and_fork_to_queue(dbos: DBOS) -> None:
     main_thread_event.wait()
     DBOS.cancel_workflow(wfid)
     workflow_event.set()
-    with pytest.raises(Exception):
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         handle.get_result()
+    assert DBOS.get_workflow_status(wfid).status == "CANCELLED"  # type: ignore[union-attr]
     assert step_one_count == 1
     assert step_two_count == 0
 

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -494,9 +494,10 @@ def test_cancel_resume_queue(dbos: DBOS) -> None:
     main_thread_event.wait()
     DBOS.cancel_workflow(wfid)
     workflow_event.set()
-    with pytest.raises(Exception):
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         handle.get_result()
     assert steps_completed == 1
+    assert DBOS.get_workflow_status(wfid).status == "CANCELLED"  # type: ignore[union-attr]
 
     # Resume the workflow. Verify it completes successfully.
     handle = DBOS.resume_workflow(wfid)


### PR DESCRIPTION
Cancellation should be a terminal state. Eliminate a race condition where a workflow cancelled right before it completed would transition to "SUCCESS" or "ERROR". Now, workflows can only leave CANCELLED by being explicitly resumed.