### PR TITLE
Explicit timestamping when creating application versions

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -589,8 +589,8 @@ class DBOS:
 
             # Register the current application version
             self._sys_db.create_application_version(GlobalParams.app_version)
-            latest = self._sys_db.get_latest_application_version()
-            if latest["version_name"] != GlobalParams.app_version:
+            if not self._sys_db.is_latest_application_version(GlobalParams.app_version):
+                latest = self._sys_db.get_latest_application_version()
                 dbos_logger.warning(
                     f"Current version '{GlobalParams.app_version}' is not the latest version. "
                     f"Latest version is '{latest['version_name']}'."

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5007,12 +5007,17 @@ class SystemDatabase(ABC):
     # ── Application Version CRUD ────────────────────────────────
 
     def create_application_version(self, version_name: str) -> None:
+        # Stamp timestamps client-side: the SQLite column default only has
+        # second resolution on Python < 3.12.
+        now_ms = int(time.time() * 1000)
         with self.engine.begin() as c:
             c.execute(
                 self.dialect.insert(SystemSchema.application_versions)
                 .values(
                     version_id=generate_uuid(),
                     version_name=version_name,
+                    version_timestamp=now_ms,
+                    created_at=now_ms,
                 )
                 .on_conflict_do_nothing(index_elements=["version_name"])
             )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3751,14 +3751,7 @@ class SystemDatabase(ABC):
                 available_tasks = max(0, queue._concurrency - global_pending_workflows)
                 max_tasks = min(max_tasks, available_tasks)
 
-            latest_version = c.execute(
-                sa.select(SystemSchema.application_versions.c.version_name)
-                .order_by(
-                    SystemSchema.application_versions.c.version_timestamp.desc()
-                )
-                .limit(1)
-            ).scalar()
-            is_latest_version = latest_version is None or latest_version == app_version
+            is_latest_version = self._is_latest_application_version(c, app_version)
 
             version_predicate = (
                 SystemSchema.workflow_status.c.application_version == app_version
@@ -5021,6 +5014,33 @@ class SystemDatabase(ABC):
                 )
                 .on_conflict_do_nothing(index_elements=["version_name"])
             )
+
+    def _is_latest_application_version(
+        self, c: sa.Connection, version_name: str
+    ) -> bool:
+        # A version is latest iff no version has a strictly greater timestamp.
+        # Ties count as latest: comparing names against an arbitrarily-ordered
+        # max row would starve one of two versions registered at the same
+        # timestamp. An unregistered version is latest only if no versions
+        # are registered at all (coalesce to -1: any row beats it).
+        my_version_timestamp = (
+            sa.select(SystemSchema.application_versions.c.version_timestamp)
+            .where(SystemSchema.application_versions.c.version_name == version_name)
+            .scalar_subquery()
+        )
+        newer_version_exists = c.execute(
+            sa.select(
+                sa.exists().where(
+                    SystemSchema.application_versions.c.version_timestamp
+                    > sa.func.coalesce(my_version_timestamp, -1)
+                )
+            )
+        ).scalar()
+        return not bool(newer_version_exists)
+
+    def is_latest_application_version(self, version_name: str) -> bool:
+        with self.engine.begin() as c:
+            return self._is_latest_application_version(c, version_name)
 
     def update_application_version_timestamp(
         self, version_name: str, new_timestamp: int


### PR DESCRIPTION
Note this doesn't solve the problem of colliding versions (should be extremely rare)