### PR TITLE
Fix Destroy Hang

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -776,17 +776,32 @@ class DBOS:
                 else:
                     break
         if self._timeout_tasks:
+            target_loop = self._background_event_loop.target_loop()
+            try:
+                current_loop: Optional[asyncio.AbstractEventLoop] = (
+                    asyncio.get_running_loop()
+                )
+            except RuntimeError:
+                current_loop = None
 
-            async def cancel_timeout_tasks() -> None:
+            if current_loop is not None and current_loop is target_loop:
+                # destroy() is running on the loop that owns the timeout
+                # tasks, so cancel them directly.
                 for task in self._timeout_tasks:
                     task.cancel()
-                await asyncio.gather(*self._timeout_tasks, return_exceptions=True)
                 self._timeout_tasks.clear()
+            else:
 
-            try:
-                self._background_event_loop.submit_coroutine(cancel_timeout_tasks())
-            except RuntimeError as e:
-                dbos_logger.warning(f"Exception cancelling timeout tasks: {e}")
+                async def cancel_timeout_tasks() -> None:
+                    for task in self._timeout_tasks:
+                        task.cancel()
+                    await asyncio.gather(*self._timeout_tasks, return_exceptions=True)
+                    self._timeout_tasks.clear()
+
+                try:
+                    self._background_event_loop.submit_coroutine(cancel_timeout_tasks())
+                except RuntimeError as e:
+                    dbos_logger.warning(f"Exception cancelling timeout tasks: {e}")
         self._background_event_loop.stop()
         if self._admin_server_field is not None:
             self._admin_server_field.stop()

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -82,13 +82,19 @@ class BackgroundEventLoop:
 
     T = TypeVar("T")
 
+    def target_loop(self) -> Optional[asyncio.AbstractEventLoop]:
+        """The loop coroutines are submitted to: the adopted main loop if one is
+        running, otherwise the background loop."""
+        if self._main_loop is not None and self._main_loop.is_running():
+            return self._main_loop
+        return self._loop
+
     def submit_coroutine(self, coro: Coroutine[Any, Any, T]) -> T:
         """Submit a coroutine to the background event loop and block until it completes."""
-        if self._main_loop is not None and self._main_loop.is_running():
-            return asyncio.run_coroutine_threadsafe(coro, self._main_loop).result()
-        if self._loop is None:
+        loop = self.target_loop()
+        if loop is None:
             raise RuntimeError("Event loop not started")
-        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
     def submit_coroutine_nowait(
         self,
@@ -100,11 +106,7 @@ class BackgroundEventLoop:
         If task_set is provided, the created task is added to it and
         automatically removed when the task completes.
         """
-        loop = (
-            self._main_loop
-            if self._main_loop is not None and self._main_loop.is_running()
-            else self._loop
-        )
+        loop = self.target_loop()
         if loop is None:
             raise RuntimeError("Event loop not started")
 

--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -93,7 +93,24 @@ class BackgroundEventLoop:
         """Submit a coroutine to the background event loop and block until it completes."""
         loop = self.target_loop()
         if loop is None:
+            coro.close()
             raise RuntimeError("Event loop not started")
+        try:
+            running_loop: Optional[asyncio.AbstractEventLoop] = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            running_loop = None
+        if running_loop is loop:
+            # We are on the target loop's own thread. Blocking on .result() here
+            # would deadlock: the loop can never run the coroutine while it is
+            # blocked waiting for it. Fail loudly instead of hanging.
+            coro.close()
+            raise RuntimeError(
+                "submit_coroutine was called from within its own event loop "
+                "thread, which would deadlock. Schedule the coroutine without "
+                "blocking (e.g. submit_coroutine_nowait) instead."
+            )
         return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
     def submit_coroutine_nowait(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import glob
 import os
 import subprocess
@@ -274,6 +275,26 @@ def retry_until_success(
     if error is not None:
         raise error
     raise RuntimeError("retry_until_success failed without an exception")
+
+
+async def retry_until_success_async(
+    func: Callable[[], T], interval: float = 1, max_attempts: int = 10
+) -> T:
+    """Async sibling of retry_until_success.
+
+    Sleeps with asyncio.sleep between attempts so the event loop stays free to
+    make progress (e.g. to run a task we are waiting on). func itself is sync.
+    """
+    error: Optional[Exception] = None
+    for _ in range(max_attempts):
+        try:
+            return func()
+        except Exception as e:
+            error = e
+            await asyncio.sleep(interval)
+    if error is not None:
+        raise error
+    raise RuntimeError("retry_until_success_async failed without an exception")
 
 
 def pytest_unconfigure(config: Any) -> None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -26,6 +26,7 @@ from dbos._error import (
     DBOSPatchNondeterminismError,
 )
 from dbos._schemas.system_database import SystemSchema
+from tests.conftest import retry_until_success_async
 
 
 @pytest.mark.asyncio
@@ -1091,9 +1092,15 @@ def test_destroy_from_adopted_main_loop_does_not_deadlock(
             with SetWorkflowTimeout(30):
                 assert wf_with_timeout() == "done"
 
-            # Let the loop actually create the parked timeout task.
-            await asyncio.sleep(0.5)
-            assert len(dbos._timeout_tasks) >= 1, "expected a pending timeout task"
+            # Poll (don't sleep a fixed amount) until the loop has actually
+            # created the parked timeout task. The async retry yields to the loop
+            # between attempts, so the task gets a chance to be created.
+            def timeout_task_is_pending() -> None:
+                assert dbos._timeout_tasks, "expected a pending timeout task"
+
+            await retry_until_success_async(
+                timeout_task_is_pending, interval=0.2, max_attempts=50
+            )
 
             # Called from the adopted main-loop thread -> deadlocks before the fix.
             DBOS.destroy(destroy_registry=True)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -25,6 +25,7 @@ from dbos._error import (
     DBOSException,
     DBOSPatchNondeterminismError,
 )
+from dbos._event_loop import BackgroundEventLoop
 from dbos._schemas.system_database import SystemSchema
 from tests.conftest import retry_until_success_async
 
@@ -1221,3 +1222,27 @@ def test_destroy_from_adopted_main_loop_does_not_deadlock(
     )
     if scenario_error:
         raise scenario_error[0]
+
+
+@pytest.mark.asyncio
+async def test_submit_coroutine_from_own_loop_raises_instead_of_hanging() -> None:
+    """submit_coroutine must fail loudly, not deadlock, when called from its own loop.
+
+    Blocking on .result() from the thread that runs the target loop can never
+    complete (the loop can't run the coroutine while blocked waiting for it), so
+    the call must raise rather than hang.
+    """
+    bg = BackgroundEventLoop()
+    # start() adopts the currently-running loop (this test's loop) as the main loop.
+    bg.start()
+    try:
+
+        async def noop() -> int:
+            return 42
+
+        assert bg.target_loop() is asyncio.get_running_loop()
+        coro = noop()
+        with pytest.raises(RuntimeError, match="deadlock"):
+            bg.submit_coroutine(coro)
+    finally:
+        bg.stop()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 import uuid
 from typing import Any, List, Optional, cast
@@ -1049,3 +1050,70 @@ async def test_concurrent_patch_async(dbos: DBOS, config: DBOSConfig) -> None:
         status = await DBOS.get_workflow_status_async(wfid)
         assert status is not None
         assert status.status == "ERROR"
+
+
+def test_destroy_from_adopted_main_loop_does_not_deadlock(
+    config: DBOSConfig, cleanup_test_databases: None
+) -> None:
+    """Reproduce the DBOS.destroy() self-deadlock.
+
+    When DBOS.launch() runs inside a running event loop, DBOS adopts that loop
+    as its main loop. A workflow with a timeout parks a "timeout task" on that
+    loop. If destroy() is then called from that same loop's thread while a
+    timeout task is still pending, destroy() schedules a cancellation coroutine
+    onto the loop and blocks the calling thread on .result() -- but the loop is
+    the calling thread, so it can never run the coroutine. Permanent hang.
+
+    We run the whole launch + timeout + destroy scenario on a dedicated thread
+    with its own event loop, then join it with a timeout. Before the fix the
+    thread deadlocks (join times out); after the fix it completes promptly.
+    """
+    DBOS.destroy(destroy_registry=True)
+    dbos = DBOS(config=config)
+
+    @DBOS.workflow()
+    def wf_with_timeout() -> str:
+        return "done"
+
+    scenario_error: List[BaseException] = []
+
+    def run_scenario() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        async def scenario() -> None:
+            # Launch from within the running loop so DBOS adopts it as main loop.
+            DBOS.launch()
+
+            # The workflow returns immediately, but its timeout task stays parked
+            # in asyncio.sleep() on this loop, so it is still pending in
+            # dbos._timeout_tasks when we destroy.
+            with SetWorkflowTimeout(30):
+                assert wf_with_timeout() == "done"
+
+            # Let the loop actually create the parked timeout task.
+            await asyncio.sleep(0.5)
+            assert len(dbos._timeout_tasks) >= 1, "expected a pending timeout task"
+
+            # Called from the adopted main-loop thread -> deadlocks before the fix.
+            DBOS.destroy(destroy_registry=True)
+
+        try:
+            loop.run_until_complete(scenario())
+        except BaseException as e:
+            scenario_error.append(e)
+        finally:
+            loop.close()
+
+    worker = threading.Thread(
+        target=run_scenario, name="dbos-destroy-scenario", daemon=True
+    )
+    worker.start()
+    worker.join(timeout=20)
+
+    assert not worker.is_alive(), (
+        "DBOS.destroy() deadlocked: it was called from the adopted main-loop "
+        "thread while a timeout task was still pending."
+    )
+    if scenario_error:
+        raise scenario_error[0]


### PR DESCRIPTION
Fix an issue where `DBOS.destroy` would deadlock and hang if timeout waiters were live on its event loop.