### PR TITLE
Fix Recv Cancellation Issue

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -540,6 +540,9 @@ def _get_wf_invoke_func(
             return output
         except DBOSWorkflowConflictIDError:
             # Await the workflow result
+            dbos.logger.warning(
+                f"Aborting duplicate execution of workflow {status["workflow_uuid"]}."
+            )
             r: R = dbos._sys_db.await_workflow_result(
                 status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
             )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -541,7 +541,7 @@ def _get_wf_invoke_func(
         except DBOSWorkflowConflictIDError:
             # Await the workflow result
             dbos.logger.warning(
-                f"Aborting duplicate execution of workflow {status["workflow_uuid"]}."
+                f"Aborting duplicate execution of workflow {status['workflow_uuid']}."
             )
             r: R = dbos._sys_db.await_workflow_result(
                 status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -420,6 +420,15 @@ class ThreadSafeEventDict:
             ]
 
 
+# Return type of the recv/get_event setup phases: either a cached result
+# (OAOO replay or value already available) or the registered event the
+# caller must wait on.
+EventSetupResult = Union[
+    tuple[Literal[True], Any],
+    tuple[Literal[False], threading.Event, float, str, int],
+]
+
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -2633,6 +2642,8 @@ class SystemDatabase(ABC):
         success, _ = self.notifications_map.set(payload, event, (workflow_uuid, topic))
         if not success:
             # This should not happen, but if it does, it means the workflow is executed concurrently.
+            # set() incremented the existing entry's count, so undo that before raising.
+            self.notifications_map.pop(payload)
             raise DBOSWorkflowConflictIDError(workflow_uuid)
 
         try:
@@ -2789,6 +2800,38 @@ class SystemDatabase(ABC):
         finally:
             self.notifications_map.pop(payload)
 
+    async def _run_event_setup_async(
+        self,
+        event_map: ThreadSafeEventDict,
+        setup_fn: Callable[..., EventSetupResult],
+        *args: Any,
+    ) -> EventSetupResult:
+        """Run a recv/get_event setup function in a worker thread, cleaning up
+        if this coroutine is cancelled while the thread is in flight.
+
+        The worker thread cannot be cancelled, so it completes the event_map
+        registration even after cancellation abandons the coroutine before its
+        try/finally cleanup is in place. A stale recv entry makes the next recv
+        on the same workflow and topic fail with DBOSWorkflowConflictIDError;
+        a stale get_event entry leaks. So shield the setup task and, on
+        cancellation, attach a callback that removes the registration once the
+        thread finishes.
+        """
+        setup_task = asyncio.create_task(asyncio.to_thread(setup_fn, *args))
+        try:
+            return await asyncio.shield(setup_task)
+        except asyncio.CancelledError:
+
+            def unregister(task: "asyncio.Task[EventSetupResult]") -> None:
+                if task.cancelled() or task.exception() is not None:
+                    return
+                result = task.result()
+                if not result[0]:
+                    event_map.pop(result[3])
+
+            setup_task.add_done_callback(unregister)
+            raise
+
     async def recv_async(
         self,
         workflow_uuid: str,
@@ -2797,7 +2840,8 @@ class SystemDatabase(ABC):
         topic: Optional[str],
         timeout_seconds: float = 60,
     ) -> Any:
-        setup = await asyncio.to_thread(
+        setup = await self._run_event_setup_async(
+            self.notifications_map,
             self.recv_setup,
             workflow_uuid,
             function_id,
@@ -3346,7 +3390,8 @@ class SystemDatabase(ABC):
         timeout_seconds: float = 60,
         caller_ctx: Optional[GetEventWorkflowContext] = None,
     ) -> Any:
-        setup = await asyncio.to_thread(
+        setup = await self._run_event_setup_async(
+            self.workflow_events_map,
             self.get_event_setup,
             target_uuid,
             key,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2607,10 +2607,7 @@ class SystemDatabase(ABC):
         timeout_function_id: int,
         topic: Optional[str],
         timeout_seconds: float = 60,
-    ) -> Union[
-        tuple[Literal[True], Any],
-        tuple[Literal[False], threading.Event, float, str, int],
-    ]:
+    ) -> EventSetupResult:
         """Setup phase of recv. Returns either:
         - (True, result) if a cached result was found (OAOO replay or message already available)
         - (False, event, actual_timeout, payload, start_time) if caller must wait on the event
@@ -3228,10 +3225,7 @@ class SystemDatabase(ABC):
         key: str,
         timeout_seconds: float = 60,
         caller_ctx: Optional[GetEventWorkflowContext] = None,
-    ) -> Union[
-        tuple[Literal[True], Any],
-        tuple[Literal[False], threading.Event, float, str, int],
-    ]:
+    ) -> EventSetupResult:
         """Setup phase of get_event. Returns either:
         - (True, result) if a cached result was found (OAOO replay)
         - (False, event, actual_timeout, payload, start_time) if caller must wait on the event

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2804,15 +2804,21 @@ class SystemDatabase(ABC):
         *args: Any,
     ) -> EventSetupResult:
         """Run a recv/get_event setup function in a worker thread, cleaning up
-        if this coroutine is cancelled while the thread is in flight.
+        synchronously if this coroutine is cancelled while the thread is in
+        flight.
 
-        The worker thread cannot be cancelled, so it completes the event_map
-        registration even after cancellation abandons the coroutine before its
-        try/finally cleanup is in place. A stale recv entry makes the next recv
-        on the same workflow and topic fail with DBOSWorkflowConflictIDError;
-        a stale get_event entry leaks. So shield the setup task and, on
-        cancellation, attach a callback that removes the registration once the
-        thread finishes.
+        The worker thread cannot be cancelled, so it finishes registering in
+        event_map even after cancellation abandons the coroutine before its
+        try/finally cleanup is in place. A leftover recv entry makes the next
+        recv on the same workflow and topic fail with
+        DBOSWorkflowConflictIDError -- a spurious "duplicate execution" that
+        parks the caller in await_workflow_result forever; a leftover
+        get_event entry leaks. So on cancellation, wait for the thread inline
+        and undo its registration *before* re-raising CancelledError: once the
+        cancelled call returns, no stale entry remains, so there is no window
+        for a concurrent recv to trip over. If a further cancellation
+        interrupts that wait, fall back to deferred cleanup via a done-callback
+        so an impatient caller is not blocked on the thread.
         """
         setup_task = asyncio.create_task(asyncio.to_thread(setup_fn, *args))
         try:
@@ -2821,12 +2827,27 @@ class SystemDatabase(ABC):
 
             def unregister(task: "asyncio.Task[EventSetupResult]") -> None:
                 if task.cancelled() or task.exception() is not None:
+                    # Setup never registered, or registered then cleaned up
+                    # after its own failure; nothing to undo.
                     return
                 result = task.result()
                 if not result[0]:
                     event_map.pop(result[3])
 
-            setup_task.add_done_callback(unregister)
+            # Wait for the thread to finish, then undo its registration. A
+            # second cancellation lands in the except below; an exception from
+            # setup is ignored because setup already cleaned up after itself.
+            try:
+                await asyncio.shield(setup_task)
+            except asyncio.CancelledError:
+                if not setup_task.done():
+                    # Cancelled again while still waiting on the thread: hand
+                    # cleanup to a done-callback rather than block any longer.
+                    setup_task.add_done_callback(unregister)
+                    raise
+            except Exception:
+                pass
+            unregister(setup_task)
             raise
 
     async def recv_async(

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -236,9 +236,10 @@ async def test_send_recv_async(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_recv_async_cancelled_during_setup(dbos: DBOS) -> None:
     """Cancelling recv_async while its setup phase runs in a worker thread
-    must not leak the notifications_map registration. A leaked entry makes
-    the next recv on the same workflow and topic raise
-    DBOSWorkflowConflictIDError."""
+    must not leave a notifications_map registration behind. Cleanup is
+    synchronous: the moment the cancelled call returns, the entry is gone, so
+    there is no window in which the next recv on the same workflow and topic
+    raises a spurious DBOSWorkflowConflictIDError."""
 
     @DBOS.workflow()
     async def noop_workflow() -> None:
@@ -269,18 +270,17 @@ async def test_recv_async_cancelled_during_setup(dbos: DBOS) -> None:
             sys_db.recv_async(wfid, 100, 101, topic, timeout_seconds=10)
         )
         assert await asyncio.to_thread(in_setup.wait, 10)
+        # Cancel while the thread is mid-registration, then let it finish so
+        # the cancellation's synchronous cleanup can run to completion.
         recv_task.cancel()
+        release_setup.set()
         with pytest.raises(asyncio.CancelledError):
             await recv_task
-        release_setup.set()
+        # Cleanup happened before CancelledError propagated -- no polling
+        # window for a concurrent recv to trip over a stale entry.
+        assert sys_db.notifications_map.get(payload) is None
     finally:
         sys_db.recv_check = original_recv_check  # type: ignore[method-assign]
-
-    # The orphaned setup thread must remove its registration once it finishes.
-    deadline = time.time() + 10
-    while sys_db.notifications_map.get(payload) is not None and time.time() < deadline:
-        await asyncio.sleep(0.05)
-    assert sys_db.notifications_map.get(payload) is None
 
     # A later recv on the same workflow and topic must not see a stale entry.
     message = await sys_db.recv_async(wfid, 102, 103, topic, timeout_seconds=0.1)
@@ -291,7 +291,8 @@ async def test_recv_async_cancelled_during_setup(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_get_event_async_cancelled_during_setup(dbos: DBOS) -> None:
     """Cancelling get_event_async while its setup phase runs in a worker
-    thread must not leak the workflow_events_map registration."""
+    thread must not leave a workflow_events_map registration behind, and
+    cleanup must complete synchronously before CancelledError propagates."""
 
     @DBOS.workflow()
     async def noop_workflow() -> None:
@@ -321,18 +322,12 @@ async def test_get_event_async_cancelled_during_setup(dbos: DBOS) -> None:
         )
         assert await asyncio.to_thread(in_setup.wait, 10)
         get_event_task.cancel()
+        release_setup.set()
         with pytest.raises(asyncio.CancelledError):
             await get_event_task
-        release_setup.set()
+        assert sys_db.workflow_events_map.get(payload) is None
     finally:
         sys_db.get_event_check = original_get_event_check  # type: ignore[method-assign]
-
-    deadline = time.time() + 10
-    while (
-        sys_db.workflow_events_map.get(payload) is not None and time.time() < deadline
-    ):
-        await asyncio.sleep(0.05)
-    assert sys_db.workflow_events_map.get(payload) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 import uuid
 from typing import Any, List, Optional, cast
@@ -230,6 +231,108 @@ async def test_send_recv_async(dbos: DBOS) -> None:
     with pytest.raises(Exception) as exc_info:
         await dbos.recv_async("test1")
     assert "recv() must be called from within a workflow" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_recv_async_cancelled_during_setup(dbos: DBOS) -> None:
+    """Cancelling recv_async while its setup phase runs in a worker thread
+    must not leak the notifications_map registration. A leaked entry makes
+    the next recv on the same workflow and topic raise
+    DBOSWorkflowConflictIDError."""
+
+    @DBOS.workflow()
+    async def noop_workflow() -> None:
+        return None
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        await noop_workflow()
+
+    sys_db = dbos._sys_db
+    topic = "cancel_topic"
+    payload = f"{wfid}::{topic}"
+
+    in_setup = threading.Event()
+    release_setup = threading.Event()
+    original_recv_check = sys_db.recv_check
+
+    # recv_setup calls recv_check after registering in notifications_map,
+    # so blocking here holds the setup thread mid-registration.
+    def blocking_recv_check(*args: Any, **kwargs: Any) -> None:
+        in_setup.set()
+        assert release_setup.wait(timeout=10)
+        original_recv_check(*args, **kwargs)
+
+    sys_db.recv_check = blocking_recv_check  # type: ignore[method-assign]
+    try:
+        recv_task = asyncio.create_task(
+            sys_db.recv_async(wfid, 100, 101, topic, timeout_seconds=10)
+        )
+        assert await asyncio.to_thread(in_setup.wait, 10)
+        recv_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await recv_task
+        release_setup.set()
+    finally:
+        sys_db.recv_check = original_recv_check  # type: ignore[method-assign]
+
+    # The orphaned setup thread must remove its registration once it finishes.
+    deadline = time.time() + 10
+    while sys_db.notifications_map.get(payload) is not None and time.time() < deadline:
+        await asyncio.sleep(0.05)
+    assert sys_db.notifications_map.get(payload) is None
+
+    # A later recv on the same workflow and topic must not see a stale entry.
+    message = await sys_db.recv_async(wfid, 102, 103, topic, timeout_seconds=0.1)
+    assert message is None
+    assert sys_db.notifications_map.get(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_get_event_async_cancelled_during_setup(dbos: DBOS) -> None:
+    """Cancelling get_event_async while its setup phase runs in a worker
+    thread must not leak the workflow_events_map registration."""
+
+    @DBOS.workflow()
+    async def noop_workflow() -> None:
+        return None
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        await noop_workflow()
+
+    sys_db = dbos._sys_db
+    key = "cancel_key"
+    payload = f"{wfid}::{key}"
+
+    in_setup = threading.Event()
+    release_setup = threading.Event()
+    original_get_event_check = sys_db.get_event_check
+
+    def blocking_get_event_check(*args: Any, **kwargs: Any) -> None:
+        in_setup.set()
+        assert release_setup.wait(timeout=10)
+        original_get_event_check(*args, **kwargs)
+
+    sys_db.get_event_check = blocking_get_event_check  # type: ignore[method-assign]
+    try:
+        get_event_task = asyncio.create_task(
+            sys_db.get_event_async(wfid, key, timeout_seconds=10)
+        )
+        assert await asyncio.to_thread(in_setup.wait, 10)
+        get_event_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await get_event_task
+        release_setup.set()
+    finally:
+        sys_db.get_event_check = original_get_event_check  # type: ignore[method-assign]
+
+    deadline = time.time() + 10
+    while (
+        sys_db.workflow_events_map.get(payload) is not None and time.time() < deadline
+    ):
+        await asyncio.sleep(0.05)
+    assert sys_db.workflow_events_map.get(payload) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If a coroutine running `DBOS.recv_async` is cancelled at the wrong place, it won't clean up its notifications map entry, creating inconsistent state.