### PR TITLE
Fix State Management During Async Cancellation

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1072,7 +1072,7 @@ async def start_workflow_async(
         is_recovery_request=is_recovery_request,
         is_dequeued_request=is_dequeued_request,
         serialization_type=serialization_type,
-        workflow_id_override=new_child_workflow_id,
+        child_workflow_id=new_child_workflow_id,
     )
 
     if status["serialization"] == DBOSPortableJSON.name():

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -362,12 +362,25 @@ def _init_workflow(
     is_recovery_request: Optional[bool],
     is_dequeued_request: Optional[bool],
     serialization_type: Optional[WorkflowSerializationFormat],
+    workflow_id_override: Optional[str] = None,
 ) -> tuple[WorkflowStatusInternal, bool]:
+    # workflow_id_override: id captured before to_thread dispatch, so a concurrent end_workflow() on shutdown can't blank the id read here.
     wfid = (
-        ctx.workflow_id
-        if len(ctx.workflow_id) > 0
-        else ctx.id_assigned_for_next_workflow
+        workflow_id_override
+        if workflow_id_override
+        else (
+            ctx.workflow_id
+            if len(ctx.workflow_id) > 0
+            else ctx.id_assigned_for_next_workflow
+        )
     )
+    if not wfid:
+        # An empty id is never valid; fail loudly instead of persisting a row that wedges recovery.
+        raise DBOSException(
+            "Attempted to initialize a workflow with an empty workflow ID. "
+            "The workflow context was likely cleared concurrently (e.g. by "
+            "shutdown) while the workflow was being recorded."
+        )
 
     # If we have a class name, the first arg is the instance and do not serialize
     if class_name is not None and class_name != "":
@@ -936,6 +949,7 @@ def start_workflow(
         is_recovery_request=is_recovery,
         is_dequeued_request=is_dequeued,
         serialization_type=serialization_type,
+        workflow_id_override=new_child_workflow_id,
     )
 
     if status["serialization"] == DBOSPortableJSON.name():
@@ -1058,6 +1072,7 @@ async def start_workflow_async(
         is_recovery_request=is_recovery_request,
         is_dequeued_request=is_dequeued_request,
         serialization_type=serialization_type,
+        workflow_id_override=new_child_workflow_id,
     )
 
     if status["serialization"] == DBOSPortableJSON.name():
@@ -1154,6 +1169,10 @@ def workflow_wrapper(
         }
         cctx = get_local_dbos_context()
         newwfctx = DBOSContext.create_start_workflow_child(cctx)
+        # Freeze the child id before to_thread dispatch: a concurrent end_workflow() on shutdown could blank newwfctx.workflow_id mid-registration.
+        child_wfid = newwfctx.id_assigned_for_next_workflow
+        parent_wfid = newwfctx.parent_workflow_id
+        parent_fid = newwfctx.parent_workflow_fid
         resctx: Optional[DBOSContext] = None
         if cctx is not None and cctx.is_workflow():
             resctx = cctx.snapshot_step_ctx(reserve_sleep_id=False)
@@ -1179,12 +1198,12 @@ def workflow_wrapper(
                 return recorded_result_inner
 
             nonlocal workflow_id
-            workflow_id = newwfctx.workflow_id
+            workflow_id = child_wfid
 
-            if newwfctx.has_parent():
+            if parent_wfid:
                 r = dbos._sys_db.check_operation_execution(
-                    newwfctx.parent_workflow_id,
-                    newwfctx.parent_workflow_fid,
+                    parent_wfid,
+                    parent_fid,
                     get_dbos_func_name(func),
                 )
                 if r and r["error"]:
@@ -1210,6 +1229,7 @@ def workflow_wrapper(
                 is_recovery_request=False,
                 is_dequeued_request=False,
                 serialization_type=fi.serialization_type,
+                workflow_id_override=child_wfid,
             )
 
             def get_recorded_result(_func: Callable[[], R]) -> R:
@@ -1223,14 +1243,14 @@ def workflow_wrapper(
 
             # TODO: maybe modify the parameters if they've been changed by `_init_workflow`
             dbos.logger.debug(
-                f"Running workflow, id: {newwfctx.workflow_id}, name: {get_dbos_func_name(func)}"
+                f"Running workflow, id: {child_wfid}, name: {get_dbos_func_name(func)}"
             )
 
-            if newwfctx.has_parent():
+            if parent_wfid:
                 dbos._sys_db.record_child_workflow(
-                    newwfctx.parent_workflow_id,
-                    newwfctx.workflow_id,
-                    newwfctx.parent_workflow_fid,
+                    parent_wfid,
+                    child_wfid,
+                    parent_fid,
                     get_dbos_func_name(func),
                 )
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -362,12 +362,12 @@ def _init_workflow(
     is_recovery_request: Optional[bool],
     is_dequeued_request: Optional[bool],
     serialization_type: Optional[WorkflowSerializationFormat],
-    workflow_id_override: Optional[str] = None,
+    child_workflow_id: Optional[str] = None,
 ) -> tuple[WorkflowStatusInternal, bool]:
-    # workflow_id_override: id captured before to_thread dispatch, so a concurrent end_workflow() on shutdown can't blank the id read here.
+    # If launching child, capture ID before to_thread dispatch, so a concurrent end_workflow() on shutdown can't blank the id read here.
     wfid = (
-        workflow_id_override
-        if workflow_id_override
+        child_workflow_id
+        if child_workflow_id
         else (
             ctx.workflow_id
             if len(ctx.workflow_id) > 0
@@ -949,7 +949,7 @@ def start_workflow(
         is_recovery_request=is_recovery,
         is_dequeued_request=is_dequeued,
         serialization_type=serialization_type,
-        workflow_id_override=new_child_workflow_id,
+        child_workflow_id=new_child_workflow_id,
     )
 
     if status["serialization"] == DBOSPortableJSON.name():
@@ -1229,7 +1229,7 @@ def workflow_wrapper(
                 is_recovery_request=False,
                 is_dequeued_request=False,
                 serialization_type=fi.serialization_type,
-                workflow_id_override=child_wfid,
+                child_workflow_id=child_wfid,
             )
 
             def get_recorded_result(_func: Callable[[], R]) -> R:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2361,6 +2361,12 @@ class SystemDatabase(ABC):
         functionID: int,
         functionName: str,
     ) -> None:
+        # An empty child id is never valid; fail loudly instead of silently wedging the parent on recovery.
+        if not childUUID:
+            raise DBOSException(
+                f"Attempted to record an empty child workflow ID for parent "
+                f"{parentUUID} (function {functionID}, {functionName})."
+            )
         sql = sa.insert(SystemSchema.operation_outputs).values(
             workflow_uuid=parentUUID,
             function_id=functionID,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -17,7 +17,7 @@ from dbos import (
     SetWorkflowTimeout,
     WorkflowHandleAsync,
 )
-from dbos._context import assert_current_dbos_context
+from dbos._context import assert_current_dbos_context, get_local_dbos_context
 from dbos._dbos import WorkflowHandle
 from dbos._dbos_config import ConfigFile
 from dbos._error import (
@@ -1246,3 +1246,90 @@ async def test_submit_coroutine_from_own_loop_raises_instead_of_hanging() -> Non
             bg.submit_coroutine(coro)
     finally:
         bg.stop()
+
+
+# Regression: a concurrent end_workflow() (shutdown) could blank an async child's id while its registration ran in a to_thread worker, persisting empty ids.
+
+
+@pytest.mark.asyncio
+async def test_async_child_id_survives_concurrent_context_clear(dbos: DBOS) -> None:
+    """Deterministically reproduce the race: while the child's registration runs in
+    a worker thread, clear the child context's workflow_id (exactly what shutdown's
+    end_workflow() does). The recorded ids must still be correct, not empty."""
+
+    @DBOS.workflow()
+    async def child(x: int) -> int:
+        return x
+
+    @DBOS.workflow()
+    async def parent(n: int) -> list:
+        return await asyncio.gather(*[child(i) for i in range(n)])
+
+    real_check = dbos._sys_db.check_operation_execution
+    real_record = dbos._sys_db.record_child_workflow
+    fired: list = []
+
+    def check_and_clear(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # First sys-db call in the child's init_wf (to_thread worker); blanking workflow_id here simulates a concurrent end_workflow() on shutdown.
+        result = real_check(*args, **kwargs)
+        ctx = get_local_dbos_context()
+        if ctx is not None and ctx.has_parent() and ctx.workflow_id:
+            ctx._test_saved_wfid = ctx.workflow_id  # type: ignore[attr-defined]
+            ctx.workflow_id = ""
+            fired.append(1)
+        return result
+
+    def record_and_restore(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # Last sys-db call in init_wf; restore the id so the child's normal __exit__ stays consistent in this non-cancelled test.
+        try:
+            return real_record(*args, **kwargs)
+        finally:
+            ctx = get_local_dbos_context()
+            saved = getattr(ctx, "_test_saved_wfid", "") if ctx is not None else ""
+            if saved:
+                ctx.workflow_id = saved  # type: ignore[union-attr]
+
+    dbos._sys_db.check_operation_execution = check_and_clear  # type: ignore[method-assign]
+    dbos._sys_db.record_child_workflow = record_and_restore  # type: ignore[method-assign]
+    try:
+        fanout = 5
+        assert (await parent(fanout)) == list(range(fanout))
+    finally:
+        dbos._sys_db.check_operation_execution = real_check  # type: ignore[method-assign]
+        dbos._sys_db.record_child_workflow = real_record  # type: ignore[method-assign]
+
+    # The injection must have actually fired (otherwise the test proves nothing).
+    assert len(fired) >= fanout
+
+    # No corrupt rows anywhere in the system database.
+    with dbos._sys_db.engine.connect() as c:
+        empty_status = c.execute(
+            sa.select(sa.func.count())
+            .select_from(SystemSchema.workflow_status)
+            .where(sa.func.length(SystemSchema.workflow_status.c.workflow_uuid) == 0)
+        ).scalar()
+        empty_links = c.execute(
+            sa.select(sa.func.count())
+            .select_from(SystemSchema.operation_outputs)
+            .where(SystemSchema.operation_outputs.c.child_workflow_id == "")
+        ).scalar()
+        child_links = c.execute(
+            sa.select(SystemSchema.operation_outputs.c.child_workflow_id).where(
+                SystemSchema.operation_outputs.c.child_workflow_id.isnot(None)
+            )
+        ).fetchall()
+
+    assert empty_status == 0
+    assert empty_links == 0
+    # Every recorded child link points at a real child workflow row.
+    for (child_id,) in child_links:
+        assert child_id
+        status = dbos._sys_db.get_workflow_status(child_id)
+        assert status is not None
+
+
+def test_record_child_workflow_rejects_empty_id(dbos: DBOS) -> None:
+    """The persistence guard: an empty child id is never valid and must fail loudly
+    rather than silently corrupt operation_outputs."""
+    with pytest.raises(DBOSException):
+        dbos._sys_db.record_child_workflow("some-parent-id", "", 0, "some.func")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1262,12 +1262,12 @@ async def test_async_child_id_survives_concurrent_context_clear(dbos: DBOS) -> N
         return x
 
     @DBOS.workflow()
-    async def parent(n: int) -> list:
-        return await asyncio.gather(*[child(i) for i in range(n)])
+    async def parent(n: int) -> List[int]:
+        return cast(List[int], await asyncio.gather(*[child(i) for i in range(n)]))
 
     real_check = dbos._sys_db.check_operation_execution
     real_record = dbos._sys_db.record_child_workflow
-    fired: list = []
+    fired: List[int] = []
 
     def check_and_clear(*args, **kwargs):  # type: ignore[no-untyped-def]
         # First sys-db call in the child's init_wf (to_thread worker); blanking workflow_id here simulates a concurrent end_workflow() on shutdown.


### PR DESCRIPTION
Fix an issue where an `asyncio.cancel` of a workflow while it launches a child (for example during event loop destruction in `DBOS.destroy`) could clear workflow context while a thread is launching the child, leading to the child being launched with a blank workflow ID.