### PR TITLE
Custom Workflow Attributes

### DIFF
--- a/dbos/__init__.py
+++ b/dbos/__init__.py
@@ -4,6 +4,7 @@ from ._context import (
     DBOSContextEnsure,
     DBOSContextSetAuth,
     SetEnqueueOptions,
+    SetWorkflowAttributes,
     SetWorkflowID,
     SetWorkflowTimeout,
 )
@@ -50,6 +51,7 @@ __all__ = [
     "EnqueueOptions",
     "KafkaMessage",
     "PortableWorkflowError",
+    "SetWorkflowAttributes",
     "SetWorkflowID",
     "SetWorkflowTimeout",
     "SetEnqueueOptions",

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -86,6 +86,7 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     serialization_type: WorkflowSerializationFormat
     class_name: str
     instance_name: str
+    attributes: Dict[str, Any]
 
 
 def validate_enqueue_options(options: EnqueueOptions) -> None:
@@ -268,6 +269,7 @@ class DBOSClient:
             "started_at_epoch_ms": None,
             "owner_xid": None,
             "delay_until_epoch_ms": delay_until_epoch_ms,
+            "attributes": options.get("attributes"),
         }
         return workflow_id, status
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -791,6 +791,7 @@ class DBOSClient:
         queues_only: bool = False,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         return self._sys_db.list_workflows(
             workflow_ids=workflow_ids,
@@ -817,6 +818,7 @@ class DBOSClient:
             queues_only=queues_only,
             was_forked_from=was_forked_from,
             has_parent=has_parent,
+            attributes=attributes,
         )
 
     async def list_workflows_async(
@@ -846,6 +848,7 @@ class DBOSClient:
         queues_only: bool = False,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         return await asyncio.to_thread(
             self.list_workflows,
@@ -873,6 +876,7 @@ class DBOSClient:
             queues_only=queues_only,
             was_forked_from=was_forked_from,
             has_parent=has_parent,
+            attributes=attributes,
         )
 
     def list_queued_workflows(
@@ -900,6 +904,7 @@ class DBOSClient:
         load_output: bool = True,
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         return self._sys_db.list_workflows(
             workflow_ids=workflow_ids,
@@ -925,6 +930,7 @@ class DBOSClient:
             executor_id=executor_id,
             queues_only=True,
             has_parent=has_parent,
+            attributes=attributes,
         )
 
     async def list_queued_workflows_async(
@@ -952,6 +958,7 @@ class DBOSClient:
         load_output: bool = True,
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         return await asyncio.to_thread(
             self.list_queued_workflows,
@@ -977,6 +984,7 @@ class DBOSClient:
             load_output=load_output,
             executor_id=executor_id,
             has_parent=has_parent,
+            attributes=attributes,
         )
 
     def list_workflow_steps(

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -355,6 +355,7 @@ class ConductorWebsocket(threading.Thread):
                                     queues_only=body.get("queues_only", False),
                                     was_forked_from=body.get("was_forked_from", None),
                                     has_parent=body.get("has_parent", None),
+                                    attributes=body.get("attributes", None),
                                 )
                             except Exception as e:
                                 error_message = f"Exception encountered when listing workflows: {traceback.format_exc()}"
@@ -408,6 +409,7 @@ class ConductorWebsocket(threading.Thread):
                                     queues_only=True,
                                     was_forked_from=q_body.get("was_forked_from", None),
                                     has_parent=q_body.get("has_parent", None),
+                                    attributes=q_body.get("attributes", None),
                                 )
                             except Exception as e:
                                 error_message = f"Exception encountered when listing queued workflows: {traceback.format_exc()}"

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -1,7 +1,17 @@
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypedDict, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 from dbos._serialization import Serializer, safe_deserialize_schedule_context
 from dbos._sys_db import (
@@ -186,6 +196,7 @@ class ListWorkflowsBody(TypedDict, total=False):
     queues_only: bool
     was_forked_from: Optional[bool]
     has_parent: Optional[bool]
+    attributes: Optional[Dict[str, Any]]
 
 
 @dataclass
@@ -217,6 +228,7 @@ class WorkflowsOutput:
     DequeuedAt: Optional[str]
     DelayUntilEpochMS: Optional[str]
     CompletedAt: Optional[str]
+    Attributes: Optional[str]
 
     @classmethod
     def from_workflow_information(cls, info: WorkflowStatus) -> "WorkflowsOutput":
@@ -253,6 +265,10 @@ class WorkflowsOutput:
         completed_at_str = (
             str(info.completed_at) if info.completed_at is not None else None
         )
+        # JSON rather than str() so the wire format is parseable by Conductor
+        attributes_str = (
+            json.dumps(info.attributes) if info.attributes is not None else None
+        )
 
         return cls(
             WorkflowUUID=info.workflow_id,
@@ -282,6 +298,7 @@ class WorkflowsOutput:
             DequeuedAt=dequeued_at_str,
             DelayUntilEpochMS=delay_until_epoch_ms_str,
             CompletedAt=completed_at_str,
+            Attributes=attributes_str,
         )
 
 
@@ -355,6 +372,7 @@ class ListQueuedWorkflowsBody(TypedDict, total=False):
     executor_id: Optional[Union[str, List[str]]]
     was_forked_from: Optional[bool]
     has_parent: Optional[bool]
+    attributes: Optional[Dict[str, Any]]
 
 
 @dataclass

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -553,6 +553,16 @@ class SetWorkflowAttributes:
             raise Exception(
                 f"Invalid workflow attributes {attributes}. Attributes must be a dict."
             )
+        # Fail fast here rather than surfacing an opaque error later when the
+        # workflow status is recorded as JSON.
+        if attributes is not None:
+            try:
+                json.dumps(attributes)
+            except (TypeError, ValueError) as e:
+                raise Exception(
+                    f"Invalid workflow attributes {attributes}. "
+                    "Attributes must be JSON-serializable."
+                ) from e
         self.created_ctx = False
         self.attributes = attributes
         self.saved_attributes: Optional[Dict[str, Any]] = None

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
 from types import TracebackType
-from typing import TYPE_CHECKING, List, Literal, Optional, Type, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, TypedDict
 
 from dbos._serialization import WorkflowSerializationFormat
 
@@ -129,6 +129,8 @@ class DBOSContext:
         self.deduplication_id: Optional[str] = None
         # A user-specified priority for the enqueuing workflow.
         self.priority: Optional[int] = None
+        # User-specified attributes to attach to the next started workflow.
+        self.workflow_attributes: Optional[Dict[str, Any]] = None
         # If the workflow is enqueued on a partitioned queue, its partition key
         self.queue_partition_key: Optional[str] = None
         # The UNIX epoch timestamp before which the workflow should not be dequeued
@@ -140,6 +142,12 @@ class DBOSContext:
         if is_for_workflow:
             rv.id_assigned_for_next_workflow = self.id_assigned_for_next_workflow
             self.id_assigned_for_next_workflow = ""
+            # Copy so later mutation of the caller's dict cannot affect the child
+            rv.workflow_attributes = (
+                dict(self.workflow_attributes)
+                if self.workflow_attributes is not None
+                else None
+            )
         rv.is_within_set_workflow_id_block = self.is_within_set_workflow_id_block
         rv.parent_workflow_id = self.workflow_id
         rv.parent_workflow_fid = self.function_id
@@ -166,6 +174,7 @@ class DBOSContext:
         rv.priority = self.priority
         rv.queue_partition_key = self.queue_partition_key
         rv.delay_until_epoch_ms = self.delay_until_epoch_ms
+        rv.workflow_attributes = self.workflow_attributes
         self.function_id += 1
         rv.function_id = self.function_id
         if reserve_sleep_id:
@@ -520,6 +529,52 @@ class SetWorkflowTimeout:
         assert_current_dbos_context().workflow_deadline_epoch_ms = (
             self.saved_workflow_deadline_epoch_ms
         )
+        # Code to clean up the basic context if we created it
+        if self.created_ctx:
+            _clear_local_dbos_context()
+        return False  # Did not handle
+
+
+class SetWorkflowAttributes:
+    """
+    Set custom key-value attributes to be attached to workflows started or enqueued
+    within the block. Attributes are recorded in the workflow status at creation and
+    are not inherited by child workflows.
+
+    Typical Usage
+        ```
+        with SetWorkflowAttributes({"customer": "acme", "region": "us-east-1"}):
+            result = workflow_function(...)
+        ```
+    """
+
+    def __init__(self, attributes: Optional[Dict[str, Any]]) -> None:
+        if attributes is not None and not isinstance(attributes, dict):
+            raise Exception(
+                f"Invalid workflow attributes {attributes}. Attributes must be a dict."
+            )
+        self.created_ctx = False
+        self.attributes = attributes
+        self.saved_attributes: Optional[Dict[str, Any]] = None
+
+    def __enter__(self) -> SetWorkflowAttributes:
+        # Code to create a basic context
+        ctx = get_local_dbos_context()
+        if ctx is None:
+            self.created_ctx = True
+            _set_local_dbos_context(DBOSContext())
+        ctx = assert_current_dbos_context()
+        self.saved_attributes = ctx.workflow_attributes
+        ctx.workflow_attributes = self.attributes
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[False]:
+        assert_current_dbos_context().workflow_attributes = self.saved_attributes
         # Code to clean up the basic context if we created it
         if self.created_ctx:
             _clear_local_dbos_context()

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -446,7 +446,11 @@ def _init_workflow(
             if enqueue_options is not None
             else None
         ),
+        "attributes": ctx.workflow_attributes,
     }
+    # Consume the attributes from the workflow's context so that workflows
+    # started inside this workflow do not inherit them.
+    ctx.workflow_attributes = None
 
     # Synchronously record the status and inputs for workflows
     try:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -2273,6 +2273,7 @@ class DBOS:
         queues_only: bool = False,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         check_async("list_workflows")
 
@@ -2302,6 +2303,7 @@ class DBOS:
                 queues_only=queues_only,
                 was_forked_from=was_forked_from,
                 has_parent=has_parent,
+                attributes=attributes,
             )
 
         return _get_dbos_instance()._sys_db.call_function_as_step(
@@ -2336,6 +2338,7 @@ class DBOS:
         queues_only: bool = False,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         step_ctx = snapshot_step_context(reserve_sleep_id=False)
         await cls._configure_asyncio_thread_pool()
@@ -2366,6 +2369,7 @@ class DBOS:
                 queues_only=queues_only,
                 was_forked_from=was_forked_from,
                 has_parent=has_parent,
+                attributes=attributes,
             )
 
         return await asyncio.to_thread(
@@ -2401,6 +2405,7 @@ class DBOS:
         load_output: bool = True,
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         check_async("list_queued_workflows")
 
@@ -2429,6 +2434,7 @@ class DBOS:
                 executor_id=executor_id,
                 queues_only=True,
                 has_parent=has_parent,
+                attributes=attributes,
             )
 
         return _get_dbos_instance()._sys_db.call_function_as_step(
@@ -2463,6 +2469,7 @@ class DBOS:
         load_output: bool = True,
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         step_ctx = snapshot_step_context(reserve_sleep_id=False)
         await cls._configure_asyncio_thread_pool()
@@ -2492,6 +2499,7 @@ class DBOS:
                 executor_id=executor_id,
                 queues_only=True,
                 has_parent=has_parent,
+                attributes=attributes,
             )
 
         return await asyncio.to_thread(

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -26,6 +26,7 @@ from dbos._client import (
 from dbos._context import (
     DBOSContextEnsure,
     SetEnqueueOptions,
+    SetWorkflowAttributes,
     SetWorkflowID,
     SetWorkflowTimeout,
     assert_current_dbos_context,
@@ -67,6 +68,7 @@ class ContextOptions(TypedDict):
     priority: Optional[int]
     app_version: Optional[str]
     workflow_timeout_sec: Optional[float]
+    attributes: Optional[Dict[str, Any]]
 
 
 # Parameters for the debouncer workflow
@@ -133,7 +135,11 @@ def debouncer_workflow(
     # After the timeout or period has elapsed, start the user workflow with the requested context parameters,
     # either directly or on a queue.
     with SetWorkflowID(ctx["workflow_id"]):
-        with SetWorkflowTimeout(ctx["workflow_timeout_sec"]):
+        # Use .get() because inputs recorded before attributes existed lack the key
+        with (
+            SetWorkflowTimeout(ctx["workflow_timeout_sec"]),
+            SetWorkflowAttributes(ctx.get("attributes")),
+        ):
             func = dbos._registry.workflow_info_map.get(options["workflow_name"], None)
             if not func:
                 raise Exception(
@@ -248,13 +254,14 @@ class Debouncer(Generic[P, R]):
                     if ctx.workflow_timeout_ms
                     else None
                 ),
+                "attributes": ctx.workflow_attributes,
             }
         while True:
             try:
                 # Attempt to enqueue a debouncer for this workflow.
                 deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
                 with SetEnqueueOptions(deduplication_id=deduplication_id):
-                    with SetWorkflowTimeout(None):
+                    with SetWorkflowTimeout(None), SetWorkflowAttributes(None):
                         internal_queue.enqueue(
                             debouncer_workflow,
                             debounce_period_sec,
@@ -350,6 +357,7 @@ class DebouncerClient:
             "deduplication_id": self.workflow_options.get("deduplication_id"),
             "priority": self.workflow_options.get("priority"),
             "workflow_timeout_sec": self.workflow_options.get("workflow_timeout"),
+            "attributes": self.workflow_options.get("attributes"),
         }
         message_id = generate_uuid()
         while True:

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -8,7 +8,7 @@ from ._logger import dbos_logger
 # autocommit (CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction
 # block on Postgres). On CockroachDB, schema changes are inherently online,
 # so this set is ignored and the regular transactional path is used.
-_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37}
+_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37, 41}
 
 
 def _concurrently(is_cockroach: bool) -> str:
@@ -853,6 +853,18 @@ FOR EACH ROW EXECUTE FUNCTION "{schema}".streams_function();
 """
 
 
+def get_dbos_migration_forty(schema: str) -> str:
+    # ADD COLUMN with no default is a fast catalog-only update.
+    return f'ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "attributes" JSONB'
+
+
+def get_dbos_migration_fortyone(schema: str, is_cockroach: bool) -> str:
+    # Supports containment (@>) filters on workflow attributes. On CockroachDB,
+    # USING GIN creates an inverted index.
+    c = _concurrently(is_cockroach)
+    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_attributes" ON "{schema}"."workflow_status" USING GIN ("attributes")'
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -896,6 +908,8 @@ def get_dbos_migrations(
         get_dbos_migration_thirtyseven(schema, is_cockroach),
         get_dbos_migration_thirtyeight(schema, is_cockroach),
         get_dbos_migration_thirtynine(schema, use_listen_notify),
+        get_dbos_migration_forty(schema),
+        get_dbos_migration_fortyone(schema, is_cockroach),
     ]
 
 
@@ -1142,6 +1156,8 @@ CREATE INDEX IF NOT EXISTS "idx_workflow_status_completed_at" ON "workflow_statu
 
 sqlite_migration_thirtyseven = 'CREATE INDEX IF NOT EXISTS "idx_workflow_status_started_at" ON "workflow_status" ("started_at_epoch_ms") WHERE "started_at_epoch_ms" IS NOT NULL'
 
+sqlite_migration_forty = 'ALTER TABLE workflow_status ADD COLUMN "attributes" TEXT'
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1179,4 +1195,7 @@ sqlite_migrations = [
     sqlite_migration_thirtyfive,
     sqlite_migration_thirtysix,
     sqlite_migration_thirtyseven,
+    # There is no SQLite version of migrations thirty-eight and thirty-nine
+    sqlite_migration_forty,
+    # There is no SQLite version of migration forty-one (GIN index)
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -8,7 +8,7 @@ from ._logger import dbos_logger
 # autocommit (CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction
 # block on Postgres). On CockroachDB, schema changes are inherently online,
 # so this set is ignored and the regular transactional path is used.
-_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37, 41}
+_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37}
 
 
 def _concurrently(is_cockroach: bool) -> str:
@@ -854,15 +854,14 @@ FOR EACH ROW EXECUTE FUNCTION "{schema}".streams_function();
 
 
 def get_dbos_migration_forty(schema: str) -> str:
-    # ADD COLUMN with no default is a fast catalog-only update.
-    return f'ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "attributes" JSONB'
-
-
-def get_dbos_migration_fortyone(schema: str, is_cockroach: bool) -> str:
-    # Supports containment (@>) filters on workflow attributes. On CockroachDB,
-    # USING GIN creates an inverted index.
-    c = _concurrently(is_cockroach)
-    return f'CREATE INDEX {c} IF NOT EXISTS "idx_workflow_status_attributes" ON "{schema}"."workflow_status" USING GIN ("attributes")'
+    # ADD COLUMN with no default is catalog-only; the partial index built in
+    # the same transaction covers zero rows, so no CONCURRENTLY is needed.
+    # The index supports containment (@>) filters on workflow attributes; on
+    # CockroachDB, USING GIN creates an inverted index.
+    return f"""
+ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "attributes" JSONB;
+CREATE INDEX IF NOT EXISTS "idx_workflow_status_attributes" ON "{schema}"."workflow_status" USING GIN ("attributes") WHERE "attributes" IS NOT NULL;
+"""
 
 
 def get_dbos_migrations(
@@ -909,7 +908,6 @@ def get_dbos_migrations(
         get_dbos_migration_thirtyeight(schema, is_cockroach),
         get_dbos_migration_thirtynine(schema, use_listen_notify),
         get_dbos_migration_forty(schema),
-        get_dbos_migration_fortyone(schema, is_cockroach),
     ]
 
 
@@ -1196,6 +1194,6 @@ sqlite_migrations = [
     sqlite_migration_thirtysix,
     sqlite_migration_thirtyseven,
     # There is no SQLite version of migrations thirty-eight and thirty-nine
+    # Unlike Postgres migration forty, this creates no index (no GIN equivalent)
     sqlite_migration_forty,
-    # There is no SQLite version of migration forty-one (GIN index)
 ]

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -1,5 +1,6 @@
 import random
 import threading
+import time
 import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional
@@ -210,6 +211,13 @@ def trigger_schedule(sys_db: "SystemDatabase", schedule_name: str) -> str:
     return workflow_id
 
 
+# During the first minute after startup, poll for schedules every second so
+# schedules registered around launch are picked up promptly rather than after
+# a full polling interval.
+_STARTUP_FAST_POLL_DURATION_SEC = 60.0
+_STARTUP_FAST_POLL_INTERVAL_SEC = 1.0
+
+
 def dynamic_scheduler_loop(
     stop_event: threading.Event, polling_interval_sec: float
 ) -> None:
@@ -220,6 +228,13 @@ def dynamic_scheduler_loop(
     # Active schedule threads keyed by schedule_id
     schedule_threads: dict[str, _ScheduleThread] = {}
 
+    startup_deadline = time.monotonic() + _STARTUP_FAST_POLL_DURATION_SEC
+
+    def poll_timeout() -> float:
+        if time.monotonic() < startup_deadline:
+            return min(_STARTUP_FAST_POLL_INTERVAL_SEC, polling_interval_sec)
+        return polling_interval_sec
+
     while not stop_event.is_set():
         try:
             schedules = dbos._sys_db.list_schedules()
@@ -227,7 +242,7 @@ def dynamic_scheduler_loop(
             dbos_logger.warning(
                 f"Exception polling schedules: {traceback.format_exc()}"
             )
-            if stop_event.wait(timeout=polling_interval_sec):
+            if stop_event.wait(timeout=poll_timeout()):
                 break
             continue
 
@@ -273,7 +288,7 @@ def dynamic_scheduler_loop(
                     schedule, dbos._sys_db.serializer
                 )
 
-        if stop_event.wait(timeout=polling_interval_sec):
+        if stop_event.wait(timeout=poll_timeout()):
             break
 
     # Clean up all threads on shutdown

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -136,6 +136,7 @@ def _enqueue_scheduled_workflow(
         "started_at_epoch_ms": None,
         "owner_xid": None,
         "delay_until_epoch_ms": None,
+        "attributes": None,
     }
     sys_db.init_workflow(
         status,

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from sqlalchemy import (
+    JSON,
     BigInteger,
     Boolean,
     Column,
@@ -17,6 +18,7 @@ from sqlalchemy import (
     Text,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 class SystemSchema:
@@ -90,6 +92,7 @@ class SystemSchema:
         Column("delay_until_epoch_ms", BigInteger, nullable=True),
         Column("rate_limited", Boolean, nullable=False, server_default="false"),
         Column("completed_at", BigInteger, nullable=True),
+        Column("attributes", JSON().with_variant(JSONB(), "postgresql"), nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index(
             "idx_workflow_status_delayed",
@@ -141,6 +144,12 @@ class SystemSchema:
             "started_at_epoch_ms",
             postgresql_where=text("started_at_epoch_ms IS NOT NULL"),
             sqlite_where=text("started_at_epoch_ms IS NOT NULL"),
+        ),
+        # Postgres-only; the SQLite migrations do not create this index
+        Index(
+            "idx_workflow_status_attributes",
+            "attributes",
+            postgresql_using="gin",
         ),
         Index(
             "uq_workflow_status_dedup_id",

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -150,6 +150,7 @@ class SystemSchema:
             "idx_workflow_status_attributes",
             "attributes",
             postgresql_using="gin",
+            postgresql_where=text("attributes IS NOT NULL"),
         ),
         Index(
             "uq_workflow_status_dedup_id",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -185,6 +185,8 @@ class WorkflowStatus:
     # The UNIX epoch timestamp at which the workflow completed (SUCCESS, ERROR,
     # or CANCELLED). None if the workflow has not completed.
     completed_at: Optional[int]
+    # Custom key-value attributes attached to the workflow at creation
+    attributes: Optional[Dict[str, Any]]
 
     # INTERNAL FIELDS
 
@@ -224,6 +226,7 @@ class WorkflowStatusInternal(TypedDict):
     serialization: Optional[str]
     owner_xid: Optional[str]
     delay_until_epoch_ms: Optional[int]
+    attributes: Optional[Dict[str, Any]]
 
 
 class MetricData(TypedDict):
@@ -673,6 +676,7 @@ class SystemDatabase(ABC):
                 parent_workflow_id=status["parent_workflow_id"],
                 owner_xid=owner_xid,
                 delay_until_epoch_ms=status["delay_until_epoch_ms"],
+                attributes=status["attributes"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
@@ -978,6 +982,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.assumed_role,
                     SystemSchema.workflow_status.c.inputs,
                     SystemSchema.workflow_status.c.serialization,
+                    SystemSchema.workflow_status.c.attributes,
                 ).where(
                     SystemSchema.workflow_status.c.workflow_uuid.in_(
                         original_workflow_ids
@@ -1014,6 +1019,7 @@ class SystemDatabase(ABC):
                             inputs=status[8],
                             assumed_role=status[7],
                             forked_from=original_workflow_id,
+                            attributes=status[10],
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
                             original_workflow_ids, forked_workflow_ids, statuses
@@ -1327,6 +1333,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.started_at_epoch_ms,
                     SystemSchema.workflow_status.c.serialization,
                     SystemSchema.workflow_status.c.delay_until_epoch_ms,
+                    SystemSchema.workflow_status.c.attributes,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -1361,6 +1368,7 @@ class SystemDatabase(ABC):
                 "serialization": row[23],
                 "owner_xid": None,
                 "delay_until_epoch_ms": row[24],
+                "attributes": row[25],
             }
             return status
 
@@ -1570,6 +1578,7 @@ class SystemDatabase(ABC):
             SystemSchema.workflow_status.c.delay_until_epoch_ms,
             SystemSchema.workflow_status.c.was_forked_from,
             SystemSchema.workflow_status.c.completed_at,
+            SystemSchema.workflow_status.c.attributes,
         ]
         if load_input:
             load_columns.append(SystemSchema.workflow_status.c.inputs)
@@ -1724,8 +1733,9 @@ class SystemDatabase(ABC):
             info.delay_until_epoch_ms = row[23]
             info.was_forked_from = row[24]
             info.completed_at = row[25]
+            info.attributes = row[26]
 
-            idx = 26
+            idx = 27
             raw_input = row[idx] if load_input else None
             if load_input:
                 idx += 1

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1529,6 +1529,7 @@ class SystemDatabase(ABC):
         queues_only: bool = False,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
+        attributes: Optional[Dict[str, Any]] = None,
     ) -> List[WorkflowStatus]:
         """
         Retrieve a list of workflows based on the search criteria.
@@ -1610,6 +1611,8 @@ class SystemDatabase(ABC):
             query = query.where(
                 SystemSchema.workflow_status.c.authenticated_user.in_(user_list)
             )
+        if attributes:
+            query = query.where(self._attributes_contains_clause(attributes))
         if start_time:
             query = query.where(
                 SystemSchema.workflow_status.c.created_at
@@ -2331,6 +2334,13 @@ class SystemDatabase(ABC):
     @abstractmethod
     def _is_unique_constraint_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a unique constraint violation."""
+        pass
+
+    @abstractmethod
+    def _attributes_contains_clause(
+        self, attributes: Dict[str, Any]
+    ) -> sa.ColumnElement[bool]:
+        """Build a clause matching workflows whose attributes contain all the given key-value pairs."""
         pass
 
     @abstractmethod

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -3,11 +3,13 @@ from typing import Any, Dict, Optional, cast
 
 import psycopg
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import DBAPIError
 
 from dbos._migration import ensure_dbos_schema, run_dbos_migrations, should_migrate
 
 from ._logger import dbos_logger
+from ._schemas.system_database import SystemSchema
 from ._sys_db import SystemDatabase
 
 
@@ -106,6 +108,16 @@ class PostgresSystemDatabase(SystemDatabase):
     def _is_unique_constraint_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a unique constraint violation in PostgreSQL."""
         return dbapi_error.orig.sqlstate == "23505"  # type: ignore
+
+    def _attributes_contains_clause(
+        self, attributes: Dict[str, Any]
+    ) -> sa.ColumnElement[bool]:
+        # Coerce to JSONB so contains() renders the @> containment operator,
+        # which is served by the GIN index on the attributes column. The
+        # column's generic JSON type would render contains() as a string LIKE.
+        return sa.type_coerce(
+            SystemSchema.workflow_status.c.attributes, JSONB
+        ).contains(attributes)
 
     def _is_foreign_key_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a foreign key violation in PostgreSQL."""

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -1,4 +1,3 @@
-import json
 import os
 import time
 from typing import Any, Dict, Optional, Tuple
@@ -9,8 +8,8 @@ from sqlalchemy.exc import DBAPIError
 
 from dbos._migration import sqlite_migrations
 
+from ._error import DBOSException
 from ._logger import dbos_logger
-from ._schemas.system_database import SystemSchema
 from ._sys_db import SystemDatabase
 
 
@@ -122,29 +121,12 @@ class SQLiteSystemDatabase(SystemDatabase):
     def _attributes_contains_clause(
         self, attributes: Dict[str, Any]
     ) -> sa.ColumnElement[bool]:
-        """Approximate Postgres JSONB containment (@>) with json_extract.
-
-        Scalar values match by equality (JSON true/false extract as 1/0, and a
-        JSON null is distinguished from a missing key via json_type). Nested
-        values match by minified-JSON equality, which is stricter than
-        Postgres's recursive subset containment.
-        """
-        col = SystemSchema.workflow_status.c.attributes
-        clauses: list[sa.ColumnElement[bool]] = []
-        for key, value in attributes.items():
-            path = f'$."{key}"'
-            extracted = sa.func.json_extract(col, path)
-            if value is None:
-                clauses.append(sa.func.json_type(col, path) == "null")
-            elif isinstance(value, bool):
-                clauses.append(extracted == (1 if value else 0))
-            elif isinstance(value, (int, float, str)):
-                clauses.append(extracted == value)
-            else:
-                clauses.append(
-                    extracted == sa.func.json_extract(json.dumps(value), "$")
-                )
-        return sa.and_(*clauses)
+        # SQLite's JSON functions cannot faithfully reproduce Postgres JSONB
+        # containment (@>), so rather than silently diverge, reject the filter.
+        raise DBOSException(
+            "Filtering workflows by attributes is not supported on SQLite. "
+            "Use a Postgres system database to filter by attributes."
+        )
 
     def _is_foreign_key_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a foreign key violation in SQLite."""

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 from typing import Any, Dict, Optional, Tuple
@@ -9,6 +10,7 @@ from sqlalchemy.exc import DBAPIError
 from dbos._migration import sqlite_migrations
 
 from ._logger import dbos_logger
+from ._schemas.system_database import SystemSchema
 from ._sys_db import SystemDatabase
 
 
@@ -116,6 +118,33 @@ class SQLiteSystemDatabase(SystemDatabase):
     def _is_unique_constraint_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a unique constraint violation in SQLite."""
         return "UNIQUE constraint failed" in str(dbapi_error.orig)
+
+    def _attributes_contains_clause(
+        self, attributes: Dict[str, Any]
+    ) -> sa.ColumnElement[bool]:
+        """Approximate Postgres JSONB containment (@>) with json_extract.
+
+        Scalar values match by equality (JSON true/false extract as 1/0, and a
+        JSON null is distinguished from a missing key via json_type). Nested
+        values match by minified-JSON equality, which is stricter than
+        Postgres's recursive subset containment.
+        """
+        col = SystemSchema.workflow_status.c.attributes
+        clauses: list[sa.ColumnElement[bool]] = []
+        for key, value in attributes.items():
+            path = f'$."{key}"'
+            extracted = sa.func.json_extract(col, path)
+            if value is None:
+                clauses.append(sa.func.json_type(col, path) == "null")
+            elif isinstance(value, bool):
+                clauses.append(extracted == (1 if value else 0))
+            elif isinstance(value, (int, float, str)):
+                clauses.append(extracted == value)
+            else:
+                clauses.append(
+                    extracted == sa.func.json_extract(json.dumps(value), "$")
+                )
+        return sa.and_(*clauses)
 
     def _is_foreign_key_violation(self, dbapi_error: DBAPIError) -> bool:
         """Check if the error is a foreign key violation in SQLite."""

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -4,7 +4,7 @@ import sys
 import uuid
 
 import psycopg
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, ResourceClosedError
 
 INTERNAL_QUEUE_NAME = "_dbos_internal_queue"
 
@@ -58,8 +58,14 @@ def retriable_postgres_exception(e: Exception) -> bool:
 def retriable_sqlite_exception(e: Exception) -> bool:
     if "database is locked" in str(e):
         return True
-    else:
-        return False
+    # Under concurrent writes, pysqlite can intermittently invalidate the
+    # cursor of an "INSERT ... RETURNING" statement before its row is fetched,
+    # surfacing as a ResourceClosedError ("does not return rows"). The enclosing
+    # transaction has rolled back and the write is idempotent (ON CONFLICT DO
+    # UPDATE), so the operation is safe to retry.
+    if isinstance(e, ResourceClosedError) and "does not return rows" in str(e):
+        return True
+    return False
 
 
 def generate_uuid() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,6 @@ def default_config() -> DBOSConfig:
         ),
         "enable_otlp": False,
         "notification_listener_polling_interval_sec": 0.01,
-        "scheduler_polling_interval_sec": 1,
     }
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -14,6 +14,8 @@ from dbos import (
     SetWorkflowID,
     WorkflowHandle,
 )
+from dbos._error import DBOSException
+from tests.conftest import using_sqlite
 
 
 def test_attributes_direct_invocation(dbos: DBOS) -> None:
@@ -104,7 +106,7 @@ def test_attributes_client(client: DBOSClient, dbos: DBOS) -> None:
     assert handle.get_status().attributes == {"source": "client"}
 
 
-def test_attributes_list_filter(dbos: DBOS) -> None:
+def test_attributes_list_filter(dbos: DBOS, skip_with_sqlite: None) -> None:
     @DBOS.workflow()
     def attr_workflow() -> None:
         return None
@@ -140,7 +142,7 @@ def test_attributes_list_filter(dbos: DBOS) -> None:
     assert matched_ids(attributes={"missing": "key"}) == set()
 
 
-def test_attributes_list_queued(dbos: DBOS) -> None:
+def test_attributes_list_queued(dbos: DBOS, skip_with_sqlite: None) -> None:
     start_event = threading.Event()
     blocking_event = threading.Event()
 
@@ -164,7 +166,7 @@ def test_attributes_list_queued(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_attributes_list_async(dbos: DBOS) -> None:
+async def test_attributes_list_async(dbos: DBOS, skip_with_sqlite: None) -> None:
     start_event = threading.Event()
     blocking_event = threading.Event()
 
@@ -189,7 +191,9 @@ async def test_attributes_list_async(dbos: DBOS) -> None:
     handle.get_result()
 
 
-def test_attributes_client_list(client: DBOSClient, dbos: DBOS) -> None:
+def test_attributes_client_list(
+    client: DBOSClient, dbos: DBOS, skip_with_sqlite: None
+) -> None:
     options: EnqueueOptions = {
         "queue_name": "unconsumed_queue",
         "workflow_name": "client_workflow",
@@ -206,7 +210,9 @@ def test_attributes_client_list(client: DBOSClient, dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_attributes_client_list_async(client: DBOSClient, dbos: DBOS) -> None:
+async def test_attributes_client_list_async(
+    client: DBOSClient, dbos: DBOS, skip_with_sqlite: None
+) -> None:
     options: EnqueueOptions = {
         "queue_name": "unconsumed_queue",
         "workflow_name": "client_workflow",
@@ -220,6 +226,13 @@ async def test_attributes_client_list_async(client: DBOSClient, dbos: DBOS) -> N
     assert {s.workflow_id for s in statuses} == {h1.workflow_id, h2.workflow_id}
     queued = await client.list_queued_workflows_async(attributes={"n": 1})
     assert [s.workflow_id for s in queued] == [h1.workflow_id]
+
+
+def test_attributes_filter_unsupported_sqlite(dbos: DBOS) -> None:
+    if not using_sqlite():
+        pytest.skip("Tests the SQLite-only error path")
+    with pytest.raises(DBOSException, match="not supported on SQLite"):
+        DBOS.list_workflows(attributes={"customer": "acme"})
 
 
 def test_attributes_debouncer(dbos: DBOS) -> None:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,5 +1,8 @@
+import threading
 import uuid
 from typing import Any
+
+import pytest
 
 from dbos import (
     DBOS,
@@ -99,6 +102,124 @@ def test_attributes_client(client: DBOSClient, dbos: DBOS) -> None:
     }
     handle: WorkflowHandle[Any] = client.enqueue(options, 1)
     assert handle.get_status().attributes == {"source": "client"}
+
+
+def test_attributes_list_filter(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def attr_workflow() -> None:
+        return None
+
+    with SetWorkflowAttributes(
+        {"customer": "acme", "tier": 1, "beta": True, "note": None}
+    ):
+        h1 = DBOS.start_workflow(attr_workflow)
+    with SetWorkflowAttributes(
+        {"customer": "bigco", "tier": 2, "meta": {"region": "us-east-1"}}
+    ):
+        h2 = DBOS.start_workflow(attr_workflow)
+    h1.get_result()
+    h2.get_result()
+
+    def matched_ids(**kwargs: Any) -> set[str]:
+        return {s.workflow_id for s in DBOS.list_workflows(**kwargs)}
+
+    # Single key
+    assert matched_ids(attributes={"customer": "acme"}) == {h1.workflow_id}
+    # Multiple keys AND together
+    assert matched_ids(attributes={"customer": "bigco", "tier": 2}) == {h2.workflow_id}
+    # Value mismatch on one key matches nothing
+    assert matched_ids(attributes={"customer": "acme", "tier": 2}) == set()
+    # Non-string value types
+    assert matched_ids(attributes={"tier": 1}) == {h1.workflow_id}
+    assert matched_ids(attributes={"beta": True}) == {h1.workflow_id}
+    assert matched_ids(attributes={"note": None}) == {h1.workflow_id}
+    assert matched_ids(attributes={"meta": {"region": "us-east-1"}}) == {h2.workflow_id}
+    # Composes with other filters
+    assert matched_ids(attributes={"tier": 1}, workflow_ids=[h2.workflow_id]) == set()
+    # Workflows without attributes never match
+    assert matched_ids(attributes={"missing": "key"}) == set()
+
+
+def test_attributes_list_queued(dbos: DBOS) -> None:
+    start_event = threading.Event()
+    blocking_event = threading.Event()
+
+    queue = Queue("attr_filter_queue")
+
+    @DBOS.workflow()
+    def blocking_workflow() -> None:
+        start_event.set()
+        blocking_event.wait()
+
+    with SetWorkflowAttributes({"side": "queued"}):
+        handle = queue.enqueue(blocking_workflow)
+    start_event.wait()
+
+    statuses = DBOS.list_queued_workflows(attributes={"side": "queued"})
+    assert [s.workflow_id for s in statuses] == [handle.workflow_id]
+    assert DBOS.list_queued_workflows(attributes={"side": "other"}) == []
+
+    blocking_event.set()
+    handle.get_result()
+
+
+@pytest.mark.asyncio
+async def test_attributes_list_async(dbos: DBOS) -> None:
+    start_event = threading.Event()
+    blocking_event = threading.Event()
+
+    queue = Queue("attr_filter_queue_async")
+
+    @DBOS.workflow()
+    def blocking_workflow() -> None:
+        start_event.set()
+        blocking_event.wait()
+
+    with SetWorkflowAttributes({"side": "async"}):
+        handle = queue.enqueue(blocking_workflow)
+    start_event.wait()
+
+    statuses = await DBOS.list_workflows_async(attributes={"side": "async"})
+    assert [s.workflow_id for s in statuses] == [handle.workflow_id]
+    queued = await DBOS.list_queued_workflows_async(attributes={"side": "async"})
+    assert [s.workflow_id for s in queued] == [handle.workflow_id]
+    assert await DBOS.list_workflows_async(attributes={"side": "other"}) == []
+
+    blocking_event.set()
+    handle.get_result()
+
+
+def test_attributes_client_list(client: DBOSClient, dbos: DBOS) -> None:
+    options: EnqueueOptions = {
+        "queue_name": "unconsumed_queue",
+        "workflow_name": "client_workflow",
+        "attributes": {"source": "client", "n": 1},
+    }
+    h1: WorkflowHandle[Any] = client.enqueue(options, 1)
+    options["attributes"] = {"source": "client", "n": 2}
+    h2: WorkflowHandle[Any] = client.enqueue(options, 2)
+
+    statuses = client.list_workflows(attributes={"source": "client"})
+    assert {s.workflow_id for s in statuses} == {h1.workflow_id, h2.workflow_id}
+    queued = client.list_queued_workflows(attributes={"n": 2})
+    assert [s.workflow_id for s in queued] == [h2.workflow_id]
+
+
+@pytest.mark.asyncio
+async def test_attributes_client_list_async(client: DBOSClient, dbos: DBOS) -> None:
+    options: EnqueueOptions = {
+        "queue_name": "unconsumed_queue",
+        "workflow_name": "client_workflow",
+        "attributes": {"source": "client_async", "n": 1},
+    }
+    h1: WorkflowHandle[Any] = client.enqueue(options, 1)
+    options["attributes"] = {"source": "client_async", "n": 2}
+    h2: WorkflowHandle[Any] = client.enqueue(options, 2)
+
+    statuses = await client.list_workflows_async(attributes={"source": "client_async"})
+    assert {s.workflow_id for s in statuses} == {h1.workflow_id, h2.workflow_id}
+    queued = await client.list_queued_workflows_async(attributes={"n": 1})
+    assert [s.workflow_id for s in queued] == [h1.workflow_id]
 
 
 def test_attributes_debouncer(dbos: DBOS) -> None:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import uuid
 from typing import Any
@@ -226,6 +227,45 @@ async def test_attributes_client_list_async(
     assert {s.workflow_id for s in statuses} == {h1.workflow_id, h2.workflow_id}
     queued = await client.list_queued_workflows_async(attributes={"n": 1})
     assert [s.workflow_id for s in queued] == [h1.workflow_id]
+
+
+def test_attributes_conductor_protocol(dbos: DBOS, skip_with_sqlite: None) -> None:
+    import dbos._conductor.protocol as p
+
+    @DBOS.workflow()
+    def conductor_workflow() -> None:
+        return None
+
+    with SetWorkflowAttributes({"customer": "acme", "tier": 1}):
+        handle = DBOS.start_workflow(conductor_workflow)
+    handle.get_result()
+
+    # Parse a list_workflows request as Conductor would send it and run the
+    # same query the handler runs
+    request = p.ListWorkflowsRequest.from_json(
+        json.dumps(
+            {
+                "type": "list_workflows",
+                "request_id": "test-request",
+                "body": {"attributes": {"customer": "acme"}},
+            }
+        )
+    )
+    infos = dbos._sys_db.list_workflows(attributes=request.body.get("attributes", None))
+    assert [i.workflow_id for i in infos] == [handle.workflow_id]
+
+    # Attributes are JSON on the wire and survive response serialization
+    output = p.WorkflowsOutput.from_workflow_information(infos[0])
+    assert output.Attributes is not None
+    assert json.loads(output.Attributes) == {"customer": "acme", "tier": 1}
+    response = p.ListWorkflowsResponse(
+        type=p.MessageType.LIST_WORKFLOWS, request_id="test-request", output=[output]
+    )
+    serialized = json.loads(response.to_json())
+    assert json.loads(serialized["output"][0]["Attributes"]) == {
+        "customer": "acme",
+        "tier": 1,
+    }
 
 
 def test_attributes_filter_unsupported_sqlite(dbos: DBOS) -> None:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,118 @@
+import uuid
+from typing import Any
+
+from dbos import (
+    DBOS,
+    DBOSClient,
+    Debouncer,
+    EnqueueOptions,
+    Queue,
+    SetWorkflowAttributes,
+    SetWorkflowID,
+    WorkflowHandle,
+)
+
+
+def test_attributes_direct_invocation(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def child_workflow() -> str:
+        assert DBOS.workflow_id is not None
+        return DBOS.workflow_id
+
+    @DBOS.workflow()
+    def parent_workflow() -> str:
+        return child_workflow()
+
+    wfid = str(uuid.uuid4())
+    attributes = {"customer": "acme", "tier": 3}
+    with SetWorkflowAttributes(attributes):
+        with SetWorkflowID(wfid):
+            child_id = parent_workflow()
+
+    status = DBOS.list_workflows(workflow_ids=[wfid])[0]
+    assert status.attributes == attributes
+
+    # Child workflows do not inherit their parent's attributes
+    child_status = DBOS.list_workflows(workflow_ids=[child_id])[0]
+    assert child_status.attributes is None
+
+    # Workflows started outside the block have no attributes
+    wfid_no_attrs = str(uuid.uuid4())
+    with SetWorkflowID(wfid_no_attrs):
+        parent_workflow()
+    assert DBOS.list_workflows(workflow_ids=[wfid_no_attrs])[0].attributes is None
+
+
+def test_attributes_start_workflow(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def noop_workflow() -> None:
+        return None
+
+    # Nested blocks override and restore attributes
+    with SetWorkflowAttributes({"region": "us-east-1"}):
+        with SetWorkflowAttributes({"region": "eu-west-1"}):
+            inner_handle = DBOS.start_workflow(noop_workflow)
+        outer_handle = DBOS.start_workflow(noop_workflow)
+
+    inner_handle.get_result()
+    outer_handle.get_result()
+    assert inner_handle.get_status().attributes == {"region": "eu-west-1"}
+    assert outer_handle.get_status().attributes == {"region": "us-east-1"}
+
+
+def test_attributes_enqueue(dbos: DBOS) -> None:
+    queue = Queue("test_attributes_queue")
+
+    @DBOS.workflow()
+    def queued_workflow(x: int) -> int:
+        return x
+
+    with SetWorkflowAttributes({"source": "queue"}):
+        handle = queue.enqueue(queued_workflow, 5)
+    assert handle.get_result() == 5
+    assert handle.get_status().attributes == {"source": "queue"}
+
+
+def test_attributes_fork(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def forkable_workflow() -> None:
+        return None
+
+    wfid = str(uuid.uuid4())
+    attributes = {"customer": "acme"}
+    with SetWorkflowAttributes(attributes):
+        with SetWorkflowID(wfid):
+            forkable_workflow()
+
+    forked_handle = DBOS.fork_workflow(wfid, 1)
+    forked_handle.get_result()
+    assert forked_handle.get_status().attributes == attributes
+
+
+def test_attributes_client(client: DBOSClient, dbos: DBOS) -> None:
+    # Enqueue to a queue nothing consumes; the workflow stays ENQUEUED, which
+    # is enough to check the attributes recorded at creation.
+    options: EnqueueOptions = {
+        "queue_name": "unconsumed_queue",
+        "workflow_name": "client_workflow",
+        "attributes": {"source": "client"},
+    }
+    handle: WorkflowHandle[Any] = client.enqueue(options, 1)
+    assert handle.get_status().attributes == {"source": "client"}
+
+
+def test_attributes_debouncer(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def debounced_workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(debounced_workflow)
+    with SetWorkflowAttributes({"source": "debouncer"}):
+        handle = debouncer.debounce("key", 1.0, 5)
+    assert handle.get_result() == 5
+    assert handle.get_status().attributes == {"source": "debouncer"}
+
+    # The internal debouncer workflow itself does not get the user's attributes
+    internal_statuses = DBOS.list_workflows(name="_dbos_debouncer_workflow")
+    for status in internal_statuses:
+        assert status.attributes is None

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -275,6 +275,20 @@ def test_attributes_filter_unsupported_sqlite(dbos: DBOS) -> None:
         DBOS.list_workflows(attributes={"customer": "acme"})
 
 
+def test_attributes_validation() -> None:
+    # A non-dict is rejected
+    with pytest.raises(Exception, match="must be a dict"):
+        SetWorkflowAttributes(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    # A dict holding a non-JSON-serializable value is rejected up front
+    with pytest.raises(Exception, match="must be JSON-serializable"):
+        SetWorkflowAttributes({"obj": object()})
+
+    # None and JSON-serializable dicts are accepted
+    SetWorkflowAttributes(None)
+    SetWorkflowAttributes({"a": 1, "b": [1, 2], "c": {"d": None}})
+
+
 def test_attributes_debouncer(dbos: DBOS) -> None:
     @DBOS.workflow()
     def debounced_workflow(x: int) -> int:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -990,3 +990,25 @@ def test_get_result_no_hang_on_connection_invalidated_error(
     assert isinstance(exc, DBAPIError), f"expected DBAPIError, got {outcome!r}"
     assert "idle-in-transaction" in str(exc)
     boom_engine.dispose()
+
+
+def test_retriable_sqlite_exception() -> None:
+    from sqlalchemy.exc import ResourceClosedError
+
+    from dbos._utils import retriable_sqlite_exception
+
+    # The pysqlite "INSERT ... RETURNING" cursor-invalidation flake is retriable
+    assert retriable_sqlite_exception(
+        ResourceClosedError(
+            "This result object does not return rows. "
+            "It has been closed automatically."
+        )
+    )
+    # "database is locked" remains retriable
+    assert retriable_sqlite_exception(Exception("database is locked"))
+    # An unrelated ResourceClosedError is not retried (would otherwise loop forever)
+    assert not retriable_sqlite_exception(
+        ResourceClosedError("This Connection is closed")
+    )
+    # Unrelated errors are not retriable
+    assert not retriable_sqlite_exception(Exception("syntax error"))


### PR DESCRIPTION
You can provide a workflow with a dict of JSON-serializable custom attributes. These are stored in Postgres as GIN-indexed JSONB and so are fully searchable.

Also add a "fast path" to pick up new schedules registered on startup.