### PR TITLE
Resilience Improvements

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1883,14 +1883,10 @@ async def run_step_async(
             )
 
         if inspect.iscoroutinefunction(func):
-            # Async step: build the Pending outcome on the loop and await it
-            # (it offloads its own blocking work via asyncio.to_thread).
+            # Async step: build the Pending outcome on the loop and await it.
             return await cast(Coroutine[Any, Any, R], invoke())
         else:
-            # Sync step: invoke_step runs the entire step synchronously -- the
-            # operation-result DB checkpoints, the user body, and any retry
-            # backoff sleep. Offload it to a worker thread so it does not block
-            # the event loop, matching the non-workflow branch below.
+            # Sync step: run it off-loop so its DB checkpoints, body, and retry sleep don't block the loop.
             return await asyncio.to_thread(lambda: cast(R, invoke()))
     else:
         if inspect.iscoroutinefunction(func):

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -619,7 +619,8 @@ class ActiveWorkflowById:
             del self._m[key]
 
     def activeList(self) -> List[str]:
-        return list(self._m.keys())
+        with self._lock:
+            return list(self._m.keys())
 
     def count_for_queue(
         self, queue_name: str, queue_partition_key: Optional[str] = None
@@ -1864,24 +1865,33 @@ async def run_step_async(
     # Otherwise, run it as a normal function.
     options = normalize_step_options(options)
     if step_ctx and step_ctx.is_workflow():
-        outcome = invoke_step(
-            dbos,
-            step_ctx,
-            func,
-            args,
-            kwargs,
-            step_name=options["name"] if options["name"] else func.__qualname__,
-            retries_allowed=options["retries_allowed"],
-            interval_seconds=options["interval_seconds"],
-            max_attempts=options["max_attempts"],
-            backoff_rate=options["backoff_rate"],
-            should_retry=options["should_retry"],
-            preemptible=options["preemptible"],
-        )
+
+        def invoke() -> Union[R, Coroutine[Any, Any, R]]:
+            return invoke_step(
+                dbos,
+                step_ctx,
+                func,
+                args,
+                kwargs,
+                step_name=options["name"] if options["name"] else func.__qualname__,
+                retries_allowed=options["retries_allowed"],
+                interval_seconds=options["interval_seconds"],
+                max_attempts=options["max_attempts"],
+                backoff_rate=options["backoff_rate"],
+                should_retry=options["should_retry"],
+                preemptible=options["preemptible"],
+            )
+
         if inspect.iscoroutinefunction(func):
-            return await cast(Coroutine[Any, Any, R], outcome)
+            # Async step: build the Pending outcome on the loop and await it
+            # (it offloads its own blocking work via asyncio.to_thread).
+            return await cast(Coroutine[Any, Any, R], invoke())
         else:
-            return cast(R, outcome)
+            # Sync step: invoke_step runs the entire step synchronously -- the
+            # operation-result DB checkpoints, the user body, and any retry
+            # backoff sleep. Offload it to a worker thread so it does not block
+            # the event loop, matching the non-workflow branch below.
+            return await asyncio.to_thread(lambda: cast(R, invoke()))
     else:
         if inspect.iscoroutinefunction(func):
             return await cast(Callable[P, Coroutine[Any, Any, R]], func)(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2320,7 +2320,6 @@ class SystemDatabase(ABC):
 
         record_operation_result_retry()
 
-    @db_retry()
     def record_get_result(
         self,
         result_workflow_id: str,
@@ -2335,23 +2334,34 @@ class SystemDatabase(ABC):
             if ctx is None or not ctx.is_workflow():
                 return
             ctx.function_id += 1  # Record the get_result as a step
-        # Because there's no corresponding check, we do nothing on conflict
-        # and do not raise a DBOSWorkflowConflictIDError
-        sql = (
-            self.dialect.insert(SystemSchema.operation_outputs)
-            .values(
-                workflow_uuid=ctx.workflow_id,
-                function_id=ctx.function_id,
-                function_name="DBOS.getResult",
-                output=output,
-                error=error,
-                child_workflow_id=result_workflow_id,
-                serialization=serialization,
+        # Capture the identifiers before entering the retry loop. db_retry can
+        # re-invoke its body after an ambiguous commit, and the function_id
+        # increment above must happen exactly once per get_result -- so it lives
+        # outside the retried function.
+        workflow_id = ctx.workflow_id
+        function_id = ctx.function_id
+
+        @db_retry()
+        def record() -> None:
+            # Because there's no corresponding check, we do nothing on conflict
+            # and do not raise a DBOSWorkflowConflictIDError
+            sql = (
+                self.dialect.insert(SystemSchema.operation_outputs)
+                .values(
+                    workflow_uuid=workflow_id,
+                    function_id=function_id,
+                    function_name="DBOS.getResult",
+                    output=output,
+                    error=error,
+                    child_workflow_id=result_workflow_id,
+                    serialization=serialization,
+                )
+                .on_conflict_do_nothing()
             )
-            .on_conflict_do_nothing()
-        )
-        with self.engine.begin() as c:
-            c.execute(sql)
+            with self.engine.begin() as c:
+                c.execute(sql)
+
+        record()
 
     @db_retry()
     def record_child_workflow(
@@ -2378,6 +2388,23 @@ class SystemDatabase(ABC):
                 c.execute(sql)
         except DBAPIError as dbapi_error:
             if self._is_unique_constraint_violation(dbapi_error):
+                # A row already exists at this (parent, function_id). If it
+                # records the same child, this is an idempotent retry (e.g.
+                # db_retry re-ran the body after the connection dropped on a
+                # prior commit) -- benign. A different child means the workflow
+                # executed nondeterministically, which is a genuine conflict.
+                with self.engine.begin() as c:
+                    existing = c.execute(
+                        sa.select(
+                            SystemSchema.operation_outputs.c.child_workflow_id
+                        ).where(
+                            SystemSchema.operation_outputs.c.workflow_uuid
+                            == parentUUID,
+                            SystemSchema.operation_outputs.c.function_id == functionID,
+                        )
+                    ).fetchone()
+                if existing is not None and existing[0] == childUUID:
+                    return
                 raise DBOSWorkflowConflictIDError(parentUUID)
             raise
 
@@ -2779,6 +2806,26 @@ class SystemDatabase(ABC):
         topic = topic if topic is not None else _dbos_null_topic
 
         with self.engine.begin() as c:
+            # Idempotency: db_retry can re-invoke this body if the connection
+            # drops after a prior attempt already committed (consuming the
+            # message and recording the result). In that case the result is
+            # durably recorded, so return it instead of consuming a second
+            # message -- otherwise the retry would consume nothing, record a
+            # conflicting timestamp, and lose the original message.
+            recorded = c.execute(
+                sa.select(
+                    SystemSchema.operation_outputs.c.output,
+                    SystemSchema.operation_outputs.c.serialization,
+                ).where(
+                    SystemSchema.operation_outputs.c.workflow_uuid == workflow_uuid,
+                    SystemSchema.operation_outputs.c.function_id == function_id,
+                )
+            ).fetchall()
+            if len(recorded) > 0:
+                return deserialize_value(
+                    recorded[0][0], recorded[0][1], self.serializer
+                )
+
             consume_stmt = (
                 sa.update(SystemSchema.notifications)
                 .where(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2334,10 +2334,7 @@ class SystemDatabase(ABC):
             if ctx is None or not ctx.is_workflow():
                 return
             ctx.function_id += 1  # Record the get_result as a step
-        # Capture the identifiers before entering the retry loop. db_retry can
-        # re-invoke its body after an ambiguous commit, and the function_id
-        # increment above must happen exactly once per get_result -- so it lives
-        # outside the retried function.
+        # Capture ids outside the retry: db_retry may re-run its body, but function_id must increment only once.
         workflow_id = ctx.workflow_id
         function_id = ctx.function_id
 
@@ -2388,11 +2385,7 @@ class SystemDatabase(ABC):
                 c.execute(sql)
         except DBAPIError as dbapi_error:
             if self._is_unique_constraint_violation(dbapi_error):
-                # A row already exists at this (parent, function_id). If it
-                # records the same child, this is an idempotent retry (e.g.
-                # db_retry re-ran the body after the connection dropped on a
-                # prior commit) -- benign. A different child means the workflow
-                # executed nondeterministically, which is a genuine conflict.
+                # Same child means an idempotent db_retry; a different child means nondeterminism (a real conflict).
                 with self.engine.begin() as c:
                     existing = c.execute(
                         sa.select(
@@ -2806,12 +2799,7 @@ class SystemDatabase(ABC):
         topic = topic if topic is not None else _dbos_null_topic
 
         with self.engine.begin() as c:
-            # Idempotency: db_retry can re-invoke this body if the connection
-            # drops after a prior attempt already committed (consuming the
-            # message and recording the result). In that case the result is
-            # durably recorded, so return it instead of consuming a second
-            # message -- otherwise the retry would consume nothing, record a
-            # conflicting timestamp, and lose the original message.
+            # Idempotency: if a prior db_retry attempt already committed, return the recorded message, not a new one.
             recorded = c.execute(
                 sa.select(
                     SystemSchema.operation_outputs.c.output,

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1045,14 +1045,18 @@ def test_recv_consume_idempotent_on_db_retry(dbos: DBOS) -> None:
     function_id = 1
     start_time = int(time.time() * 1000)
 
+    # Which of the two messages is consumed first depends on created_at_epoch_ms
+    # ordering, which can tie under coarse timestamp resolution -- the
+    # idempotency property holds for either, so don't assume an order.
     first = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
-    assert first == "msg1"
+    assert first in ("msg1", "msg2")
 
-    # A db_retry re-run re-invokes recv_consume with identical arguments.
+    # A db_retry re-run re-invokes recv_consume with identical arguments. It must
+    # return the same already-recorded message, not consume the other one.
     replay = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
-    assert replay == "msg1"
+    assert replay == first
 
-    # The replay must not have consumed msg2.
+    # The replay must not have consumed the second message.
     with dbos._sys_db.engine.connect() as c:
         unconsumed = c.execute(
             sa.select(SystemSchema.notifications.c.message).where(
@@ -1165,7 +1169,7 @@ def test_record_get_result_increments_function_id_once_on_db_retry(
         dbos._sys_db.engine = proxy  # type: ignore[assignment]
         dbos._sys_db.record_get_result(str(uuid.uuid4()), "some-output", None, None)
     finally:
-        dbos._sys_db.engine = real_engine  # type: ignore[assignment]
+        dbos._sys_db.engine = real_engine
         _set_local_dbos_context(prev)
 
     # The injected failure actually forced a retry...

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -11,18 +11,22 @@ from sqlalchemy.exc import DBAPIError, InvalidRequestError, OperationalError
 
 from dbos import DBOS, SetWorkflowID
 from dbos._client import DBOSClient
+from dbos._context import DBOSContext, _set_local_dbos_context, get_local_dbos_context
 from dbos._dbos import WorkflowHandle
 from dbos._dbos_config import DBOSConfig
 from dbos._error import (
     DBOSAwaitedWorkflowCancelledError,
     DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded,
+    DBOSException,
     DBOSMaxStepRetriesExceeded,
     DBOSNotAuthorizedError,
     DBOSQueueDeduplicatedError,
     DBOSUnexpectedStepError,
+    DBOSWorkflowConflictIDError,
     MaxRecoveryAttemptsExceededError,
 )
 from dbos._registrations import DEFAULT_MAX_RECOVERY_ATTEMPTS
+from dbos._schemas.system_database import SystemSchema
 from dbos._serialization import DefaultSerializer, safe_deserialize
 from dbos._sys_db import WorkflowStatusString
 from dbos._sys_db_postgres import PostgresSystemDatabase
@@ -1012,3 +1016,169 @@ def test_retriable_sqlite_exception() -> None:
     )
     # Unrelated errors are not retriable
     assert not retriable_sqlite_exception(Exception("syntax error"))
+
+
+def _make_status_row(dbos: DBOS, workflow_id: str) -> None:
+    """Run a trivial workflow under a fixed id so a workflow_status row exists
+    (operation_outputs and notifications both FK to it)."""
+
+    @DBOS.workflow()
+    def _noop() -> None:
+        return None
+
+    with SetWorkflowID(workflow_id):
+        _noop()
+
+
+def test_recv_consume_idempotent_on_db_retry(dbos: DBOS) -> None:
+    """recv_consume is wrapped in db_retry, which re-runs the whole body if the
+    connection drops after the consume committed but before the result was
+    acknowledged. The re-run must return the already-recorded message rather
+    than consume a *second* message (or raise a spurious conflict from
+    re-recording the result at the same function_id)."""
+    dest_id = str(uuid.uuid4())
+    _make_status_row(dbos, dest_id)
+
+    DBOS.send(dest_id, "msg1")
+    DBOS.send(dest_id, "msg2")
+
+    function_id = 1
+    start_time = int(time.time() * 1000)
+
+    first = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
+    assert first == "msg1"
+
+    # A db_retry re-run re-invokes recv_consume with identical arguments.
+    replay = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
+    assert replay == "msg1"
+
+    # The replay must not have consumed msg2.
+    with dbos._sys_db.engine.connect() as c:
+        unconsumed = c.execute(
+            sa.select(SystemSchema.notifications.c.message).where(
+                SystemSchema.notifications.c.destination_uuid == dest_id,
+                SystemSchema.notifications.c.consumed == False,
+            )
+        ).fetchall()
+    assert len(unconsumed) == 1
+
+
+def test_recv_consume_idempotent_on_timeout(dbos: DBOS) -> None:
+    """The idempotency path must also round-trip the no-message (timeout) case,
+    where the recorded output is a serialized None rather than NULL."""
+    dest_id = str(uuid.uuid4())
+    _make_status_row(dbos, dest_id)
+
+    function_id = 1
+    start_time = int(time.time() * 1000)
+
+    # No message available: records None as the durable result.
+    first = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
+    assert first is None
+
+    # Re-run returns the recorded None, not a freshly consumed message even if
+    # one has since arrived.
+    DBOS.send(dest_id, "late")
+    replay = dbos._sys_db.recv_consume(dest_id, function_id, None, start_time)
+    assert replay is None
+
+    with dbos._sys_db.engine.connect() as c:
+        unconsumed = c.execute(
+            sa.select(SystemSchema.notifications.c.message).where(
+                SystemSchema.notifications.c.destination_uuid == dest_id,
+                SystemSchema.notifications.c.consumed == False,
+            )
+        ).fetchall()
+    assert len(unconsumed) == 1
+
+
+def test_record_child_workflow_idempotent_on_db_retry(dbos: DBOS) -> None:
+    """record_child_workflow is wrapped in db_retry. If a prior attempt
+    committed and the connection then dropped, the re-run hits a unique
+    violation; recording the *same* child is an idempotent replay (return),
+    while a *different* child is real nondeterminism (conflict)."""
+    parent_id = str(uuid.uuid4())
+    _make_status_row(dbos, parent_id)
+
+    child_id = str(uuid.uuid4())
+    function_id = 1
+    function_name = "test_child"
+
+    dbos._sys_db.record_child_workflow(parent_id, child_id, function_id, function_name)
+
+    # Re-recording the same child at the same function_id is idempotent.
+    dbos._sys_db.record_child_workflow(parent_id, child_id, function_id, function_name)
+
+    # A different child at the same function_id is a genuine conflict.
+    with pytest.raises(DBOSWorkflowConflictIDError):
+        dbos._sys_db.record_child_workflow(
+            parent_id, str(uuid.uuid4()), function_id, function_name
+        )
+
+    # An empty child id is rejected loudly rather than silently wedging recovery.
+    with pytest.raises(DBOSException):
+        dbos._sys_db.record_child_workflow(parent_id, "", 2, function_name)
+
+
+class _RetryOnceEngine:
+    """Engine proxy whose first begin() on the test's own thread raises a
+    retriable error (a simulated dropped connection), forcing the surrounding
+    db_retry loop to re-run its body exactly once. Calls from other threads
+    (background pollers) and all later calls delegate to the real engine."""
+
+    def __init__(self, real: Any, thread_id: int) -> None:
+        self._real = real
+        self._thread_id = thread_id
+        self.fired = False
+
+    def begin(self) -> Any:
+        if not self.fired and threading.get_ident() == self._thread_id:
+            self.fired = True
+            raise Exception("database is locked")  # retriable on pg and sqlite
+        return self._real.begin()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+def test_record_get_result_increments_function_id_once_on_db_retry(
+    dbos: DBOS,
+) -> None:
+    """record_get_result increments ctx.function_id once as part of recording
+    the get_result step. The increment must happen outside the db_retry loop:
+    if the DB write retries, the function_id must not advance a second time, or
+    the workflow's step sequence desyncs from its recorded history."""
+    workflow_id = str(uuid.uuid4())
+    _make_status_row(dbos, workflow_id)
+
+    ctx = DBOSContext()
+    ctx.workflow_id = workflow_id
+    ctx.function_id = 0
+    assert ctx.is_workflow()
+
+    real_engine = dbos._sys_db.engine
+    proxy = _RetryOnceEngine(real_engine, threading.get_ident())
+
+    prev = get_local_dbos_context()
+    _set_local_dbos_context(ctx)
+    try:
+        dbos._sys_db.engine = proxy  # type: ignore[assignment]
+        dbos._sys_db.record_get_result(str(uuid.uuid4()), "some-output", None, None)
+    finally:
+        dbos._sys_db.engine = real_engine  # type: ignore[assignment]
+        _set_local_dbos_context(prev)
+
+    # The injected failure actually forced a retry...
+    assert proxy.fired
+    # ...but the function_id advanced exactly once (0 -> 1).
+    assert ctx.function_id == 1
+
+    # Exactly one get_result row was recorded, at that function_id.
+    with dbos._sys_db.engine.connect() as c:
+        rows = c.execute(
+            sa.select(SystemSchema.operation_outputs.c.function_id).where(
+                SystemSchema.operation_outputs.c.workflow_uuid == workflow_id,
+                SystemSchema.operation_outputs.c.function_name == "DBOS.getResult",
+            )
+        ).fetchall()
+    assert [r[0] for r in rows] == [1]


### PR DESCRIPTION
- Fix an issue where a database connection issue triggering retries could increment `function_id` multiple times.
- Fix an issue where calling a sync step with `run_step_async` would block the event loop