### PR TITLE
Debouncer Optimizations

### DIFF
--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -83,7 +83,7 @@ class DebouncerMessage(TypedDict):
     inputs: WorkflowInputs
     message_id: str
     debounce_period_sec: float
-    # When set, the debouncer skips the set_event ack (best-effort re-arm)
+    # When set, the debouncer skips the set_event ack (best-effort mode)
     best_effort: bool
 
 
@@ -139,7 +139,7 @@ async def debouncer_workflow(
             break
         workflow_inputs = message["inputs"]
         debounce_period_sec = message["debounce_period_sec"]
-        # Acknowledge receipt unless the sender opted into best-effort re-arm
+        # Acknowledge receipt unless the sender opted into best-effort mode
         if not message.get("best_effort"):
             await DBOS.set_event_async(message["message_id"], message["message_id"])
 
@@ -292,7 +292,7 @@ class Debouncer(Generic[P, R]):
 
         while True:
             # Check for an existing debouncer first; avoids a failed enqueue (which leaves
-            # a dead workflow_status tuple) on every re-arm of a hot key.
+            # a dead workflow_status tuple) on every call for a hot key.
             dedup_wfid = dbos._sys_db.call_function_as_step(
                 get_deduplicated_workflow,
                 "DBOS.get_deduplicated_workflow",
@@ -321,7 +321,7 @@ class Debouncer(Generic[P, R]):
                     )
                     if dedup_wfid is None:
                         continue
-            # An existing debouncer was found: send it a message to re-arm.
+            # An existing debouncer was found: send it a message to extend its window.
             workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
             message: DebouncerMessage = {
                 "message_id": message_id,
@@ -400,7 +400,7 @@ class DebouncerClient:
         deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
         while True:
             # Check for an existing debouncer first; avoids a failed enqueue (which leaves
-            # a dead workflow_status tuple) on every re-arm of a hot key.
+            # a dead workflow_status tuple) on every call for a hot key.
             dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
                 queue_name=INTERNAL_QUEUE_NAME,
                 deduplication_id=deduplication_id,
@@ -432,7 +432,7 @@ class DebouncerClient:
                     )
                     if dedup_wfid is None:
                         continue
-            # An existing debouncer was found: send it a message to re-arm.
+            # An existing debouncer was found: send it a message to extend its window.
             workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
             message: DebouncerMessage = {
                 "message_id": message_id,

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -194,8 +194,9 @@ class Debouncer(Generic[P, R]):
         best_effort: bool = False,
     ):
         self.func_name = workflow_name
-        # Best-effort re-arm skips the send/ack handshake: cheaper on the hot path,
-        # but a re-arm racing the debouncer's firing may be silently dropped.
+        # Best-effort mode skips acknowledgment of new inputs.
+        # This improves performance but inputs may be dropped if they arrive
+        # at the same instance the debounced workflow fires.
         self.best_effort = best_effort
         self.options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
@@ -368,8 +369,9 @@ class DebouncerClient:
         best_effort: bool = False,
     ):
         self.workflow_options = workflow_options
-        # Best-effort re-arm skips the send/ack handshake: cheaper on the hot path,
-        # but a re-arm racing the debouncer's firing may be silently dropped.
+        # Best-effort mode skips acknowledgment of new inputs.
+        # This improves performance but inputs may be dropped if they arrive
+        # at the same instance the debounced workflow fires.
         self.best_effort = best_effort
         self.debouncer_options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -194,9 +194,9 @@ class Debouncer(Generic[P, R]):
         best_effort: bool = False,
     ):
         self.func_name = workflow_name
-        # Best-effort mode skips acknowledgment of new inputs.
-        # This improves performance but inputs may be dropped if they arrive
-        # at the same instance the debounced workflow fires.
+        # Best-effort mode skips input acknowledgment: faster, but an input may be
+        # dropped if it arrives just as the debounced workflow fires (the returned handle
+        # resolves to a result computed without that input).
         self.best_effort = best_effort
         self.options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
@@ -291,8 +291,8 @@ class Debouncer(Generic[P, R]):
             )
 
         while True:
-            # Check for an existing debouncer first; avoids a failed enqueue (which leaves
-            # a dead workflow_status tuple) on every call for a hot key.
+            # Check for an existing debouncer first to avoid a wasted enqueue INSERT and
+            # the DBOSQueueDeduplicatedError it raises on every call for a hot key.
             dedup_wfid = dbos._sys_db.call_function_as_step(
                 get_deduplicated_workflow,
                 "DBOS.get_deduplicated_workflow",
@@ -369,9 +369,9 @@ class DebouncerClient:
         best_effort: bool = False,
     ):
         self.workflow_options = workflow_options
-        # Best-effort mode skips acknowledgment of new inputs.
-        # This improves performance but inputs may be dropped if they arrive
-        # at the same instance the debounced workflow fires.
+        # Best-effort mode skips input acknowledgment: faster, but an input may be
+        # dropped if it arrives just as the debounced workflow fires (the returned handle
+        # resolves to a result computed without that input).
         self.best_effort = best_effort
         self.debouncer_options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
@@ -399,8 +399,8 @@ class DebouncerClient:
         message_id = generate_uuid()
         deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
         while True:
-            # Check for an existing debouncer first; avoids a failed enqueue (which leaves
-            # a dead workflow_status tuple) on every call for a hot key.
+            # Check for an existing debouncer first to avoid a wasted enqueue INSERT and
+            # the DBOSQueueDeduplicatedError it raises on every call for a hot key.
             dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
                 queue_name=INTERNAL_QUEUE_NAME,
                 deduplication_id=deduplication_id,

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -83,6 +83,8 @@ class DebouncerMessage(TypedDict):
     inputs: WorkflowInputs
     message_id: str
     debounce_period_sec: float
+    # When set, the debouncer skips the set_event ack (best-effort re-arm)
+    best_effort: bool
 
 
 async def debouncer_workflow(
@@ -102,24 +104,34 @@ async def debouncer_workflow(
     # It waits until debounce_period_sec have passed since the last message or until
     # debounce_timeout_sec has elapsed.
     async def get_debounce_deadline_epoch_sec() -> float:
-        return (
-            time.time() + options["debounce_timeout_sec"]
-            if options["debounce_timeout_sec"]
-            else math.inf
-        )
+        timeout_sec = options["debounce_timeout_sec"]
+        assert timeout_sec is not None  # only called when a timeout is configured
+        return time.time() + timeout_sec
 
     async def get_time() -> float:
         return time.time()
 
-    debounce_deadline_epoch_sec = await DBOS.run_step_async(
-        {"name": "get_debounce_deadline_epoch_sec"}, get_debounce_deadline_epoch_sec
-    )
+    # Only track a deadline when an overall timeout is set; otherwise it is infinite
+    # and reading the clock each iteration would be a durable step with no effect.
+    has_deadline = bool(options["debounce_timeout_sec"])
+    if has_deadline:
+        debounce_deadline_epoch_sec = await DBOS.run_step_async(
+            {"name": "get_debounce_deadline_epoch_sec"}, get_debounce_deadline_epoch_sec
+        )
+    else:
+        debounce_deadline_epoch_sec = math.inf
+
     debounce_period_sec = initial_debounce_period_sec
     while True:
-        now = await DBOS.run_step_async({"name": "get_time"}, get_time)
-        if now >= debounce_deadline_epoch_sec:
-            break
-        timeout = min(debounce_period_sec, max(debounce_deadline_epoch_sec - now, 0))
+        if has_deadline:
+            now = await DBOS.run_step_async({"name": "get_time"}, get_time)
+            if now >= debounce_deadline_epoch_sec:
+                break
+            timeout = min(
+                debounce_period_sec, max(debounce_deadline_epoch_sec - now, 0)
+            )
+        else:
+            timeout = debounce_period_sec
         message: Optional[DebouncerMessage] = await DBOS.recv_async(
             _DEBOUNCER_TOPIC, timeout_seconds=timeout
         )
@@ -127,8 +139,9 @@ async def debouncer_workflow(
             break
         workflow_inputs = message["inputs"]
         debounce_period_sec = message["debounce_period_sec"]
-        # Acknowledge receipt of the message
-        await DBOS.set_event_async(message["message_id"], message["message_id"])
+        # Acknowledge receipt unless the sender opted into best-effort re-arm
+        if not message.get("best_effort"):
+            await DBOS.set_event_async(message["message_id"], message["message_id"])
 
     # After the timeout or period has elapsed, enqueue the user workflow with the requested
     # context parameters.
@@ -178,8 +191,12 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        best_effort: bool = False,
     ):
         self.func_name = workflow_name
+        # Best-effort re-arm skips the send/ack handshake: cheaper on the hot path,
+        # but a re-arm racing the debouncer's firing may be silently dropped.
+        self.best_effort = best_effort
         self.options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
             "queue_name": _resolve_queue_name(queue),
@@ -192,6 +209,7 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        best_effort: bool = False,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -200,6 +218,7 @@ class Debouncer(Generic[P, R]):
             get_dbos_func_name(workflow),
             debounce_timeout_sec=debounce_timeout_sec,
             queue=queue,
+            best_effort=best_effort,
         )
 
     @staticmethod
@@ -208,6 +227,7 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        best_effort: bool = False,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -216,6 +236,7 @@ class Debouncer(Generic[P, R]):
             get_dbos_func_name(workflow),
             debounce_timeout_sec=debounce_timeout_sec,
             queue=queue,
+            best_effort=best_effort,
         )
 
     def debounce(
@@ -259,58 +280,65 @@ class Debouncer(Generic[P, R]):
                 ),
                 "attributes": ctx.workflow_attributes,
             }
-        while True:
-            try:
-                # Attempt to enqueue a debouncer for this workflow.
-                deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
-                with SetEnqueueOptions(deduplication_id=deduplication_id):
-                    with SetWorkflowTimeout(None), SetWorkflowAttributes(None):
-                        internal_queue.enqueue(
-                            debouncer_workflow,
-                            debounce_period_sec,
-                            ctxOptions,
-                            self.options,
-                            *args,
-                            **kwargs,
-                        )
-                return WorkflowHandlePolling(user_workflow_id, dbos)
-            except DBOSQueueDeduplicatedError:
-                # If there is already a debouncer, send a message to it.
-                # Deterministically retrieve the ID of the debouncer
-                def get_deduplicated_workflow() -> Optional[str]:
-                    return dbos._sys_db.get_deduplicated_workflow(
-                        queue_name=internal_queue.name,
-                        deduplication_id=deduplication_id,
-                    )
+        deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
 
-                dedup_wfid = dbos._sys_db.call_function_as_step(
-                    get_deduplicated_workflow,
-                    "DBOS.get_deduplicated_workflow",
-                    snapshot_step_context(reserve_sleep_id=False),
-                )
-                if dedup_wfid is None:
-                    continue
-                else:
-                    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
-                    message: DebouncerMessage = {
-                        "message_id": message_id,
-                        "inputs": workflow_inputs,
-                        "debounce_period_sec": debounce_period_sec,
-                    }
-                    DBOS.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
-                    # Wait for the debouncer to acknowledge receipt of the message.
-                    # If the message is not acknowledged, this likely means the debouncer started its workflow
-                    # and exited without processing this message, so try again.
-                    if not DBOS.get_event(dedup_wfid, message_id, timeout_seconds=1):
-                        continue
-                    # Retrieve the user workflow ID from the input to the debouncer
-                    # and return a handle to it
-                    dedup_workflow_input = (
-                        DBOS.retrieve_workflow(dedup_wfid).get_status().input
-                    )
-                    assert dedup_workflow_input is not None
-                    user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
+        # Deterministically retrieve the ID of the debouncer for this key, if one exists
+        def get_deduplicated_workflow() -> Optional[str]:
+            return dbos._sys_db.get_deduplicated_workflow(
+                queue_name=internal_queue.name,
+                deduplication_id=deduplication_id,
+            )
+
+        while True:
+            # Check for an existing debouncer first; avoids a failed enqueue (which leaves
+            # a dead workflow_status tuple) on every re-arm of a hot key.
+            dedup_wfid = dbos._sys_db.call_function_as_step(
+                get_deduplicated_workflow,
+                "DBOS.get_deduplicated_workflow",
+                snapshot_step_context(reserve_sleep_id=False),
+            )
+            if dedup_wfid is None:
+                try:
+                    # No existing debouncer: attempt to enqueue one.
+                    with SetEnqueueOptions(deduplication_id=deduplication_id):
+                        with SetWorkflowTimeout(None), SetWorkflowAttributes(None):
+                            internal_queue.enqueue(
+                                debouncer_workflow,
+                                debounce_period_sec,
+                                ctxOptions,
+                                self.options,
+                                *args,
+                                **kwargs,
+                            )
                     return WorkflowHandlePolling(user_workflow_id, dbos)
+                except DBOSQueueDeduplicatedError:
+                    # A debouncer was created concurrently; re-read it and send instead.
+                    dedup_wfid = dbos._sys_db.call_function_as_step(
+                        get_deduplicated_workflow,
+                        "DBOS.get_deduplicated_workflow",
+                        snapshot_step_context(reserve_sleep_id=False),
+                    )
+                    if dedup_wfid is None:
+                        continue
+            # An existing debouncer was found: send it a message to re-arm.
+            workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
+            message: DebouncerMessage = {
+                "message_id": message_id,
+                "inputs": workflow_inputs,
+                "debounce_period_sec": debounce_period_sec,
+                "best_effort": self.best_effort,
+            }
+            DBOS.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
+            # Wait for the debouncer to ack (unless best-effort); no ack means it already
+            # fired and exited without processing this message, so try again.
+            if not self.best_effort:
+                if not DBOS.get_event(dedup_wfid, message_id, timeout_seconds=1):
+                    continue
+            # Retrieve the user workflow ID from the debouncer's input and return a handle
+            dedup_workflow_input = DBOS.retrieve_workflow(dedup_wfid).get_status().input
+            assert dedup_workflow_input is not None
+            user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
+            return WorkflowHandlePolling(user_workflow_id, dbos)
 
     async def debounce_async(
         self,
@@ -337,8 +365,12 @@ class DebouncerClient:
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        best_effort: bool = False,
     ):
         self.workflow_options = workflow_options
+        # Best-effort re-arm skips the send/ack handshake: cheaper on the hot path,
+        # but a re-arm racing the debouncer's firing may be silently dropped.
+        self.best_effort = best_effort
         self.debouncer_options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
             "queue_name": _resolve_queue_name(queue),
@@ -363,61 +395,62 @@ class DebouncerClient:
             "attributes": self.workflow_options.get("attributes"),
         }
         message_id = generate_uuid()
+        deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
         while True:
-            try:
-                # Attempt to enqueue a debouncer for this workflow.
-                deduplication_id = (
-                    f"{self.debouncer_options['workflow_name']}-{debounce_key}"
-                )
-                debouncer_options: EnqueueOptions = {
-                    "workflow_name": DEBOUNCER_WORKFLOW_NAME,
-                    "queue_name": INTERNAL_QUEUE_NAME,
-                    "deduplication_id": deduplication_id,
-                }
-                self.client.enqueue(
-                    debouncer_options,
-                    debounce_period_sec,
-                    ctxOptions,
-                    self.debouncer_options,
-                    *args,
-                    **kwargs,
-                )
-                return WorkflowHandleClientPolling[R](
-                    ctxOptions["workflow_id"], self.client._sys_db
-                )
-            except DBOSQueueDeduplicatedError:
-                # If there is already a debouncer, send a message to it.
-                dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
-                    queue_name=INTERNAL_QUEUE_NAME,
-                    deduplication_id=deduplication_id,
-                )
-                if dedup_wfid is None:
-                    continue
-                else:
-                    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
-                    message: DebouncerMessage = {
-                        "message_id": message_id,
-                        "inputs": workflow_inputs,
-                        "debounce_period_sec": debounce_period_sec,
+            # Check for an existing debouncer first; avoids a failed enqueue (which leaves
+            # a dead workflow_status tuple) on every re-arm of a hot key.
+            dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
+                queue_name=INTERNAL_QUEUE_NAME,
+                deduplication_id=deduplication_id,
+            )
+            if dedup_wfid is None:
+                try:
+                    # No existing debouncer: attempt to enqueue one.
+                    debouncer_options: EnqueueOptions = {
+                        "workflow_name": DEBOUNCER_WORKFLOW_NAME,
+                        "queue_name": INTERNAL_QUEUE_NAME,
+                        "deduplication_id": deduplication_id,
                     }
-                    self.client.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
-                    # Wait for the debouncer to acknowledge receipt of the message.
-                    # If the message is not acknowledged, this likely means the debouncer started its workflow
-                    # and exited without processing this message, so try again.
-                    if not self.client.get_event(
-                        dedup_wfid, message_id, timeout_seconds=1
-                    ):
-                        continue
-                    # Retrieve the user workflow ID from the input to the debouncer
-                    # and return a handle to it
-                    dedup_workflow_input = (
-                        self.client.retrieve_workflow(dedup_wfid).get_status().input
+                    self.client.enqueue(
+                        debouncer_options,
+                        debounce_period_sec,
+                        ctxOptions,
+                        self.debouncer_options,
+                        *args,
+                        **kwargs,
                     )
-                    assert dedup_workflow_input is not None
-                    user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
                     return WorkflowHandleClientPolling[R](
-                        user_workflow_id, self.client._sys_db
+                        ctxOptions["workflow_id"], self.client._sys_db
                     )
+                except DBOSQueueDeduplicatedError:
+                    # A debouncer was created concurrently; re-read it and send instead.
+                    dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
+                        queue_name=INTERNAL_QUEUE_NAME,
+                        deduplication_id=deduplication_id,
+                    )
+                    if dedup_wfid is None:
+                        continue
+            # An existing debouncer was found: send it a message to re-arm.
+            workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
+            message: DebouncerMessage = {
+                "message_id": message_id,
+                "inputs": workflow_inputs,
+                "debounce_period_sec": debounce_period_sec,
+                "best_effort": self.best_effort,
+            }
+            self.client.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
+            # Wait for the debouncer to ack (unless best-effort); no ack means it already
+            # fired and exited without processing this message, so try again.
+            if not self.best_effort:
+                if not self.client.get_event(dedup_wfid, message_id, timeout_seconds=1):
+                    continue
+            # Retrieve the user workflow ID from the debouncer's input and return a handle
+            dedup_workflow_input = (
+                self.client.retrieve_workflow(dedup_wfid).get_status().input
+            )
+            assert dedup_workflow_input is not None
+            user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
+            return WorkflowHandleClientPolling[R](user_workflow_id, self.client._sys_db)
 
     async def debounce_async(
         self, deboucne_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -160,7 +160,7 @@ def test_debouncer_best_effort(dbos: DBOS) -> None:
 
     first_value, second_value, third_value = 0, 1, 2
 
-    # Best-effort re-arm skips the send/ack handshake but still coalesces.
+    # Best-effort mode skips the send/ack handshake but still coalesces.
     debouncer = Debouncer.create(workflow, best_effort=True)
     debounce_period_sec = 2
 

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -18,16 +18,22 @@ from dbos._queue import Queue
 from dbos._utils import GlobalParams
 
 
-def _debouncer_step_names(user_workflow_id: str) -> list[str]:
-    # Return the recorded step names of the debouncer that enqueued the given workflow.
+def _debouncer_id(user_workflow_id: str) -> str:
+    # Return the workflow ID of the debouncer that enqueued the given user workflow.
     debouncers = [
         w
         for w in DBOS.list_workflows(name=DEBOUNCER_WORKFLOW_NAME)
         if w.input is not None and w.input["args"][1]["workflow_id"] == user_workflow_id
     ]
     assert len(debouncers) == 1
+    return debouncers[0].workflow_id
+
+
+def _debouncer_step_names(user_workflow_id: str) -> list[str]:
+    # Return the recorded step names of the debouncer that enqueued the given workflow.
     return [
-        s["function_name"] for s in DBOS.list_workflow_steps(debouncers[0].workflow_id)
+        s["function_name"]
+        for s in DBOS.list_workflow_steps(_debouncer_id(user_workflow_id))
     ]
 
 
@@ -179,6 +185,56 @@ def test_debouncer_best_effort(dbos: DBOS) -> None:
     assert "get_time" not in step_names
     assert "get_debounce_deadline_epoch_sec" not in step_names
     assert step_names.count("DBOS.recv") >= 1
+
+
+def test_debouncer_best_effort_refreshes_after_fire(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    # Once a best-effort debouncer fires, its dedup id is cleared on completion, so a
+    # later call for the same key cannot send to the dead debouncer: it must start a
+    # fresh one, and the returned handle must still resolve to the new value. This is
+    # the concurrent-fire window the happy-path test cannot reach.
+    debouncer = Debouncer.create(workflow, best_effort=True)
+    short_period = 1
+
+    first_handle = debouncer.debounce("key", short_period, 0)
+    assert first_handle.get_result() == 0
+    # Block until the first debouncer fully completes (dedup id cleared) before retrying.
+    DBOS.retrieve_workflow(_debouncer_id(first_handle.workflow_id)).get_result()
+
+    second_handle = debouncer.debounce("key", short_period, 1)
+    assert second_handle.workflow_id != first_handle.workflow_id
+    assert second_handle.get_result() == 1
+
+
+def test_debouncer_client_best_effort(dbos: DBOS, client: DBOSClient) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    DBOS.register_queue("test-queue")
+    options: EnqueueOptions = {
+        "workflow_name": workflow.__qualname__,
+        "queue_name": "test-queue",
+    }
+    # Best-effort works over the client path too: it coalesces and skips the ack.
+    debouncer = DebouncerClient(client, options, best_effort=True)
+    debounce_period_sec = 2
+
+    first_handle = debouncer.debounce("key", debounce_period_sec, 0)
+    second_handle = debouncer.debounce("key", debounce_period_sec, 1)
+    third_handle = debouncer.debounce("key", debounce_period_sec, 2)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.workflow_id == third_handle.workflow_id
+    assert first_handle.get_result() == 2
+
+    # Best-effort skips the ack, so the debouncer records no setEvent step.
+    step_names = _debouncer_step_names(first_handle.workflow_id)
+    assert "DBOS.setEvent" not in step_names
 
 
 def test_debouncer_no_timeout_skips_clock_reads(dbos: DBOS) -> None:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -196,11 +196,11 @@ def test_debouncer_no_timeout_skips_clock_reads(dbos: DBOS) -> None:
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.get_result() == 1
 
-    # No overall timeout → no clock-read steps (optimization A) ...
+    # No overall timeout means no clock-read steps are recorded
     step_names = _debouncer_step_names(first_handle.workflow_id)
     assert "get_time" not in step_names
     assert "get_debounce_deadline_epoch_sec" not in step_names
-    # ... but acks are still recorded because best_effort was not set.
+    # But acks are still recorded because best_effort was not set
     assert "DBOS.setEvent" in step_names
 
 

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -225,9 +225,15 @@ def test_debouncer_client_best_effort(dbos: DBOS, client: DBOSClient) -> None:
     debouncer = DebouncerClient(client, options, best_effort=True)
     debounce_period_sec = 2
 
-    first_handle = debouncer.debounce("key", debounce_period_sec, 0)
-    second_handle = debouncer.debounce("key", debounce_period_sec, 1)
-    third_handle = debouncer.debounce("key", debounce_period_sec, 2)
+    first_handle: WorkflowHandle[int] = debouncer.debounce(
+        "key", debounce_period_sec, 0
+    )
+    second_handle: WorkflowHandle[int] = debouncer.debounce(
+        "key", debounce_period_sec, 1
+    )
+    third_handle: WorkflowHandle[int] = debouncer.debounce(
+        "key", debounce_period_sec, 2
+    )
     assert first_handle.workflow_id == second_handle.workflow_id
     assert first_handle.workflow_id == third_handle.workflow_id
     assert first_handle.get_result() == 2

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -13,8 +13,22 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
+from dbos._core import DEBOUNCER_WORKFLOW_NAME
 from dbos._queue import Queue
 from dbos._utils import GlobalParams
+
+
+def _debouncer_step_names(user_workflow_id: str) -> list[str]:
+    # Return the recorded step names of the debouncer that enqueued the given workflow.
+    debouncers = [
+        w
+        for w in DBOS.list_workflows(name=DEBOUNCER_WORKFLOW_NAME)
+        if w.input is not None and w.input["args"][1]["workflow_id"] == user_workflow_id
+    ]
+    assert len(debouncers) == 1
+    return [
+        s["function_name"] for s in DBOS.list_workflow_steps(debouncers[0].workflow_id)
+    ]
 
 
 def test_debouncer(dbos: DBOS) -> None:
@@ -136,6 +150,78 @@ def test_multiple_debouncers(dbos: DBOS) -> None:
     assert second_handle.get_result() == second_value
     assert third_handle.get_result() == fourth_value
     assert fourth_handle.get_result() == fourth_value
+
+
+def test_debouncer_best_effort(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    first_value, second_value, third_value = 0, 1, 2
+
+    # Best-effort re-arm skips the send/ack handshake but still coalesces.
+    debouncer = Debouncer.create(workflow, best_effort=True)
+    debounce_period_sec = 2
+
+    first_handle = debouncer.debounce("key", debounce_period_sec, first_value)
+    second_handle = debouncer.debounce("key", debounce_period_sec, second_value)
+    third_handle = debouncer.debounce("key", debounce_period_sec, third_value)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.workflow_id == third_handle.workflow_id
+    assert first_handle.get_result() == third_value
+    assert third_handle.get_result() == third_value
+
+    # Best-effort means the debouncer records no acks, and without an overall timeout
+    # it records no per-iteration clock reads either.
+    step_names = _debouncer_step_names(first_handle.workflow_id)
+    assert "DBOS.setEvent" not in step_names
+    assert "get_time" not in step_names
+    assert "get_debounce_deadline_epoch_sec" not in step_names
+    assert step_names.count("DBOS.recv") >= 1
+
+
+def test_debouncer_no_timeout_skips_clock_reads(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    # Default debouncer: acks enabled, no overall timeout.
+    debouncer = Debouncer.create(workflow)
+    debounce_period_sec = 2
+
+    first_handle = debouncer.debounce("key", debounce_period_sec, 0)
+    second_handle = debouncer.debounce("key", debounce_period_sec, 1)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.get_result() == 1
+
+    # No overall timeout → no clock-read steps (optimization A) ...
+    step_names = _debouncer_step_names(first_handle.workflow_id)
+    assert "get_time" not in step_names
+    assert "get_debounce_deadline_epoch_sec" not in step_names
+    # ... but acks are still recorded because best_effort was not set.
+    assert "DBOS.setEvent" in step_names
+
+
+def test_debouncer_timeout_records_clock_reads(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    # With an overall timeout, the deadline is tracked, so clock reads are recorded.
+    debouncer = Debouncer.create(workflow, debounce_timeout_sec=2)
+    long_debounce_period = 10000000
+
+    first_handle = debouncer.debounce("key", long_debounce_period, 0)
+    second_handle = debouncer.debounce("key", long_debounce_period, 1)
+    assert first_handle.workflow_id == second_handle.workflow_id
+    assert first_handle.get_result() == 1
+
+    step_names = _debouncer_step_names(first_handle.workflow_id)
+    assert "get_debounce_deadline_epoch_sec" in step_names
+    assert "get_time" in step_names
 
 
 def test_debouncer_queue(dbos: DBOS) -> None:


### PR DESCRIPTION
- Retrieve time in a step only when a timeout requires it
- Check for an existing debounced workflow before enqueueing one to short-circuit the common case
- Add a "best-effort" mode that does not require an acknowledgment from the debouncer workflow, significantly improving performance at the cost of inputs possibly being dropped if they arrive at the same instance the debounced workflow fires.