### PR TITLE
Add enqueue_in_transaction for caller-owned SQLAlchemy transactions

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -19,6 +19,7 @@ from typing import (
 from zoneinfo import ZoneInfo
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Session
 
 from dbos._context import MaxPriority, MinPriority
 from dbos._core import DEFAULT_POLLING_INTERVAL
@@ -38,7 +39,6 @@ if TYPE_CHECKING:
 from dbos._croniter import croniter  # type: ignore
 from dbos._dbos_config import get_system_database_url, is_valid_database_url
 from dbos._error import DBOSException, DBOSNonExistentWorkflowError
-from dbos._registrations import DEFAULT_MAX_RECOVERY_ATTEMPTS
 from dbos._scheduler import backfill_schedule, trigger_schedule
 from dbos._serialization import (
     DefaultSerializer,
@@ -196,14 +196,13 @@ class DBOSClient:
     def destroy(self) -> None:
         self._sys_db.destroy()
 
-    def _enqueue(self, options: EnqueueOptions, *args: Any, **kwargs: Any) -> str:
+    def _build_enqueue_status(
+        self, options: EnqueueOptions, *args: Any, **kwargs: Any
+    ) -> tuple[str, WorkflowStatusInternal]:
         validate_enqueue_options(options)
         workflow_name = options["workflow_name"]
         queue_name = options["queue_name"]
 
-        max_recovery_attempts = options.get("max_recovery_attempts")
-        if max_recovery_attempts is None:
-            max_recovery_attempts = DEFAULT_MAX_RECOVERY_ATTEMPTS
         workflow_id = options.get("workflow_id")
         if workflow_id is None:
             workflow_id = generate_uuid()
@@ -270,13 +269,32 @@ class DBOSClient:
             "owner_xid": None,
             "delay_until_epoch_ms": delay_until_epoch_ms,
         }
+        return workflow_id, status
 
+    def _enqueue(self, options: EnqueueOptions, *args: Any, **kwargs: Any) -> str:
+        workflow_id, status = self._build_enqueue_status(options, *args, **kwargs)
         self._sys_db.init_workflow(
             status,
             max_recovery_attempts=None,
             owner_xid=None,
             is_dequeued_request=False,
             is_recovery_request=False,
+        )
+        return workflow_id
+
+    def _enqueue_with_connection(
+        self,
+        conn_or_session: Union[sa.Connection, Session],
+        options: EnqueueOptions,
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        workflow_id, status = self._build_enqueue_status(options, *args, **kwargs)
+        self._sys_db.init_workflow_with_connection(
+            status,
+            conn_or_session,
+            max_recovery_attempts=None,
+            owner_xid=None,
         )
         return workflow_id
 
@@ -290,6 +308,41 @@ class DBOSClient:
         self, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> "WorkflowHandleAsync[R]":
         workflow_id = await asyncio.to_thread(self._enqueue, options, *args, **kwargs)
+        return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)
+
+    def enqueue_in_transaction(
+        self,
+        conn_or_session: Union[sa.Connection, Session],
+        options: EnqueueOptions,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "WorkflowHandle[R]":
+        """
+        Enqueue a workflow within a caller-owned SQLAlchemy transaction.
+
+        The caller must commit or roll back the transaction. The returned handle
+        is valid immediately, but ``get_result()`` should only be used after the
+        transaction commits. ``conn_or_session`` must target the DBOS system
+        database.
+        """
+        workflow_id = self._enqueue_with_connection(
+            conn_or_session, options, *args, **kwargs
+        )
+        return WorkflowHandleClientPolling[R](workflow_id, self._sys_db)
+
+    async def enqueue_in_transaction_async(
+        self,
+        conn_or_session: Union[sa.Connection, Session],
+        options: EnqueueOptions,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "WorkflowHandleAsync[R]":
+        """
+        Async variant of :meth:`enqueue_in_transaction`.
+        """
+        workflow_id = await asyncio.to_thread(
+            self._enqueue_with_connection, conn_or_session, options, *args, **kwargs
+        )
         return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)
 
     def register_queue(

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -318,32 +318,16 @@ class DBOSClient:
         **kwargs: Any,
     ) -> "WorkflowHandle[R]":
         """
-        Enqueue a workflow within a caller-owned SQLAlchemy transaction.
+        Enqueue a workflow within a caller-owned synchronous SQLAlchemy transaction.
 
         The caller must commit or roll back the transaction. The returned handle
-        is valid immediately, but ``get_result()`` should only be used after the
-        transaction commits. ``conn_or_session`` must target the DBOS system
-        database.
+        is not valid until the transaction commits. ``conn_or_session`` must
+        target the DBOS system database.
         """
         workflow_id = self._enqueue_with_connection(
             conn_or_session, options, *args, **kwargs
         )
         return WorkflowHandleClientPolling[R](workflow_id, self._sys_db)
-
-    async def enqueue_in_transaction_async(
-        self,
-        conn_or_session: Union[sa.Connection, Session],
-        options: EnqueueOptions,
-        *args: Any,
-        **kwargs: Any,
-    ) -> "WorkflowHandleAsync[R]":
-        """
-        Async variant of :meth:`enqueue_in_transaction`.
-        """
-        workflow_id = await asyncio.to_thread(
-            self._enqueue_with_connection, conn_or_session, options, *args, **kwargs
-        )
-        return WorkflowHandleClientAsyncPolling[R](workflow_id, self._sys_db)
 
     def register_queue(
         self,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -323,6 +323,9 @@ class DBOSClient:
         The caller must commit or roll back the transaction. The returned handle
         is not valid until the transaction commits. ``conn_or_session`` must
         target the DBOS system database.
+
+        From an async context, bridge to this synchronous method with
+        ``await async_conn.run_sync(lambda sync_conn: client.enqueue_in_transaction(sync_conn, options, *args))``.
         """
         workflow_id = self._enqueue_with_connection(
             conn_or_session, options, *args, **kwargs

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -28,6 +28,7 @@ from typing import (
 
 import sqlalchemy as sa
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from dbos._debug_trigger import DebugTriggers
@@ -3702,6 +3703,33 @@ class SystemDatabase(ABC):
             )
         DebugTriggers.debug_trigger_point(DebugTriggers.DEBUG_TRIGGER_INITWF_COMMIT)
         return wf_status, workflow_deadline_epoch_ms, should_execute
+
+    def init_workflow_with_connection(
+        self,
+        status: WorkflowStatusInternal,
+        conn: Union[sa.Connection, Session],
+        *,
+        max_recovery_attempts: Optional[int] = None,
+        owner_xid: Optional[str] = None,
+        is_recovery_request: Optional[bool] = False,
+        is_dequeued_request: Optional[bool] = False,
+    ) -> tuple[WorkflowStatuses, Optional[int], bool]:
+        """
+        Record the initial status and inputs for a workflow using a caller-owned
+        SQLAlchemy Connection or ORM Session.
+
+        Does not begin, commit, rollback, or retry. The caller owns the
+        transaction. The connection or session must target the DBOS system
+        database; it cannot atomically span a separate application database.
+        """
+        return self._insert_workflow_status(
+            status,
+            conn,
+            max_recovery_attempts=max_recovery_attempts,
+            owner_xid=owner_xid,
+            is_recovery_request=is_recovery_request,
+            is_dequeued_request=is_dequeued_request,
+        )
 
     def check_connection(self) -> None:
         try:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -611,7 +611,7 @@ class SystemDatabase(ABC):
     def _insert_workflow_status(
         self,
         status: WorkflowStatusInternal,
-        conn: sa.Connection,
+        conn: Union[sa.Connection, Session],
         *,
         max_recovery_attempts: Optional[int],
         owner_xid: Optional[str],

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3733,8 +3733,6 @@ class SystemDatabase(ABC):
         *,
         max_recovery_attempts: Optional[int] = None,
         owner_xid: Optional[str] = None,
-        is_recovery_request: Optional[bool] = False,
-        is_dequeued_request: Optional[bool] = False,
     ) -> tuple[WorkflowStatuses, Optional[int], bool]:
         """
         Record the initial status and inputs for a workflow using a caller-owned
@@ -3749,8 +3747,8 @@ class SystemDatabase(ABC):
             conn,
             max_recovery_attempts=max_recovery_attempts,
             owner_xid=owner_xid,
-            is_recovery_request=is_recovery_request,
-            is_dequeued_request=is_dequeued_request,
+            is_recovery_request=False,
+            is_dequeued_request=False,
         )
 
     def check_connection(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, TypedDict
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import Session
 
 from dbos import (
@@ -386,6 +387,16 @@ def test_client_get_event_update(client: DBOSClient, dbos: DBOS) -> None:
     with SetWorkflowID(wfid):
         handle = DBOS.start_workflow(event_test, key, value, 10)
 
+    # The client has no notification listener, so get_event only learns of a value
+    # by polling, and its fallback poll interval (60s) is longer than this
+    # workflow's 10s pre-update window. Wait (non-blocking, timeout=0) for the
+    # workflow's initial set_event to become visible so the assertion below does
+    # not race the first commit and instead read the later "updated-" value.
+    start = time.time()
+    while client.get_event(wfid, key, 0) != value:
+        assert time.time() - start < 10, "workflow did not publish initial event"
+        time.sleep(0.05)
+
     client_value = client.get_event(wfid, key, 10)
     assert client_value == value
     result = handle.get_result()
@@ -553,7 +564,9 @@ def test_enqueue_in_transaction_commit(dbos: DBOS, client: DBOSClient) -> None:
 
     with client._sys_db.engine.connect() as conn:
         with conn.begin():
-            handle = client.enqueue_in_transaction(conn, options, "tx-commit")
+            handle: WorkflowHandle[str] = client.enqueue_in_transaction(
+                conn, options, "tx-commit"
+            )
             assert handle.get_workflow_id() == wfid
             row = conn.execute(
                 sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
@@ -630,8 +643,12 @@ def test_enqueue_in_transaction_deduplication(dbos: DBOS, client: DBOSClient) ->
 
     with client._sys_db.engine.connect() as conn:
         with conn.begin():
-            handle = client.enqueue_in_transaction(conn, options, "abc")
-            handle2 = client.enqueue_in_transaction(conn, options, "def")
+            handle: WorkflowHandle[str] = client.enqueue_in_transaction(
+                conn, options, "abc"
+            )
+            handle2: WorkflowHandle[str] = client.enqueue_in_transaction(
+                conn, options, "def"
+            )
 
     wfid2 = str(uuid.uuid4())
     options["workflow_id"] = wfid2
@@ -663,7 +680,9 @@ def test_enqueue_in_transaction_session(dbos: DBOS, client: DBOSClient) -> None:
 
     with Session(client._sys_db.engine) as session:
         with session.begin():
-            handle = client.enqueue_in_transaction(session, options, "session-commit")
+            handle: WorkflowHandle[str] = client.enqueue_in_transaction(
+                session, options, "session-commit"
+            )
     assert handle.get_result() == "session-commit"
 
     wfid2 = str(uuid.uuid4())
@@ -679,7 +698,12 @@ def test_enqueue_in_transaction_session(dbos: DBOS, client: DBOSClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_enqueue_in_transaction_async(dbos: DBOS, client: DBOSClient) -> None:
+async def test_enqueue_in_transaction_run_sync(
+    dbos: DBOS, client: DBOSClient, skip_with_sqlite: None
+) -> None:
+    # Async applications use a caller-owned async transaction by bridging to the
+    # synchronous enqueue_in_transaction via AsyncConnection.run_sync, which hands
+    # the callable the underlying sync Connection bound to the same transaction.
     await asyncio.to_thread(run_client_collateral)
 
     wfid = str(uuid.uuid4())
@@ -689,15 +713,27 @@ async def test_enqueue_in_transaction_async(dbos: DBOS, client: DBOSClient) -> N
         "workflow_id": wfid,
     }
 
-    with client._sys_db.engine.connect() as conn:
-        with conn.begin():
-            handle = await client.enqueue_in_transaction_async(
-                conn, options, "async-tx"
-            )
-            assert handle.get_workflow_id() == wfid
+    async_engine = create_async_engine(client._sys_db.engine.url)
+    try:
+        async with async_engine.connect() as conn:
+            async with conn.begin():
+                handle: WorkflowHandle[str] = await conn.run_sync(
+                    lambda sync_conn: client.enqueue_in_transaction(
+                        sync_conn, options, "run-sync-tx"
+                    )
+                )
+                assert handle.get_workflow_id() == wfid
+    finally:
+        await async_engine.dispose()
 
-    result = await handle.get_result()
-    assert result == "async-tx"
+    async_handle: WorkflowHandleAsync[str] = await client.retrieve_workflow_async(wfid)
+    result = await async_handle.get_result()
+    assert result == "run-sync-tx"
+
+    list_results = client.list_workflows()
+    assert len(list_results) == 1
+    assert list_results[0].workflow_id == wfid
+    assert list_results[0].status == "SUCCESS"
 
 
 def test_enqueue_with_priority(dbos: DBOS, client: DBOSClient) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, TypedDict
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
 
 from dbos import (
     DBOS,
@@ -22,6 +23,8 @@ from dbos import (
     SetWorkflowID,
 )
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
+from dbos._error import DBOSNonExistentWorkflowError
+from dbos._schemas.system_database import SystemSchema
 from tests import client_collateral
 from tests.client_collateral import event_test, retrieve_test, send_test
 
@@ -36,6 +39,16 @@ def run_client_collateral() -> None:
     dirname = os.path.dirname(__file__)
     filename = os.path.join(dirname, "client_collateral.py")
     runpy.run_path(filename)
+
+
+def _workflow_exists(client: DBOSClient, workflow_id: str) -> bool:
+    with client._sys_db.engine.connect() as conn:
+        row = conn.execute(
+            sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+            )
+        ).fetchone()
+        return row is not None
 
 
 def test_client_no_migrate(
@@ -526,6 +539,165 @@ def test_enqueue_with_deduplication(dbos: DBOS, client: DBOSClient) -> None:
 
     assert handle.get_result() == "abc"
     assert handle2.get_result() == "abc"
+
+
+def test_enqueue_in_transaction_commit(dbos: DBOS, client: DBOSClient) -> None:
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+
+    with client._sys_db.engine.connect() as conn:
+        with conn.begin():
+            handle = client.enqueue_in_transaction(conn, options, "tx-commit")
+            assert handle.get_workflow_id() == wfid
+            row = conn.execute(
+                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                    SystemSchema.workflow_status.c.workflow_uuid == wfid
+                )
+            ).fetchone()
+            assert row is not None
+
+    result = handle.get_result()
+    assert result == "tx-commit"
+
+    list_results = client.list_workflows()
+    assert len(list_results) == 1
+    assert list_results[0].workflow_id == wfid
+    assert list_results[0].status == "SUCCESS"
+
+
+def test_enqueue_in_transaction_rollback(dbos: DBOS, client: DBOSClient) -> None:
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+
+    with client._sys_db.engine.connect() as conn:
+        trans = conn.begin()
+        client.enqueue_in_transaction(conn, options, "tx-rollback")
+        trans.rollback()
+
+    assert not _workflow_exists(client, wfid)
+    with pytest.raises(DBOSNonExistentWorkflowError):
+        client.retrieve_workflow(wfid)
+
+
+def test_enqueue_in_transaction_pre_commit_invisible(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+    engine = client._sys_db.engine
+
+    with engine.connect() as conn:
+        with conn.begin():
+            client.enqueue_in_transaction(conn, options, "tx-invisible")
+            with engine.connect() as other_conn:
+                row = other_conn.execute(
+                    sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                        SystemSchema.workflow_status.c.workflow_uuid == wfid
+                    )
+                ).fetchone()
+                assert row is None
+
+
+def test_enqueue_in_transaction_deduplication(dbos: DBOS, client: DBOSClient) -> None:
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    dedup_id = f"dedup-{wfid}"
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+        "deduplication_id": dedup_id,
+    }
+
+    with client._sys_db.engine.connect() as conn:
+        with conn.begin():
+            handle = client.enqueue_in_transaction(conn, options, "abc")
+            handle2 = client.enqueue_in_transaction(conn, options, "def")
+
+    wfid2 = str(uuid.uuid4())
+    options["workflow_id"] = wfid2
+    with client._sys_db.engine.connect() as conn:
+        with conn.begin():
+            with pytest.raises(Exception) as exc_info:
+                client.enqueue_in_transaction(conn, options, "def")
+    assert (
+        f"Workflow {wfid2} was deduplicated due to an existing workflow in queue test_queue with deduplication ID {dedup_id}."
+        in str(exc_info.value)
+    )
+
+    list_results = client.list_queued_workflows()
+    assert len(list_results) == 1
+    assert list_results[0].workflow_id == wfid
+    assert handle.get_result() == "abc"
+    assert handle2.get_result() == "abc"
+
+
+def test_enqueue_in_transaction_session(dbos: DBOS, client: DBOSClient) -> None:
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+
+    with Session(client._sys_db.engine) as session:
+        with session.begin():
+            handle = client.enqueue_in_transaction(session, options, "session-commit")
+    assert handle.get_result() == "session-commit"
+
+    wfid2 = str(uuid.uuid4())
+    options["workflow_id"] = wfid2
+    session = Session(client._sys_db.engine)
+    try:
+        trans = session.begin()
+        client.enqueue_in_transaction(session, options, "session-rollback")
+        trans.rollback()
+    finally:
+        session.close()
+    assert not _workflow_exists(client, wfid2)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_in_transaction_async(dbos: DBOS, client: DBOSClient) -> None:
+    await asyncio.to_thread(run_client_collateral)
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+
+    with client._sys_db.engine.connect() as conn:
+        with conn.begin():
+            handle = await client.enqueue_in_transaction_async(
+                conn, options, "async-tx"
+            )
+            assert handle.get_workflow_id() == wfid
+
+    result = await handle.get_result()
+    assert result == "async-tx"
 
 
 def test_enqueue_with_priority(dbos: DBOS, client: DBOSClient) -> None:


### PR DESCRIPTION
## Summary

- Add `SystemDatabase.init_workflow_with_connection()` that reuses the existing `_insert_workflow_status()` path with a caller-provided SQLAlchemy `Connection` or ORM `Session`, without beginning, committing, rolling back, or retrying.
- Add `DBOSClient.enqueue_in_transaction()` and `enqueue_in_transaction_async()` so enqueue writes can participate in a caller-owned transaction. Status construction is shared via `_build_enqueue_status()`; existing `enqueue()` behavior is unchanged.
- Add tests covering commit, rollback, pre-commit invisibility from another connection, unchanged deduplication behavior, ORM `Session` support, and the async API.

Fixes #634

## Implementation notes

- `conn_or_session` must target the DBOS system database; it cannot atomically span a separate application database.
- The returned handle is valid immediately, but `get_result()` should only be used after the transaction commits.
- No `@db_retry()` on the caller-owned path — retrying inside someone else's transaction is unsafe after a DB error.

## Test plan

- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_commit`
- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_rollback`
- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_pre_commit_invisible`
- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_deduplication`
- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_session`
- [x] `pytest tests/test_client.py::test_enqueue_in_transaction_async`
- [x] `pytest tests/test_client.py` (full client suite, 29 passed)