### PR TITLE
Isolate System Database Schema

### DIFF
--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -7,7 +7,7 @@ on:
     workflow_dispatch:
 
 jobs:
-  integration:
+  chaos:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup PDM
       uses: pdm-project/setup-pdm@v4
       with:
-        python-version: '3.9.x'
+        python-version: '3.10'
         architecture: 'x64'
 
     - name: Install Dependencies
@@ -28,7 +28,7 @@ jobs:
     - name: Build package
       run: pdm build
 
-    - name: Publish package to TestPyPI
+    - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist/

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -84,10 +84,7 @@ class ApplicationDatabase(ABC):
             self.schema = None
         else:
             self.schema = schema if schema else "dbos"
-        # Apply the real schema per-engine via schema_translate_map so the shared
-        # ApplicationSchema table metadata isn't mutated (None renders unqualified
-        # for SQLite). This also keeps user tables untouched: only the placeholder
-        # schema is translated.
+        # Translate the placeholder schema to this instance's schema per-engine (None for SQLite = unqualified).
         self.engine = self._create_engine(
             database_url, engine_kwargs
         ).execution_options(schema_translate_map={SCHEMA_PLACEHOLDER: self.schema})

--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -12,6 +12,7 @@ from dbos._serialization import Serializer
 
 from ._error import DBOSUnexpectedStepError, DBOSWorkflowConflictIDError
 from ._logger import dbos_logger
+from ._schemas import SCHEMA_PLACEHOLDER
 from ._schemas.application_database import ApplicationSchema
 from ._sys_db import StepInfo
 
@@ -83,8 +84,13 @@ class ApplicationDatabase(ABC):
             self.schema = None
         else:
             self.schema = schema if schema else "dbos"
-        ApplicationSchema.transaction_outputs.schema = schema
-        self.engine = self._create_engine(database_url, engine_kwargs)
+        # Apply the real schema per-engine via schema_translate_map so the shared
+        # ApplicationSchema table metadata isn't mutated (None renders unqualified
+        # for SQLite). This also keeps user tables untouched: only the placeholder
+        # schema is translated.
+        self.engine = self._create_engine(
+            database_url, engine_kwargs
+        ).execution_options(schema_translate_map={SCHEMA_PLACEHOLDER: self.schema})
         self._engine_kwargs = engine_kwargs
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.serializer = serializer
@@ -316,8 +322,6 @@ class SQLiteApplicationDatabase(ApplicationDatabase):
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
         """Create a SQLite engine."""
-        # TODO: Make the schema dynamic so this isn't needed
-        ApplicationSchema.transaction_outputs.schema = None
         sqlite_kwargs = engine_kwargs.copy()
         connect_args = sqlite_kwargs.get("connect_args", {})
         if connect_args:

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -133,8 +133,7 @@ class AsyncSQLAlchemyDatasource(ABC):
         else:
             base_engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
-        # Apply the real schema per-engine via schema_translate_map instead of
-        # mutating shared table metadata (None renders unqualified for SQLite).
+        # Translate the placeholder schema to this instance's schema per-engine (None for SQLite = unqualified).
         self.engine = base_engine.execution_options(
             schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
         )
@@ -433,8 +432,7 @@ class SQLAlchemyDatasource(ABC):
         else:
             base_engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
-        # Apply the real schema per-engine via schema_translate_map instead of
-        # mutating shared table metadata (None renders unqualified for SQLite).
+        # Translate the placeholder schema to this instance's schema per-engine (None for SQLite = unqualified).
         self.engine = base_engine.execution_options(
             schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
         )

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -31,6 +31,7 @@ from dbos._app_db import RecordedResult
 from dbos._context import DBOSContextEnsure, get_local_dbos_context
 from dbos._dbos import IsolationLevel
 from dbos._error import DBOSException
+from dbos._schemas import SCHEMA_PLACEHOLDER
 from dbos._schemas.datasource_database import DatasourceSchema
 from dbos._serialization import (
     DBOSDefaultSerializer,
@@ -126,13 +127,17 @@ class AsyncSQLAlchemyDatasource(ABC):
         )
         self.dialect = sq if database_url.startswith("sqlite") else pg
         self.schema = _resolve_schema(database_url, schema)
-        DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
-            self.engine = engine
+            base_engine = engine
             self.created_engine = False
         else:
-            self.engine = self._create_engine(database_url, engine_kwargs)
+            base_engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
+        # Apply the real schema per-engine via schema_translate_map instead of
+        # mutating shared table metadata (None renders unqualified for SQLite).
+        self.engine = base_engine.execution_options(
+            schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
+        )
         self._engine_kwargs = engine_kwargs
         self.sessionmaker = async_sessionmaker(bind=self.engine)
         self.serializer = serializer
@@ -422,13 +427,17 @@ class SQLAlchemyDatasource(ABC):
         )
         self.dialect = sq if database_url.startswith("sqlite") else pg
         self.schema = _resolve_schema(database_url, schema)
-        DatasourceSchema.datasource_outputs.schema = self.schema
         if engine:
-            self.engine = engine
+            base_engine = engine
             self.created_engine = False
         else:
-            self.engine = self._create_engine(database_url, engine_kwargs)
+            base_engine = self._create_engine(database_url, engine_kwargs)
             self.created_engine = True
+        # Apply the real schema per-engine via schema_translate_map instead of
+        # mutating shared table metadata (None renders unqualified for SQLite).
+        self.engine = base_engine.execution_options(
+            schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
+        )
         self._engine_kwargs = engine_kwargs
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.serializer = serializer

--- a/dbos/_datasource_sqlite.py
+++ b/dbos/_datasource_sqlite.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
 from dbos._migration import get_sqlite_timestamp_expr
-from dbos._schemas.datasource_database import DatasourceSchema
 
 from ._logger import dbos_logger
 
@@ -87,7 +86,6 @@ class SqliteSyncDatasource(SQLAlchemyDatasource):
     def _create_engine(
         self, database_url: str, engine_kwargs: Dict[str, Any]
     ) -> sa.Engine:
-        DatasourceSchema.datasource_outputs.schema = None
         return sa.create_engine(database_url, **_filter_sqlite_kwargs(engine_kwargs))
 
     def run_migrations(self) -> None:

--- a/dbos/_schemas/__init__.py
+++ b/dbos/_schemas/__init__.py
@@ -1,0 +1,9 @@
+# Symbolic schema name used in all DBOS table definitions. It is never sent to
+# the database directly: each engine carries a SQLAlchemy ``schema_translate_map``
+# that rewrites this placeholder to the real per-instance schema (or ``None`` for
+# SQLite) at execution time. This keeps the schema per-engine instead of mutating
+# shared table metadata, so multiple DBOS instances/clients with different schemas
+# can coexist in one process. A distinctive sentinel (rather than "dbos") avoids
+# accidentally translating user tables that legitimately live in a schema named
+# "dbos" within a shared application/datasource database.
+SCHEMA_PLACEHOLDER = "__dbos_placeholder_schema__"

--- a/dbos/_schemas/__init__.py
+++ b/dbos/_schemas/__init__.py
@@ -1,9 +1,2 @@
-# Symbolic schema name used in all DBOS table definitions. It is never sent to
-# the database directly: each engine carries a SQLAlchemy ``schema_translate_map``
-# that rewrites this placeholder to the real per-instance schema (or ``None`` for
-# SQLite) at execution time. This keeps the schema per-engine instead of mutating
-# shared table metadata, so multiple DBOS instances/clients with different schemas
-# can coexist in one process. A distinctive sentinel (rather than "dbos") avoids
-# accidentally translating user tables that legitimately live in a schema named
-# "dbos" within a shared application/datasource database.
+# Placeholder schema in all table definitions; each engine's schema_translate_map rewrites it to the real schema (a sentinel, not "dbos", to avoid clashing with a user's real "dbos" schema).
 SCHEMA_PLACEHOLDER = "__dbos_placeholder_schema__"

--- a/dbos/_schemas/application_database.py
+++ b/dbos/_schemas/application_database.py
@@ -14,8 +14,7 @@ from . import SCHEMA_PLACEHOLDER
 
 
 class ApplicationSchema:
-    # Tables are defined against a fixed placeholder schema; the real schema is
-    # applied per-engine via schema_translate_map (see ApplicationDatabase.__init__).
+    # Real schema is applied per-engine via schema_translate_map.
     metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
 
     transaction_outputs = Table(

--- a/dbos/_schemas/application_database.py
+++ b/dbos/_schemas/application_database.py
@@ -10,10 +10,13 @@ from sqlalchemy import (
     text,
 )
 
+from . import SCHEMA_PLACEHOLDER
+
 
 class ApplicationSchema:
-    schema = "dbos"
-    metadata_obj = MetaData(schema=schema)
+    # Tables are defined against a fixed placeholder schema; the real schema is
+    # applied per-engine via schema_translate_map (see ApplicationDatabase.__init__).
+    metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
 
     transaction_outputs = Table(
         "transaction_outputs",

--- a/dbos/_schemas/datasource_database.py
+++ b/dbos/_schemas/datasource_database.py
@@ -8,10 +8,13 @@ from sqlalchemy import (
     Text,
 )
 
+from . import SCHEMA_PLACEHOLDER
+
 
 class DatasourceSchema:
-    schema = "dbos"
-    metadata_obj = MetaData(schema=schema)
+    # Tables are defined against a fixed placeholder schema; the real schema is
+    # applied per-engine via schema_translate_map (see the datasource __init__s).
+    metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
 
     datasource_outputs = Table(
         "datasource_outputs",

--- a/dbos/_schemas/datasource_database.py
+++ b/dbos/_schemas/datasource_database.py
@@ -12,8 +12,7 @@ from . import SCHEMA_PLACEHOLDER
 
 
 class DatasourceSchema:
-    # Tables are defined against a fixed placeholder schema; the real schema is
-    # applied per-engine via schema_translate_map (see the datasource __init__s).
+    # Real schema is applied per-engine via schema_translate_map.
     metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
 
     datasource_outputs = Table(

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from sqlalchemy import (
     JSON,
     BigInteger,
@@ -20,30 +18,15 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
+from . import SCHEMA_PLACEHOLDER
+
 
 class SystemSchema:
     ### System table schema
-    metadata_obj = MetaData(schema="dbos")
+    # Tables are defined against a fixed placeholder schema; the real schema is
+    # applied per-engine via schema_translate_map (see SystemDatabase.__init__).
+    metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
     sysdb_suffix = "_dbos_sys"
-
-    @classmethod
-    def set_schema(cls, schema_name: Optional[str]) -> None:
-        """
-        Set the schema for all DBOS system tables.
-
-        Args:
-            schema_name: The name of the schema to use for system tables
-        """
-        cls.metadata_obj.schema = schema_name
-        cls.workflow_status.schema = schema_name
-        cls.operation_outputs.schema = schema_name
-        cls.notifications.schema = schema_name
-        cls.workflow_events.schema = schema_name
-        cls.streams.schema = schema_name
-        cls.workflow_events_history.schema = schema_name
-        cls.workflow_schedules.schema = schema_name
-        cls.application_versions.schema = schema_name
-        cls.queues.schema = schema_name
 
     workflow_status = Table(
         "workflow_status",

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -23,8 +23,7 @@ from . import SCHEMA_PLACEHOLDER
 
 class SystemSchema:
     ### System table schema
-    # Tables are defined against a fixed placeholder schema; the real schema is
-    # applied per-engine via schema_translate_map (see SystemDatabase.__init__).
+    # Real schema is applied per-engine via schema_translate_map.
     metadata_obj = MetaData(schema=SCHEMA_PLACEHOLDER)
     sysdb_suffix = "_dbos_sys"
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -614,7 +614,8 @@ class SystemDatabase(ABC):
     def destroy(self) -> None:
         self._run_background_processes = False
         self._cleanup_connections()
-        self.engine.dispose()
+        if self.created_engine:
+            self.engine.dispose()
 
     @abstractmethod
     def _cleanup_connections(self) -> None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -578,10 +578,7 @@ class SystemDatabase(ABC):
         else:
             base_engine = self._create_engine(system_database_url, engine_kwargs)
             self.created_engine = True
-        # Apply the real schema per-engine so multiple instances/clients with
-        # different schemas don't clobber shared table metadata. Tables are
-        # defined against SCHEMA_PLACEHOLDER; translate it to self.schema here
-        # (None for SQLite renders unqualified names).
+        # Translate the placeholder schema to this instance's schema per-engine (None for SQLite = unqualified).
         self.engine = base_engine.execution_options(
             schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
         )
@@ -3909,15 +3906,7 @@ class SystemDatabase(ABC):
         return wf_status, workflow_deadline_epoch_ms, should_execute
 
     def _apply_caller_schema(self, conn: Union[sa.Connection, Session]) -> None:
-        """Apply this system database's schema_translate_map to a caller-owned
-        Connection or Session.
-
-        System tables are defined against SCHEMA_PLACEHOLDER and rely on the
-        engine's schema_translate_map to resolve the real schema. A caller may
-        pass a connection built from an engine that lacks that map, so set it
-        here. Only the private placeholder key is added, so the caller's own
-        statements are unaffected.
-        """
+        """Translate the placeholder schema on a caller-owned Connection/Session (the caller's own statements are unaffected)."""
         translate = {SCHEMA_PLACEHOLDER: self.schema}
         if isinstance(conn, Session):
             conn.connection(execution_options={"schema_translate_map": translate})

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3907,11 +3907,15 @@ class SystemDatabase(ABC):
 
     def _apply_caller_schema(self, conn: Union[sa.Connection, Session]) -> None:
         """Translate the placeholder schema on a caller-owned Connection/Session (the caller's own statements are unaffected)."""
-        translate = {SCHEMA_PLACEHOLDER: self.schema}
+        # Set the option in place on the underlying Connection. Session.connection(execution_options=...)
+        # is silently ignored once the caller has already procured the connection (run any statement) in
+        # this transaction, which is the normal case for a caller-owned transaction.
         if isinstance(conn, Session):
-            conn.connection(execution_options={"schema_translate_map": translate})
-        else:
-            conn.execution_options(schema_translate_map=translate)
+            conn = conn.connection()
+        existing = conn.get_execution_options().get("schema_translate_map") or {}
+        conn.execution_options(
+            schema_translate_map={**existing, SCHEMA_PLACEHOLDER: self.schema}
+        )
 
     def init_workflow_with_connection(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -54,6 +54,7 @@ from ._error import (
 )
 from ._logger import dbos_logger
 from ._outcome import NoResult
+from ._schemas import SCHEMA_PLACEHOLDER
 from ._schemas.system_database import SystemSchema
 from ._serialization import (
     DBOSPortableJSON,
@@ -570,14 +571,20 @@ class SystemDatabase(ABC):
             self.schema = None
         else:
             self.schema = schema if schema else "dbos"
-        SystemSchema.set_schema(self.schema)
 
         if engine:
-            self.engine = engine
+            base_engine = engine
             self.created_engine = False
         else:
-            self.engine = self._create_engine(system_database_url, engine_kwargs)
+            base_engine = self._create_engine(system_database_url, engine_kwargs)
             self.created_engine = True
+        # Apply the real schema per-engine so multiple instances/clients with
+        # different schemas don't clobber shared table metadata. Tables are
+        # defined against SCHEMA_PLACEHOLDER; translate it to self.schema here
+        # (None for SQLite renders unqualified names).
+        self.engine = base_engine.execution_options(
+            schema_translate_map={SCHEMA_PLACEHOLDER: self.schema}
+        )
         self._engine_kwargs = engine_kwargs
 
         self.notifications_map = ThreadSafeEventDict()
@@ -2568,6 +2575,7 @@ class SystemDatabase(ABC):
         it commits. The connection or session must target the DBOS system
         database.
         """
+        self._apply_caller_schema(conn)
         self._send_bulk_txn(
             messages,
             conn,
@@ -3900,6 +3908,22 @@ class SystemDatabase(ABC):
         DebugTriggers.debug_trigger_point(DebugTriggers.DEBUG_TRIGGER_INITWF_COMMIT)
         return wf_status, workflow_deadline_epoch_ms, should_execute
 
+    def _apply_caller_schema(self, conn: Union[sa.Connection, Session]) -> None:
+        """Apply this system database's schema_translate_map to a caller-owned
+        Connection or Session.
+
+        System tables are defined against SCHEMA_PLACEHOLDER and rely on the
+        engine's schema_translate_map to resolve the real schema. A caller may
+        pass a connection built from an engine that lacks that map, so set it
+        here. Only the private placeholder key is added, so the caller's own
+        statements are unaffected.
+        """
+        translate = {SCHEMA_PLACEHOLDER: self.schema}
+        if isinstance(conn, Session):
+            conn.connection(execution_options={"schema_translate_map": translate})
+        else:
+            conn.execution_options(schema_translate_map=translate)
+
     def init_workflow_with_connection(
         self,
         status: WorkflowStatusInternal,
@@ -3916,6 +3940,7 @@ class SystemDatabase(ABC):
         transaction. The connection or session must target the DBOS system
         database; it cannot atomically span a separate application database.
         """
+        self._apply_caller_schema(conn)
         return self._insert_workflow_status(
             status,
             conn,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -732,6 +732,36 @@ def test_enqueue_in_transaction_session(dbos: DBOS, client: DBOSClient) -> None:
     assert not _workflow_exists(client, wfid2)
 
 
+def test_enqueue_in_transaction_session_after_statement(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    # Regression: a caller brings its own engine/Session (which does not carry DBOS's
+    # internal schema_translate_map) and runs a statement before the DBOS call, procuring
+    # its connection. Session.connection(execution_options=...) is silently ignored once a
+    # connection is established, so _apply_caller_schema must translate the placeholder
+    # schema on the underlying Connection directly or the enqueue targets a nonexistent schema.
+    run_client_collateral()
+
+    wfid = str(uuid.uuid4())
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "retrieve_test",
+        "workflow_id": wfid,
+    }
+
+    engine = sa.create_engine(client._sys_db.engine.url)
+    try:
+        with Session(engine) as session:
+            with session.begin():
+                session.execute(sa.text("SELECT 1"))  # procure the connection first
+                handle: WorkflowHandle[str] = client.enqueue_in_transaction(
+                    session, options, "after-statement"
+                )
+    finally:
+        engine.dispose()
+    assert handle.get_result() == "after-statement"
+
+
 @pytest.mark.asyncio
 async def test_enqueue_in_transaction_run_sync(
     dbos: DBOS, client: DBOSClient, skip_with_sqlite: None
@@ -791,6 +821,35 @@ def test_send_in_transaction_commit(dbos: DBOS, client: DBOSClient) -> None:
                 )
             ).fetchone()
             assert row is not None
+
+    assert handle.get_result() == message
+
+
+def test_send_in_transaction_session_after_statement(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    # Regression: a caller brings its own engine/Session (which does not carry DBOS's
+    # internal schema_translate_map) and runs a statement before the DBOS call, procuring
+    # its connection. _apply_caller_schema must still translate the placeholder schema on
+    # the underlying Connection; otherwise the send targets a nonexistent placeholder schema.
+    run_client_collateral()
+
+    now = time.time_ns()
+    topic = f"test-topic-{now}"
+    message = f"Hello, DBOS! {now}"
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        handle = DBOS.start_workflow(send_test, topic)
+    wfid = handle.get_workflow_id()
+
+    engine = sa.create_engine(client._sys_db.engine.url)
+    try:
+        with Session(engine) as session:
+            with session.begin():
+                session.execute(sa.text("SELECT 1"))  # procure the connection first
+                client.send_in_transaction(session, wfid, message, topic)
+    finally:
+        engine.dispose()
 
     assert handle.get_result() == message
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2496,7 +2496,9 @@ def test_custom_engine(
         send_evt.wait()
         return DBOS.recv()
 
-    assert dbos._sys_db.engine == engine
+    # DBOS derives a schema-aware engine (carrying schema_translate_map) from the
+    # custom engine, sharing its connection pool rather than using it verbatim.
+    assert dbos._sys_db.engine.pool is engine.pool
     handle = DBOS.start_workflow(recv_workflow)
     ready_evt.wait()
     DBOS.send(handle.workflow_id, val)

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2496,8 +2496,7 @@ def test_custom_engine(
         send_evt.wait()
         return DBOS.recv()
 
-    # DBOS derives a schema-aware engine (carrying schema_translate_map) from the
-    # custom engine, sharing its connection pool rather than using it verbatim.
+    # DBOS derives a schema-aware engine sharing the custom engine's pool.
     assert dbos._sys_db.engine.pool is engine.pool
     handle = DBOS.start_workflow(recv_workflow)
     ready_evt.wait()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -83,6 +83,89 @@ def test_systemdb_migration_custom_schema(
     DBOS.destroy()
 
 
+def test_two_schemas_isolated_in_one_process(
+    config: DBOSConfig,
+    skip_with_sqlite: None,
+    cleanup_test_databases: None,
+) -> None:
+    """Two system databases with different schemas must stay isolated within one
+    process. Before per-engine schema_translate_map, the second instance's
+    set_schema() clobbered shared table metadata, so both ended up using one
+    schema (the regression this guards against)."""
+    sys_db_url = config["system_database_url"]
+    assert sys_db_url is not None
+
+    db_a = SystemDatabase.create(
+        system_database_url=sys_db_url,
+        engine_kwargs={},
+        engine=None,
+        schema="schema_alpha",
+        executor_id=None,
+        serializer=DefaultSerializer(),
+        use_listen_notify=False,
+    )
+    db_b = SystemDatabase.create(
+        system_database_url=sys_db_url,
+        engine_kwargs={},
+        engine=None,
+        schema="schema_beta",
+        executor_id=None,
+        serializer=DefaultSerializer(),
+        use_listen_notify=False,
+    )
+    try:
+        db_a.run_migrations()
+        db_b.run_migrations()
+
+        # Write a row through each instance *after* both were constructed. With
+        # the old shared-global schema, db_a's Core insert would have targeted
+        # db_b's schema (last writer of set_schema wins).
+        ins = SystemSchema.application_versions.insert()
+        with db_a.engine.begin() as conn:
+            conn.execute(
+                ins.values(
+                    version_id="alpha-row",
+                    version_name="alpha-row",
+                    version_timestamp=1,
+                    created_at=1,
+                )
+            )
+        with db_b.engine.begin() as conn:
+            conn.execute(
+                ins.values(
+                    version_id="beta-row",
+                    version_name="beta-row",
+                    version_timestamp=1,
+                    created_at=1,
+                )
+            )
+
+        # Each instance's Core queries see only its own schema's row.
+        sel = sa.select(SystemSchema.application_versions.c.version_id)
+        with db_a.engine.begin() as conn:
+            assert [r[0] for r in conn.execute(sel)] == ["alpha-row"]
+        with db_b.engine.begin() as conn:
+            assert [r[0] for r in conn.execute(sel)] == ["beta-row"]
+
+        # And the rows physically live in the correct schemas.
+        with db_a.engine.begin() as conn:
+            assert (
+                conn.execute(
+                    sa.text("SELECT version_id FROM schema_alpha.application_versions")
+                ).scalar_one()
+                == "alpha-row"
+            )
+            assert (
+                conn.execute(
+                    sa.text("SELECT version_id FROM schema_beta.application_versions")
+                ).scalar_one()
+                == "beta-row"
+            )
+    finally:
+        db_a.destroy()
+        db_b.destroy()
+
+
 def test_reset(
     config: DBOSConfig, db_engine: sa.Engine, skip_with_sqlite: None
 ) -> None:

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -88,10 +88,7 @@ def test_two_schemas_isolated_in_one_process(
     skip_with_sqlite: None,
     cleanup_test_databases: None,
 ) -> None:
-    """Two system databases with different schemas must stay isolated within one
-    process. Before per-engine schema_translate_map, the second instance's
-    set_schema() clobbered shared table metadata, so both ended up using one
-    schema (the regression this guards against)."""
+    """Two system databases with different schemas must stay isolated within one process."""
     sys_db_url = config["system_database_url"]
     assert sys_db_url is not None
 
@@ -117,9 +114,7 @@ def test_two_schemas_isolated_in_one_process(
         db_a.run_migrations()
         db_b.run_migrations()
 
-        # Write a row through each instance *after* both were constructed. With
-        # the old shared-global schema, db_a's Core insert would have targeted
-        # db_b's schema (last writer of set_schema wins).
+        # Write a row through each instance; it should land in that instance's schema.
         ins = SystemSchema.application_versions.insert()
         with db_a.engine.begin() as conn:
             conn.execute(


### PR DESCRIPTION
Fix an issue where system database schema was stored in a mutable global variable, potentially causing conflicts between clients.