### PR TITLE
Keep a strong reference to running async workflow tasks so GC cannot destroy them mid-execution

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1069,8 +1069,16 @@ async def start_workflow_async(
         return WorkflowHandleAsyncPolling(new_child_workflow_id, dbos)
 
     coro = _execute_workflow_async(dbos, status, func, new_wf_ctx, args, kwargs)
+    inner_task = asyncio.create_task(coro)
+    # Hold a strong reference to the workflow task until it completes: the
+    # event loop only keeps weak references to tasks, and callers (notably
+    # execute_workflow_by_id on the dequeue path) may discard the returned
+    # handle. Without this, a cyclic GC pass can destroy the pending task
+    # mid-execution, killing the workflow with GeneratorExit (#710).
+    dbos._workflow_tasks.add(inner_task)
+    inner_task.add_done_callback(dbos._workflow_tasks.discard)
     # Shield the workflow task from cancellation
-    task = asyncio.shield(asyncio.create_task(coro))
+    task = asyncio.shield(inner_task)
     return WorkflowHandleAsyncTask(new_child_workflow_id, task, dbos)
 
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -410,6 +410,11 @@ class DBOS:
         self._executor_field: Optional[ThreadPoolExecutor] = None
         self._background_threads: List[threading.Thread] = []
         self._timeout_tasks: set[asyncio.Task[None]] = set()
+        # Strong references to running async workflow tasks: the event loop
+        # only keeps weak references, so without these a garbage-collection
+        # pass can destroy a pending workflow task mid-execution (#710).
+        # Entries remove themselves on completion via done-callback.
+        self._workflow_tasks: set["asyncio.Task[Any]"] = set()
         self.conductor_url: Optional[str] = conductor_url
         if config.get("conductor_url"):
             self.conductor_url = config.get("conductor_url")

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -954,9 +954,7 @@ def test_get_result_no_hang_on_connection_invalidated_error(
     @DBOS.step()
     def boom_step() -> None:
         with boom_engine.begin() as c:
-            c.execute(
-                sa.text("SET LOCAL idle_in_transaction_session_timeout = '400'")
-            )
+            c.execute(sa.text("SET LOCAL idle_in_transaction_session_timeout = '400'"))
             c.execute(sa.text("SELECT 1"))
             time.sleep(1.0)  # leave the transaction idle past the timeout
             c.execute(sa.text("SELECT 1"))  # -> InternalError, connection_invalidated

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import multiprocessing
 import multiprocessing.synchronize
 import os
@@ -6,6 +7,7 @@ import subprocess
 import threading
 import time
 import uuid
+import weakref
 from typing import Any, List
 
 import pytest
@@ -2748,13 +2750,7 @@ def test_set_workflow_delay(dbos: DBOS) -> None:
 
 
 def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
-    """Regression test for #710: the dequeue path discards the workflow
-    handle, so DBOS must hold its own strong reference to the running
-    task. Without it, a garbage-collection pass destroys the pending task
-    and throws GeneratorExit into the workflow mid-execution.
-    """
-    import gc
-    import weakref
+    """Regression test for https://github.com/dbos-inc/dbos-transact-py/issues/710"""
 
     entered = threading.Event()
     interrupted: List[str] = []

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -35,7 +35,11 @@ from dbos._error import (
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from dbos._utils import GlobalParams
-from tests.conftest import default_config, queue_entries_are_cleaned_up
+from tests.conftest import (
+    default_config,
+    queue_entries_are_cleaned_up,
+    retry_until_success,
+)
 
 
 def test_simple_queue(dbos: DBOS) -> None:
@@ -2800,7 +2804,7 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
     # Once the workflow completes, the done-callback must release the strong
     # reference so finished tasks are not leaked. The result is recorded
     # before the task finishes, so poll briefly for the callback to run.
-    deadline = time.time() + 10
-    while dbos._workflow_tasks and time.time() < deadline:
-        time.sleep(0.1)
-    assert not dbos._workflow_tasks
+    def check_task_released() -> None:
+        assert not dbos._workflow_tasks
+
+    retry_until_success(check_task_released, interval=0.1, max_attempts=50)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2745,3 +2745,49 @@ def test_set_workflow_delay(dbos: DBOS) -> None:
 
     assert handle2.get_result() == "done"
     assert handle2.get_status().status == WorkflowStatusString.SUCCESS.value
+
+
+def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
+    """Regression test for #710: the dequeue path discards the workflow
+    handle, so DBOS must hold its own strong reference to the running
+    task. Without it, a garbage-collection pass destroys the pending task
+    and throws GeneratorExit into the workflow mid-execution.
+    """
+    import gc
+
+    entered = threading.Event()
+    interrupted: List[str] = []
+
+    @DBOS.workflow()
+    async def hanging_workflow() -> str:
+        entered.set()
+        try:
+            # Suspend on a future rooted only in this frame, as application
+            # code awaiting library internals can. Only the reference in
+            # dbos._workflow_tasks keeps this task reachable.
+            await asyncio.get_running_loop().create_future()
+        except BaseException as exc:
+            interrupted.append(type(exc).__name__)
+            raise
+        return "unreachable"
+
+    DBOS.register_queue("gc_pin_queue")
+    DBOS.enqueue_workflow("gc_pin_queue", hanging_workflow)
+
+    assert entered.wait(timeout=30)
+    time.sleep(0.2)  # let the workflow suspend on its future
+    gc.collect()
+    time.sleep(0.2)
+
+    # Unpinned, gc.collect() destroys the task: interrupted == ["GeneratorExit"]
+    assert interrupted == []
+    assert len(dbos._workflow_tasks) == 1
+
+    # Clean up the deliberately-hanging workflow.
+    (task,) = dbos._workflow_tasks
+    task.get_loop().call_soon_threadsafe(task.cancel)
+    for _ in range(300):
+        if interrupted:
+            break
+        time.sleep(0.1)
+    assert interrupted == ["CancelledError"]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2754,28 +2754,40 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
     and throws GeneratorExit into the workflow mid-execution.
     """
     import gc
+    import weakref
 
     entered = threading.Event()
     interrupted: List[str] = []
+    loops: List[asyncio.AbstractEventLoop] = []
+    fut_refs: List["weakref.ref[asyncio.Future[str]]"] = []
 
     @DBOS.workflow()
     async def hanging_workflow() -> str:
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[str] = loop.create_future()
+        loops.append(loop)
+        # Expose the future only weakly so the test does not itself keep the
+        # workflow task reachable.
+        fut_refs.append(weakref.ref(fut))
         entered.set()
         try:
             # Suspend on a future rooted only in this frame, as application
             # code awaiting library internals can. Only the reference in
             # dbos._workflow_tasks keeps this task reachable.
-            await asyncio.get_running_loop().create_future()
+            return await fut
         except BaseException as exc:
             interrupted.append(type(exc).__name__)
             raise
-        return "unreachable"
 
     DBOS.register_queue("gc_pin_queue")
-    DBOS.enqueue_workflow("gc_pin_queue", hanging_workflow)
+    handle = DBOS.enqueue_workflow("gc_pin_queue", hanging_workflow)
 
     assert entered.wait(timeout=30)
     time.sleep(0.2)  # let the workflow suspend on its future
+
+    # The running task must be pinned in the instance-level strong-reference set
+    assert len(dbos._workflow_tasks) == 1
+
     gc.collect()
     time.sleep(0.2)
 
@@ -2783,11 +2795,16 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
     assert interrupted == []
     assert len(dbos._workflow_tasks) == 1
 
-    # Clean up the deliberately-hanging workflow.
-    (task,) = dbos._workflow_tasks
-    task.get_loop().call_soon_threadsafe(task.cancel)
-    for _ in range(300):
-        if interrupted:
-            break
+    # The workflow is still alive: unblock it and verify it completes.
+    fut = fut_refs[0]()
+    assert fut is not None, "workflow's pending future was garbage-collected"
+    loops[0].call_soon_threadsafe(fut.set_result, "done")
+    assert handle.get_result() == "done"  # type: ignore
+
+    # Once the workflow completes, the done-callback must release the strong
+    # reference so finished tasks are not leaked. The result is recorded
+    # before the task finishes, so poll briefly for the callback to run.
+    deadline = time.time() + 10
+    while dbos._workflow_tasks and time.time() < deadline:
         time.sleep(0.1)
-    assert interrupted == ["CancelledError"]
+    assert not dbos._workflow_tasks


### PR DESCRIPTION
Fixes #710.

## Problem

`start_workflow_async` creates each async workflow task as `asyncio.shield(asyncio.create_task(coro))` and wraps it in a `WorkflowHandleAsyncTask` — but on the dequeue path, `execute_workflow_by_id` discards that handle and returns a `WorkflowHandlePolling` instead. After that, nothing holds a strong reference to the running task: the event loop only keeps weak references, and the shield future and inner task reference each other only through their done-callbacks (an unreachable cycle).

Whenever the workflow is suspended on an await whose future is rooted only in the task's own frame (a bare `loop.create_future()`, common inside async libraries), a cyclic GC pass destroys the pending task mid-execution:

```
Task was destroyed but it is pending!
task: <Task pending coro=<_execute_workflow_async() running at dbos/_core.py:681>
      cb=[shield.<locals>._inner_done_callback()...]>
RuntimeError: coroutine ignored GeneratorExit
```

The workflow is recorded as ERROR with `RuntimeError: coroutine ignored GeneratorExit`, and because `GeneratorExit` is a `BaseException`, application-level error handling inside the workflow never runs. We were hitting this randomly in production-like load (frequency tracks GC pressure); details and a minimal repro in #710.

## Fix

Hold a strong reference to every async workflow task in `DBOS._workflow_tasks` until it completes, self-removing via done-callback — the same pattern as the existing `DBOS._timeout_tasks` set and the `asyncio.create_task` docs recommendation.

## Testing

- New `test_enqueued_async_workflow_survives_gc` in `tests/test_queue.py`: enqueues an async workflow that suspends on a frame-local future, forces `gc.collect()`, and asserts the workflow is still alive and pinned. The test is differential — on `main` without the fix it fails with `interrupted == ['GeneratorExit']`; with the fix it passes.
- `tests/test_async.py` + `tests/test_queue.py` pass under `DBOS_DATABASE=SQLITE` (72 passed, 1 skipped).
