### PR TITLE
Make psycopg optional so DBOS runs on pg8000 (minimal)

### DIFF
--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, TypedDict
 
-import psycopg
+try:
+    import psycopg
+except ImportError:  # optional: psycopg only needed for the psycopg driver / LISTEN-NOTIFY
+    psycopg = None  # type: ignore[assignment]
 import sqlalchemy as sa
 from sqlalchemy import inspect, text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
 from dbos._migration import get_sqlite_timestamp_expr
+from dbos._pg_errors import is_serialization_error
 from dbos._serialization import Serializer
 
 from ._error import DBOSUnexpectedStepError, DBOSWorkflowConflictIDError
@@ -348,11 +352,7 @@ class PostgresApplicationDatabase(ApplicationDatabase):
         # 40001: serialization_failure (MVCC conflict)
         # 40P01: deadlock_detected
         driver_error = dbapi_error.orig
-        return (
-            driver_error is not None
-            and isinstance(driver_error, psycopg.OperationalError)
-            and driver_error.sqlstate in ("40001", "40P01")
-        )
+        return is_serialization_error(dbapi_error)
 
 
 class SQLiteApplicationDatabase(ApplicationDatabase):

--- a/dbos/_datasource_postgres.py
+++ b/dbos/_datasource_postgres.py
@@ -1,12 +1,16 @@
 from typing import Any, Dict
 
-import psycopg
+try:
+    import psycopg
+except ImportError:  # optional: psycopg only needed for the psycopg driver / LISTEN-NOTIFY
+    psycopg = None  # type: ignore[assignment]
 import sqlalchemy as sa
 from sqlalchemy import URL
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from dbos._datasource import AsyncSQLAlchemyDatasource, SQLAlchemyDatasource
+from dbos._pg_errors import is_serialization_error
 
 from ._logger import dbos_logger
 
@@ -19,12 +23,7 @@ def _is_postgres_serialization_error(error: Exception) -> bool:
     """
     if not isinstance(error, DBAPIError):
         return False
-    driver_error = error.orig
-    return (
-        driver_error is not None
-        and isinstance(driver_error, psycopg.OperationalError)
-        and driver_error.sqlstate in ("40001", "40P01")
-    )
+    return is_serialization_error(error)
 
 
 def _make_url(database_url: str) -> URL:

--- a/dbos/_docker_pg_helper.py
+++ b/dbos/_docker_pg_helper.py
@@ -4,7 +4,10 @@ import os
 import subprocess
 import time
 
-import psycopg
+try:
+    import psycopg
+except ImportError:  # optional: psycopg only needed for the psycopg driver / LISTEN-NOTIFY
+    psycopg = None  # type: ignore[assignment]
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 from typing import Any, Dict, Optional, Tuple

--- a/dbos/_pg_errors.py
+++ b/dbos/_pg_errors.py
@@ -1,0 +1,50 @@
+"""Driver-neutral PostgreSQL error classification (SQLSTATE-based).
+
+Lets DBOS's retry/serialization logic work with any PostgreSQL DBAPI driver
+(psycopg, pg8000, ...) without importing psycopg. pg8000 surfaces the Postgres
+error code in ``args[0]["C"]``; psycopg exposes ``.sqlstate`` — handle both.
+"""
+from __future__ import annotations
+from typing import Optional
+from sqlalchemy.exc import DBAPIError, OperationalError
+
+
+def get_sqlstate(orig: Optional[BaseException]) -> Optional[str]:
+    if orig is None:
+        return None
+    sqlstate = getattr(orig, "sqlstate", None)
+    if sqlstate:
+        return str(sqlstate)
+    args = getattr(orig, "args", ())
+    if args and isinstance(args[0], dict):
+        code = args[0].get("C")
+        if code:
+            return str(code)
+    return None
+
+
+def is_serialization_error(e: DBAPIError) -> bool:
+    return get_sqlstate(getattr(e, "orig", None)) in ("40001", "40P01")
+
+
+def is_serialization_or_lock_error(e: Exception) -> bool:
+    if not isinstance(e, (DBAPIError, OperationalError)):
+        return False
+    return get_sqlstate(getattr(e, "orig", None)) in ("40001", "40P01", "55P03")
+
+
+def retriable_postgres_exception(e: Exception) -> bool:
+    if not isinstance(e, DBAPIError):
+        return False
+    if e.connection_invalidated:
+        return True
+    orig = e.orig
+    if orig is None:
+        return False
+    msg = str(orig).lower()
+    if "connection failed" in msg or "server closed the connection unexpectedly" in msg:
+        return True
+    if "timeout" in msg and "connection" in msg:
+        return True
+    code = get_sqlstate(orig) or ""
+    return code.startswith(("53", "08", "57"))

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -8,12 +8,12 @@ QueueConflictResolution = Literal[
     "update_if_latest_version", "always_update", "never_update"
 ]
 
-from psycopg import errors
 from sqlalchemy.exc import OperationalError
 
 from dbos._context import DBOSContext, get_local_dbos_context
 from dbos._error import DBOSException
 from dbos._logger import dbos_logger
+from dbos._pg_errors import is_serialization_or_lock_error
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
 from ._core import P, R, execute_workflow_by_id, start_workflow, start_workflow_async
@@ -509,9 +509,7 @@ def queue_worker_thread(
                     except Exception as e:
                         dbos.logger.error(f"Error executing workflow {id}: {e}")
         except OperationalError as e:
-            if isinstance(
-                e.orig, (errors.SerializationFailure, errors.LockNotAvailable)
-            ):
+            if is_serialization_or_lock_error(e):
                 # If a serialization error is encountered, increase the polling interval
                 polling_interval = min(
                     max_polling_interval,

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -1,7 +1,10 @@
 import time
 from typing import Any, Dict, Optional, cast
 
-import psycopg
+try:
+    import psycopg
+except ImportError:  # optional: psycopg only needed for the psycopg driver / LISTEN-NOTIFY
+    psycopg = None  # type: ignore[assignment]
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import DBAPIError

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -6,8 +6,13 @@ import uuid
 from types import TracebackType
 from typing import Optional, Type
 
-import psycopg
+try:
+    import psycopg
+except ImportError:  # optional: psycopg only needed for the psycopg driver / LISTEN-NOTIFY
+    psycopg = None  # type: ignore[assignment]
 from sqlalchemy.exc import DBAPIError, ResourceClosedError
+
+from dbos._pg_errors import retriable_postgres_exception as _pg_retriable
 
 INTERNAL_QUEUE_NAME = "_dbos_internal_queue"
 
@@ -66,35 +71,9 @@ class GlobalParams:
 
 
 def retriable_postgres_exception(e: Exception) -> bool:
-    if not isinstance(e, DBAPIError):
-        return False
-    if e.connection_invalidated:
-        return True
-    if isinstance(e.orig, psycopg.OperationalError):
-        driver_error: psycopg.OperationalError = e.orig
-        pgcode = driver_error.sqlstate or ""
-        # Failure to establish connection
-        if "connection failed" in str(driver_error):
-            return True
-        # Error within database transaction
-        elif "server closed the connection unexpectedly" in str(driver_error):
-            return True
-        # Connection timeout
-        if isinstance(driver_error, psycopg.errors.ConnectionTimeout):
-            return True
-        # Insufficient resources
-        elif pgcode.startswith("53"):
-            return True
-        # Connection exception
-        elif pgcode.startswith("08"):
-            return True
-        # Operator intervention
-        elif pgcode.startswith("57"):
-            return True
-        else:
-            return False
-    else:
-        return False
+    # Driver-neutral (SQLSTATE-based) classification so retry logic works with
+    # any PostgreSQL DBAPI driver (psycopg, pg8000, ...).
+    return _pg_retriable(e)
 
 
 def retriable_sqlite_exception(e: Exception) -> bool:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "otel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:77e0ccbba299921d897952c2ff53942b8465c3c545964bdeed5c8698e09718e0"
+content_hash = "sha256:3ade70212c5e99347db8082b028795d6cce74e009752a2506bf4cad843d8fcc9"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1138,7 +1138,7 @@ name = "psycopg"
 version = "3.2.12"
 requires_python = ">=3.8"
 summary = "PostgreSQL database adapter for Python"
-groups = ["default"]
+groups = ["dev"]
 dependencies = [
     "backports-zoneinfo>=0.2.0; python_version < \"3.9\"",
     "typing-extensions>=4.6; python_version < \"3.13\"",
@@ -1154,7 +1154,7 @@ name = "psycopg-binary"
 version = "3.2.12"
 requires_python = ">=3.8"
 summary = "PostgreSQL database adapter for Python -- C optimisation distribution"
-groups = ["default"]
+groups = ["dev"]
 marker = "implementation_name != \"pypy\""
 files = [
     {file = "psycopg_binary-3.2.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:13cd057f406d2c8063ae8b489395b089a7f23c39aff223b5ea39f0c4dd640550"},
@@ -1275,7 +1275,7 @@ version = "3.2.12"
 extras = ["binary"]
 requires_python = ">=3.8"
 summary = "PostgreSQL database adapter for Python"
-groups = ["default"]
+groups = ["dev"]
 dependencies = [
     "psycopg-binary==3.2.12; implementation_name != \"pypy\"",
     "psycopg==3.2.12",
@@ -2005,7 +2005,7 @@ name = "tzdata"
 version = "2024.2"
 requires_python = ">=2"
 summary = "Provider of IANA time zone data"
-groups = ["default"]
+groups = ["dev"]
 marker = "sys_platform == \"win32\""
 files = [
     {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 dependencies = [
     "pyyaml>=6.0.2",
     "python-dateutil>=2.9.0.post0",
-    "psycopg[binary]>=3.1", # Keep compatibility with 3.1--older Python installations/machines can't always install 3.2
     "websockets>=14.0",
     "typer-slim>=0.17.4",
     "sqlalchemy[asyncio]>=2.0.43",
@@ -41,6 +40,12 @@ classifiers = [
 dbos = "dbos.cli.cli:app"
 
 [project.optional-dependencies]
+psycopg = [
+    "psycopg[binary]>=3.1",
+]
+pg8000 = [
+    "pg8000>=1.31",
+]
 otel = [
     "opentelemetry-api>=1.37.0",
     "opentelemetry-sdk>=1.37.0",
@@ -107,6 +112,7 @@ dev = [
     "uvicorn>=0.35.0",
     "fastapi>=0.121.0",
     "httpx>=0.28.1",
+    "psycopg[binary]>=3.1",
     "psycopg2-binary>=2.9.11",
     "sqlalchemy-cockroachdb>=2.0.3",
     "aiosqlite>=0.20.0",


### PR DESCRIPTION
DBOS already lets callers inject a prebuilt SQLAlchemy engine via the system_database_engine config, which bypasses DBOS's own psycopg-forcing engine creation, and use_listen_notify=False selects polling instead of the psycopg LISTEN/NOTIFY path. So supporting a non-psycopg (e.g. pg8000, BSD) driver only requires making psycopg absent-tolerant:

- pyproject: drop psycopg from core deps; add `psycopg` and `pg8000` extras.
- New dbos/_pg_errors.py: driver-neutral, SQLSTATE-based error classification (reads psycopg `.sqlstate` OR pg8000 `args[0]["C"]`) for serialization, lock, and retriable-connection errors.
- Guard every top-level `import psycopg` so `import dbos` works without it.
- Route the psycopg-specific error checks in _utils, _queue, _app_db and _datasource_postgres through the driver-neutral helpers.

Deliberately unchanged: engine creation, _migration.py, cli/migration.py, and the LISTEN/NOTIFY listener body (only its import is guarded) -- those are bypassed by engine injection + polling, so leaving them intact keeps upstream merges conflict-free.