### PR TITLE
Debounce With Delay

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -87,9 +87,6 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     class_name: str
     instance_name: str
     attributes: Dict[str, Any]
-    # Internal debouncer fields; not part of the public enqueue API.
-    debounce_deadline_epoch_ms: Optional[int]
-    is_debounced: bool
 
 
 def validate_enqueue_options(options: EnqueueOptions) -> None:
@@ -284,8 +281,9 @@ class DBOSClient:
             "delay_until_epoch_ms": delay_until_epoch_ms,
             "attributes": options.get("attributes"),
             "schedule_name": None,
-            "debounce_deadline_epoch_ms": options.get("debounce_deadline_epoch_ms"),
-            "is_debounced": options.get("is_debounced", False),
+            # Set only by the debouncer via _enqueue_debounced, never from options.
+            "debounce_deadline_epoch_ms": None,
+            "is_debounced": False,
         }
         return workflow_id, status
 
@@ -313,6 +311,30 @@ class DBOSClient:
             conn_or_session,
             max_recovery_attempts=None,
             owner_xid=None,
+        )
+        return workflow_id
+
+    def _enqueue_debounced(
+        self,
+        options: EnqueueOptions,
+        debounce_deadline_epoch_ms: Optional[int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        """Internal: enqueue a debounced workflow for DebouncerClient.
+
+        The debounce fields are not part of the public EnqueueOptions API, so
+        they are stamped onto the built status here rather than passed in options.
+        """
+        workflow_id, status = self._build_enqueue_status(options, *args, **kwargs)
+        status["debounce_deadline_epoch_ms"] = debounce_deadline_epoch_ms
+        status["is_debounced"] = True
+        self._sys_db.init_workflow(
+            status,
+            max_recovery_attempts=None,
+            owner_xid=None,
+            is_dequeued_request=False,
+            is_recovery_request=False,
         )
         return workflow_id
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -87,6 +87,9 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     class_name: str
     instance_name: str
     attributes: Dict[str, Any]
+    # Internal debouncer fields; not part of the public enqueue API.
+    debounce_deadline_epoch_ms: Optional[int]
+    is_debounced: bool
 
 
 def validate_enqueue_options(options: EnqueueOptions) -> None:
@@ -271,6 +274,8 @@ class DBOSClient:
             "delay_until_epoch_ms": delay_until_epoch_ms,
             "attributes": options.get("attributes"),
             "schedule_name": None,
+            "debounce_deadline_epoch_ms": options.get("debounce_deadline_epoch_ms"),
+            "is_debounced": options.get("is_debounced", False),
         }
         return workflow_id, status
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -136,11 +136,9 @@ class DBOSContext:
         self.queue_partition_key: Optional[str] = None
         # The UNIX epoch timestamp before which the workflow should not be dequeued
         self.delay_until_epoch_ms: Optional[int] = None
-        # Absolute cap (Unix epoch ms) beyond which debounce bounces may not
-        # extend the delay of the next enqueued workflow.
+        # Absolute cap (Unix epoch ms) beyond which bounces may not extend the next enqueued workflow's delay.
         self.debounce_deadline_epoch_ms: Optional[int] = None
-        # Whether the next enqueued workflow is debounced (its deduplication_id
-        # is a debounce key to be cleared on the DELAYED->ENQUEUED transition).
+        # Whether the next enqueued workflow is debounced (its dedup ID is a debounce key cleared on DELAYED->ENQUEUED).
         self.is_debounced: bool = False
 
     def create_child(self, *, is_for_workflow: bool) -> DBOSContext:

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -690,6 +690,13 @@ class SetWorkflowDebounce:
     debounce deadline, and the is_debounced flag on the context, restoring them
     on exit. Unlike SetEnqueueOptions, it leaves priority/app_version/partition
     untouched so a debounced workflow still inherits the caller's other options.
+
+    It also clears any propagated workflow deadline: a debounce called inside a
+    workflow that has a timeout would otherwise pass that workflow's absolute
+    deadline to the debounced workflow, which — because a debounce delay can be
+    long — could expire before the debounced workflow ever runs. The debounced
+    workflow's own timeout (an explicit SetWorkflowTimeout, kept in
+    workflow_timeout_ms) is unaffected and is applied fresh on dequeue.
     """
 
     def __init__(
@@ -707,6 +714,7 @@ class SetWorkflowDebounce:
         self.saved_delay_until_epoch_ms: Optional[int] = None
         self.saved_debounce_deadline_epoch_ms: Optional[int] = None
         self.saved_is_debounced: bool = False
+        self.saved_workflow_deadline_epoch_ms: Optional[int] = None
 
     def __enter__(self) -> SetWorkflowDebounce:
         ctx = get_local_dbos_context()
@@ -718,10 +726,13 @@ class SetWorkflowDebounce:
         self.saved_delay_until_epoch_ms = ctx.delay_until_epoch_ms
         self.saved_debounce_deadline_epoch_ms = ctx.debounce_deadline_epoch_ms
         self.saved_is_debounced = ctx.is_debounced
+        self.saved_workflow_deadline_epoch_ms = ctx.workflow_deadline_epoch_ms
         ctx.deduplication_id = self.deduplication_id
         ctx.delay_until_epoch_ms = self.delay_until_epoch_ms
         ctx.debounce_deadline_epoch_ms = self.debounce_deadline_epoch_ms
         ctx.is_debounced = True
+        # Don't inherit the caller workflow's deadline onto the debounced workflow.
+        ctx.workflow_deadline_epoch_ms = None
         return self
 
     def __exit__(
@@ -735,6 +746,7 @@ class SetWorkflowDebounce:
         curr_ctx.delay_until_epoch_ms = self.saved_delay_until_epoch_ms
         curr_ctx.debounce_deadline_epoch_ms = self.saved_debounce_deadline_epoch_ms
         curr_ctx.is_debounced = self.saved_is_debounced
+        curr_ctx.workflow_deadline_epoch_ms = self.saved_workflow_deadline_epoch_ms
         if self.created_ctx:
             _clear_local_dbos_context()
         return False

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -136,6 +136,12 @@ class DBOSContext:
         self.queue_partition_key: Optional[str] = None
         # The UNIX epoch timestamp before which the workflow should not be dequeued
         self.delay_until_epoch_ms: Optional[int] = None
+        # Absolute cap (Unix epoch ms) beyond which debounce bounces may not
+        # extend the delay of the next enqueued workflow.
+        self.debounce_deadline_epoch_ms: Optional[int] = None
+        # Whether the next enqueued workflow is debounced (its deduplication_id
+        # is a debounce key to be cleared on the DELAYED->ENQUEUED transition).
+        self.is_debounced: bool = False
 
     def create_child(self, *, is_for_workflow: bool) -> DBOSContext:
         rv = DBOSContext()
@@ -175,6 +181,8 @@ class DBOSContext:
         rv.priority = self.priority
         rv.queue_partition_key = self.queue_partition_key
         rv.delay_until_epoch_ms = self.delay_until_epoch_ms
+        rv.debounce_deadline_epoch_ms = self.debounce_deadline_epoch_ms
+        rv.is_debounced = self.is_debounced
         rv.workflow_attributes = self.workflow_attributes
         self.function_id += 1
         rv.function_id = self.function_id
@@ -672,6 +680,63 @@ class SetEnqueueOptions:
         curr_ctx.queue_partition_key = self.saved_queue_partition_key
         curr_ctx.delay_until_epoch_ms = self.saved_delay_until_epoch_ms
         # Code to clean up the basic context if we created it
+        if self.created_ctx:
+            _clear_local_dbos_context()
+        return False
+
+
+class SetWorkflowDebounce:
+    """Internal: mark the next enqueued workflow as debounced.
+
+    Sets the deduplication ID (a debounce key), the initial delay, the absolute
+    debounce deadline, and the is_debounced flag on the context, restoring them
+    on exit. Unlike SetEnqueueOptions, it leaves priority/app_version/partition
+    untouched so a debounced workflow still inherits the caller's other options.
+    """
+
+    def __init__(
+        self,
+        *,
+        deduplication_id: str,
+        delay_until_epoch_ms: int,
+        debounce_deadline_epoch_ms: Optional[int],
+    ) -> None:
+        self.created_ctx = False
+        self.deduplication_id = deduplication_id
+        self.delay_until_epoch_ms = delay_until_epoch_ms
+        self.debounce_deadline_epoch_ms = debounce_deadline_epoch_ms
+        self.saved_deduplication_id: Optional[str] = None
+        self.saved_delay_until_epoch_ms: Optional[int] = None
+        self.saved_debounce_deadline_epoch_ms: Optional[int] = None
+        self.saved_is_debounced: bool = False
+
+    def __enter__(self) -> SetWorkflowDebounce:
+        ctx = get_local_dbos_context()
+        if ctx is None:
+            self.created_ctx = True
+            _set_local_dbos_context(DBOSContext())
+        ctx = assert_current_dbos_context()
+        self.saved_deduplication_id = ctx.deduplication_id
+        self.saved_delay_until_epoch_ms = ctx.delay_until_epoch_ms
+        self.saved_debounce_deadline_epoch_ms = ctx.debounce_deadline_epoch_ms
+        self.saved_is_debounced = ctx.is_debounced
+        ctx.deduplication_id = self.deduplication_id
+        ctx.delay_until_epoch_ms = self.delay_until_epoch_ms
+        ctx.debounce_deadline_epoch_ms = self.debounce_deadline_epoch_ms
+        ctx.is_debounced = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[False]:
+        curr_ctx = assert_current_dbos_context()
+        curr_ctx.deduplication_id = self.saved_deduplication_id
+        curr_ctx.delay_until_epoch_ms = self.saved_delay_until_epoch_ms
+        curr_ctx.debounce_deadline_epoch_ms = self.saved_debounce_deadline_epoch_ms
+        curr_ctx.is_debounced = self.saved_is_debounced
         if self.created_ctx:
             _clear_local_dbos_context()
         return False

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -112,7 +112,6 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 F = TypeVar("F", bound=Callable[..., Any])
 
 TEMP_SEND_WF_NAME = "<temp>.temp_send_workflow"
-DEBOUNCER_WORKFLOW_NAME = "_dbos_debouncer_workflow"
 DEFAULT_POLLING_INTERVAL = 1.0
 
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -464,6 +464,14 @@ def _init_workflow(
             if enqueue_options is not None
             else None
         ),
+        "debounce_deadline_epoch_ms": (
+            enqueue_options["debounce_deadline_epoch_ms"]
+            if enqueue_options is not None
+            else None
+        ),
+        "is_debounced": (
+            enqueue_options["is_debounced"] if enqueue_options is not None else False
+        ),
         "attributes": ctx.workflow_attributes,
         # schedule_name is only set by the persistent scheduler, which builds
         # the workflow status directly rather than going through this path.
@@ -957,6 +965,10 @@ def start_workflow(
         delay_until_epoch_ms=(
             local_ctx.delay_until_epoch_ms if local_ctx is not None else None
         ),
+        debounce_deadline_epoch_ms=(
+            local_ctx.debounce_deadline_epoch_ms if local_ctx is not None else None
+        ),
+        is_debounced=(local_ctx.is_debounced if local_ctx is not None else False),
     )
     new_wf_ctx = DBOSContext.create_start_workflow_child(local_ctx)
     new_child_workflow_id = new_wf_ctx.id_assigned_for_next_workflow
@@ -1077,6 +1089,10 @@ async def start_workflow_async(
         delay_until_epoch_ms=(
             local_ctx.delay_until_epoch_ms if local_ctx is not None else None
         ),
+        debounce_deadline_epoch_ms=(
+            local_ctx.debounce_deadline_epoch_ms if local_ctx is not None else None
+        ),
+        is_debounced=(local_ctx.is_debounced if local_ctx is not None else False),
     )
     new_child_workflow_id = new_wf_ctx.id_assigned_for_next_workflow
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -37,7 +37,6 @@ from typing import (
 from zoneinfo import ZoneInfo
 
 from dbos._conductor.conductor import ConductorWebsocket
-from dbos._debouncer import debouncer_workflow
 from dbos._serialization import (
     DefaultSerializer,
     Serializer,
@@ -52,7 +51,6 @@ from dbos._workflow_commands import fork_workflow
 
 from ._classproperty import classproperty
 from ._core import (
-    DEBOUNCER_WORKFLOW_NAME,
     DEFAULT_POLLING_INTERVAL,
     TEMP_SEND_WF_NAME,
     ActiveWorkflowById,
@@ -489,11 +487,6 @@ class DBOS:
             self.send(destination_id, message, topic)
 
         decorate_workflow(self._registry, TEMP_SEND_WF_NAME, None)(send_temp_workflow)
-
-        # Register the debouncer workflow
-        decorate_workflow(self._registry, DEBOUNCER_WORKFLOW_NAME, None)(
-            debouncer_workflow
-        )
 
         for handler in dbos_logger.handlers:
             handler.flush()

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -68,9 +68,18 @@ def _is_queue_deduplicated_error(e: BaseException) -> bool:
     return False
 
 
-def _reject_conflicting_options(*, has_deduplication_id: bool, has_delay: bool) -> None:
+def _reject_conflicting_options(
+    *,
+    has_deduplication_id: bool,
+    has_delay: bool,
+    has_priority: bool,
+    has_partition_key: bool,
+) -> None:
     """A debounce owns the workflow's deduplication ID (the debounce key) and its
-    delay (the debounce period), so a caller must not also set them."""
+    delay (the debounce period), so a caller must not also set them. Priority and
+    partition keys are rejected because they cannot apply to a debounced enqueue
+    (the default internal queue has no priority, and partitioned queues do not
+    support the deduplication a debounce requires)."""
     if has_deduplication_id:
         raise DBOSException(
             "Cannot debounce a workflow with a deduplication_id set: the debounce "
@@ -80,6 +89,16 @@ def _reject_conflicting_options(*, has_deduplication_id: bool, has_delay: bool) 
         raise DBOSException(
             "Cannot debounce a workflow with a delay set: the debounce period "
             "controls the workflow's delay."
+        )
+    if has_priority:
+        raise DBOSException(
+            "Cannot debounce a workflow with a priority set: priority is not "
+            "supported for debounced workflows."
+        )
+    if has_partition_key:
+        raise DBOSException(
+            "Cannot debounce a workflow with a queue partition key set: partitioned "
+            "queues do not support deduplication, which debouncing requires."
         )
 
 
@@ -199,12 +218,14 @@ class Debouncer(Generic[P, R]):
 
         dbos = _get_dbos_instance()
 
-        # The caller must not set a deduplication_id or delay: the debounce owns both.
+        # The caller must not set a deduplication_id, delay, priority, or partition key.
         ctx = get_local_dbos_context()
         if ctx is not None:
             _reject_conflicting_options(
                 has_deduplication_id=ctx.deduplication_id is not None,
                 has_delay=ctx.delay_until_epoch_ms is not None,
+                has_priority=ctx.priority is not None,
+                has_partition_key=ctx.queue_partition_key is not None,
             )
 
         # Resolve the queue the debounced workflow will run on.
@@ -316,11 +337,14 @@ class DebouncerClient:
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
-        # The workflow options must not set a deduplication_id or delay: the debounce owns both.
+        # The workflow options must not set a deduplication_id, delay, priority, or partition key.
         _reject_conflicting_options(
             has_deduplication_id=self.workflow_options.get("deduplication_id")
             is not None,
             has_delay=self.workflow_options.get("delay_seconds") is not None,
+            has_priority=self.workflow_options.get("priority") is not None,
+            has_partition_key=self.workflow_options.get("queue_partition_key")
+            is not None,
         )
 
         # Run on the debouncer's queue if one was given, else the queue named in the workflow options.

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -136,8 +136,7 @@ class Debouncer(Generic[P, R]):
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
     ) -> DebounceResult:
-        # Serialize the new inputs the same way the initial enqueue did, so a
-        # bounce that replaces them stays consistent with the workflow's format.
+        # Serialize new inputs with the workflow's format so a bounce stays consistent with the initial enqueue.
         fi = get_func_info(func)
         serialization_type = fi.serialization_type if fi is not None else None
         inputs, serialization = serialize_args(
@@ -189,13 +188,7 @@ class Debouncer(Generic[P, R]):
         timeout_sec = self.options["debounce_timeout_sec"]
 
         while True:
-            # Try to extend an existing debounced workflow for this key first. This
-            # is the hot path for a burst of calls, and it makes the dedup key the
-            # sole coalescing mechanism: a caller-pinned workflow ID reused across
-            # calls bounces the existing workflow here rather than colliding on
-            # workflow_uuid (which would silently drop the new input). Run as a
-            # checkpointed step so a debounce called from within a workflow replays
-            # deterministically.
+            # Try to extend an existing debounced workflow for this key first (hot path, sole coalescing mechanism); a checkpointed step so an in-workflow debounce replays deterministically.
             result = dbos._sys_db.call_function_as_step(
                 lambda: self._bounce(
                     dbos,
@@ -222,9 +215,7 @@ class Debouncer(Generic[P, R]):
             if action == "retry":
                 continue
 
-            # action == "enqueue": the key is free, so create a fresh debounced
-            # workflow. These times are only observed when a fresh workflow is
-            # created; on replay the enqueue short-circuits through its checkpoint.
+            # action == "enqueue": key is free, create a fresh debounced workflow (these times are observed only on fresh creation; replay short-circuits through the checkpoint).
             now_ms = int(time.time() * 1000)
             deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
             delay_until_ms = now_ms + int(debounce_period_sec * 1000)
@@ -238,8 +229,7 @@ class Debouncer(Generic[P, R]):
                 ):
                     return queue.enqueue(func, *args, **kwargs)
             except DBOSQueueDeduplicatedError:
-                # A concurrent debounce grabbed the key between the bounce and this
-                # enqueue; loop to bounce that workflow instead.
+                # A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
                 continue
 
     async def debounce_async(
@@ -279,8 +269,7 @@ class DebouncerClient:
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
-        # Run the debounced workflow on the debouncer's queue if one was given,
-        # otherwise on the queue named in the workflow options.
+        # Run on the debouncer's queue if one was given, else the queue named in the workflow options.
         queue_name = (
             self.debouncer_options["queue_name"] or self.workflow_options["queue_name"]
         )
@@ -289,10 +278,7 @@ class DebouncerClient:
         serialization_type = self.workflow_options.get("serialization_type")
 
         while True:
-            # Try to extend an existing debounced workflow for this key first, so
-            # the dedup key is the sole coalescing mechanism (a caller-pinned
-            # workflow ID reused across calls bounces the existing workflow rather
-            # than colliding on workflow_uuid and dropping the new input).
+            # Try to extend an existing debounced workflow for this key first, so the dedup key is the sole coalescing mechanism.
             inputs, serialization = serialize_args(
                 args, kwargs, serialization_type, self.client._serializer
             )
@@ -317,8 +303,7 @@ class DebouncerClient:
             if action == "retry":
                 continue
 
-            # action == "enqueue": the key is free, so create a fresh debounced
-            # workflow.
+            # action == "enqueue": the key is free, so create a fresh debounced workflow.
             now_ms = int(time.time() * 1000)
             deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
             delay_sec = debounce_period_sec
@@ -338,8 +323,7 @@ class DebouncerClient:
             try:
                 return self.client.enqueue(options, *args, **kwargs)
             except DBOSQueueDeduplicatedError:
-                # A concurrent debounce grabbed the key between the bounce and this
-                # enqueue; loop to bounce that workflow instead.
+                # A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
                 continue
 
     async def debounce_async(

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -18,6 +18,8 @@ from typing import (
     cast,
 )
 
+import sqlalchemy as sa
+
 from dbos._client import (
     DBOSClient,
     EnqueueOptions,
@@ -25,6 +27,7 @@ from dbos._client import (
     WorkflowHandleClientPolling,
 )
 from dbos._context import (
+    EnterDBOSStepCtx,
     SetWorkflowDebounce,
     get_local_dbos_context,
     snapshot_step_context,
@@ -192,6 +195,7 @@ class Debouncer(Generic[P, R]):
         debounce_period_sec: float,
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
+        conn: Optional[sa.Connection] = None,
     ) -> DebounceResult:
         # Serialize new inputs with the workflow's format so a bounce stays consistent with the initial enqueue.
         fi = get_func_info(func)
@@ -207,6 +211,7 @@ class Debouncer(Generic[P, R]):
             delay_until_epoch_ms=delay_until_epoch_ms,
             inputs=inputs,
             serialization=serialization,
+            conn=conn,
         )
         return result
 
@@ -262,9 +267,31 @@ class Debouncer(Generic[P, R]):
         timeout_sec = self.options["debounce_timeout_sec"]
 
         while True:
-            # Try to extend an existing debounced workflow for this key first (hot path, sole coalescing mechanism); a checkpointed step so an in-workflow debounce replays deterministically.
-            result = dbos._sys_db.call_function_as_step(
-                lambda: self._bounce(
+            # Try to extend an existing debounced workflow for this key first (hot path, sole coalescing mechanism).
+            # In a workflow, the bounce runs via call_txn_as_step so it commits atomically with its step checkpoint: a crash can never commit one without the other, which on recovery would re-bounce work that already ran.
+            step_ctx = snapshot_step_context(reserve_sleep_id=False)
+            result: DebounceResult
+            if step_ctx is not None and step_ctx.is_workflow():
+                with EnterDBOSStepCtx(
+                    {"name": "debounce_delayed_workflow"}, step_ctx
+                ) as step:
+                    result = dbos._sys_db.call_txn_as_step(
+                        step.workflow_id,
+                        step.curr_step_function_id,
+                        "DBOS.debounce_delayed_workflow",
+                        lambda c: self._bounce(
+                            dbos,
+                            func,
+                            queue.name,
+                            deduplication_id,
+                            debounce_period_sec,
+                            args,
+                            kwargs,
+                            conn=c,
+                        ),
+                    )
+            else:
+                result = self._bounce(
                     dbos,
                     func,
                     queue.name,
@@ -272,10 +299,7 @@ class Debouncer(Generic[P, R]):
                     debounce_period_sec,
                     args,
                     kwargs,
-                ),
-                "DBOS.debounce_delayed_workflow",
-                snapshot_step_context(reserve_sleep_id=False),
-            )
+                )
             action = _classify_bounce(result, self.options["workflow_name"])
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -66,30 +66,32 @@ def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
     return queue
 
 
-# The action to take after attempting to bounce an existing debounced workflow.
-_BounceAction = Literal["return", "retry", "wait", "raise"]
+# The action a debounce caller should take after a bounce attempt.
+_BounceAction = Literal["return", "enqueue", "wait", "raise", "retry"]
 
 
-def _classify_bounce(result: DebounceResult) -> Tuple[_BounceAction, Optional[str]]:
+def _classify_bounce(result: DebounceResult) -> _BounceAction:
     """Decide what a debounce caller should do after a bounce attempt.
 
-    - "return": an existing debounced workflow was extended; return a handle to it.
-    - "retry": the key is unheld (the previous debounced workflow already started)
-      or a rare race occurred; try enqueueing a fresh workflow again.
+    - "return": an existing debounced workflow was extended; return a handle to
+      ``result["bounced_workflow_id"]``.
+    - "enqueue": the key is unheld; enqueue a fresh debounced workflow.
     - "wait": a legacy debouncer workflow holds the key during a version upgrade;
       wait for it to drain, then retry.
     - "raise": the key is held by a non-debounced workflow (a caller's own
       deduplicated workflow); surface the deduplication conflict.
+    - "retry": a debounced holder flipped out of DELAYED mid-bounce (a rare
+      race); retry the bounce.
     """
     if result["bounced_workflow_id"] is not None:
-        return "return", result["bounced_workflow_id"]
+        return "return"
     if result["holder_workflow_id"] is None:
-        return "retry", None
+        return "enqueue"
     if result["holder_name"] == DEBOUNCER_WORKFLOW_NAME:
-        return "wait", None
+        return "wait"
     if not result["holder_is_debounced"]:
-        return "raise", None
-    return "retry", None
+        return "raise"
+    return "retry"
 
 
 # Options saved from the local context to pass through to the debounced function
@@ -315,50 +317,61 @@ class Debouncer(Generic[P, R]):
         timeout_sec = self.options["debounce_timeout_sec"]
 
         while True:
-            # These are only observed the first time a fresh workflow is created;
-            # on replay the enqueue short-circuits through its checkpoint.
+            # Try to extend an existing debounced workflow for this key first. This
+            # is the hot path for a burst of calls, and it makes the dedup key the
+            # sole coalescing mechanism: a caller-pinned workflow ID reused across
+            # calls bounces the existing workflow here rather than colliding on
+            # workflow_uuid (which would silently drop the new input). Run as a
+            # checkpointed step so a debounce called from within a workflow replays
+            # deterministically.
+            result = dbos._sys_db.call_function_as_step(
+                lambda: self._bounce(
+                    dbos,
+                    func,
+                    queue.name,
+                    deduplication_id,
+                    debounce_period_sec,
+                    args,
+                    kwargs,
+                ),
+                "DBOS.debounce_delayed_workflow",
+                snapshot_step_context(reserve_sleep_id=False),
+            )
+            action = _classify_bounce(result)
+            if action == "return":
+                bounced_wfid = result["bounced_workflow_id"]
+                assert bounced_wfid is not None
+                return WorkflowHandlePolling(bounced_wfid, dbos)
+            if action == "raise":
+                assert result["holder_workflow_id"] is not None
+                raise DBOSQueueDeduplicatedError(
+                    result["holder_workflow_id"], queue.name, deduplication_id
+                )
+            if action == "wait":
+                time.sleep(_LEGACY_DRAIN_RETRY_SEC)
+                continue
+            if action == "retry":
+                continue
+
+            # action == "enqueue": the key is free, so create a fresh debounced
+            # workflow. These times are only observed when a fresh workflow is
+            # created; on replay the enqueue short-circuits through its checkpoint.
             now_ms = int(time.time() * 1000)
             deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
             delay_until_ms = now_ms + int(debounce_period_sec * 1000)
             if deadline_ms is not None:
                 delay_until_ms = min(delay_until_ms, deadline_ms)
             try:
-                # Enqueue a fresh debounced workflow. The debounce key occupies the
-                # deduplication slot, so a concurrent debounce for the same key
-                # collides here and falls through to the bounce path below.
                 with SetWorkflowDebounce(
                     deduplication_id=deduplication_id,
                     delay_until_epoch_ms=delay_until_ms,
                     debounce_deadline_epoch_ms=deadline_ms,
                 ):
-                    handle = queue.enqueue(func, *args, **kwargs)
-                return handle
+                    return queue.enqueue(func, *args, **kwargs)
             except DBOSQueueDeduplicatedError:
-                # A debounced workflow already exists for this key. Extend its
-                # delay and replace its inputs, as a checkpointed step so a
-                # debounce called from within a workflow replays deterministically.
-                result = dbos._sys_db.call_function_as_step(
-                    lambda: self._bounce(
-                        dbos,
-                        func,
-                        queue.name,
-                        deduplication_id,
-                        debounce_period_sec,
-                        args,
-                        kwargs,
-                    ),
-                    "DBOS.debounce_delayed_workflow",
-                    snapshot_step_context(reserve_sleep_id=False),
-                )
-                action, bounced_wfid = _classify_bounce(result)
-                if action == "return":
-                    assert bounced_wfid is not None
-                    return WorkflowHandlePolling(bounced_wfid, dbos)
-                if action == "raise":
-                    raise
-                if action == "wait":
-                    time.sleep(_LEGACY_DRAIN_RETRY_SEC)
-                # "retry"/"wait": loop and attempt a fresh enqueue again.
+                # A concurrent debounce grabbed the key between the bounce and this
+                # enqueue; loop to bounce that workflow instead.
+                continue
 
     async def debounce_async(
         self,
@@ -407,6 +420,39 @@ class DebouncerClient:
         serialization_type = self.workflow_options.get("serialization_type")
 
         while True:
+            # Try to extend an existing debounced workflow for this key first, so
+            # the dedup key is the sole coalescing mechanism (a caller-pinned
+            # workflow ID reused across calls bounces the existing workflow rather
+            # than colliding on workflow_uuid and dropping the new input).
+            inputs, serialization = serialize_args(
+                args, kwargs, serialization_type, self.client._serializer
+            )
+            bounce_delay_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
+            result = self.client._sys_db.debounce_delayed_workflow(
+                queue_name=queue_name,
+                deduplication_id=deduplication_id,
+                delay_until_epoch_ms=bounce_delay_ms,
+                inputs=inputs,
+                serialization=serialization,
+            )
+            action = _classify_bounce(result)
+            if action == "return":
+                bounced_wfid = result["bounced_workflow_id"]
+                assert bounced_wfid is not None
+                return WorkflowHandleClientPolling[R](bounced_wfid, self.client._sys_db)
+            if action == "raise":
+                assert result["holder_workflow_id"] is not None
+                raise DBOSQueueDeduplicatedError(
+                    result["holder_workflow_id"], queue_name, deduplication_id
+                )
+            if action == "wait":
+                time.sleep(_LEGACY_DRAIN_RETRY_SEC)
+                continue
+            if action == "retry":
+                continue
+
+            # action == "enqueue": the key is free, so create a fresh debounced
+            # workflow.
             now_ms = int(time.time() * 1000)
             deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
             delay_sec = debounce_period_sec
@@ -424,34 +470,11 @@ class DebouncerClient:
                 },
             )
             try:
-                # Enqueue a fresh debounced workflow. A concurrent debounce for the
-                # same key collides on the deduplication slot and bounces below.
                 return self.client.enqueue(options, *args, **kwargs)
             except DBOSQueueDeduplicatedError:
-                # A debounced workflow already exists for this key; extend its
-                # delay and replace its inputs.
-                inputs, serialization = serialize_args(
-                    args, kwargs, serialization_type, self.client._serializer
-                )
-                bounce_delay_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
-                result = self.client._sys_db.debounce_delayed_workflow(
-                    queue_name=queue_name,
-                    deduplication_id=deduplication_id,
-                    delay_until_epoch_ms=bounce_delay_ms,
-                    inputs=inputs,
-                    serialization=serialization,
-                )
-                action, bounced_wfid = _classify_bounce(result)
-                if action == "return":
-                    assert bounced_wfid is not None
-                    return WorkflowHandleClientPolling[R](
-                        bounced_wfid, self.client._sys_db
-                    )
-                if action == "raise":
-                    raise
-                if action == "wait":
-                    time.sleep(_LEGACY_DRAIN_RETRY_SEC)
-                # "retry"/"wait": loop and attempt a fresh enqueue again.
+                # A concurrent debounce grabbed the key between the bounce and this
+                # enqueue; loop to bounce that workflow instead.
+                continue
 
     async def debounce_async(
         self, deboucne_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -1,5 +1,4 @@
 import asyncio
-import math
 import time
 import types
 from typing import (
@@ -25,23 +24,12 @@ from dbos._client import (
     WorkflowHandleClientAsyncPolling,
     WorkflowHandleClientPolling,
 )
-from dbos._context import (
-    SetEnqueueOptions,
-    SetWorkflowAttributes,
-    SetWorkflowDebounce,
-    SetWorkflowID,
-    SetWorkflowTimeout,
-    snapshot_step_context,
-)
-from dbos._core import (
-    DEBOUNCER_WORKFLOW_NAME,
-    WorkflowHandleAsyncPolling,
-    WorkflowHandlePolling,
-)
+from dbos._context import SetWorkflowDebounce, snapshot_step_context
+from dbos._core import WorkflowHandleAsyncPolling, WorkflowHandlePolling
 from dbos._error import DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name, get_func_info
-from dbos._serialization import WorkflowInputs, serialize_args
+from dbos._serialization import serialize_args
 from dbos._sys_db import DebounceResult
 
 if TYPE_CHECKING:
@@ -49,13 +37,6 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")  # A generic type for workflow parameters
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values
-
-
-_DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
-
-# How long to wait before retrying when a legacy (pre-delay-based) debouncer
-# workflow still holds a debounce key during a version upgrade.
-_LEGACY_DRAIN_RETRY_SEC = 1.0
 
 
 def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
@@ -67,7 +48,7 @@ def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
 
 
 # The action a debounce caller should take after a bounce attempt.
-_BounceAction = Literal["return", "enqueue", "wait", "raise", "retry"]
+_BounceAction = Literal["return", "enqueue", "raise", "retry"]
 
 
 def _classify_bounce(result: DebounceResult) -> _BounceAction:
@@ -76,8 +57,6 @@ def _classify_bounce(result: DebounceResult) -> _BounceAction:
     - "return": an existing debounced workflow was extended; return a handle to
       ``result["bounced_workflow_id"]``.
     - "enqueue": the key is unheld; enqueue a fresh debounced workflow.
-    - "wait": a legacy debouncer workflow holds the key during a version upgrade;
-      wait for it to drain, then retry.
     - "raise": the key is held by a non-debounced workflow (a caller's own
       deduplicated workflow); surface the deduplication conflict.
     - "retry": a debounced holder flipped out of DELAYED mid-bounce (a rare
@@ -87,123 +66,16 @@ def _classify_bounce(result: DebounceResult) -> _BounceAction:
         return "return"
     if result["holder_workflow_id"] is None:
         return "enqueue"
-    if result["holder_name"] == DEBOUNCER_WORKFLOW_NAME:
-        return "wait"
     if not result["holder_is_debounced"]:
         return "raise"
     return "retry"
 
 
-# Options saved from the local context to pass through to the debounced function
-class ContextOptions(TypedDict):
-    workflow_id: str
-    deduplication_id: Optional[str]
-    priority: Optional[int]
-    app_version: Optional[str]
-    workflow_timeout_sec: Optional[float]
-    attributes: Optional[Dict[str, Any]]
-
-
-# Parameters for the debouncer workflow
+# Parameters for the debouncer
 class DebouncerOptions(TypedDict):
     workflow_name: str
     debounce_timeout_sec: Optional[float]
     queue_name: Optional[str]
-
-
-# The message sent from a debounce to the debouncer workflow
-class DebouncerMessage(TypedDict):
-    inputs: WorkflowInputs
-    message_id: str
-    debounce_period_sec: float
-
-
-# DEPRECATED: retained only so debouncer workflows enqueued before the switch to
-# delay-based debouncing can drain during a version upgrade. New debounces no
-# longer enqueue this workflow. Remove in a future release.
-async def debouncer_workflow(
-    initial_debounce_period_sec: float,
-    ctx: ContextOptions,
-    options: DebouncerOptions,
-    *args: Tuple[Any, ...],
-    **kwargs: Dict[str, Any],
-) -> None:
-    from dbos._dbos import DBOS, _get_dbos_instance
-
-    dbos = _get_dbos_instance()
-
-    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
-
-    # Every time the debounced workflow is called, a message is sent to this workflow.
-    # It waits until debounce_period_sec have passed since the last message or until
-    # debounce_timeout_sec has elapsed.
-    async def get_debounce_deadline_epoch_sec() -> float:
-        return (
-            time.time() + options["debounce_timeout_sec"]
-            if options["debounce_timeout_sec"]
-            else math.inf
-        )
-
-    async def get_time() -> float:
-        return time.time()
-
-    debounce_deadline_epoch_sec = await DBOS.run_step_async(
-        {"name": "get_debounce_deadline_epoch_sec"}, get_debounce_deadline_epoch_sec
-    )
-    debounce_period_sec = initial_debounce_period_sec
-    while True:
-        now = await DBOS.run_step_async({"name": "get_time"}, get_time)
-        if now >= debounce_deadline_epoch_sec:
-            break
-        timeout = min(debounce_period_sec, max(debounce_deadline_epoch_sec - now, 0))
-        message: Optional[DebouncerMessage] = await DBOS.recv_async(
-            _DEBOUNCER_TOPIC, timeout_seconds=timeout
-        )
-        if message is None:
-            break
-        workflow_inputs = message["inputs"]
-        debounce_period_sec = message["debounce_period_sec"]
-        # Acknowledge receipt of the message
-        await DBOS.set_event_async(message["message_id"], message["message_id"])
-
-    # After the timeout or period has elapsed, enqueue the user workflow with the requested
-    # context parameters.
-    func = dbos._registry.workflow_info_map.get(options["workflow_name"], None)
-    if not func:
-        raise Exception(
-            f"Invalid workflow name provided to debouncer: {options['workflow_name']}"
-        )
-    if options["queue_name"]:
-        queue = dbos._registry.queue_info_map.get(options["queue_name"], None)
-        if not queue:
-            queue = await DBOS.retrieve_queue_async(options["queue_name"])
-        if not queue:
-            raise Exception(
-                f"Invalid queue name provided to debouncer: {options['queue_name']}"
-            )
-    else:
-        queue = dbos._registry.get_internal_queue()
-    with SetWorkflowID(ctx["workflow_id"]):
-        # Use .get() because inputs recorded before attributes existed lack the key
-        with (
-            SetWorkflowTimeout(ctx["workflow_timeout_sec"]),
-            SetWorkflowAttributes(ctx.get("attributes")),
-        ):
-            if options["queue_name"]:
-                # Apply the caller's enqueue options only on a user-specified queue,
-                # matching the original behavior (the direct-start path applied none).
-                with SetEnqueueOptions(
-                    deduplication_id=ctx["deduplication_id"],
-                    priority=ctx["priority"],
-                    app_version=ctx["app_version"],
-                ):
-                    await queue.enqueue_async(
-                        func, *workflow_inputs["args"], **workflow_inputs["kwargs"]
-                    )
-            else:
-                await queue.enqueue_async(
-                    func, *workflow_inputs["args"], **workflow_inputs["kwargs"]
-                )
 
 
 class Debouncer(Generic[P, R]):
@@ -347,9 +219,6 @@ class Debouncer(Generic[P, R]):
                 raise DBOSQueueDeduplicatedError(
                     result["holder_workflow_id"], queue.name, deduplication_id
                 )
-            if action == "wait":
-                time.sleep(_LEGACY_DRAIN_RETRY_SEC)
-                continue
             if action == "retry":
                 continue
 
@@ -445,9 +314,6 @@ class DebouncerClient:
                 raise DBOSQueueDeduplicatedError(
                     result["holder_workflow_id"], queue_name, deduplication_id
                 )
-            if action == "wait":
-                time.sleep(_LEGACY_DRAIN_RETRY_SEC)
-                continue
             if action == "retry":
                 continue
 

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -228,6 +228,12 @@ class Debouncer(Generic[P, R]):
                 has_partition_key=ctx.queue_partition_key is not None,
             )
 
+        # Capture a SetWorkflowID-pinned ID once: it is re-applied on every enqueue attempt (a lost dedup race consumes it before raising) and must not stay armed for the caller's next workflow when a bounce coalesces or a conflict raises.
+        pinned_workflow_id: Optional[str] = None
+        if ctx is not None and ctx.id_assigned_for_next_workflow:
+            pinned_workflow_id = ctx.id_assigned_for_next_workflow
+            ctx.id_assigned_for_next_workflow = ""
+
         # Resolve the queue the debounced workflow will run on.
         queue_name = self.options["queue_name"]
         if queue_name:
@@ -286,6 +292,10 @@ class Debouncer(Generic[P, R]):
             delay_until_ms = now_ms + int(debounce_period_sec * 1000)
             if deadline_ms is not None:
                 delay_until_ms = min(delay_until_ms, deadline_ms)
+            # Re-apply the pinned ID for this attempt; queue.enqueue consumes it.
+            if pinned_workflow_id is not None:
+                assert ctx is not None
+                ctx.id_assigned_for_next_workflow = pinned_workflow_id
             try:
                 with SetWorkflowDebounce(
                     deduplication_id=deduplication_id,

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -24,9 +24,13 @@ from dbos._client import (
     WorkflowHandleClientAsyncPolling,
     WorkflowHandleClientPolling,
 )
-from dbos._context import SetWorkflowDebounce, snapshot_step_context
+from dbos._context import (
+    SetWorkflowDebounce,
+    get_local_dbos_context,
+    snapshot_step_context,
+)
 from dbos._core import WorkflowHandleAsyncPolling, WorkflowHandlePolling
-from dbos._error import DBOSQueueDeduplicatedError
+from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name, get_func_info
 from dbos._serialization import serialize_args
@@ -45,6 +49,21 @@ def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
     if isinstance(queue, Queue):
         return queue.name
     return queue
+
+
+def _reject_conflicting_options(*, has_deduplication_id: bool, has_delay: bool) -> None:
+    """A debounce owns the workflow's deduplication ID (the debounce key) and its
+    delay (the debounce period), so a caller must not also set them."""
+    if has_deduplication_id:
+        raise DBOSException(
+            "Cannot debounce a workflow with a deduplication_id set: the debounce "
+            "key is used as the workflow's deduplication ID."
+        )
+    if has_delay:
+        raise DBOSException(
+            "Cannot debounce a workflow with a delay set: the debounce period "
+            "controls the workflow's delay."
+        )
 
 
 # The action a debounce caller should take after a bounce attempt.
@@ -163,6 +182,14 @@ class Debouncer(Generic[P, R]):
 
         dbos = _get_dbos_instance()
 
+        # The caller must not set a deduplication_id or delay: the debounce owns both.
+        ctx = get_local_dbos_context()
+        if ctx is not None:
+            _reject_conflicting_options(
+                has_deduplication_id=ctx.deduplication_id is not None,
+                has_delay=ctx.delay_until_epoch_ms is not None,
+            )
+
         # Resolve the queue the debounced workflow will run on.
         queue_name = self.options["queue_name"]
         if queue_name:
@@ -269,6 +296,13 @@ class DebouncerClient:
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
+        # The workflow options must not set a deduplication_id or delay: the debounce owns both.
+        _reject_conflicting_options(
+            has_deduplication_id=self.workflow_options.get("deduplication_id")
+            is not None,
+            has_delay=self.workflow_options.get("delay_seconds") is not None,
+        )
+
         # Run on the debouncer's queue if one was given, else the queue named in the workflow options.
         queue_name = (
             self.debouncer_options["queue_name"] or self.workflow_options["queue_name"]

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -9,12 +9,14 @@ from typing import (
     Coroutine,
     Dict,
     Generic,
+    Literal,
     Optional,
     ParamSpec,
     Tuple,
     TypedDict,
     TypeVar,
     Union,
+    cast,
 )
 
 from dbos._client import (
@@ -24,12 +26,11 @@ from dbos._client import (
     WorkflowHandleClientPolling,
 )
 from dbos._context import (
-    DBOSContextEnsure,
     SetEnqueueOptions,
     SetWorkflowAttributes,
+    SetWorkflowDebounce,
     SetWorkflowID,
     SetWorkflowTimeout,
-    assert_current_dbos_context,
     snapshot_step_context,
 )
 from dbos._core import (
@@ -39,9 +40,9 @@ from dbos._core import (
 )
 from dbos._error import DBOSQueueDeduplicatedError
 from dbos._queue import Queue
-from dbos._registrations import get_dbos_func_name
-from dbos._serialization import WorkflowInputs
-from dbos._utils import INTERNAL_QUEUE_NAME, generate_uuid
+from dbos._registrations import get_dbos_func_name, get_func_info
+from dbos._serialization import WorkflowInputs, serialize_args
+from dbos._sys_db import DebounceResult
 
 if TYPE_CHECKING:
     from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
@@ -52,6 +53,10 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
 _DEBOUNCER_TOPIC = "DEBOUNCER_TOPIC"
 
+# How long to wait before retrying when a legacy (pre-delay-based) debouncer
+# workflow still holds a debounce key during a version upgrade.
+_LEGACY_DRAIN_RETRY_SEC = 1.0
+
 
 def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
     if queue is None:
@@ -59,6 +64,32 @@ def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
     if isinstance(queue, Queue):
         return queue.name
     return queue
+
+
+# The action to take after attempting to bounce an existing debounced workflow.
+_BounceAction = Literal["return", "retry", "wait", "raise"]
+
+
+def _classify_bounce(result: DebounceResult) -> Tuple[_BounceAction, Optional[str]]:
+    """Decide what a debounce caller should do after a bounce attempt.
+
+    - "return": an existing debounced workflow was extended; return a handle to it.
+    - "retry": the key is unheld (the previous debounced workflow already started)
+      or a rare race occurred; try enqueueing a fresh workflow again.
+    - "wait": a legacy debouncer workflow holds the key during a version upgrade;
+      wait for it to drain, then retry.
+    - "raise": the key is held by a non-debounced workflow (a caller's own
+      deduplicated workflow); surface the deduplication conflict.
+    """
+    if result["bounced_workflow_id"] is not None:
+        return "return", result["bounced_workflow_id"]
+    if result["holder_workflow_id"] is None:
+        return "retry", None
+    if result["holder_name"] == DEBOUNCER_WORKFLOW_NAME:
+        return "wait", None
+    if not result["holder_is_debounced"]:
+        return "raise", None
+    return "retry", None
 
 
 # Options saved from the local context to pass through to the debounced function
@@ -85,6 +116,9 @@ class DebouncerMessage(TypedDict):
     debounce_period_sec: float
 
 
+# DEPRECATED: retained only so debouncer workflows enqueued before the switch to
+# delay-based debouncing can drain during a version upgrade. New debounces no
+# longer enqueue this workflow. Remove in a future release.
 async def debouncer_workflow(
     initial_debounce_period_sec: float,
     ctx: ContextOptions,
@@ -218,6 +252,33 @@ class Debouncer(Generic[P, R]):
             queue=queue,
         )
 
+    def _bounce(
+        self,
+        dbos: Any,
+        func: Callable[..., Any],
+        queue_name: str,
+        deduplication_id: str,
+        debounce_period_sec: float,
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+    ) -> DebounceResult:
+        # Serialize the new inputs the same way the initial enqueue did, so a
+        # bounce that replaces them stays consistent with the workflow's format.
+        fi = get_func_info(func)
+        serialization_type = fi.serialization_type if fi is not None else None
+        inputs, serialization = serialize_args(
+            args, kwargs, serialization_type, dbos._serializer
+        )
+        delay_until_epoch_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
+        result: DebounceResult = dbos._sys_db.debounce_delayed_workflow(
+            queue_name=queue_name,
+            deduplication_id=deduplication_id,
+            delay_until_epoch_ms=delay_until_epoch_ms,
+            inputs=inputs,
+            serialization=serialization,
+        )
+        return result
+
     def debounce(
         self,
         debounce_key: str,
@@ -228,89 +289,76 @@ class Debouncer(Generic[P, R]):
         from dbos._dbos import DBOS, _get_dbos_instance
 
         dbos = _get_dbos_instance()
-        internal_queue = dbos._registry.get_internal_queue()
 
-        # Read all workflow settings from context, pass them through ContextOptions
-        # into the debouncer to apply to the user workflow, then reset the context
-        # so workflow settings aren't applied to the debouncer.
-        with DBOSContextEnsure():
-            ctx = assert_current_dbos_context()
+        # Resolve the queue the debounced workflow will run on.
+        queue_name = self.options["queue_name"]
+        if queue_name:
+            queue: Optional[Queue] = dbos._registry.queue_info_map.get(queue_name)
+            if queue is None:
+                queue = DBOS.retrieve_queue(queue_name)
+            if queue is None:
+                raise Exception(
+                    f"Invalid queue name provided to debouncer: {queue_name}"
+                )
+        else:
+            queue = dbos._registry.get_internal_queue()
+        assert queue is not None
 
-            # Deterministically generate the user workflow ID and message ID
-            def assign_debounce_ids() -> tuple[str, str]:
-                return generate_uuid(), ctx.assign_workflow_id()
-
-            message_id, user_workflow_id = dbos._sys_db.call_function_as_step(
-                assign_debounce_ids,
-                "DBOS.assign_debounce_ids",
-                snapshot_step_context(reserve_sleep_id=False),
+        # Resolve the workflow function so bounced inputs serialize identically.
+        func = dbos._registry.workflow_info_map.get(self.options["workflow_name"])
+        if func is None:
+            raise Exception(
+                f"Invalid workflow name provided to debouncer: {self.options['workflow_name']}"
             )
-            ctx.id_assigned_for_next_workflow = ""
-            ctx.is_within_set_workflow_id_block = False
-            ctxOptions: ContextOptions = {
-                "workflow_id": user_workflow_id,
-                "app_version": ctx.app_version,
-                "deduplication_id": ctx.deduplication_id,
-                "priority": ctx.priority,
-                "workflow_timeout_sec": (
-                    ctx.workflow_timeout_ms / 1000.0
-                    if ctx.workflow_timeout_ms
-                    else None
-                ),
-                "attributes": ctx.workflow_attributes,
-            }
-        while True:
-            try:
-                # Attempt to enqueue a debouncer for this workflow.
-                deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
-                with SetEnqueueOptions(deduplication_id=deduplication_id):
-                    with SetWorkflowTimeout(None), SetWorkflowAttributes(None):
-                        internal_queue.enqueue(
-                            debouncer_workflow,
-                            debounce_period_sec,
-                            ctxOptions,
-                            self.options,
-                            *args,
-                            **kwargs,
-                        )
-                return WorkflowHandlePolling(user_workflow_id, dbos)
-            except DBOSQueueDeduplicatedError:
-                # If there is already a debouncer, send a message to it.
-                # Deterministically retrieve the ID of the debouncer
-                def get_deduplicated_workflow() -> Optional[str]:
-                    return dbos._sys_db.get_deduplicated_workflow(
-                        queue_name=internal_queue.name,
-                        deduplication_id=deduplication_id,
-                    )
 
-                dedup_wfid = dbos._sys_db.call_function_as_step(
-                    get_deduplicated_workflow,
-                    "DBOS.get_deduplicated_workflow",
+        deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
+        timeout_sec = self.options["debounce_timeout_sec"]
+
+        while True:
+            # These are only observed the first time a fresh workflow is created;
+            # on replay the enqueue short-circuits through its checkpoint.
+            now_ms = int(time.time() * 1000)
+            deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
+            delay_until_ms = now_ms + int(debounce_period_sec * 1000)
+            if deadline_ms is not None:
+                delay_until_ms = min(delay_until_ms, deadline_ms)
+            try:
+                # Enqueue a fresh debounced workflow. The debounce key occupies the
+                # deduplication slot, so a concurrent debounce for the same key
+                # collides here and falls through to the bounce path below.
+                with SetWorkflowDebounce(
+                    deduplication_id=deduplication_id,
+                    delay_until_epoch_ms=delay_until_ms,
+                    debounce_deadline_epoch_ms=deadline_ms,
+                ):
+                    handle = queue.enqueue(func, *args, **kwargs)
+                return handle
+            except DBOSQueueDeduplicatedError:
+                # A debounced workflow already exists for this key. Extend its
+                # delay and replace its inputs, as a checkpointed step so a
+                # debounce called from within a workflow replays deterministically.
+                result = dbos._sys_db.call_function_as_step(
+                    lambda: self._bounce(
+                        dbos,
+                        func,
+                        queue.name,
+                        deduplication_id,
+                        debounce_period_sec,
+                        args,
+                        kwargs,
+                    ),
+                    "DBOS.debounce_delayed_workflow",
                     snapshot_step_context(reserve_sleep_id=False),
                 )
-                if dedup_wfid is None:
-                    continue
-                else:
-                    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
-                    message: DebouncerMessage = {
-                        "message_id": message_id,
-                        "inputs": workflow_inputs,
-                        "debounce_period_sec": debounce_period_sec,
-                    }
-                    DBOS.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
-                    # Wait for the debouncer to acknowledge receipt of the message.
-                    # If the message is not acknowledged, this likely means the debouncer started its workflow
-                    # and exited without processing this message, so try again.
-                    if not DBOS.get_event(dedup_wfid, message_id, timeout_seconds=1):
-                        continue
-                    # Retrieve the user workflow ID from the input to the debouncer
-                    # and return a handle to it
-                    dedup_workflow_input = (
-                        DBOS.retrieve_workflow(dedup_wfid).get_status().input
-                    )
-                    assert dedup_workflow_input is not None
-                    user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
-                    return WorkflowHandlePolling(user_workflow_id, dbos)
+                action, bounced_wfid = _classify_bounce(result)
+                if action == "return":
+                    assert bounced_wfid is not None
+                    return WorkflowHandlePolling(bounced_wfid, dbos)
+                if action == "raise":
+                    raise
+                if action == "wait":
+                    time.sleep(_LEGACY_DRAIN_RETRY_SEC)
+                # "retry"/"wait": loop and attempt a fresh enqueue again.
 
     async def debounce_async(
         self,
@@ -349,75 +397,61 @@ class DebouncerClient:
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
+        # Run the debounced workflow on the debouncer's queue if one was given,
+        # otherwise on the queue named in the workflow options.
+        queue_name = (
+            self.debouncer_options["queue_name"] or self.workflow_options["queue_name"]
+        )
+        deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
+        timeout_sec = self.debouncer_options["debounce_timeout_sec"]
+        serialization_type = self.workflow_options.get("serialization_type")
 
-        ctxOptions: ContextOptions = {
-            "workflow_id": (
-                self.workflow_options["workflow_id"]
-                if self.workflow_options.get("workflow_id")
-                else generate_uuid()
-            ),
-            "app_version": self.workflow_options.get("app_version"),
-            "deduplication_id": self.workflow_options.get("deduplication_id"),
-            "priority": self.workflow_options.get("priority"),
-            "workflow_timeout_sec": self.workflow_options.get("workflow_timeout"),
-            "attributes": self.workflow_options.get("attributes"),
-        }
-        message_id = generate_uuid()
         while True:
-            try:
-                # Attempt to enqueue a debouncer for this workflow.
-                deduplication_id = (
-                    f"{self.debouncer_options['workflow_name']}-{debounce_key}"
-                )
-                debouncer_options: EnqueueOptions = {
-                    "workflow_name": DEBOUNCER_WORKFLOW_NAME,
-                    "queue_name": INTERNAL_QUEUE_NAME,
+            now_ms = int(time.time() * 1000)
+            deadline_ms = int(now_ms + timeout_sec * 1000) if timeout_sec else None
+            delay_sec = debounce_period_sec
+            if deadline_ms is not None:
+                delay_sec = min(delay_sec, max((deadline_ms - now_ms) / 1000.0, 0.0))
+            options = cast(
+                EnqueueOptions,
+                {
+                    **self.workflow_options,
+                    "queue_name": queue_name,
                     "deduplication_id": deduplication_id,
-                }
-                self.client.enqueue(
-                    debouncer_options,
-                    debounce_period_sec,
-                    ctxOptions,
-                    self.debouncer_options,
-                    *args,
-                    **kwargs,
-                )
-                return WorkflowHandleClientPolling[R](
-                    ctxOptions["workflow_id"], self.client._sys_db
-                )
+                    "delay_seconds": delay_sec,
+                    "debounce_deadline_epoch_ms": deadline_ms,
+                    "is_debounced": True,
+                },
+            )
+            try:
+                # Enqueue a fresh debounced workflow. A concurrent debounce for the
+                # same key collides on the deduplication slot and bounces below.
+                return self.client.enqueue(options, *args, **kwargs)
             except DBOSQueueDeduplicatedError:
-                # If there is already a debouncer, send a message to it.
-                dedup_wfid = self.client._sys_db.get_deduplicated_workflow(
-                    queue_name=INTERNAL_QUEUE_NAME,
-                    deduplication_id=deduplication_id,
+                # A debounced workflow already exists for this key; extend its
+                # delay and replace its inputs.
+                inputs, serialization = serialize_args(
+                    args, kwargs, serialization_type, self.client._serializer
                 )
-                if dedup_wfid is None:
-                    continue
-                else:
-                    workflow_inputs: WorkflowInputs = {"args": args, "kwargs": kwargs}
-                    message: DebouncerMessage = {
-                        "message_id": message_id,
-                        "inputs": workflow_inputs,
-                        "debounce_period_sec": debounce_period_sec,
-                    }
-                    self.client.send(dedup_wfid, message, _DEBOUNCER_TOPIC)
-                    # Wait for the debouncer to acknowledge receipt of the message.
-                    # If the message is not acknowledged, this likely means the debouncer started its workflow
-                    # and exited without processing this message, so try again.
-                    if not self.client.get_event(
-                        dedup_wfid, message_id, timeout_seconds=1
-                    ):
-                        continue
-                    # Retrieve the user workflow ID from the input to the debouncer
-                    # and return a handle to it
-                    dedup_workflow_input = (
-                        self.client.retrieve_workflow(dedup_wfid).get_status().input
-                    )
-                    assert dedup_workflow_input is not None
-                    user_workflow_id = dedup_workflow_input["args"][1]["workflow_id"]
+                bounce_delay_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
+                result = self.client._sys_db.debounce_delayed_workflow(
+                    queue_name=queue_name,
+                    deduplication_id=deduplication_id,
+                    delay_until_epoch_ms=bounce_delay_ms,
+                    inputs=inputs,
+                    serialization=serialization,
+                )
+                action, bounced_wfid = _classify_bounce(result)
+                if action == "return":
+                    assert bounced_wfid is not None
                     return WorkflowHandleClientPolling[R](
-                        user_workflow_id, self.client._sys_db
+                        bounced_wfid, self.client._sys_db
                     )
+                if action == "raise":
+                    raise
+                if action == "wait":
+                    time.sleep(_LEGACY_DRAIN_RETRY_SEC)
+                # "retry"/"wait": loop and attempt a fresh enqueue again.
 
     async def debounce_async(
         self, deboucne_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -404,12 +404,14 @@ class DebouncerClient:
                     "queue_name": queue_name,
                     "deduplication_id": deduplication_id,
                     "delay_seconds": delay_sec,
-                    "debounce_deadline_epoch_ms": deadline_ms,
-                    "is_debounced": True,
                 },
             )
             try:
-                return self.client.enqueue(options, *args, **kwargs)
+                # The debounce fields are not part of the public EnqueueOptions API, so pass them through the internal debounced-enqueue path.
+                workflow_id = self.client._enqueue_debounced(
+                    options, deadline_ms, *args, **kwargs
+                )
+                return WorkflowHandleClientPolling[R](workflow_id, self.client._sys_db)
             except DBOSQueueDeduplicatedError:
                 # A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
                 continue

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -106,22 +106,24 @@ def _reject_conflicting_options(
 _BounceAction = Literal["return", "enqueue", "raise", "retry"]
 
 
-def _classify_bounce(result: DebounceResult) -> _BounceAction:
+def _classify_bounce(result: DebounceResult, workflow_name: str) -> _BounceAction:
     """Decide what a debounce caller should do after a bounce attempt.
 
     - "return": an existing debounced workflow was extended; return a handle to
       ``result["bounced_workflow_id"]``.
     - "enqueue": the key is unheld; enqueue a fresh debounced workflow.
-    - "raise": the key is held by a non-debounced workflow (a caller's own
-      deduplicated workflow); surface the deduplication conflict.
-    - "retry": a debounced holder flipped out of DELAYED mid-bounce (a rare
-      race); retry the bounce.
+    - "raise": the key is held by a non-debounced workflow or by a different
+      workflow whose debounce key collides; surface the deduplication conflict.
+    - "retry": a same-name debounced holder flipped out of DELAYED mid-bounce
+      (a rare race); retry the bounce.
     """
     if result["bounced_workflow_id"] is not None:
         return "return"
     if result["holder_workflow_id"] is None:
         return "enqueue"
     if not result["holder_is_debounced"]:
+        return "raise"
+    if result["holder_workflow_name"] != workflow_name:
         return "raise"
     return "retry"
 
@@ -199,6 +201,7 @@ class Debouncer(Generic[P, R]):
         )
         delay_until_epoch_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
         result: DebounceResult = dbos._sys_db.debounce_delayed_workflow(
+            workflow_name=self.options["workflow_name"],
             queue_name=queue_name,
             deduplication_id=deduplication_id,
             delay_until_epoch_ms=delay_until_epoch_ms,
@@ -273,7 +276,7 @@ class Debouncer(Generic[P, R]):
                 "DBOS.debounce_delayed_workflow",
                 snapshot_step_context(reserve_sleep_id=False),
             )
-            action = _classify_bounce(result)
+            action = _classify_bounce(result, self.options["workflow_name"])
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
                 assert bounced_wfid is not None
@@ -372,13 +375,14 @@ class DebouncerClient:
             )
             bounce_delay_ms = int(time.time() * 1000 + debounce_period_sec * 1000)
             result = self.client._sys_db.debounce_delayed_workflow(
+                workflow_name=self.debouncer_options["workflow_name"],
                 queue_name=queue_name,
                 deduplication_id=deduplication_id,
                 delay_until_epoch_ms=bounce_delay_ms,
                 inputs=inputs,
                 serialization=serialization,
             )
-            action = _classify_bounce(result)
+            action = _classify_bounce(result, self.debouncer_options["workflow_name"])
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
                 assert bounced_wfid is not None

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -33,7 +33,7 @@ from dbos._core import WorkflowHandleAsyncPolling, WorkflowHandlePolling
 from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name, get_func_info
-from dbos._serialization import serialize_args
+from dbos._serialization import PortableWorkflowError, serialize_args
 from dbos._sys_db import DebounceResult
 
 if TYPE_CHECKING:
@@ -49,6 +49,23 @@ def _resolve_queue_name(queue: Optional[Union[Queue, str]]) -> Optional[str]:
     if isinstance(queue, Queue):
         return queue.name
     return queue
+
+
+def _is_queue_deduplicated_error(e: BaseException) -> bool:
+    """True if ``e`` is a queue-deduplication error, including its replay form.
+
+    When an in-workflow debounce's fresh enqueue loses the dedup race, the
+    DBOSQueueDeduplicatedError is checkpointed at the parent's function ID. On
+    replay it is re-raised from that checkpoint, but a workflow using portable
+    (cross-language JSON) serialization deserializes it to a PortableWorkflowError
+    (which carries the original type name), not the original type. Match both so
+    the retry loop still recognizes the collision on replay instead of erroring.
+    """
+    if isinstance(e, DBOSQueueDeduplicatedError):
+        return True
+    if isinstance(e, PortableWorkflowError):
+        return e.name == DBOSQueueDeduplicatedError.__name__
+    return False
 
 
 def _reject_conflicting_options(*, has_deduplication_id: bool, has_delay: bool) -> None:
@@ -255,8 +272,11 @@ class Debouncer(Generic[P, R]):
                     debounce_deadline_epoch_ms=deadline_ms,
                 ):
                     return queue.enqueue(func, *args, **kwargs)
-            except DBOSQueueDeduplicatedError:
+            except (DBOSQueueDeduplicatedError, PortableWorkflowError) as e:
                 # A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
+                # (Also catches the portable-serialization replay form of the dedup error; see _is_queue_deduplicated_error.)
+                if not _is_queue_deduplicated_error(e):
+                    raise
                 continue
 
     async def debounce_async(

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -875,6 +875,18 @@ CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "{schema}"."wo
 """
 
 
+def get_dbos_migration_fortytwo(schema: str) -> str:
+    # ADD COLUMN with no default (or a constant default) is catalog-only, so no
+    # table rewrite. These columns support the debouncer: is_debounced marks a
+    # workflow whose deduplication_id is a debounce key to be cleared when the
+    # workflow transitions from DELAYED to ENQUEUED, and debounce_deadline_epoch_ms
+    # caps how far bounces may extend the delay.
+    return f"""
+ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "debounce_deadline_epoch_ms" BIGINT DEFAULT NULL;
+ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced" BOOLEAN NOT NULL DEFAULT FALSE;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -920,6 +932,7 @@ def get_dbos_migrations(
         get_dbos_migration_thirtynine(schema, use_listen_notify),
         get_dbos_migration_forty(schema),
         get_dbos_migration_fortyone(schema),
+        get_dbos_migration_fortytwo(schema),
     ]
 
 
@@ -1173,6 +1186,11 @@ ALTER TABLE workflow_status ADD COLUMN "schedule_name" TEXT;
 CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "workflow_status" ("schedule_name") WHERE "schedule_name" IS NOT NULL;
 """
 
+sqlite_migration_fortytwo = """
+ALTER TABLE workflow_status ADD COLUMN "debounce_deadline_epoch_ms" BIGINT DEFAULT NULL;
+ALTER TABLE workflow_status ADD COLUMN "is_debounced" BOOLEAN NOT NULL DEFAULT FALSE;
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1214,4 +1232,5 @@ sqlite_migrations = [
     # Unlike Postgres migration forty, this creates no index (no GIN equivalent)
     sqlite_migration_forty,
     sqlite_migration_fortyone,
+    sqlite_migration_fortytwo,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -876,11 +876,6 @@ CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "{schema}"."wo
 
 
 def get_dbos_migration_fortytwo(schema: str) -> str:
-    # ADD COLUMN with no default (or a constant default) is catalog-only, so no
-    # table rewrite. These columns support the debouncer: is_debounced marks a
-    # workflow whose deduplication_id is a debounce key to be cleared when the
-    # workflow transitions from DELAYED to ENQUEUED, and debounce_deadline_epoch_ms
-    # caps how far bounces may extend the delay.
     return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "debounce_deadline_epoch_ms" BIGINT DEFAULT NULL;
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -155,6 +155,8 @@ def _enqueue_scheduled_workflow(
         "delay_until_epoch_ms": None,
         "attributes": None,
         "schedule_name": schedule_name,
+        "debounce_deadline_epoch_ms": None,
+        "is_debounced": False,
     }
     sys_db.init_workflow(
         status,

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -76,6 +76,8 @@ class SystemSchema:
         Column("completed_at", BigInteger, nullable=True),
         Column("attributes", JSON().with_variant(JSONB(), "postgresql"), nullable=True),
         Column("schedule_name", Text, nullable=True),
+        Column("debounce_deadline_epoch_ms", BigInteger, nullable=True),
+        Column("is_debounced", Boolean, nullable=False, server_default="false"),
         Index("workflow_status_created_at_index", "created_at"),
         Index(
             "idx_workflow_status_delayed",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1020,7 +1020,6 @@ class SystemDatabase(ABC):
                 )
             )
 
-    @db_retry()
     def debounce_delayed_workflow(
         self,
         *,
@@ -1030,6 +1029,7 @@ class SystemDatabase(ABC):
         delay_until_epoch_ms: int,
         inputs: str,
         serialization: Optional[str],
+        conn: Optional[sa.Connection] = None,
     ) -> DebounceResult:
         """Extend an existing debounced DELAYED workflow's delay and update its inputs.
 
@@ -1039,9 +1039,13 @@ class SystemDatabase(ABC):
         (e.g. "a"+"b-c" vs "a-b"+"c") never overwrites another workflow's inputs.
         If nothing matched, returns the current holder (or that the key is unheld)
         so the caller can decide whether to start fresh or surface a conflict.
+
+        Runs on ``conn`` if given, joining its transaction (e.g. a checkpointed
+        step's via call_txn_as_step); otherwise in its own retried transaction.
         """
-        wsc = SystemSchema.workflow_status.c
-        with self.engine.begin() as c:
+
+        def _do(c: sa.Connection) -> DebounceResult:
+            wsc = SystemSchema.workflow_status.c
             # Cap the new delay at the debounce deadline, if any (CASE not LEAST/min, for Postgres/SQLite portability).
             capped_delay = sa.case(
                 (
@@ -1094,6 +1098,16 @@ class SystemDatabase(ABC):
                 "holder_is_debounced": bool(holder[1]),
                 "holder_workflow_name": holder[2],
             }
+
+        if conn is not None:
+            return _do(conn)
+
+        @db_retry()
+        def _standalone() -> DebounceResult:
+            with self.engine.begin() as c:
+                return _do(c)
+
+        return _standalone()
 
     def update_workflow_attributes(
         self, workflow_id: str, attributes: Optional[Dict[str, Any]]
@@ -5333,4 +5347,5 @@ class SystemDatabase(ABC):
                 "error": None,
             }
             self._record_operation_result_txn(output, int(time.time() * 1000), conn=c)
-            return result
+        DebugTriggers.debug_trigger_point(DebugTriggers.DEBUG_TRIGGER_STEP_COMMIT)
+        return result

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -232,6 +232,12 @@ class WorkflowStatusInternal(TypedDict):
     delay_until_epoch_ms: Optional[int]
     attributes: Optional[Dict[str, Any]]
     schedule_name: Optional[str]
+    # Absolute cap (Unix epoch ms) beyond which debounce bounces may not extend
+    # the delay. None means the workflow is not debounced or has no timeout.
+    debounce_deadline_epoch_ms: Optional[int]
+    # True if this workflow's deduplication_id is a debounce key that must be
+    # cleared when the workflow transitions from DELAYED to ENQUEUED.
+    is_debounced: bool
 
 
 class MetricData(TypedDict):
@@ -255,6 +261,26 @@ class EnqueueOptionsInternal(TypedDict):
     queue_partition_key: Optional[str]
     # The UNIX epoch timestamp before which the workflow should not be dequeued
     delay_until_epoch_ms: Optional[int]
+    # Absolute cap (Unix epoch ms) beyond which debounce bounces may not extend
+    # the delay. None means the workflow is not debounced or has no timeout.
+    debounce_deadline_epoch_ms: Optional[int]
+    # True if this workflow's deduplication_id is a debounce key to be cleared
+    # when the workflow transitions from DELAYED to ENQUEUED.
+    is_debounced: bool
+
+
+class DebounceResult(TypedDict):
+    # The winner's workflow ID if an existing debounced DELAYED workflow was
+    # found and its delay/inputs were extended; None if no bounce occurred.
+    bounced_workflow_id: Optional[str]
+    # The current holder of (queue_name, deduplication_id) when no bounce
+    # occurred, or None if the key is unheld (it was cleared when the previous
+    # debounced workflow transitioned from DELAYED to ENQUEUED).
+    holder_workflow_id: Optional[str]
+    # The holder's workflow function name, used to detect a legacy debouncer.
+    holder_name: Optional[str]
+    # Whether the holder is itself a debounced workflow.
+    holder_is_debounced: bool
 
 
 class RecordedResult(TypedDict):
@@ -696,6 +722,8 @@ class SystemDatabase(ABC):
                 delay_until_epoch_ms=status["delay_until_epoch_ms"],
                 attributes=status["attributes"],
                 schedule_name=status["schedule_name"],
+                debounce_deadline_epoch_ms=status["debounce_deadline_epoch_ms"],
+                is_debounced=status["is_debounced"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
@@ -957,6 +985,81 @@ class SystemDatabase(ABC):
                     updated_at=func.extract("epoch", func.now()) * 1000,
                 )
             )
+
+    def debounce_delayed_workflow(
+        self,
+        *,
+        queue_name: str,
+        deduplication_id: str,
+        delay_until_epoch_ms: int,
+        inputs: str,
+        serialization: Optional[str],
+    ) -> DebounceResult:
+        """Extend an existing debounced DELAYED workflow's delay and update its inputs.
+
+        Performed as a single atomic transaction. The new delay is capped at the
+        workflow's debounce_deadline_epoch_ms, if one is set. If no debounced
+        DELAYED workflow holds this (queue_name, deduplication_id), returns
+        information about the current holder (or that the key is unheld) so the
+        caller can decide whether to start a fresh workflow or surface a conflict.
+        """
+        wsc = SystemSchema.workflow_status.c
+        with self.engine.begin() as c:
+            # Cap the new delay at the debounce deadline, if any. Written as a
+            # CASE (not LEAST/min) to stay portable across Postgres and SQLite.
+            capped_delay = sa.case(
+                (
+                    sa.and_(
+                        wsc.debounce_deadline_epoch_ms.isnot(None),
+                        wsc.debounce_deadline_epoch_ms < delay_until_epoch_ms,
+                    ),
+                    wsc.debounce_deadline_epoch_ms,
+                ),
+                else_=delay_until_epoch_ms,
+            )
+            updated = c.execute(
+                sa.update(SystemSchema.workflow_status)
+                .where(wsc.queue_name == queue_name)
+                .where(wsc.deduplication_id == deduplication_id)
+                .where(wsc.status == WorkflowStatusString.DELAYED.value)
+                .where(wsc.is_debounced == True)
+                .values(
+                    delay_until_epoch_ms=capped_delay,
+                    inputs=inputs,
+                    serialization=serialization,
+                    updated_at=self._now_ms_sql(),
+                )
+                .returning(wsc.workflow_uuid)
+            ).fetchone()
+            if updated is not None:
+                return {
+                    "bounced_workflow_id": updated[0],
+                    "holder_workflow_id": None,
+                    "holder_name": None,
+                    "holder_is_debounced": False,
+                }
+            # No debounced DELAYED workflow matched. The key may be unheld (the
+            # previous debounced workflow already flipped to ENQUEUED and cleared
+            # it) or held by another workflow (a user's own deduplicated workflow,
+            # or a legacy debouncer during a version upgrade).
+            holder = c.execute(
+                sa.select(wsc.workflow_uuid, wsc.name, wsc.is_debounced)
+                .where(wsc.queue_name == queue_name)
+                .where(wsc.deduplication_id == deduplication_id)
+            ).fetchone()
+            if holder is None:
+                return {
+                    "bounced_workflow_id": None,
+                    "holder_workflow_id": None,
+                    "holder_name": None,
+                    "holder_is_debounced": False,
+                }
+            return {
+                "bounced_workflow_id": None,
+                "holder_workflow_id": holder[0],
+                "holder_name": holder[1],
+                "holder_is_debounced": bool(holder[2]),
+            }
 
     def update_workflow_attributes(
         self, workflow_id: str, attributes: Optional[Dict[str, Any]]
@@ -1369,6 +1472,8 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.delay_until_epoch_ms,
                     SystemSchema.workflow_status.c.attributes,
                     SystemSchema.workflow_status.c.schedule_name,
+                    SystemSchema.workflow_status.c.debounce_deadline_epoch_ms,
+                    SystemSchema.workflow_status.c.is_debounced,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -1405,6 +1510,8 @@ class SystemDatabase(ABC):
                 "delay_until_epoch_ms": row[24],
                 "attributes": row[25],
                 "schedule_name": row[26],
+                "debounce_deadline_epoch_ms": row[27],
+                "is_debounced": bool(row[28]),
             }
             return status
 
@@ -3658,7 +3765,13 @@ class SystemDatabase(ABC):
             return [row[0] for row in rows]
 
     def transition_delayed_workflows(self) -> None:
-        """Transition DELAYED workflows whose delay has expired to ENQUEUED."""
+        """Transition DELAYED workflows whose delay has expired to ENQUEUED.
+
+        For debounced workflows, clear the deduplication_id in the same atomic
+        update: the ID is a debounce key held only while the workflow is DELAYED,
+        so a later debounce with the same key starts a fresh workflow instead of
+        bouncing this one (which is now committed to running).
+        """
         now_ms = int(time.time() * 1000)
         with self.engine.begin() as c:
             c.execute(
@@ -3668,7 +3781,16 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.DELAYED.value
                 )
                 .where(SystemSchema.workflow_status.c.delay_until_epoch_ms <= now_ms)
-                .values(status=WorkflowStatusString.ENQUEUED.value)
+                .values(
+                    status=WorkflowStatusString.ENQUEUED.value,
+                    deduplication_id=sa.case(
+                        (
+                            SystemSchema.workflow_status.c.is_debounced == True,
+                            None,
+                        ),
+                        else_=SystemSchema.workflow_status.c.deduplication_id,
+                    ),
+                )
             )
 
     def start_queued_workflows(
@@ -4503,6 +4625,8 @@ class SystemDatabase(ABC):
                         SystemSchema.workflow_status.c.completed_at,
                         SystemSchema.workflow_status.c.attributes,
                         SystemSchema.workflow_status.c.schedule_name,
+                        SystemSchema.workflow_status.c.debounce_deadline_epoch_ms,
+                        SystemSchema.workflow_status.c.is_debounced,
                         # owner_xid is intentionally omitted: it is a transient
                         # transaction-ownership token, not logical workflow state
                         # (get_workflow_status also returns None for it), and a
@@ -4547,6 +4671,8 @@ class SystemDatabase(ABC):
                     "completed_at": status_row[30],
                     "attributes": status_row[31],
                     "schedule_name": status_row[32],
+                    "debounce_deadline_epoch_ms": status_row[33],
+                    "is_debounced": status_row[34],
                 }
 
                 # Export operation_outputs
@@ -4708,6 +4834,10 @@ class SystemDatabase(ABC):
                         completed_at=status.get("completed_at"),
                         attributes=status.get("attributes"),
                         schedule_name=status.get("schedule_name"),
+                        debounce_deadline_epoch_ms=status.get(
+                            "debounce_deadline_epoch_ms"
+                        ),
+                        is_debounced=status.get("is_debounced", False),
                     )
                 )
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1018,6 +1018,7 @@ class SystemDatabase(ABC):
                 )
             )
 
+    @db_retry()
     def debounce_delayed_workflow(
         self,
         *,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -233,11 +233,9 @@ class WorkflowStatusInternal(TypedDict):
     delay_until_epoch_ms: Optional[int]
     attributes: Optional[Dict[str, Any]]
     schedule_name: Optional[str]
-    # Absolute cap (Unix epoch ms) beyond which debounce bounces may not extend
-    # the delay. None means the workflow is not debounced or has no timeout.
+    # Absolute cap (Unix epoch ms) beyond which bounces may not extend the delay; None if not debounced or no timeout.
     debounce_deadline_epoch_ms: Optional[int]
-    # True if this workflow's deduplication_id is a debounce key that must be
-    # cleared when the workflow transitions from DELAYED to ENQUEUED.
+    # True if this workflow's dedup ID is a debounce key to clear on the DELAYED->ENQUEUED transition.
     is_debounced: bool
 
 
@@ -262,21 +260,16 @@ class EnqueueOptionsInternal(TypedDict):
     queue_partition_key: Optional[str]
     # The UNIX epoch timestamp before which the workflow should not be dequeued
     delay_until_epoch_ms: Optional[int]
-    # Absolute cap (Unix epoch ms) beyond which debounce bounces may not extend
-    # the delay. None means the workflow is not debounced or has no timeout.
+    # Absolute cap (Unix epoch ms) beyond which bounces may not extend the delay; None if not debounced or no timeout.
     debounce_deadline_epoch_ms: Optional[int]
-    # True if this workflow's deduplication_id is a debounce key to be cleared
-    # when the workflow transitions from DELAYED to ENQUEUED.
+    # True if this workflow's dedup ID is a debounce key to clear on the DELAYED->ENQUEUED transition.
     is_debounced: bool
 
 
 class DebounceResult(TypedDict):
-    # The winner's workflow ID if an existing debounced DELAYED workflow was
-    # found and its delay/inputs were extended; None if no bounce occurred.
+    # The winner's workflow ID if an existing debounced DELAYED workflow was extended; None if no bounce occurred.
     bounced_workflow_id: Optional[str]
-    # The current holder of (queue_name, deduplication_id) when no bounce
-    # occurred, or None if the key is unheld (it was cleared when the previous
-    # debounced workflow transitioned from DELAYED to ENQUEUED).
+    # The current holder of (queue_name, deduplication_id) when no bounce occurred, or None if the key is unheld.
     holder_workflow_id: Optional[str]
     # Whether the holder is itself a debounced workflow.
     holder_is_debounced: bool
@@ -1044,8 +1037,7 @@ class SystemDatabase(ABC):
         """
         wsc = SystemSchema.workflow_status.c
         with self.engine.begin() as c:
-            # Cap the new delay at the debounce deadline, if any. Written as a
-            # CASE (not LEAST/min) to stay portable across Postgres and SQLite.
+            # Cap the new delay at the debounce deadline, if any (CASE not LEAST/min, for Postgres/SQLite portability).
             capped_delay = sa.case(
                 (
                     sa.and_(
@@ -1076,9 +1068,7 @@ class SystemDatabase(ABC):
                     "holder_workflow_id": None,
                     "holder_is_debounced": False,
                 }
-            # No debounced DELAYED workflow matched. The key may be unheld (the
-            # previous debounced workflow already flipped to ENQUEUED and cleared
-            # it) or held by another workflow (a user's own deduplicated workflow).
+            # No debounced DELAYED workflow matched: the key is unheld, or held by another (e.g. a user's own deduplicated) workflow.
             holder = c.execute(
                 sa.select(wsc.workflow_uuid, wsc.is_debounced)
                 .where(wsc.queue_name == queue_name)
@@ -3929,8 +3919,7 @@ class SystemDatabase(ABC):
                 )
 
             # Retrieve the first max_tasks workflows in the queue.
-            # Only retrieve workflows of the local version. Version-less workflows
-            # are only dequeued when this worker is running the latest version.
+            # Only dequeue workflows of the local version; version-less ones only when this worker runs the latest version.
             skip_locks = queue._concurrency is None
             query = (
                 sa.select(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1542,33 +1542,6 @@ class SystemDatabase(ABC):
             return status
 
     @db_retry()
-    def get_deduplicated_workflow(
-        self, queue_name: str, deduplication_id: str
-    ) -> Optional[str]:
-        """
-        Get the workflow ID associated with a given queue name and deduplication ID.
-
-        Args:
-            queue_name: The name of the queue
-            deduplication_id: The deduplication ID
-
-        Returns:
-            The workflow UUID if found, None otherwise
-        """
-        with self.engine.begin() as c:
-            row = c.execute(
-                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
-                    SystemSchema.workflow_status.c.queue_name == queue_name,
-                    SystemSchema.workflow_status.c.deduplication_id == deduplication_id,
-                )
-            ).fetchone()
-
-            if row is None:
-                return None
-            workflow_id: str = row[0]
-            return workflow_id
-
-    @db_retry()
     def _read_workflow_result_row(self, workflow_id: str) -> Optional[Any]:
         # Polling read under the limiter; acquired inside the db_retry body so the permit frees across backoff (like check_first_workflow_id).
         with self.poll_limiter, self.engine.begin() as c:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -273,6 +273,8 @@ class DebounceResult(TypedDict):
     holder_workflow_id: Optional[str]
     # Whether the holder is itself a debounced workflow.
     holder_is_debounced: bool
+    # The holder's workflow name; a mismatch with the caller's means a debounce-key collision between workflows.
+    holder_workflow_name: Optional[str]
 
 
 class RecordedResult(TypedDict):
@@ -1022,6 +1024,7 @@ class SystemDatabase(ABC):
     def debounce_delayed_workflow(
         self,
         *,
+        workflow_name: str,
         queue_name: str,
         deduplication_id: str,
         delay_until_epoch_ms: int,
@@ -1031,10 +1034,11 @@ class SystemDatabase(ABC):
         """Extend an existing debounced DELAYED workflow's delay and update its inputs.
 
         Performed as a single atomic transaction. The new delay is capped at the
-        workflow's debounce_deadline_epoch_ms, if one is set. If no debounced
-        DELAYED workflow holds this (queue_name, deduplication_id), returns
-        information about the current holder (or that the key is unheld) so the
-        caller can decide whether to start a fresh workflow or surface a conflict.
+        workflow's debounce_deadline_epoch_ms, if one is set. Matching on
+        workflow_name ensures a debounce-key collision between different workflows
+        (e.g. "a"+"b-c" vs "a-b"+"c") never overwrites another workflow's inputs.
+        If nothing matched, returns the current holder (or that the key is unheld)
+        so the caller can decide whether to start fresh or surface a conflict.
         """
         wsc = SystemSchema.workflow_status.c
         with self.engine.begin() as c:
@@ -1051,6 +1055,7 @@ class SystemDatabase(ABC):
             )
             updated = c.execute(
                 sa.update(SystemSchema.workflow_status)
+                .where(wsc.name == workflow_name)
                 .where(wsc.queue_name == queue_name)
                 .where(wsc.deduplication_id == deduplication_id)
                 .where(wsc.status == WorkflowStatusString.DELAYED.value)
@@ -1068,10 +1073,11 @@ class SystemDatabase(ABC):
                     "bounced_workflow_id": updated[0],
                     "holder_workflow_id": None,
                     "holder_is_debounced": False,
+                    "holder_workflow_name": None,
                 }
-            # No debounced DELAYED workflow matched: the key is unheld, or held by another (e.g. a user's own deduplicated) workflow.
+            # No match: the key is unheld, or held by a non-debounced or name-colliding workflow.
             holder = c.execute(
-                sa.select(wsc.workflow_uuid, wsc.is_debounced)
+                sa.select(wsc.workflow_uuid, wsc.is_debounced, wsc.name)
                 .where(wsc.queue_name == queue_name)
                 .where(wsc.deduplication_id == deduplication_id)
             ).fetchone()
@@ -1080,11 +1086,13 @@ class SystemDatabase(ABC):
                     "bounced_workflow_id": None,
                     "holder_workflow_id": None,
                     "holder_is_debounced": False,
+                    "holder_workflow_name": None,
                 }
             return {
                 "bounced_workflow_id": None,
                 "holder_workflow_id": holder[0],
                 "holder_is_debounced": bool(holder[1]),
+                "holder_workflow_name": holder[2],
             }
 
     def update_workflow_attributes(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -277,8 +277,6 @@ class DebounceResult(TypedDict):
     # occurred, or None if the key is unheld (it was cleared when the previous
     # debounced workflow transitioned from DELAYED to ENQUEUED).
     holder_workflow_id: Optional[str]
-    # The holder's workflow function name, used to detect a legacy debouncer.
-    holder_name: Optional[str]
     # Whether the holder is itself a debounced workflow.
     holder_is_debounced: bool
 
@@ -1035,15 +1033,13 @@ class SystemDatabase(ABC):
                 return {
                     "bounced_workflow_id": updated[0],
                     "holder_workflow_id": None,
-                    "holder_name": None,
                     "holder_is_debounced": False,
                 }
             # No debounced DELAYED workflow matched. The key may be unheld (the
             # previous debounced workflow already flipped to ENQUEUED and cleared
-            # it) or held by another workflow (a user's own deduplicated workflow,
-            # or a legacy debouncer during a version upgrade).
+            # it) or held by another workflow (a user's own deduplicated workflow).
             holder = c.execute(
-                sa.select(wsc.workflow_uuid, wsc.name, wsc.is_debounced)
+                sa.select(wsc.workflow_uuid, wsc.is_debounced)
                 .where(wsc.queue_name == queue_name)
                 .where(wsc.deduplication_id == deduplication_id)
             ).fetchone()
@@ -1051,14 +1047,12 @@ class SystemDatabase(ABC):
                 return {
                     "bounced_workflow_id": None,
                     "holder_workflow_id": None,
-                    "holder_name": None,
                     "holder_is_debounced": False,
                 }
             return {
                 "bounced_workflow_id": None,
                 "holder_workflow_id": holder[0],
-                "holder_name": holder[1],
-                "holder_is_debounced": bool(holder[2]),
+                "holder_is_debounced": bool(holder[1]),
             }
 
     def update_workflow_attributes(
@@ -3875,9 +3869,7 @@ class SystemDatabase(ABC):
 
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
-                .order_by(
-                    SystemSchema.application_versions.c.version_timestamp.desc()
-                )
+                .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
                 .limit(1)
             ).scalar()
             is_latest_version = latest_version is None or latest_version == app_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "License :: OSI Approved :: MIT License",

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -466,8 +466,3 @@ def test_attributes_debouncer(dbos: DBOS) -> None:
         handle = debouncer.debounce("key", 1.0, 5)
     assert handle.get_result() == 5
     assert handle.get_status().attributes == {"source": "debouncer"}
-
-    # The internal debouncer workflow itself does not get the user's attributes
-    internal_statuses = DBOS.list_workflows(name="_dbos_debouncer_workflow")
-    for status in internal_statuses:
-        assert status.attributes is None

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -653,3 +653,69 @@ def test_debounce_rejects_caller_dedup_and_delay(
     )
     with pytest.raises(DBOSException, match="partition key"):
         partition_client.debounce("k", 1.0, 1)
+
+
+def test_debounce_bounce_path_does_not_leak_pinned_id(dbos: DBOS) -> None:
+    # Regression test: a SetWorkflowID pinned around a debounce that coalesces (bounce path) is captured by the debounce and must not stay armed on the workflow's context, or the next child workflow the parent starts would silently run under the pinned ID.
+
+    @DBOS.workflow()
+    def child(x: int) -> int:
+        return x
+
+    @DBOS.workflow()
+    def other(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(child)
+
+    @DBOS.workflow()
+    def parent(pinned_id: str) -> tuple[str, str]:
+        # The first call creates the delayed workflow; the pinned second call bounces it, so the pinned ID goes unused.
+        first = debouncer.debounce("leak-key", 1000000, 1)
+        with SetWorkflowID(pinned_id):
+            bounced = debouncer.debounce("leak-key", 1000000, 2)
+        assert bounced.workflow_id == first.workflow_id
+        next_handle = DBOS.start_workflow(other, 3)
+        return first.workflow_id, next_handle.workflow_id
+
+    pinned_id = str(uuid.uuid4())
+    delayed_wfid, next_wfid = DBOS.start_workflow(parent, pinned_id).get_result()
+
+    # The next child workflow did not inherit the unused pinned ID.
+    assert next_wfid != pinned_id
+    assert DBOS.retrieve_workflow(next_wfid).get_result() == 3
+
+    DBOS.cancel_workflow(delayed_wfid)
+
+
+def test_debounce_pinned_id_survives_enqueue_dedup_race(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test: a fresh-enqueue attempt consumes a SetWorkflowID-pinned ID from the context before its INSERT can lose the dedup race. The retry loop must re-apply the pinned ID so the workflow is still created under it, not a generated UUID.
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+
+    original_init = dbos._sys_db.init_workflow
+    init_calls = {"count": 0}
+
+    def init_raising_dedup_once(*args: Any, **kwargs: Any) -> Any:
+        # The first enqueue's insert loses the dedup race after the pinned ID was already consumed; later calls behave normally.
+        init_calls["count"] += 1
+        if init_calls["count"] == 1:
+            raise DBOSQueueDeduplicatedError("racer", "queue", "dedup")
+        return original_init(*args, **kwargs)
+
+    monkeypatch.setattr(dbos._sys_db, "init_workflow", init_raising_dedup_once)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = debouncer.debounce("pin-race-key", 0.5, 7)
+
+    # The retried enqueue reused the pinned ID rather than minting a random one.
+    assert init_calls["count"] >= 2
+    assert handle.workflow_id == wfid
+    assert handle.get_result() == 7

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -448,3 +448,85 @@ def test_debounce_fixed_workflow_id_reuse(dbos: DBOS) -> None:
     assert third_handle.workflow_id == wfid2
     assert fourth_handle.workflow_id == wfid2
     assert fourth_handle.get_result() == 4
+
+
+def test_debounce_inworkflow_does_not_inherit_parent_deadline(dbos: DBOS) -> None:
+
+    ran = {"child": False}
+
+    @DBOS.workflow()
+    def child(x: int) -> int:
+        ran["child"] = True
+        return x
+
+    debouncer = Debouncer.create(child)
+
+    # Debounce from inside a workflow whose timeout (1s) is shorter than the
+    # debounce delay (3s). The debounced workflow must NOT inherit the parent's
+    # absolute deadline, or it would expire while DELAYED and be cancelled
+    # before it ever runs.
+    @DBOS.workflow()
+    def parent() -> str:
+        handle = debouncer.debounce("deadline-key", 3.0, 5)
+        return handle.workflow_id
+
+    with SetWorkflowTimeout(1.0):
+        parent_handle = DBOS.start_workflow(parent)
+    child_wfid = parent_handle.get_result()
+
+    # The debounced workflow carries no inherited deadline while delayed.
+    status = dbos._sys_db.get_workflow_status(child_wfid)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["workflow_deadline_epoch_ms"] is None
+
+    # It runs to completion after the delay rather than being cancelled.
+    child_handle: WorkflowHandle[int] = DBOS.retrieve_workflow(child_wfid)
+    assert child_handle.get_result() == 5
+    assert ran["child"] is True
+    assert child_handle.get_status().status == "SUCCESS"
+
+
+def test_debounce_inworkflow_replay_is_deterministic(dbos: DBOS) -> None:
+
+    child_runs = {"count": 0}
+
+    @DBOS.workflow()
+    def child(x: int) -> int:
+        child_runs["count"] += 1
+        return x
+
+    debouncer = Debouncer.create(child)
+
+    parent_body_runs = {"count": 0}
+
+    @DBOS.workflow()
+    def parent() -> str:
+        parent_body_runs["count"] += 1
+        handle = debouncer.debounce("replay-key", 1.0, 7)
+        return handle.workflow_id
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        parent_handle = DBOS.start_workflow(parent)
+    child_wfid = parent_handle.get_result()
+    assert parent_body_runs["count"] == 1
+
+    # Force the parent to replay from its checkpoint. The bounce step and the
+    # subsequent enqueue are both checkpointed, so replay must re-run the body,
+    # return the SAME child id, and NOT enqueue a second child.
+    dbos._sys_db.update_workflow_outcome(wfid, "PENDING")
+    recovery_handles = DBOS._recover_pending_workflows()
+    replayed = [h for h in recovery_handles if h.workflow_id == wfid]
+    assert len(replayed) == 1
+    assert replayed[0].get_result() == child_wfid
+    assert parent_body_runs["count"] == 2
+
+    # Exactly one child workflow exists for this key: replay did not double-enqueue.
+    child_name = get_dbos_func_name(child)
+    assert len(DBOS.list_workflows(name=child_name)) == 1
+
+    # The single debounced child runs to completion exactly once.
+    child_handle: WorkflowHandle[int] = DBOS.retrieve_workflow(child_wfid)
+    assert child_handle.get_result() == 7
+    assert child_runs["count"] == 1

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 import pytest
 
@@ -523,6 +524,50 @@ def test_debounce_inworkflow_replay_is_deterministic(dbos: DBOS) -> None:
     child_handle: WorkflowHandle[int] = DBOS.retrieve_workflow(child_wfid)
     assert child_handle.get_result() == 7
     assert child_runs["count"] == 1
+
+
+def test_debounce_retries_replayed_portable_dedup_error(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test: when an in-workflow debounce's fresh enqueue loses the dedup race, the
+    # DBOSQueueDeduplicatedError is checkpointed at the parent's function ID. On replay it is
+    # re-raised from that checkpoint, but a workflow using portable (cross-language JSON)
+    # serialization deserializes it to a PortableWorkflowError carrying only the original type
+    # name -- not the original type. The retry loop must still recognize that form and bounce the
+    # existing workflow; otherwise the replayed workflow errors instead of retrying.
+    from dbos._serialization import PortableWorkflowError
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+
+    original_enqueue = Queue.enqueue
+    enqueue_calls = {"count": 0}
+
+    def enqueue_raising_portable_dedup_once(
+        self: Queue, func: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        # The first enqueue raises the exact object a replay produces from a checkpointed,
+        # portable-serialized dedup error; subsequent enqueues behave normally.
+        enqueue_calls["count"] += 1
+        if enqueue_calls["count"] == 1:
+            raise PortableWorkflowError(
+                "Workflow was deduplicated",
+                DBOSQueueDeduplicatedError.__name__,
+                None,
+                None,
+            )
+        return original_enqueue(self, func, *args, **kwargs)
+
+    monkeypatch.setattr(Queue, "enqueue", enqueue_raising_portable_dedup_once)
+
+    handle = debouncer.debounce("portable-key", 0.5, 5)
+
+    # The loop recognized the replay-form dedup error and retried instead of propagating it.
+    assert enqueue_calls["count"] == 2
+    assert handle.get_result() == 5
 
 
 def test_debounce_rejects_caller_dedup_and_delay(

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -13,7 +13,9 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
+from dbos._error import DBOSQueueDeduplicatedError
 from dbos._queue import Queue
+from dbos._registrations import get_dbos_func_name
 from dbos._utils import GlobalParams
 
 
@@ -322,3 +324,99 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
     )
     assert handle.workflow_id == wfid
     assert await handle.get_result() == first_value
+
+
+def test_debounce_flip_clears_dedup(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+    # A huge period keeps the workflow DELAYED until a later bounce shortens it.
+    handle = debouncer.debounce("key", 1000000, 1)
+
+    # While delayed, the workflow is marked debounced and holds the debounce key.
+    status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["is_debounced"] is True
+    assert status["deduplication_id"] == f"{get_dbos_func_name(workflow)}-key"
+
+    # A bounce extends the delay and replaces the input; the same workflow runs.
+    handle2 = debouncer.debounce("key", 1, 2)
+    assert handle2.workflow_id == handle.workflow_id
+    assert handle2.get_result() == 2
+
+    # When the workflow transitioned from DELAYED to ENQUEUED, its debounce key
+    # was cleared, so a later debounce with the same key starts a fresh workflow.
+    status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+    assert status is not None
+    assert status["deduplication_id"] is None
+
+    handle3 = debouncer.debounce("key", 1, 3)
+    assert handle3.workflow_id != handle.workflow_id
+    assert handle3.get_result() == 3
+
+
+def test_debounce_cancel_then_redebounce(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+    handle = debouncer.debounce("key", 1000000, 1)
+    status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+    assert status is not None and status["status"] == "DELAYED"
+
+    # Cancelling a delayed debounced workflow clears its debounce key.
+    DBOS.cancel_workflow(handle.workflow_id)
+
+    # A new debounce with the same key therefore starts a fresh workflow.
+    handle2 = debouncer.debounce("key", 1, 2)
+    assert handle2.workflow_id != handle.workflow_id
+    assert handle2.get_result() == 2
+
+
+def test_debounce_deadline_caps_initial_delay(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    # A huge period with a finite timeout: the delay is capped at the deadline.
+    debouncer = Debouncer.create(workflow, debounce_timeout_sec=1000)
+    handle = debouncer.debounce("key", 1000000, 1)
+
+    status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["is_debounced"] is True
+    assert status["debounce_deadline_epoch_ms"] is not None
+    assert status["delay_until_epoch_ms"] is not None
+    assert status["delay_until_epoch_ms"] <= status["debounce_deadline_epoch_ms"]
+
+    DBOS.cancel_workflow(handle.workflow_id)
+
+
+def test_debounce_user_dedup_conflict_raises(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        DBOS.sleep(1000000)
+        return x
+
+    # A non-debounced workflow occupies the debounce key on the internal queue.
+    dedup_id = f"{get_dbos_func_name(workflow)}-key"
+    internal_queue = dbos._registry.get_internal_queue()
+    with SetEnqueueOptions(deduplication_id=dedup_id):
+        blocker = internal_queue.enqueue(workflow, 1)
+
+    # The key is held by a workflow that is not itself debounced, so debouncing
+    # the same key surfaces the deduplication conflict rather than hijacking it.
+    debouncer = Debouncer.create(workflow)
+    with pytest.raises(DBOSQueueDeduplicatedError):
+        debouncer.debounce("key", 1, 2)
+
+    DBOS.cancel_workflow(blocker.workflow_id)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -13,7 +13,7 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
-from dbos._error import DBOSQueueDeduplicatedError
+from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name
 from dbos._utils import GlobalParams
@@ -179,12 +179,10 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
 
-    # Test SetEnqueueOptions works
+    # SetEnqueueOptions priority/app_version pass through (a deduplication_id/delay would be rejected, see test_debounce_rejects_*).
     test_version = "test_version"
     GlobalParams.app_version = test_version
-    with SetEnqueueOptions(
-        priority=1, deduplication_id="test", app_version=test_version
-    ):
+    with SetEnqueueOptions(priority=1, app_version=test_version):
         handle = debouncer.debounce("key", debounce_period_sec, first_value)
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
@@ -461,10 +459,7 @@ def test_debounce_inworkflow_does_not_inherit_parent_deadline(dbos: DBOS) -> Non
 
     debouncer = Debouncer.create(child)
 
-    # Debounce from inside a workflow whose timeout (1s) is shorter than the
-    # debounce delay (3s). The debounced workflow must NOT inherit the parent's
-    # absolute deadline, or it would expire while DELAYED and be cancelled
-    # before it ever runs.
+    # Debounce inside a workflow whose timeout (1s) is shorter than the debounce delay (3s); the debounced workflow must not inherit the parent's deadline or it would be cancelled before running.
     @DBOS.workflow()
     def parent() -> str:
         handle = debouncer.debounce("deadline-key", 3.0, 5)
@@ -512,9 +507,7 @@ def test_debounce_inworkflow_replay_is_deterministic(dbos: DBOS) -> None:
     child_wfid = parent_handle.get_result()
     assert parent_body_runs["count"] == 1
 
-    # Force the parent to replay from its checkpoint. The bounce step and the
-    # subsequent enqueue are both checkpointed, so replay must re-run the body,
-    # return the SAME child id, and NOT enqueue a second child.
+    # Force the parent to replay from its checkpoint: the bounce step and enqueue are checkpointed, so replay must re-run the body, return the same child id, and not enqueue a second child.
     dbos._sys_db.update_workflow_outcome(wfid, "PENDING")
     recovery_handles = DBOS._recover_pending_workflows()
     replayed = [h for h in recovery_handles if h.workflow_id == wfid]
@@ -530,3 +523,54 @@ def test_debounce_inworkflow_replay_is_deterministic(dbos: DBOS) -> None:
     child_handle: WorkflowHandle[int] = DBOS.retrieve_workflow(child_wfid)
     assert child_handle.get_result() == 7
     assert child_runs["count"] == 1
+
+
+def test_debounce_rejects_caller_dedup_and_delay(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    # A debounce owns the workflow's deduplication ID and delay, so a caller that sets either must fail loudly rather than have it silently ignored.
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+
+    # Local: a caller-set deduplication_id is rejected.
+    with pytest.raises(DBOSException, match="deduplication_id"):
+        with SetEnqueueOptions(deduplication_id="caller-dedup"):
+            debouncer.debounce("k", 1.0, 1)
+
+    # Local: a caller-set delay is rejected.
+    with pytest.raises(DBOSException, match="delay"):
+        with SetEnqueueOptions(delay_seconds=100.0):
+            debouncer.debounce("k", 1.0, 1)
+
+    # Neither conflicting option left a workflow behind.
+    assert len(DBOS.list_workflows(name=get_dbos_func_name(workflow))) == 0
+
+    DBOS.register_queue("reject-queue")
+
+    # Client: a deduplication_id in the workflow options is rejected.
+    dedup_client = DebouncerClient(
+        client,
+        {
+            "workflow_name": workflow.__qualname__,
+            "queue_name": "reject-queue",
+            "deduplication_id": "caller-dedup",
+        },
+    )
+    with pytest.raises(DBOSException, match="deduplication_id"):
+        dedup_client.debounce("k", 1.0, 1)
+
+    # Client: a delay in the workflow options is rejected.
+    delay_client = DebouncerClient(
+        client,
+        {
+            "workflow_name": workflow.__qualname__,
+            "queue_name": "reject-queue",
+            "delay_seconds": 100.0,
+        },
+    )
+    with pytest.raises(DBOSException, match="delay"):
+        delay_client.debounce("k", 1.0, 1)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -180,10 +180,10 @@ def test_debouncer_queue(dbos: DBOS) -> None:
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
 
-    # SetEnqueueOptions priority/app_version pass through (a deduplication_id/delay would be rejected, see test_debounce_rejects_*).
+    # SetEnqueueOptions app_version passes through (deduplication_id/delay/priority/partition key are rejected, see test_debounce_rejects_*).
     test_version = "test_version"
     GlobalParams.app_version = test_version
-    with SetEnqueueOptions(priority=1, app_version=test_version):
+    with SetEnqueueOptions(app_version=test_version):
         handle = debouncer.debounce("key", debounce_period_sec, first_value)
     assert handle.get_result() == first_value
     assert handle.get_status().queue_name == queue.name
@@ -573,7 +573,7 @@ def test_debounce_retries_replayed_portable_dedup_error(
 def test_debounce_rejects_caller_dedup_and_delay(
     dbos: DBOS, client: DBOSClient
 ) -> None:
-    # A debounce owns the workflow's deduplication ID and delay, so a caller that sets either must fail loudly rather than have it silently ignored.
+    # A debounce owns the workflow's deduplication ID and delay, and priority/partition keys cannot apply to a debounced enqueue, so a caller that sets any of them must fail loudly rather than have it silently ignored or break later.
 
     @DBOS.workflow()
     def workflow(x: int) -> int:
@@ -591,7 +591,17 @@ def test_debounce_rejects_caller_dedup_and_delay(
         with SetEnqueueOptions(delay_seconds=100.0):
             debouncer.debounce("k", 1.0, 1)
 
-    # Neither conflicting option left a workflow behind.
+    # Local: a caller-set priority is rejected.
+    with pytest.raises(DBOSException, match="priority"):
+        with SetEnqueueOptions(priority=1):
+            debouncer.debounce("k", 1.0, 1)
+
+    # Local: a caller-set partition key is rejected.
+    with pytest.raises(DBOSException, match="partition key"):
+        with SetEnqueueOptions(queue_partition_key="caller-partition"):
+            debouncer.debounce("k", 1.0, 1)
+
+    # No conflicting option left a workflow behind.
     assert len(DBOS.list_workflows(name=get_dbos_func_name(workflow))) == 0
 
     DBOS.register_queue("reject-queue")
@@ -619,3 +629,27 @@ def test_debounce_rejects_caller_dedup_and_delay(
     )
     with pytest.raises(DBOSException, match="delay"):
         delay_client.debounce("k", 1.0, 1)
+
+    # Client: a priority in the workflow options is rejected.
+    priority_client = DebouncerClient(
+        client,
+        {
+            "workflow_name": workflow.__qualname__,
+            "queue_name": "reject-queue",
+            "priority": 1,
+        },
+    )
+    with pytest.raises(DBOSException, match="priority"):
+        priority_client.debounce("k", 1.0, 1)
+
+    # Client: a partition key in the workflow options is rejected.
+    partition_client = DebouncerClient(
+        client,
+        {
+            "workflow_name": workflow.__qualname__,
+            "queue_name": "reject-queue",
+            "queue_partition_key": "caller-partition",
+        },
+    )
+    with pytest.raises(DBOSException, match="partition key"):
+        partition_client.debounce("k", 1.0, 1)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -348,8 +348,7 @@ def test_debounce_flip_clears_dedup(dbos: DBOS) -> None:
     assert handle2.workflow_id == handle.workflow_id
     assert handle2.get_result() == 2
 
-    # When the workflow transitioned from DELAYED to ENQUEUED, its debounce key
-    # was cleared, so a later debounce with the same key starts a fresh workflow.
+    # On the DELAYED->ENQUEUED transition its debounce key was cleared, so a later debounce with the same key starts fresh.
     status = dbos._sys_db.get_workflow_status(handle.workflow_id)
     assert status is not None
     assert status["deduplication_id"] is None
@@ -413,8 +412,7 @@ def test_debounce_user_dedup_conflict_raises(dbos: DBOS) -> None:
     with SetEnqueueOptions(deduplication_id=dedup_id):
         blocker = internal_queue.enqueue(workflow, 1)
 
-    # The key is held by a workflow that is not itself debounced, so debouncing
-    # the same key surfaces the deduplication conflict rather than hijacking it.
+    # The key is held by a non-debounced workflow, so debouncing it surfaces the dedup conflict rather than hijacking it.
     debouncer = Debouncer.create(workflow)
     with pytest.raises(DBOSQueueDeduplicatedError):
         debouncer.debounce("key", 1, 2)
@@ -430,9 +428,7 @@ def test_debounce_fixed_workflow_id_reuse(dbos: DBOS) -> None:
 
     debouncer = Debouncer.create(workflow)
 
-    # Pinning the same workflow ID across debounces of the same key must still
-    # bounce the existing DELAYED workflow (last input wins), not silently drop
-    # the new input by colliding on workflow_uuid.
+    # Pinning the same workflow ID across debounces of one key must still bounce the existing workflow (last input wins), not drop it on a workflow_uuid collision.
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         first_handle = debouncer.debounce("key", 2, 1)
@@ -443,8 +439,7 @@ def test_debounce_fixed_workflow_id_reuse(dbos: DBOS) -> None:
     assert first_handle.get_result() == 2
     assert second_handle.get_result() == 2
 
-    # A huge initial period pinned to an ID, then a short one under the same ID,
-    # must still shorten the delay so the workflow actually runs.
+    # A huge initial period then a short one under the same pinned ID must still shorten the delay so the workflow runs.
     wfid2 = str(uuid.uuid4())
     with SetWorkflowID(wfid2):
         third_handle = debouncer.debounce("key2", 1000000, 3)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -15,6 +15,7 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
+from dbos._debug_trigger import DebugAction, DebugTriggers
 from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name
@@ -771,3 +772,136 @@ def test_debounce_key_collision_between_workflows(
     assert handle_a2.workflow_id == handle_a.workflow_id
 
     DBOS.cancel_workflow(handle_a.workflow_id)
+
+
+def test_debounce_bounce_atomic_with_checkpoint(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test (exactly-once): an in-workflow bounce commits atomically with its step
+    # checkpoint. If the checkpoint write fails, the bounce must roll back with it; otherwise a
+    # recovered parent would re-bounce or re-enqueue work that already committed, running it twice.
+    runs = {"count": 0}
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        runs["count"] += 1
+        return x
+
+    debouncer = Debouncer.create(workflow)
+
+    # A fresh debounced workflow, kept DELAYED by a huge period.
+    w_handle = debouncer.debounce("atomic-key", 1000000, 1)
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None and status["status"] == "DELAYED"
+    delay_before = status["delay_until_epoch_ms"]
+    assert delay_before is not None
+
+    # The bounce's checkpoint write fails once, after the bounce UPDATE ran in the same transaction.
+    original_record = dbos._sys_db._record_operation_result_txn
+    fail = {"armed": True}
+
+    def record_failing_once(*args: Any, **kwargs: Any) -> Any:
+        if (
+            fail["armed"]
+            and args[0]["function_name"] == "DBOS.debounce_delayed_workflow"
+        ):
+            fail["armed"] = False
+            raise RuntimeError("crash before checkpoint commit")
+        return original_record(*args, **kwargs)
+
+    monkeypatch.setattr(
+        dbos._sys_db, "_record_operation_result_txn", record_failing_once
+    )
+
+    @DBOS.workflow()
+    def parent() -> str:
+        handle = debouncer.debounce("atomic-key", 2000000, 2)
+        return handle.workflow_id
+
+    pwfid = str(uuid.uuid4())
+    with SetWorkflowID(pwfid):
+        parent_handle = DBOS.start_workflow(parent)
+    with pytest.raises(Exception, match="crash before checkpoint commit"):
+        parent_handle.get_result()
+
+    # The failed checkpoint rolled back the bounce with it: the delay (set in the same UPDATE as the inputs) is unchanged.
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["delay_until_epoch_ms"] == delay_before
+
+    # Recovery replays the parent: no checkpoint exists, so the bounce re-executes and lands exactly once.
+    dbos._sys_db.update_workflow_outcome(pwfid, "PENDING")
+    recovery_handles = DBOS._recover_pending_workflows()
+    replayed = [h for h in recovery_handles if h.workflow_id == pwfid]
+    assert len(replayed) == 1
+    assert replayed[0].get_result() == w_handle.workflow_id
+
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None
+    assert status["delay_until_epoch_ms"] is not None
+    assert status["delay_until_epoch_ms"] > delay_before
+
+    # Exactly one workflow exists for the key; shortening the delay runs it exactly once with the bounced input.
+    assert len(DBOS.list_workflows(name=get_dbos_func_name(workflow))) == 1
+    final_handle = debouncer.debounce("atomic-key", 0.5, 2)
+    assert final_handle.workflow_id == w_handle.workflow_id
+    assert final_handle.get_result() == 2
+    assert runs["count"] == 1
+
+
+def test_debounce_bounce_checkpoint_survives_post_commit_crash(dbos: DBOS) -> None:
+    # Regression test (exactly-once): a crash immediately after the atomic bounce+checkpoint
+    # commit must replay through the checkpoint on recovery -- same handle, no second bounce.
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+    w_handle = debouncer.debounce("post-commit-key", 1000000, 1)
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None and status["status"] == "DELAYED"
+    delay_before = status["delay_until_epoch_ms"]
+    assert delay_before is not None
+
+    @DBOS.workflow()
+    def parent() -> str:
+        handle = debouncer.debounce("post-commit-key", 2000000, 2)
+        return handle.workflow_id
+
+    # Crash the parent right after the bounce's transaction commits.
+    DebugTriggers.set_debug_trigger(
+        DebugTriggers.DEBUG_TRIGGER_STEP_COMMIT,
+        DebugAction().set_exception_to_throw(
+            RuntimeError("crash after checkpoint commit")
+        ),
+    )
+    try:
+        pwfid = str(uuid.uuid4())
+        with SetWorkflowID(pwfid):
+            parent_handle = DBOS.start_workflow(parent)
+        with pytest.raises(Exception, match="crash after checkpoint commit"):
+            parent_handle.get_result()
+    finally:
+        DebugTriggers.clear_debug_triggers()
+
+    # The bounce and its checkpoint both committed before the crash.
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None
+    assert status["delay_until_epoch_ms"] is not None
+    assert status["delay_until_epoch_ms"] > delay_before
+    delay_after_crash = status["delay_until_epoch_ms"]
+
+    # Replay short-circuits through the checkpoint: same handle, and no re-executed bounce re-extends the delay.
+    dbos._sys_db.update_workflow_outcome(pwfid, "PENDING")
+    recovery_handles = DBOS._recover_pending_workflows()
+    replayed = [h for h in recovery_handles if h.workflow_id == pwfid]
+    assert len(replayed) == 1
+    assert replayed[0].get_result() == w_handle.workflow_id
+
+    status = dbos._sys_db.get_workflow_status(w_handle.workflow_id)
+    assert status is not None
+    assert status["delay_until_epoch_ms"] == delay_after_crash
+
+    DBOS.cancel_workflow(w_handle.workflow_id)

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -420,3 +420,36 @@ def test_debounce_user_dedup_conflict_raises(dbos: DBOS) -> None:
         debouncer.debounce("key", 1, 2)
 
     DBOS.cancel_workflow(blocker.workflow_id)
+
+
+def test_debounce_fixed_workflow_id_reuse(dbos: DBOS) -> None:
+
+    @DBOS.workflow()
+    def workflow(x: int) -> int:
+        return x
+
+    debouncer = Debouncer.create(workflow)
+
+    # Pinning the same workflow ID across debounces of the same key must still
+    # bounce the existing DELAYED workflow (last input wins), not silently drop
+    # the new input by colliding on workflow_uuid.
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        first_handle = debouncer.debounce("key", 2, 1)
+    with SetWorkflowID(wfid):
+        second_handle = debouncer.debounce("key", 2, 2)
+    assert first_handle.workflow_id == wfid
+    assert second_handle.workflow_id == wfid
+    assert first_handle.get_result() == 2
+    assert second_handle.get_result() == 2
+
+    # A huge initial period pinned to an ID, then a short one under the same ID,
+    # must still shorten the delay so the workflow actually runs.
+    wfid2 = str(uuid.uuid4())
+    with SetWorkflowID(wfid2):
+        third_handle = debouncer.debounce("key2", 1000000, 3)
+    with SetWorkflowID(wfid2):
+        fourth_handle = debouncer.debounce("key2", 1, 4)
+    assert third_handle.workflow_id == wfid2
+    assert fourth_handle.workflow_id == wfid2
+    assert fourth_handle.get_result() == 4

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 from typing import Any
 
@@ -327,8 +328,13 @@ async def test_debouncer_client_async(dbos: DBOS, client: DBOSClient) -> None:
 
 def test_debounce_flip_clears_dedup(dbos: DBOS) -> None:
 
+    started = threading.Event()
+    blocker = threading.Event()
+
     @DBOS.workflow()
     def workflow(x: int) -> int:
+        started.set()
+        blocker.wait()
         return x
 
     debouncer = Debouncer.create(workflow)
@@ -342,18 +348,25 @@ def test_debounce_flip_clears_dedup(dbos: DBOS) -> None:
     assert status["is_debounced"] is True
     assert status["deduplication_id"] == f"{get_dbos_func_name(workflow)}-key"
 
-    # A bounce extends the delay and replaces the input; the same workflow runs.
+    # A bounce shortens the delay and replaces the input; the same workflow runs.
     handle2 = debouncer.debounce("key", 1, 2)
     assert handle2.workflow_id == handle.workflow_id
-    assert handle2.get_result() == 2
 
-    # On the DELAYED->ENQUEUED transition its debounce key was cleared, so a later debounce with the same key starts fresh.
+    # Wait for the flip: the workflow starts but blocks, so it's in flight, not complete.
+    assert started.wait(timeout=60)
+
+    # The flip cleared the debounce key; assert while still running since completion also clears it.
     status = dbos._sys_db.get_workflow_status(handle.workflow_id)
     assert status is not None
+    assert status["status"] == "PENDING"
     assert status["deduplication_id"] is None
 
+    # A same-key debounce therefore starts fresh even before the first workflow finishes.
     handle3 = debouncer.debounce("key", 1, 3)
     assert handle3.workflow_id != handle.workflow_id
+
+    blocker.set()
+    assert handle2.get_result() == 2
     assert handle3.get_result() == 3
 
 
@@ -719,3 +732,42 @@ def test_debounce_pinned_id_survives_enqueue_dedup_race(
     assert init_calls["count"] >= 2
     assert handle.workflow_id == wfid
     assert handle.get_result() == 7
+
+
+def test_debounce_key_collision_between_workflows(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    # Regression test: "colw"+"b-k" and "colw-b"+"k" both yield dedup ID "colw-b-k" (hyphenated names are client-only).
+    # The collider must surface the conflict, not overwrite the other workflow's row.
+    queue_name = f"collision-queue-{uuid.uuid4()}"
+    DBOS.register_queue(queue_name)
+
+    debouncer_a = DebouncerClient(
+        client, {"workflow_name": "colw", "queue_name": queue_name}
+    )
+    debouncer_b = DebouncerClient(
+        client, {"workflow_name": "colw-b", "queue_name": queue_name}
+    )
+
+    # A huge period keeps workflow "colw" DELAYED, holding dedup ID "colw-b-k".
+    handle_a: WorkflowHandle[int] = debouncer_a.debounce("b-k", 1000000, 1)
+    status = dbos._sys_db.get_workflow_status(handle_a.workflow_id)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["deduplication_id"] == "colw-b-k"
+
+    # The colliding debounce for workflow "colw-b" raises instead of hijacking the row.
+    with pytest.raises(DBOSQueueDeduplicatedError):
+        debouncer_b.debounce("k", 1, 2)
+
+    # The victim is untouched: still DELAYED under its own name.
+    status = dbos._sys_db.get_workflow_status(handle_a.workflow_id)
+    assert status is not None
+    assert status["status"] == "DELAYED"
+    assert status["name"] == "colw"
+
+    # A same-name bounce still coalesces onto the existing workflow.
+    handle_a2: WorkflowHandle[int] = debouncer_a.debounce("b-k", 1000000, 3)
+    assert handle_a2.workflow_id == handle_a.workflow_id
+
+    DBOS.cancel_workflow(handle_a.workflow_id)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -5,7 +5,9 @@ from dbos import DBOS, DBOSConfig
 from dbos._error import DBOSUnexpectedStepError
 
 
-def test_patch(dbos: DBOS, config: DBOSConfig) -> None:
+def test_patch(
+    dbos: DBOS, config: DBOSConfig, skip_with_sqlite_imprecise_time: None
+) -> None:
     DBOS.destroy(destroy_registry=True)
     config["enable_patching"] = True
     test_version = "test_version"
@@ -224,7 +226,9 @@ def test_patch(dbos: DBOS, config: DBOSConfig) -> None:
 
 
 @pytest.mark.asyncio
-async def test_patch_async(dbos: DBOS, config: DBOSConfig) -> None:
+async def test_patch_async(
+    dbos: DBOS, config: DBOSConfig, skip_with_sqlite_imprecise_time: None
+) -> None:
     DBOS.destroy(destroy_registry=True)
     config["enable_patching"] = True
     DBOS(config=config)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2625,7 +2625,9 @@ def test_polling_interval(dbos: DBOS) -> None:
         assert time.time() - start_time < 1.0
 
 
-def test_listen_queue(dbos: DBOS, config: DBOSConfig) -> None:
+def test_listen_queue(
+    dbos: DBOS, config: DBOSConfig, skip_with_sqlite_imprecise_time: None
+) -> None:
     DBOS.destroy(destroy_registry=True)
     DBOS(config=config)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2427,9 +2427,7 @@ async def test_enqueue_version_async(dbos: DBOS) -> None:
 
 
 def test_dequeue_no_version_requires_latest(dbos: DBOS, client: DBOSClient) -> None:
-    # A worker only dequeues version-less (application_version IS NULL) workflows
-    # when it is running the latest registered application version. Workflows
-    # tagged with the worker's own version are always dequeued.
+    # A worker dequeues version-less (application_version IS NULL) workflows only when running the latest registered version; own-version workflows are always dequeued.
     queue_name = f"test_dequeue_latest_{uuid.uuid4()}"
     DBOS.register_queue(queue_name)
 
@@ -2462,10 +2460,7 @@ def test_dequeue_no_version_requires_latest(dbos: DBOS, client: DBOSClient) -> N
     assert versioned_handle.get_result() == 7
 
     # The version-less workflow is NOT dequeued: this worker is not the latest.
-    assert (
-        versionless_handle.get_status().status
-        == WorkflowStatusString.ENQUEUED.value
-    )
+    assert versionless_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
 
     # Make this worker the latest version again; now the version-less workflow runs.
     dbos._sys_db.update_application_version_timestamp(


### PR DESCRIPTION
Reimplement the debouncer to use `DELAYED` workflows instead of an internal workflow with signaling mechanism. This both simplifies and improves the performance of the debouncer, eliminating the rounds of communication in the previous implementation. Re-opens and closes https://github.com/dbos-inc/dbos-transact-py/issues/724.

Migration note: this eliminates `_dbos_debouncer_workflow`. If using debouncers but not using versioning, upon upgrading to the version containing this PR, you should cancel any leftover `_dbos_debouncer_workflow` as they will not be recovered. Actual running workflows will not be affected. This notice will be added to the release notes of the next version.