### PR TITLE
Add Retry Options to Transactions

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1378,7 +1378,15 @@ def decorate_workflow(
 
 
 def decorate_transaction(
-    dbosreg: "DBOSRegistry", name: Optional[str], isolation_level: "IsolationLevel"
+    dbosreg: "DBOSRegistry",
+    name: Optional[str],
+    isolation_level: "IsolationLevel",
+    *,
+    retries_allowed: bool = False,
+    interval_seconds: float = 1.0,
+    max_attempts: int = 3,
+    backoff_rate: float = 2.0,
+    should_retry: Optional[Callable[[BaseException], bool]] = None,
 ) -> Callable[[F], F]:
     def decorator(func: F) -> F:
 
@@ -1457,8 +1465,15 @@ def decorate_transaction(
                     retry_wait_seconds = 0.001
                     backoff_factor = 1.5
                     max_retry_wait_seconds = 2.0
+                    # Application-error retry budget. A serialization conflict is
+                    # retried separately (below) and does not consume it; with
+                    # retries_allowed=False this is a single attempt — prior behavior.
+                    txn_attempts = max_attempts if retries_allowed else 1
+                    txn_attempt = 0
+                    max_txn_retry_interval_seconds = 3600.0
                     while True:
                         has_recorded_error = False
+                        retrying_app_error = False
                         txn_error: Optional[Exception] = None
                         try:
                             with session.begin():
@@ -1564,10 +1579,39 @@ def decorate_transaction(
                             raise
                         except Exception as error:
                             txn_error = error
+                            # An application error: retry the whole transaction if the
+                            # budget allows and the predicate accepts it, re-running the
+                            # function on a fresh transaction (the failed attempt's
+                            # writes were already rolled back on exiting session.begin).
+                            # Otherwise fall through to record the error and re-raise.
+                            if (
+                                retries_allowed
+                                and txn_attempt + 1 < txn_attempts
+                                and (should_retry is None or should_retry(error))
+                            ):
+                                retrying_app_error = True
+                                dbos.logger.warning(
+                                    f"Transaction {transaction_name} being automatically "
+                                    f"retried (attempt {txn_attempt + 2} of {txn_attempts})",
+                                    exc_info=error,
+                                )
+                                time.sleep(
+                                    min(
+                                        interval_seconds * (backoff_rate**txn_attempt),
+                                        max_txn_retry_interval_seconds,
+                                    )
+                                )
+                                txn_attempt += 1
+                                continue
                             raise
                         finally:
-                            # Don't record the error if it was already recorded
-                            if txn_error and not has_recorded_error:
+                            # Don't record the error if it was already recorded, or if
+                            # we are going to retry the whole transaction.
+                            if (
+                                txn_error
+                                and not has_recorded_error
+                                and not retrying_app_error
+                            ):
                                 serialized_e, serialization = serialize_exception(
                                     txn_error, None, dbos._serializer
                                 )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1583,9 +1583,12 @@ def decorate_transaction(
                             # budget allows and the predicate accepts it, re-running the
                             # function on a fresh transaction (the failed attempt's
                             # writes were already rolled back on exiting session.begin).
-                            # Otherwise fall through to record the error and re-raise.
+                            # A replayed recorded error is terminal, not a fresh failure,
+                            # so it is never retried. Otherwise fall through to record and
+                            # re-raise.
                             if (
                                 retries_allowed
+                                and not has_recorded_error
                                 and txn_attempt + 1 < txn_attempts
                                 and (should_retry is None or should_retry(error))
                             ):

--- a/dbos/_datasource.py
+++ b/dbos/_datasource.py
@@ -48,6 +48,9 @@ from ._logger import dbos_logger
 _INITIAL_RETRY_WAIT_SECONDS = 0.001
 _RETRY_BACKOFF_FACTOR = 1.5
 _MAX_RETRY_WAIT_SECONDS = 2.0
+# Cap for the (opt-in) application-error retry backoff, matching the step
+# retry policy's max interval of one hour.
+_MAX_TXN_RETRY_WAIT_SECONDS = 3600.0
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -61,6 +64,20 @@ def _parse_ds_options(
         ds_options.get("isolation_level") if ds_options else None
     ) or "SERIALIZABLE"
     return name, isolation_level
+
+
+def _parse_ds_retry(
+    ds_options: Optional["DatasourceOptions"],
+) -> "tuple[bool, float, int, float, Optional[Callable[[BaseException], bool]]]":
+    """The opt-in application-error retry policy, defaulting to a single attempt."""
+    o = ds_options or {}
+    return (
+        o.get("retries_allowed", False),
+        o.get("interval_seconds", 1.0),
+        o.get("max_attempts", 3),
+        o.get("backoff_rate", 2.0),
+        o.get("should_retry", None),
+    )
 
 
 def _replay_recorded(recorded: "RecordedResult", serializer: "Serializer") -> Any:
@@ -106,6 +123,11 @@ def _resolve_schema(database_url: str, schema: Optional[str]) -> Optional[str]:
 class DatasourceOptions(TypedDict, total=False):
     name: Optional[str]
     isolation_level: Optional[IsolationLevel]
+    retries_allowed: bool
+    interval_seconds: float
+    max_attempts: int
+    backoff_rate: float
+    should_retry: Optional[Callable[[BaseException], bool]]
 
 
 class AsyncSQLAlchemyDatasource(ABC):
@@ -253,6 +275,9 @@ class AsyncSQLAlchemyDatasource(ABC):
         **kwargs: P.kwargs,
     ) -> R:
         name, isolation_level = _parse_ds_options(ds_options, func)
+        retries_allowed, interval_seconds, max_attempts, backoff_rate, should_retry = (
+            _parse_ds_retry(ds_options)
+        )
 
         if not inspect.iscoroutinefunction(func):
             raise DBOSException(
@@ -277,6 +302,10 @@ class AsyncSQLAlchemyDatasource(ABC):
 
             output: R
             retry_wait_seconds = _INITIAL_RETRY_WAIT_SECONDS
+            # Application-error retry budget (serialization conflicts are retried
+            # separately, below, and don't consume it). Default: a single attempt.
+            txn_attempts = max_attempts if retries_allowed else 1
+            txn_attempt = 0
             with DBOSContextEnsure() as exec_ctx:
                 while True:
                     async with self.sessionmaker() as session:
@@ -332,6 +361,23 @@ class AsyncSQLAlchemyDatasource(ABC):
                                 )
                             raise
                         except Exception as e:
+                            # Application error: retry the whole transaction if the
+                            # budget allows and should_retry accepts it, re-running on
+                            # a fresh transaction (this attempt already rolled back on
+                            # exiting session.begin). Otherwise record and re-raise.
+                            if (
+                                retries_allowed
+                                and txn_attempt + 1 < txn_attempts
+                                and (should_retry is None or should_retry(e))
+                            ):
+                                await asyncio.sleep(
+                                    min(
+                                        interval_seconds * (backoff_rate**txn_attempt),
+                                        _MAX_TXN_RETRY_WAIT_SECONDS,
+                                    )
+                                )
+                                txn_attempt += 1
+                                continue
                             if in_wf:
                                 serialized_e, serialization = serialize_exception(
                                     e, None, self.serializer
@@ -373,6 +419,11 @@ class AsyncSQLAlchemyDatasource(ABC):
         *,
         name: Optional[str] = None,
         isolation_level: IsolationLevel = "SERIALIZABLE",
+        retries_allowed: bool = False,
+        interval_seconds: float = 1.0,
+        max_attempts: int = 3,
+        backoff_rate: float = 2.0,
+        should_retry: Optional[Callable[[BaseException], bool]] = None,
     ) -> Callable[
         [Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]
     ]: ...
@@ -383,6 +434,11 @@ class AsyncSQLAlchemyDatasource(ABC):
         *,
         name: Optional[str] = None,
         isolation_level: IsolationLevel = "SERIALIZABLE",
+        retries_allowed: bool = False,
+        interval_seconds: float = 1.0,
+        max_attempts: int = 3,
+        backoff_rate: float = 2.0,
+        should_retry: Optional[Callable[[BaseException], bool]] = None,
     ) -> Any:
         def decorator(
             f: Callable[..., Coroutine[Any, Any, Any]],
@@ -395,6 +451,13 @@ class AsyncSQLAlchemyDatasource(ABC):
             ds_options: DatasourceOptions = {"isolation_level": isolation_level}
             if name is not None:
                 ds_options["name"] = name
+            if retries_allowed:
+                ds_options["retries_allowed"] = True
+                ds_options["interval_seconds"] = interval_seconds
+                ds_options["max_attempts"] = max_attempts
+                ds_options["backoff_rate"] = backoff_rate
+            if should_retry is not None:
+                ds_options["should_retry"] = should_retry
 
             @wraps(f)
             async def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -550,6 +613,9 @@ class SQLAlchemyDatasource(ABC):
         **kwargs: P.kwargs,
     ) -> R:
         name, isolation_level = _parse_ds_options(ds_options, func)
+        retries_allowed, interval_seconds, max_attempts, backoff_rate, should_retry = (
+            _parse_ds_retry(ds_options)
+        )
 
         if inspect.iscoroutinefunction(func):
             raise DBOSException(
@@ -574,6 +640,10 @@ class SQLAlchemyDatasource(ABC):
 
             output: R
             retry_wait_seconds = _INITIAL_RETRY_WAIT_SECONDS
+            # Application-error retry budget (serialization conflicts are retried
+            # separately, below, and don't consume it). Default: a single attempt.
+            txn_attempts = max_attempts if retries_allowed else 1
+            txn_attempt = 0
             with DBOSContextEnsure() as exec_ctx:
                 while True:
                     with self.sessionmaker() as session:
@@ -629,6 +699,23 @@ class SQLAlchemyDatasource(ABC):
                                 )
                             raise
                         except Exception as e:
+                            # Application error: retry the whole transaction if the
+                            # budget allows and should_retry accepts it, re-running on
+                            # a fresh transaction (this attempt already rolled back on
+                            # exiting session.begin). Otherwise record and re-raise.
+                            if (
+                                retries_allowed
+                                and txn_attempt + 1 < txn_attempts
+                                and (should_retry is None or should_retry(e))
+                            ):
+                                time.sleep(
+                                    min(
+                                        interval_seconds * (backoff_rate**txn_attempt),
+                                        _MAX_TXN_RETRY_WAIT_SECONDS,
+                                    )
+                                )
+                                txn_attempt += 1
+                                continue
                             if in_wf:
                                 serialized_e, serialization = serialize_exception(
                                     e, None, self.serializer
@@ -660,6 +747,11 @@ class SQLAlchemyDatasource(ABC):
         *,
         name: Optional[str] = None,
         isolation_level: IsolationLevel = "SERIALIZABLE",
+        retries_allowed: bool = False,
+        interval_seconds: float = 1.0,
+        max_attempts: int = 3,
+        backoff_rate: float = 2.0,
+        should_retry: Optional[Callable[[BaseException], bool]] = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
     def transaction(
@@ -668,6 +760,11 @@ class SQLAlchemyDatasource(ABC):
         *,
         name: Optional[str] = None,
         isolation_level: IsolationLevel = "SERIALIZABLE",
+        retries_allowed: bool = False,
+        interval_seconds: float = 1.0,
+        max_attempts: int = 3,
+        backoff_rate: float = 2.0,
+        should_retry: Optional[Callable[[BaseException], bool]] = None,
     ) -> Any:
         def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
             if inspect.iscoroutinefunction(f):
@@ -678,6 +775,13 @@ class SQLAlchemyDatasource(ABC):
             ds_options: DatasourceOptions = {"isolation_level": isolation_level}
             if name is not None:
                 ds_options["name"] = name
+            if retries_allowed:
+                ds_options["retries_allowed"] = True
+                ds_options["interval_seconds"] = interval_seconds
+                ds_options["max_attempts"] = max_attempts
+                ds_options["backoff_rate"] = backoff_rate
+            if should_retry is not None:
+                ds_options["should_retry"] = should_retry
 
             @wraps(f)
             def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1035,7 +1035,9 @@ class DBOS:
             isolation_level(IsolationLevel): Transaction isolation level
             retries_allowed(bool): If true, retry the transaction when its function
                 raises an exception. Serialization conflicts are always retried,
-                independent of this setting.
+                independent of this setting. A retry re-runs the whole function;
+                database writes roll back between attempts, but any non-transactional
+                side effects repeat.
             interval_seconds(float): Time between retry attempts
             backoff_rate(float): Multiplier for exponentially increasing `interval_seconds` between retries
             max_attempts(int): Maximum number of attempts (including the first) before re-raising

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1022,16 +1022,37 @@ class DBOS:
         isolation_level: IsolationLevel = "SERIALIZABLE",
         *,
         name: Optional[str] = None,
+        retries_allowed: bool = False,
+        interval_seconds: float = 1.0,
+        max_attempts: int = 3,
+        backoff_rate: float = 2.0,
+        should_retry: Optional[Callable[[BaseException], bool]] = None,
     ) -> Callable[[F], F]:
         """
         Decorate a function for use as a DBOS transaction.
 
         Args:
             isolation_level(IsolationLevel): Transaction isolation level
+            retries_allowed(bool): If true, retry the transaction when its function
+                raises an exception. Serialization conflicts are always retried,
+                independent of this setting.
+            interval_seconds(float): Time between retry attempts
+            backoff_rate(float): Multiplier for exponentially increasing `interval_seconds` between retries
+            max_attempts(int): Maximum number of attempts (including the first) before re-raising
+            should_retry(Callable[[BaseException], bool]): Optional predicate called with a
+                raised exception to decide whether the transaction should be retried.
+                Returning False re-raises immediately without further retries.
 
         """
         return decorate_transaction(
-            _get_or_create_dbos_registry(), name, isolation_level
+            _get_or_create_dbos_registry(),
+            name,
+            isolation_level,
+            retries_allowed=retries_allowed,
+            interval_seconds=interval_seconds,
+            max_attempts=max_attempts,
+            backoff_rate=backoff_rate,
+            should_retry=should_retry,
         )
 
     @classmethod

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -928,3 +928,97 @@ async def test_async_ds_recovers_from_sysdb_loss(
     with SetWorkflowID(wfid):
         assert await my_workflow() == "recovered"
     assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Application-error retry policy (opt-in; mirrors @DBOS.step / Go RunAsTransaction)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_ds_txn_retries_to_success(
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
+) -> None:
+    """@ds.transaction(retries_allowed=True) re-runs the body on an app error."""
+    runs = {"n": 0}
+
+    @sync_ds.transaction(retries_allowed=True, max_attempts=3, interval_seconds=0.001)
+    def flaky(value: str) -> str:
+        runs["n"] += 1
+        if runs["n"] < 3:
+            raise ValueError("transient")
+        return f"ok:{value}"
+
+    @DBOS.workflow()
+    def wf(value: str) -> str:
+        return flaky(value)
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        assert wf("x") == "ok:x"
+    assert runs["n"] == 3  # one initial attempt plus two retries
+
+
+def test_sync_ds_txn_no_retry_by_default(
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
+) -> None:
+    runs = {"n": 0}
+
+    @sync_ds.transaction
+    def boom() -> str:
+        runs["n"] += 1
+        raise ValueError("boom")
+
+    @DBOS.workflow()
+    def wf() -> str:
+        return boom()
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        with pytest.raises(ValueError, match="boom"):
+            wf()
+    assert runs["n"] == 1  # default retries_allowed=False: runs once
+
+
+def test_sync_ds_txn_should_retry_stops(
+    dbos: DBOS, sync_ds: SQLAlchemyDatasource
+) -> None:
+    runs = {"n": 0}
+
+    @sync_ds.transaction(
+        retries_allowed=True,
+        max_attempts=5,
+        interval_seconds=0.001,
+        should_retry=lambda e: False,
+    )
+    def permanent() -> str:
+        runs["n"] += 1
+        raise ValueError("permanent")
+
+    @DBOS.workflow()
+    def wf() -> str:
+        return permanent()
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        with pytest.raises(ValueError, match="permanent"):
+            wf()
+    assert runs["n"] == 1  # predicate rejected: no retries despite max_attempts=5
+
+
+@pytest.mark.asyncio
+async def test_async_ds_txn_retries_to_success(
+    dbos: DBOS, async_ds: AsyncSQLAlchemyDatasource
+) -> None:
+    runs = {"n": 0}
+
+    @async_ds.transaction(retries_allowed=True, max_attempts=3, interval_seconds=0.001)
+    async def flaky(value: str) -> str:
+        runs["n"] += 1
+        if runs["n"] < 3:
+            raise ValueError("transient")
+        return f"ok:{value}"
+
+    @DBOS.workflow()
+    async def wf(value: str) -> str:
+        return await flaky(value)
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        assert await wf("x") == "ok:x"
+    assert runs["n"] == 3

--- a/tests/test_transaction_retries.py
+++ b/tests/test_transaction_retries.py
@@ -1,0 +1,80 @@
+"""Application-error retries for @DBOS.transaction.
+
+A transaction only retried serialization conflicts; an application error raised
+by the function was recorded and re-raised on the first attempt. These tests
+cover the opt-in application-error retry policy (retries_allowed / max_attempts /
+interval_seconds / backoff_rate / should_retry), which mirrors @DBOS.step and the
+Go SDK's RunAsTransaction step-retry options. Serialization retries are unchanged
+and independent of this policy.
+"""
+
+import pytest
+import sqlalchemy as sa
+
+from dbos import DBOS
+
+
+def test_transaction_retries_to_success(dbos: DBOS) -> None:
+    runs = 0
+
+    @DBOS.transaction(retries_allowed=True, max_attempts=3, interval_seconds=0.001)
+    def flaky(x: str) -> str:
+        nonlocal runs
+        DBOS.sql_session.execute(sa.text("SELECT 1"))
+        runs += 1
+        if runs < 3:
+            raise Exception("transient")
+        return x + "-ok"
+
+    assert flaky("v") == "v-ok"
+    assert runs == 3  # one initial attempt plus two retries
+
+
+def test_transaction_no_retry_by_default(dbos: DBOS) -> None:
+    runs = 0
+
+    @DBOS.transaction()
+    def boom(x: str) -> str:
+        nonlocal runs
+        DBOS.sql_session.execute(sa.text("SELECT 1"))
+        runs += 1
+        raise Exception("boom")
+
+    with pytest.raises(Exception, match="boom"):
+        boom("v")
+    assert runs == 1  # default retries_allowed=False: runs once, then raises
+
+
+def test_transaction_exhausts_retries_then_raises(dbos: DBOS) -> None:
+    runs = 0
+
+    @DBOS.transaction(retries_allowed=True, max_attempts=3, interval_seconds=0.001)
+    def always_fails(x: str) -> str:
+        nonlocal runs
+        DBOS.sql_session.execute(sa.text("SELECT 1"))
+        runs += 1
+        raise Exception("nope")
+
+    with pytest.raises(Exception, match="nope"):
+        always_fails("v")
+    assert runs == 3  # max_attempts total, then the error is recorded and raised
+
+
+def test_transaction_should_retry_predicate_stops(dbos: DBOS) -> None:
+    runs = 0
+
+    @DBOS.transaction(
+        retries_allowed=True,
+        max_attempts=5,
+        interval_seconds=0.001,
+        should_retry=lambda e: False,
+    )
+    def permanent(x: str) -> str:
+        nonlocal runs
+        DBOS.sql_session.execute(sa.text("SELECT 1"))
+        runs += 1
+        raise Exception("permanent")
+
+    with pytest.raises(Exception, match="permanent"):
+        permanent("v")
+    assert runs == 1  # predicate rejected the error: no retries despite max_attempts=5

--- a/tests/test_transaction_retries.py
+++ b/tests/test_transaction_retries.py
@@ -8,10 +8,14 @@ Go SDK's RunAsTransaction step-retry options. Serialization retries are unchange
 and independent of this policy.
 """
 
+import time
+import uuid
+
 import pytest
 import sqlalchemy as sa
 
-from dbos import DBOS
+from dbos import DBOS, SetWorkflowID
+from dbos._schemas.system_database import SystemSchema
 
 
 def test_transaction_retries_to_success(dbos: DBOS) -> None:
@@ -78,3 +82,50 @@ def test_transaction_should_retry_predicate_stops(dbos: DBOS) -> None:
     with pytest.raises(Exception, match="permanent"):
         permanent("v")
     assert runs == 1  # predicate rejected the error: no retries despite max_attempts=5
+
+
+def test_transaction_recorded_error_replays_without_retrying(dbos: DBOS) -> None:
+    """A recorded transaction error, replayed on recovery, must be re-raised
+    immediately — not fed back into the retry loop (which would sleep the whole
+    backoff again for an already-decided outcome)."""
+    runs = {"n": 0}
+
+    @DBOS.transaction(retries_allowed=True, max_attempts=2, interval_seconds=0.5)
+    def failing() -> None:
+        DBOS.sql_session.execute(sa.text("SELECT 1"))
+        runs["n"] += 1
+        raise ValueError("permanent")
+
+    @DBOS.workflow()
+    def wf() -> None:
+        return failing()
+
+    wfid = str(uuid.uuid4())
+    # First run: the transaction exhausts its retry budget and records the error
+    # (in transaction_outputs, the app DB, and operation_outputs, the system DB).
+    with SetWorkflowID(wfid):
+        with pytest.raises(ValueError, match="permanent"):
+            wf()
+    assert runs["n"] == 2  # one initial attempt plus one retry, then recorded
+
+    # Simulate the crash window: drop the system-DB workflow record. The CASCADE
+    # wipes operation_outputs, but transaction_outputs (app DB, no such FK) stays.
+    # On re-run the top-level replay check misses and the in-loop check finds the
+    # recorded error — the path that must not be retried.
+    with dbos._sys_db.engine.begin() as conn:
+        conn.execute(
+            sa.delete(SystemSchema.workflow_status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == wfid
+            )
+        )
+
+    start = time.time()
+    with SetWorkflowID(wfid):
+        with pytest.raises(ValueError, match="permanent"):
+            wf()
+    elapsed = time.time() - start
+    assert runs["n"] == 2, "the body is not re-run on replay of a recorded error"
+    assert elapsed < 0.3, (
+        f"replay of a recorded error must be immediate, not spin the retry "
+        f"backoff (took {elapsed:.2f}s)"
+    )


### PR DESCRIPTION
Python transactions retry serialization conflicts but not application errors — if the function raises, the error is recorded and re-raised on the first attempt. `@DBOS.step` already has `retries_allowed` / `max_attempts` / `interval_seconds` / `backoff_rate` / `should_retry`, and Go's `RunAsTransaction` takes the same step retry options ([documented](https://github.com/dbos-inc/dbos-transact-golang/blob/91f7bb0f085227bacc1855c7bf9da6269ecd7b29/dbos/datasource.go#L317), [tested](https://github.com/dbos-inc/dbos-transact-golang/blob/91f7bb0f085227bacc1855c7bf9da6269ecd7b29/dbos/datasource_test.go#L421-L454)). This adds that policy to Python transactions — both the classic `@DBOS.transaction` and `DataSource.transaction` (sync + async).

I'm raising this as a proposal, not a fix. Python may have left it out deliberately — a transaction is one ACID operation, and a user who wants app-level retries can already wrap it in a `@DBOS.step`. The default stays `retries_allowed=False`, so nothing changes unless a user opts in. 

```python
@DBOS.transaction(retries_allowed=True, max_attempts=3, interval_seconds=0.05)
def charge(amount: int) -> str:
    ...
    raise Exception("transient")   # retried on a fresh transaction
```

On an application error, if the budget allows and `should_retry` accepts it, the whole function re-runs on a fresh transaction (writes roll back between attempts) with exponential backoff; the error is recorded only once the budget is exhausted. Serialization conflicts are retried as before.

Tested on SQLite for both APIs: retries to success, default no-retry, budget exhaustion, `should_retry` stops early, and a recorded error replayed on recovery re-raises immediately without re-entering the retry loop.

