### PR TITLE
Fix get_result error poisoning

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1369,15 +1369,9 @@ class SystemDatabase(ABC):
             return workflow_id
 
     @db_retry()
-    def check_workflow_result(self, workflow_id: str) -> Union[NoResult, Any]:
-        """Check if a workflow has completed and return its result.
-
-        Returns NoResult() if the workflow is still pending/enqueued/delayed/not found.
-        Returns the deserialized output on success.
-        Raises on error, cancellation, or max recovery attempts exceeded.
-        """
+    def _read_workflow_result_row(self, workflow_id: str) -> Optional[Any]:
         with self.engine.begin() as c:
-            row = c.execute(
+            return c.execute(
                 sa.select(
                     SystemSchema.workflow_status.c.status,
                     SystemSchema.workflow_status.c.output,
@@ -1385,23 +1379,30 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.serialization,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
             ).fetchone()
-            if row is not None:
-                status = row[0]
-                if status == WorkflowStatusString.SUCCESS.value:
-                    output = row[1]
-                    return deserialize_value(output, row[3], self.serializer)
-                elif status == WorkflowStatusString.ERROR.value:
-                    error = row[2]
-                    e: Exception = deserialize_exception(error, row[3], self.serializer)
-                    raise e
-                elif status == WorkflowStatusString.CANCELLED.value:
-                    # Raise AwaitedWorkflowCancelledError here, not the cancellation exception
-                    # because the awaiting workflow is not being cancelled.
-                    raise DBOSAwaitedWorkflowCancelledError(workflow_id)
-                elif (
-                    status == WorkflowStatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED.value
-                ):
-                    raise DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded(workflow_id)
+
+    def check_workflow_result(self, workflow_id: str) -> Union[NoResult, Any]:
+        """Check if a workflow has completed and return its result.
+
+        Returns NoResult() if the workflow is still pending/enqueued/delayed/not found.
+        Returns the deserialized output on success.
+        Raises on error, cancellation, or max recovery attempts exceeded.
+        """
+        row = self._read_workflow_result_row(workflow_id)
+        if row is not None:
+            status = row[0]
+            if status == WorkflowStatusString.SUCCESS.value:
+                output = row[1]
+                return deserialize_value(output, row[3], self.serializer)
+            elif status == WorkflowStatusString.ERROR.value:
+                error = row[2]
+                e: Exception = deserialize_exception(error, row[3], self.serializer)
+                raise e
+            elif status == WorkflowStatusString.CANCELLED.value:
+                # Raise AwaitedWorkflowCancelledError here, not the cancellation exception
+                # because the awaiting workflow is not being cancelled.
+                raise DBOSAwaitedWorkflowCancelledError(workflow_id)
+            elif status == WorkflowStatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED.value:
+                raise DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded(workflow_id)
         return NoResult()
 
     def await_workflow_result(self, workflow_id: str, polling_interval: float) -> Any:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, cast
 import pytest
 import sqlalchemy as sa
 from psycopg.errors import SerializationFailure
-from sqlalchemy.exc import InvalidRequestError, OperationalError
+from sqlalchemy.exc import DBAPIError, InvalidRequestError, OperationalError
 
 from dbos import DBOS, SetWorkflowID
 from dbos._client import DBOSClient
@@ -939,3 +939,56 @@ def test_recovery_attempts(dbos: DBOS, config: DBOSConfig) -> None:
     retry_until_success(check_attempt_3)
     event.set()
     DBOS.destroy(destroy_registry=True)
+
+
+def test_get_result_no_hang_on_connection_invalidated_error(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """Test that a DBAPIError doesn't poison the parent workflow's get_result()
+    (check_workflow_result is wrapped in db_retry, so if we just rethrow an error that contains
+    a db retryable error from the child, get_result() is stuck retrying forever
+    """
+    # Dedicated engine so reproducing the timeout doesn't disturb the sys-db pool.
+    boom_engine = sa.create_engine(dbos._sys_db.engine.url)
+
+    @DBOS.step()
+    def boom_step() -> None:
+        with boom_engine.begin() as c:
+            c.execute(
+                sa.text("SET LOCAL idle_in_transaction_session_timeout = '400'")
+            )
+            c.execute(sa.text("SELECT 1"))
+            time.sleep(1.0)  # leave the transaction idle past the timeout
+            c.execute(sa.text("SELECT 1"))  # -> InternalError, connection_invalidated
+
+    @DBOS.workflow()
+    def child() -> None:
+        boom_step()
+
+    handle: WorkflowHandle[None] = DBOS.start_workflow(child)
+
+    with pytest.raises(DBAPIError):
+        handle.get_result()
+
+    poll_handle: WorkflowHandle[None] = DBOS.retrieve_workflow(handle.workflow_id)
+    outcome: dict[str, Any] = {}
+
+    def retrieve() -> None:
+        try:
+            poll_handle.get_result()
+            outcome["returned"] = True
+        except Exception as e:
+            outcome["exc"] = e
+
+    t = threading.Thread(target=retrieve, daemon=True)
+    t.start()
+    t.join(timeout=15)
+
+    assert not t.is_alive(), (
+        "get_result() hung: db_retry treated the child's stored "
+        "connection-invalidated DBAPIError as a retriable connection failure"
+    )
+    exc = outcome.get("exc")
+    assert isinstance(exc, DBAPIError), f"expected DBAPIError, got {outcome!r}"
+    assert "idle-in-transaction" in str(exc)
+    boom_engine.dispose()


### PR DESCRIPTION
If a child workflow returns a DB-retryable error, which we re-raise, `get_result()` will get stuck in `db_retry()`