### PR TITLE
Stream Optimizations

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -48,6 +48,7 @@ from dbos._serialization import (
     serialize_args,
 )
 from dbos._sys_db import (
+    STREAM_READ_BATCH_SIZE,
     ClientScheduleInput,
     SendMessage,
     StepInfo,
@@ -1191,30 +1192,33 @@ class DBOSClient:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                try:
-                    value = self._sys_db.read_stream(workflow_id, key, offset)
-                    if value == _dbos_stream_closed_sentinel:
-                        break
-                    yield value
-                    offset += 1
-                except ValueError:
-                    if final_read:
-                        break
-                    # No value yet: stop if the workflow is done, else wait for a
-                    # notification. Workflow completion fires none, so the wait
-                    # is bounded by the polling interval to notice termination.
-                    status = get_workflow(self._sys_db, workflow_id)
-                    if status is None:
-                        break
-                    if not workflow_is_active(status.status):
-                        # The workflow may have written between the read above and
-                        # this status check; all its writes are committed by now,
-                        # so read to the end of the stream before stopping.
-                        final_read = True
-                        continue
-                    event.wait(
-                        timeout=self._sys_db._notification_listener_polling_interval_sec
-                    )
+                # One round trip for both the next values and the workflow's status.
+                status, values = self._sys_db.read_stream_batch(
+                    workflow_id, key, offset, STREAM_READ_BATCH_SIZE
+                )
+                if status is None:
+                    break
+                if values:
+                    for value in values:
+                        if value == _dbos_stream_closed_sentinel:
+                            return
+                        yield value
+                        offset += 1
+                    # A full batch means more may be buffered; fetch again before waiting.
+                    continue
+                if final_read:
+                    break
+                # No value yet: stop if the workflow is done, else wait for a
+                # notification. Workflow completion fires none, so the wait
+                # is bounded by the polling interval to notice termination.
+                if not workflow_is_active(status):
+                    # Re-read once before stopping. The status shares this read's snapshot, so a
+                    # terminal status already implies the stream is drained; this only guards that.
+                    final_read = True
+                    continue
+                event.wait(
+                    timeout=self._sys_db._notification_listener_polling_interval_sec
+                )
         finally:
             self._sys_db.unregister_stream_listener(payload)
 
@@ -1241,40 +1245,43 @@ class DBOSClient:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                try:
-                    value = await asyncio.to_thread(
-                        self._sys_db.read_stream, workflow_id, key, offset
-                    )
-                    if value == _dbos_stream_closed_sentinel:
+                # One round trip for both the next values and the workflow's status.
+                status, values = await asyncio.to_thread(
+                    self._sys_db.read_stream_batch,
+                    workflow_id,
+                    key,
+                    offset,
+                    STREAM_READ_BATCH_SIZE,
+                )
+                if status is None:
+                    break
+                if values:
+                    for value in values:
+                        if value == _dbos_stream_closed_sentinel:
+                            return
+                        yield value
+                        offset += 1
+                    # A full batch means more may be buffered; fetch again before waiting.
+                    continue
+                if final_read:
+                    break
+                # No value yet: stop if the workflow is done, else wait for a
+                # notification. Poll the event with short asyncio sleeps (no
+                # held thread), bounded by the fallback re-check interval.
+                if not workflow_is_active(status):
+                    # Re-read once before stopping. The status shares this read's snapshot, so a
+                    # terminal status already implies the stream is drained; this only guards that.
+                    final_read = True
+                    continue
+                deadline = (
+                    time.time()
+                    + self._sys_db._notification_listener_polling_interval_sec
+                )
+                while not event.is_set():
+                    remaining = deadline - time.time()
+                    if remaining <= 0:
                         break
-                    yield value
-                    offset += 1
-                except ValueError:
-                    if final_read:
-                        break
-                    # No value yet: stop if the workflow is done, else wait for a
-                    # notification. Poll the event with short asyncio sleeps (no
-                    # held thread), bounded by the fallback re-check interval.
-                    status = await asyncio.to_thread(
-                        get_workflow, self._sys_db, workflow_id
-                    )
-                    if status is None:
-                        break
-                    if not workflow_is_active(status.status):
-                        # The workflow may have written between the read above and
-                        # this status check; all its writes are committed by now,
-                        # so read to the end of the stream before stopping.
-                        final_read = True
-                        continue
-                    deadline = (
-                        time.time()
-                        + self._sys_db._notification_listener_polling_interval_sec
-                    )
-                    while not event.is_set():
-                        remaining = deadline - time.time()
-                        if remaining <= 0:
-                            break
-                        await asyncio.sleep(min(remaining, 0.1))
+                    await asyncio.sleep(min(remaining, 0.1))
         finally:
             self._sys_db.unregister_stream_listener(payload)
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1209,8 +1209,7 @@ class DBOSClient:
                 # notification. Workflow completion fires none, so the wait
                 # is bounded by the polling interval to notice termination.
                 if not workflow_is_active(status):
-                    # Re-read once before stopping. The status shares this read's snapshot, so a
-                    # terminal status already implies the stream is drained; this only guards that.
+                    # Cancel and timeout set a terminal status out-of-band while the workflow is still writing, so drain to the first empty offset before stopping.
                     final_read = True
                     continue
                 event.wait(
@@ -1261,8 +1260,7 @@ class DBOSClient:
                 # notification. Poll the event with short asyncio sleeps (no
                 # held thread), bounded by the fallback re-check interval.
                 if not workflow_is_active(status):
-                    # Re-read once before stopping. The status shares this read's snapshot, so a
-                    # terminal status already implies the stream is drained; this only guards that.
+                    # Cancel and timeout set a terminal status out-of-band while the workflow is still writing, so drain to the first empty offset before stopping.
                     final_read = True
                     continue
                 deadline = (

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -48,7 +48,6 @@ from dbos._serialization import (
     serialize_args,
 )
 from dbos._sys_db import (
-    STREAM_READ_BATCH_SIZE,
     ClientScheduleInput,
     SendMessage,
     StepInfo,
@@ -59,6 +58,7 @@ from dbos._sys_db import (
     WorkflowStatusInternal,
     WorkflowStatusString,
     _dbos_stream_closed_sentinel,
+    _no_stream_value,
     workflow_is_active,
 )
 from dbos._workflow_commands import fork_workflow, get_workflow
@@ -1192,19 +1192,16 @@ class DBOSClient:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                # One round trip for both the next values and the workflow's status.
-                status, values = self._sys_db.read_stream_batch(
-                    workflow_id, key, offset, STREAM_READ_BATCH_SIZE
-                )
+                # One round trip for both the value and the workflow's status.
+                status, value = self._sys_db.read_stream_value(workflow_id, key, offset)
                 if status is None:
                     break
-                if values:
-                    for value in values:
-                        if value == _dbos_stream_closed_sentinel:
-                            return
-                        yield value
-                        offset += 1
-                    # A full batch means more may be buffered; fetch again before waiting.
+                if value is not _no_stream_value:
+                    if value == _dbos_stream_closed_sentinel:
+                        return
+                    yield value
+                    offset += 1
+                    # More may be buffered; read the next offset before waiting.
                     continue
                 if final_read:
                     break
@@ -1245,23 +1242,18 @@ class DBOSClient:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                # One round trip for both the next values and the workflow's status.
-                status, values = await asyncio.to_thread(
-                    self._sys_db.read_stream_batch,
-                    workflow_id,
-                    key,
-                    offset,
-                    STREAM_READ_BATCH_SIZE,
+                # One round trip for both the value and the workflow's status.
+                status, value = await asyncio.to_thread(
+                    self._sys_db.read_stream_value, workflow_id, key, offset
                 )
                 if status is None:
                     break
-                if values:
-                    for value in values:
-                        if value == _dbos_stream_closed_sentinel:
-                            return
-                        yield value
-                        offset += 1
-                    # A full batch means more may be buffered; fetch again before waiting.
+                if value is not _no_stream_value:
+                    if value == _dbos_stream_closed_sentinel:
+                        return
+                    yield value
+                    offset += 1
+                    # More may be buffered; read the next offset before waiting.
                     continue
                 if final_read:
                     break

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -176,7 +176,9 @@ T = TypeVar("T")
 # read_stream_async sub-polls its in-memory notification event tightly for the first window (low push latency), then relaxes for long-idle streams to save event-loop wakeups.
 _STREAM_EVENT_FAST_POLL_SEC = 0.01
 _STREAM_EVENT_FAST_POLL_WINDOW_SEC = 10.0
-_STREAM_EVENT_SLOW_POLL_SEC = 1.0
+# Must stay well under the fallback poll interval: at or above it, min(remaining, sub_poll) becomes one
+# sleep to the deadline and the notification event is never observed mid-wait.
+_STREAM_EVENT_SLOW_POLL_SEC = 0.1
 
 IsolationLevel = Literal[
     "SERIALIZABLE",

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -99,6 +99,7 @@ from ._scheduler import (
 )
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
+    DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
     GetEventWorkflowContext,
     SendMessage,
     StepInfo,
@@ -567,6 +568,12 @@ class DBOS:
                 )
                 or 1.0
             )
+            stream_notification_debounce_sec = (
+                self._config.get("runtimeConfig", {}).get(
+                    "stream_notification_debounce_sec"
+                )
+                or DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC
+            )
             self._sys_db_field = SystemDatabase.create(
                 system_database_url=get_system_database_url(self._config),
                 engine_kwargs=self._config["database"]["sys_db_engine_kwargs"],
@@ -576,6 +583,7 @@ class DBOS:
                 use_listen_notify=self._config["use_listen_notify"],
                 executor_id=GlobalParams.executor_id,
                 notification_listener_polling_interval_sec=self._notification_listener_polling_interval_sec,
+                stream_notification_debounce_sec=stream_notification_debounce_sec,
                 polling_concurrency=self._config["database"].get(
                     "sys_db_polling_concurrency"
                 ),
@@ -643,6 +651,16 @@ class DBOS:
             )
             notification_listener_thread.start()
             self._background_threads.append(notification_listener_thread)
+
+            # Push coalesced stream-write notifications off the write path.
+            # No-op unless the backend pushes notifications (Postgres + L/N).
+            dbos_logger.debug("Starting stream notifier thread")
+            stream_notifier_thread = threading.Thread(
+                target=self._sys_db.run_stream_notifier,
+                daemon=True,
+            )
+            stream_notifier_thread.start()
+            self._background_threads.append(stream_notifier_thread)
 
             # Create the internal queue if it has not yet been created
             self._registry.get_internal_queue()

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -100,6 +100,7 @@ from ._scheduler import (
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
     DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
+    STREAM_READ_BATCH_SIZE,
     GetEventWorkflowContext,
     SendMessage,
     StepInfo,
@@ -3272,33 +3273,31 @@ class DBOS:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                try:
-                    value = sys_db.read_stream(workflow_id, key, offset)
-                    if value == _dbos_stream_closed_sentinel:
-                        break
-                    yield value
-                    offset += 1
-                except ValueError:
-                    if final_read:
-                        break
-                    # No value yet: stop if the workflow is done, else wait for a
-                    # notification. Workflow completion fires none, so the wait
-                    # is bounded by the polling interval to notice termination.
-                    # One query, no input/output payloads (vs retrieve_workflow(...).get_status(), which queries twice).
-                    wf_status = get_workflow(
-                        sys_db, workflow_id, load_input=False, load_output=False
-                    )
-                    if wf_status is None:
-                        raise DBOSNonExistentWorkflowError("target", workflow_id)
-                    if not workflow_is_active(wf_status.status):
-                        # The workflow may have written between the read above and
-                        # this status check; all its writes are committed by now,
-                        # so read to the end of the stream before stopping.
-                        final_read = True
-                        continue
-                    event.wait(
-                        timeout=sys_db._notification_listener_polling_interval_sec
-                    )
+                # One round trip for both the next values and the workflow's status.
+                status, values = sys_db.read_stream_batch(
+                    workflow_id, key, offset, STREAM_READ_BATCH_SIZE
+                )
+                if status is None:
+                    raise DBOSNonExistentWorkflowError("target", workflow_id)
+                if values:
+                    for value in values:
+                        if value == _dbos_stream_closed_sentinel:
+                            return
+                        yield value
+                        offset += 1
+                    # A full batch means more may be buffered; fetch again before waiting.
+                    continue
+                if final_read:
+                    break
+                # No value yet: stop if the workflow is done, else wait for a
+                # notification. Workflow completion fires none, so the wait
+                # is bounded by the polling interval to notice termination.
+                if not workflow_is_active(status):
+                    # Re-read once before stopping. The status shares this read's snapshot, so a
+                    # terminal status already implies the stream is drained; this only guards that.
+                    final_read = True
+                    continue
+                event.wait(timeout=sys_db._notification_listener_polling_interval_sec)
         finally:
             sys_db.unregister_stream_listener(payload)
 
@@ -3387,52 +3386,50 @@ class DBOS:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                try:
-                    value = await asyncio.to_thread(
-                        sys_db.read_stream, workflow_id, key, offset
-                    )
-                    if value == _dbos_stream_closed_sentinel:
-                        break
-                    yield value
-                    offset += 1
+                # One round trip for both the next values and the workflow's status.
+                status, values = await asyncio.to_thread(
+                    sys_db.read_stream_batch,
+                    workflow_id,
+                    key,
+                    offset,
+                    STREAM_READ_BATCH_SIZE,
+                )
+                if status is None:
+                    raise DBOSNonExistentWorkflowError("target", workflow_id)
+                if values:
+                    for value in values:
+                        if value == _dbos_stream_closed_sentinel:
+                            return
+                        yield value
+                        offset += 1
                     wait_started_at = None
-                except ValueError:
-                    if final_read:
+                    # A full batch means more may be buffered; fetch again before waiting.
+                    continue
+                if final_read:
+                    break
+                # No value yet: stop if the workflow is done, else wait for a
+                # notification. Poll the event with short asyncio sleeps (no
+                # held thread), bounded by the fallback re-check interval.
+                if not workflow_is_active(status):
+                    # Re-read once before stopping. The status shares this read's snapshot, so a
+                    # terminal status already implies the stream is drained; this only guards that.
+                    final_read = True
+                    continue
+                if wait_started_at is None:
+                    wait_started_at = time.time()
+                deadline = time.time() + polling_interval
+                while not event.is_set():
+                    remaining = deadline - time.time()
+                    if remaining <= 0:
                         break
-                    # No value yet: stop if the workflow is done, else wait for a
-                    # notification. Poll the event with short asyncio sleeps (no
-                    # held thread), bounded by the fallback re-check interval.
-                    # One query, no input/output payloads (vs retrieve_workflow_async(...).get_status(), which queries twice).
-                    wf_status = await asyncio.to_thread(
-                        get_workflow,
-                        sys_db,
-                        workflow_id,
-                        load_input=False,
-                        load_output=False,
+                    # Sub-poll tightly while the value is fresh-awaited, then relax.
+                    sub_poll = (
+                        _STREAM_EVENT_FAST_POLL_SEC
+                        if time.time() - wait_started_at
+                        < _STREAM_EVENT_FAST_POLL_WINDOW_SEC
+                        else _STREAM_EVENT_SLOW_POLL_SEC
                     )
-                    if wf_status is None:
-                        raise DBOSNonExistentWorkflowError("target", workflow_id)
-                    if not workflow_is_active(wf_status.status):
-                        # The workflow may have written between the read above and
-                        # this status check; all its writes are committed by now,
-                        # so read to the end of the stream before stopping.
-                        final_read = True
-                        continue
-                    if wait_started_at is None:
-                        wait_started_at = time.time()
-                    deadline = time.time() + polling_interval
-                    while not event.is_set():
-                        remaining = deadline - time.time()
-                        if remaining <= 0:
-                            break
-                        # Sub-poll tightly while the value is fresh-awaited, then relax.
-                        sub_poll = (
-                            _STREAM_EVENT_FAST_POLL_SEC
-                            if time.time() - wait_started_at
-                            < _STREAM_EVENT_FAST_POLL_WINDOW_SEC
-                            else _STREAM_EVENT_SLOW_POLL_SEC
-                        )
-                        await asyncio.sleep(min(remaining, sub_poll))
+                    await asyncio.sleep(min(remaining, sub_poll))
         finally:
             sys_db.unregister_stream_listener(payload)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -100,7 +100,6 @@ from ._scheduler import (
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
     DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
-    STREAM_READ_BATCH_SIZE,
     GetEventWorkflowContext,
     SendMessage,
     StepInfo,
@@ -109,6 +108,7 @@ from ._sys_db import (
     WorkflowSchedule,
     WorkflowStatus,
     _dbos_stream_closed_sentinel,
+    _no_stream_value,
     workflow_is_active,
 )
 from ._tracer import DBOSTracer, dbos_tracer
@@ -3279,19 +3279,16 @@ class DBOS:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                # One round trip for both the next values and the workflow's status.
-                status, values = sys_db.read_stream_batch(
-                    workflow_id, key, offset, STREAM_READ_BATCH_SIZE
-                )
+                # One round trip for both the value and the workflow's status.
+                status, value = sys_db.read_stream_value(workflow_id, key, offset)
                 if status is None:
                     raise DBOSNonExistentWorkflowError("target", workflow_id)
-                if values:
-                    for value in values:
-                        if value == _dbos_stream_closed_sentinel:
-                            return
-                        yield value
-                        offset += 1
-                    # A full batch means more may be buffered; fetch again before waiting.
+                if value is not _no_stream_value:
+                    if value == _dbos_stream_closed_sentinel:
+                        return
+                    yield value
+                    offset += 1
+                    # More may be buffered; read the next offset before waiting.
                     continue
                 if final_read:
                     break
@@ -3392,24 +3389,19 @@ class DBOS:
                 # Clear before reading so a notification arriving after the read
                 # leaves the event set and the wait below returns immediately.
                 event.clear()
-                # One round trip for both the next values and the workflow's status.
-                status, values = await asyncio.to_thread(
-                    sys_db.read_stream_batch,
-                    workflow_id,
-                    key,
-                    offset,
-                    STREAM_READ_BATCH_SIZE,
+                # One round trip for both the value and the workflow's status.
+                status, value = await asyncio.to_thread(
+                    sys_db.read_stream_value, workflow_id, key, offset
                 )
                 if status is None:
                     raise DBOSNonExistentWorkflowError("target", workflow_id)
-                if values:
-                    for value in values:
-                        if value == _dbos_stream_closed_sentinel:
-                            return
-                        yield value
-                        offset += 1
+                if value is not _no_stream_value:
+                    if value == _dbos_stream_closed_sentinel:
+                        return
+                    yield value
+                    offset += 1
                     wait_started_at = None
-                    # A full batch means more may be buffered; fetch again before waiting.
+                    # More may be buffered; read the next offset before waiting.
                     continue
                 if final_read:
                     break

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -99,7 +99,7 @@ from ._scheduler import (
 )
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
-    DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
+    DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
     GetEventWorkflowContext,
     SendMessage,
     StepInfo,
@@ -568,11 +568,11 @@ class DBOS:
                 )
                 or 1.0
             )
-            stream_notification_debounce_sec = (
+            stream_notification_coalesce_sec = (
                 self._config.get("runtimeConfig", {}).get(
-                    "stream_notification_debounce_sec"
+                    "stream_notification_coalesce_sec"
                 )
-                or DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC
+                or DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC
             )
             self._sys_db_field = SystemDatabase.create(
                 system_database_url=get_system_database_url(self._config),
@@ -583,7 +583,7 @@ class DBOS:
                 use_listen_notify=self._config["use_listen_notify"],
                 executor_id=GlobalParams.executor_id,
                 notification_listener_polling_interval_sec=self._notification_listener_polling_interval_sec,
-                stream_notification_debounce_sec=stream_notification_debounce_sec,
+                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
                 polling_concurrency=self._config["database"].get(
                     "sys_db_polling_concurrency"
                 ),
@@ -652,8 +652,7 @@ class DBOS:
             notification_listener_thread.start()
             self._background_threads.append(notification_listener_thread)
 
-            # Push coalesced stream-write notifications off the write path.
-            # No-op unless the backend pushes notifications (Postgres + L/N).
+            # Push coalesced stream-write notifications off the write path (no-op unless Postgres + L/N).
             dbos_logger.debug("Starting stream notifier thread")
             stream_notifier_thread = threading.Thread(
                 target=self._sys_db.run_stream_notifier,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3284,8 +3284,13 @@ class DBOS:
                     # No value yet: stop if the workflow is done, else wait for a
                     # notification. Workflow completion fires none, so the wait
                     # is bounded by the polling interval to notice termination.
-                    status = cls.retrieve_workflow(workflow_id).get_status().status
-                    if not workflow_is_active(status):
+                    # One query, no input/output payloads (vs retrieve_workflow(...).get_status(), which queries twice).
+                    wf_status = get_workflow(
+                        sys_db, workflow_id, load_input=False, load_output=False
+                    )
+                    if wf_status is None:
+                        raise DBOSNonExistentWorkflowError("target", workflow_id)
+                    if not workflow_is_active(wf_status.status):
                         # The workflow may have written between the read above and
                         # this status check; all its writes are committed by now,
                         # so read to the end of the stream before stopping.
@@ -3397,11 +3402,17 @@ class DBOS:
                     # No value yet: stop if the workflow is done, else wait for a
                     # notification. Poll the event with short asyncio sleeps (no
                     # held thread), bounded by the fallback re-check interval.
-                    handle: WorkflowHandleAsync[Any] = (
-                        await cls.retrieve_workflow_async(workflow_id)
+                    # One query, no input/output payloads (vs retrieve_workflow_async(...).get_status(), which queries twice).
+                    wf_status = await asyncio.to_thread(
+                        get_workflow,
+                        sys_db,
+                        workflow_id,
+                        load_input=False,
+                        load_output=False,
                     )
-                    status = await handle.get_status()
-                    if not workflow_is_active(status.status):
+                    if wf_status is None:
+                        raise DBOSNonExistentWorkflowError("target", workflow_id)
+                    if not workflow_is_active(wf_status.status):
                         # The workflow may have written between the read above and
                         # this status check; all its writes are committed by now,
                         # so read to the end of the stream before stopping.

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -172,6 +172,11 @@ R = TypeVar("R", covariant=True)  # A generic type for workflow return values
 
 T = TypeVar("T")
 
+# read_stream_async sub-polls its in-memory notification event tightly for the first window (low push latency), then relaxes for long-idle streams to save event-loop wakeups.
+_STREAM_EVENT_FAST_POLL_SEC = 0.01
+_STREAM_EVENT_FAST_POLL_WINDOW_SEC = 10.0
+_STREAM_EVENT_SLOW_POLL_SEC = 1.0
+
 IsolationLevel = Literal[
     "SERIALIZABLE",
     "REPEATABLE READ",
@@ -3370,6 +3375,8 @@ class DBOS:
 
         event, payload = sys_db.register_stream_listener(workflow_id, key)
         final_read = False
+        # When the current value's wait began, or None once a value is delivered; drives the adaptive event sub-poll below.
+        wait_started_at: Optional[float] = None
         try:
             while True:
                 # Clear before reading so a notification arriving after the read
@@ -3383,6 +3390,7 @@ class DBOS:
                         break
                     yield value
                     offset += 1
+                    wait_started_at = None
                 except ValueError:
                     if final_read:
                         break
@@ -3399,12 +3407,21 @@ class DBOS:
                         # so read to the end of the stream before stopping.
                         final_read = True
                         continue
+                    if wait_started_at is None:
+                        wait_started_at = time.time()
                     deadline = time.time() + polling_interval
                     while not event.is_set():
                         remaining = deadline - time.time()
                         if remaining <= 0:
                             break
-                        await asyncio.sleep(min(remaining, 0.1))
+                        # Sub-poll tightly while the value is fresh-awaited, then relax.
+                        sub_poll = (
+                            _STREAM_EVENT_FAST_POLL_SEC
+                            if time.time() - wait_started_at
+                            < _STREAM_EVENT_FAST_POLL_WINDOW_SEC
+                            else _STREAM_EVENT_SLOW_POLL_SEC
+                        )
+                        await asyncio.sleep(min(remaining, sub_poll))
         finally:
             sys_db.unregister_stream_listener(payload)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -622,7 +622,7 @@ class DBOS:
                     f"Latest version is '{latest['version_name']}'."
                 )
 
-            # Kafka consumers name their queue, so it is only resolvable now that every queue is registered; check before starting any thread, so a rejected consumer fails launch with nothing to unwind.
+            # Kafka consumers name their queue, so it is only resolvable now that every queue is registered; check here so a rejected consumer fails launch before any consumer or queue thread starts.
             if self._registry.kafka_registrations:
                 from ._kafka import validate_kafka_consumers
 
@@ -3298,8 +3298,7 @@ class DBOS:
                 # notification. Workflow completion fires none, so the wait
                 # is bounded by the polling interval to notice termination.
                 if not workflow_is_active(status):
-                    # Re-read once before stopping. The status shares this read's snapshot, so a
-                    # terminal status already implies the stream is drained; this only guards that.
+                    # Cancel and timeout set a terminal status out-of-band while the workflow is still writing, so drain to the first empty offset before stopping.
                     final_read = True
                     continue
                 event.wait(timeout=sys_db._notification_listener_polling_interval_sec)
@@ -3411,8 +3410,7 @@ class DBOS:
                 # notification. Poll the event with short asyncio sleeps (no
                 # held thread), bounded by the fallback re-check interval.
                 if not workflow_is_active(status):
-                    # Re-read once before stopping. The status shares this read's snapshot, so a
-                    # terminal status already implies the stream is drained; this only guards that.
+                    # Cancel and timeout set a terminal status out-of-band while the workflow is still writing, so drain to the first empty offset before stopping.
                     final_read = True
                     continue
                 if wait_started_at is None:

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -47,7 +47,7 @@ class DBOSConfig(TypedDict, total=False):
         serializer (Serializer): A custom serializer and deserializer DBOS uses when storing program data in the system database
         use_listen_notify (bool): Whether to use LISTEN/NOTIFY or polling to listen for notifications and events.  Defaults to True. As this affects migrations, may not be changed after the system database is first created.
         notification_listener_polling_interval_sec (float): Polling interval in seconds for the notification listener background process. Defaults to 1.0. Minimum value is 0.001. Lower values can speed up test execution.
-        stream_notification_debounce_sec (float): Debounce interval in seconds for coalescing stream-write notifications pushed via LISTEN/NOTIFY. Defaults to 0.01. Bounds stream read latency and caps the rate of notifying commits independent of write throughput. Minimum value is 0.001.
+        stream_notification_coalesce_sec (float): Interval in seconds for coalescing stream-write notifications pushed via LISTEN/NOTIFY. Bounds stream read latency and caps the rate of notifying commits independent of write throughput. Defaults to 0.01. Minimum value is 0.001.
         scheduler_polling_interval_sec (float): Polling interval in seconds for the scheduler thread to detect new workflow schedules. Defaults to 30.0.
         otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
             "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward
@@ -84,7 +84,7 @@ class DBOSConfig(TypedDict, total=False):
     use_listen_notify: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
-    stream_notification_debounce_sec: Optional[float]
+    stream_notification_coalesce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
     otel_attribute_format: Optional[Literal["legacy", "semconv"]]
 
@@ -96,7 +96,7 @@ class RuntimeConfig(TypedDict, total=False):
     run_admin_server: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
-    stream_notification_debounce_sec: Optional[float]
+    stream_notification_coalesce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
 
 
@@ -199,15 +199,15 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         translated_config["runtimeConfig"][
             "notification_listener_polling_interval_sec"
         ] = interval
-    if "stream_notification_debounce_sec" in config:
-        debounce = config["stream_notification_debounce_sec"]
-        if debounce is not None and debounce < 0.001:
+    if "stream_notification_coalesce_sec" in config:
+        coalesce = config["stream_notification_coalesce_sec"]
+        if coalesce is not None and coalesce < 0.001:
             raise DBOSInitializationError(
-                f"stream_notification_debounce_sec must be at least 0.001 seconds, got {debounce}"
+                f"stream_notification_coalesce_sec must be at least 0.001 seconds, got {coalesce}"
             )
         translated_config["runtimeConfig"][
-            "stream_notification_debounce_sec"
-        ] = debounce
+            "stream_notification_coalesce_sec"
+        ] = coalesce
     if "scheduler_polling_interval_sec" in config:
         translated_config["runtimeConfig"]["scheduler_polling_interval_sec"] = config[
             "scheduler_polling_interval_sec"

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 from importlib import resources
@@ -201,9 +202,10 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         ] = interval
     if "stream_notification_coalesce_sec" in config:
         coalesce = config["stream_notification_coalesce_sec"]
-        if coalesce is not None and coalesce < 0.001:
+        # Reject NaN/inf too (they slip past a bare < 0.001) so run_stream_notifier's time.sleep can't crash.
+        if coalesce is not None and (not math.isfinite(coalesce) or coalesce < 0.001):
             raise DBOSInitializationError(
-                f"stream_notification_coalesce_sec must be at least 0.001 seconds, got {coalesce}"
+                f"stream_notification_coalesce_sec must be a finite number at least 0.001 seconds, got {coalesce}"
             )
         translated_config["runtimeConfig"][
             "stream_notification_coalesce_sec"

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -193,9 +193,10 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         ]
     if "notification_listener_polling_interval_sec" in config:
         interval = config["notification_listener_polling_interval_sec"]
-        if interval is not None and interval < 0.001:
+        # Reject NaN/inf too (they slip past a bare < 0.001) so the listener's time.sleep can't crash.
+        if interval is not None and (not math.isfinite(interval) or interval < 0.001):
             raise DBOSInitializationError(
-                f"notification_listener_polling_interval_sec must be at least 0.001 seconds, got {interval}"
+                f"notification_listener_polling_interval_sec must be a finite number at least 0.001 seconds, got {interval}"
             )
         translated_config["runtimeConfig"][
             "notification_listener_polling_interval_sec"

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -47,6 +47,7 @@ class DBOSConfig(TypedDict, total=False):
         serializer (Serializer): A custom serializer and deserializer DBOS uses when storing program data in the system database
         use_listen_notify (bool): Whether to use LISTEN/NOTIFY or polling to listen for notifications and events.  Defaults to True. As this affects migrations, may not be changed after the system database is first created.
         notification_listener_polling_interval_sec (float): Polling interval in seconds for the notification listener background process. Defaults to 1.0. Minimum value is 0.001. Lower values can speed up test execution.
+        stream_notification_debounce_sec (float): Debounce interval in seconds for coalescing stream-write notifications pushed via LISTEN/NOTIFY. Defaults to 0.01. Bounds stream read latency and caps the rate of notifying commits independent of write throughput. Minimum value is 0.001.
         scheduler_polling_interval_sec (float): Polling interval in seconds for the scheduler thread to detect new workflow schedules. Defaults to 30.0.
         otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
             "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward
@@ -83,6 +84,7 @@ class DBOSConfig(TypedDict, total=False):
     use_listen_notify: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
+    stream_notification_debounce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
     otel_attribute_format: Optional[Literal["legacy", "semconv"]]
 
@@ -94,6 +96,7 @@ class RuntimeConfig(TypedDict, total=False):
     run_admin_server: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
+    stream_notification_debounce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
 
 
@@ -196,6 +199,15 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         translated_config["runtimeConfig"][
             "notification_listener_polling_interval_sec"
         ] = interval
+    if "stream_notification_debounce_sec" in config:
+        debounce = config["stream_notification_debounce_sec"]
+        if debounce is not None and debounce < 0.001:
+            raise DBOSInitializationError(
+                f"stream_notification_debounce_sec must be at least 0.001 seconds, got {debounce}"
+            )
+        translated_config["runtimeConfig"][
+            "stream_notification_debounce_sec"
+        ] = debounce
     if "scheduler_polling_interval_sec" in config:
         translated_config["runtimeConfig"]["scheduler_polling_interval_sec"] = config[
             "scheduler_polling_interval_sec"

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -883,11 +883,7 @@ ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced"
 
 
 def get_dbos_migration_fortythree(schema: str, use_listen_notify: bool) -> str:
-    # The per-row streams NOTIFY trigger (migration 39) fired pg_notify inside
-    # every stream write's commit, serializing high-throughput writers on the
-    # async-notify queue lock. Notifications are now coalesced and pushed from
-    # the application layer (run_stream_notifier), so drop the trigger. Gated on
-    # use_listen_notify to match migration 39: the trigger only exists there.
+    # Drop the per-row streams NOTIFY trigger (migration 39): notifications are now coalesced and pushed by run_stream_notifier off the write path. Gated to match migration 39.
     if not use_listen_notify:
         return ""
     return f"""

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -882,6 +882,20 @@ ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced"
 """
 
 
+def get_dbos_migration_fortythree(schema: str, use_listen_notify: bool) -> str:
+    # The per-row streams NOTIFY trigger (migration 39) fired pg_notify inside
+    # every stream write's commit, serializing high-throughput writers on the
+    # async-notify queue lock. Notifications are now coalesced and pushed from
+    # the application layer (run_stream_notifier), so drop the trigger. Gated on
+    # use_listen_notify to match migration 39: the trigger only exists there.
+    if not use_listen_notify:
+        return ""
+    return f"""
+DROP TRIGGER IF EXISTS dbos_streams_trigger ON "{schema}".streams;
+DROP FUNCTION IF EXISTS "{schema}".streams_function();
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -928,6 +942,7 @@ def get_dbos_migrations(
         get_dbos_migration_forty(schema),
         get_dbos_migration_fortyone(schema),
         get_dbos_migration_fortytwo(schema),
+        get_dbos_migration_fortythree(schema, use_listen_notify),
     ]
 
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -507,10 +507,8 @@ def db_retry(
 # Fallback pool size for defaulting polling concurrency when the engine's is unknown (mirrors configure_db_engine_parameters).
 DEFAULT_SYS_DB_POOL_SIZE = 20
 
-# Debounce interval for coalescing stream-write notifications off the write path.
-# Bounds worst-case read latency; also caps the rate of notifying commits (which
-# serialize on Postgres's async-notify queue lock) independent of write throughput.
-DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC = 0.01
+# Interval for coalescing stream-write notifications off the write path; caps the rate of notifying commits regardless of write throughput.
+DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC = 0.01
 
 
 class SystemDatabase(ABC):
@@ -525,7 +523,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
-        stream_notification_debounce_sec: float = DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
+        stream_notification_coalesce_sec: float = DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
@@ -541,7 +539,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
-                stream_notification_debounce_sec=stream_notification_debounce_sec,
+                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
             )
         else:
@@ -556,7 +554,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
-                stream_notification_debounce_sec=stream_notification_debounce_sec,
+                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
             )
 
@@ -571,7 +569,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
-        stream_notification_debounce_sec: float = DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
+        stream_notification_coalesce_sec: float = DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
     ):
         import sqlalchemy.dialects.postgresql as pg
@@ -637,10 +635,9 @@ class SystemDatabase(ABC):
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
         )
-        self._stream_notification_debounce_sec = stream_notification_debounce_sec
+        self._stream_notification_coalesce_sec = stream_notification_coalesce_sec
 
-        # Stream-write notifications, coalesced by (workflow_uuid, key) and
-        # flushed off the write path by run_stream_notifier (Postgres + L/N only).
+        # Coalesced stream-write notification payloads, flushed off the write path by run_stream_notifier (Postgres + L/N only).
         self._pending_stream_notifications: Set[str] = set()
         self._stream_notifier_lock = threading.Lock()
 
@@ -3109,14 +3106,11 @@ class SystemDatabase(ABC):
         self._notification_listener()
 
     def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
-        """Hint that a stream row was written to (workflow_uuid, key). Backends
-        that push notifications override this to coalesce a wakeup; polling
-        backends ignore it (readers re-read at their offset on the next poll)."""
+        """Hint that (workflow_uuid, key) was written; push-notification backends override to coalesce a wakeup, pollers ignore it."""
         pass
 
     def run_stream_notifier(self) -> None:
-        """Background loop that flushes coalesced stream-write notifications.
-        No-op except on backends that push notifications (Postgres + L/N)."""
+        """Background loop flushing coalesced stream-write notifications; no-op except on push-notification backends (Postgres + L/N)."""
         pass
 
     def recv(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4501,30 +4501,6 @@ class SystemDatabase(ABC):
         self.streams_map.pop(payload)
 
     @db_retry()
-    def read_stream(self, workflow_uuid: str, key: str, offset: int) -> Any:
-        """Read the value at the specified offset for the given workflow_uuid and key."""
-
-        # Polling read (listener-less clients poll the offset) under the limiter; inside db_retry so the permit frees across backoff.
-        with self.poll_limiter, self.engine.begin() as c:
-            result = c.execute(
-                sa.select(
-                    SystemSchema.streams.c.value, SystemSchema.streams.c.serialization
-                ).where(
-                    SystemSchema.streams.c.workflow_uuid == workflow_uuid,
-                    SystemSchema.streams.c.key == key,
-                    SystemSchema.streams.c.offset == offset,
-                )
-            ).fetchone()
-
-            if result is None:
-                raise ValueError(
-                    f"No value found for workflow_uuid={workflow_uuid}, key={key}, offset={offset}"
-                )
-
-            # Deserialize the value before returning
-            return deserialize_value(result[0], result[1], self.serializer)
-
-    @db_retry()
     def read_stream_batch(
         self, workflow_uuid: str, key: str, offset: int, limit: int
     ) -> Tuple[Optional[str], List[Any]]:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -507,6 +507,11 @@ def db_retry(
 # Fallback pool size for defaulting polling concurrency when the engine's is unknown (mirrors configure_db_engine_parameters).
 DEFAULT_SYS_DB_POOL_SIZE = 20
 
+# Debounce interval for coalescing stream-write notifications off the write path.
+# Bounds worst-case read latency; also caps the rate of notifying commits (which
+# serialize on Postgres's async-notify queue lock) independent of write throughput.
+DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC = 0.01
+
 
 class SystemDatabase(ABC):
 
@@ -520,6 +525,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
+        stream_notification_debounce_sec: float = DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
         polling_concurrency: Optional[int] = None,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
@@ -535,6 +541,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
+                stream_notification_debounce_sec=stream_notification_debounce_sec,
                 polling_concurrency=polling_concurrency,
             )
         else:
@@ -549,6 +556,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
+                stream_notification_debounce_sec=stream_notification_debounce_sec,
                 polling_concurrency=polling_concurrency,
             )
 
@@ -563,6 +571,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
+        stream_notification_debounce_sec: float = DEFAULT_STREAM_NOTIFICATION_DEBOUNCE_SEC,
         polling_concurrency: Optional[int] = None,
     ):
         import sqlalchemy.dialects.postgresql as pg
@@ -628,6 +637,12 @@ class SystemDatabase(ABC):
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
         )
+        self._stream_notification_debounce_sec = stream_notification_debounce_sec
+
+        # Stream-write notifications, coalesced by (workflow_uuid, key) and
+        # flushed off the write path by run_stream_notifier (Postgres + L/N only).
+        self._pending_stream_notifications: Set[str] = set()
+        self._stream_notifier_lock = threading.Lock()
 
         self._listener_thread_lock = threading.Lock()
         self._listener_running = False
@@ -3093,6 +3108,17 @@ class SystemDatabase(ABC):
         self._listener_running = True
         self._notification_listener()
 
+    def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
+        """Hint that a stream row was written to (workflow_uuid, key). Backends
+        that push notifications override this to coalesce a wakeup; polling
+        backends ignore it (readers re-read at their offset on the next poll)."""
+        pass
+
+    def run_stream_notifier(self) -> None:
+        """Background loop that flushes coalesced stream-write notifications.
+        No-op except on backends that push notifications (Postgres + L/N)."""
+        pass
+
     def recv(
         self,
         workflow_uuid: str,
@@ -4371,6 +4397,7 @@ class SystemDatabase(ABC):
             try:
                 with self.engine.begin() as c:
                     c.execute(stmt)
+                self._signal_stream_write(workflow_uuid, key)
                 return
             except sa.exc.IntegrityError:
                 dbos_logger.warning(
@@ -4444,6 +4471,7 @@ class SystemDatabase(ABC):
                 self._record_operation_result_txn(
                     output, int(time.time() * 1000), conn=c
                 )
+            self._signal_stream_write(workflow_uuid, key)
             return
 
     def close_stream(self, workflow_uuid: str, function_id: int, key: str) -> None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -510,6 +510,9 @@ DEFAULT_SYS_DB_POOL_SIZE = 20
 # Interval for coalescing stream-write notifications off the write path; caps the rate of notifying commits regardless of write throughput.
 DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC = 0.01
 
+# Values a stream reader fetches per round trip; amortizes the trip over a backlog while bounding how much it buffers at once.
+STREAM_READ_BATCH_SIZE = 100
+
 
 class SystemDatabase(ABC):
 
@@ -4520,6 +4523,53 @@ class SystemDatabase(ABC):
 
             # Deserialize the value before returning
             return deserialize_value(result[0], result[1], self.serializer)
+
+    @db_retry()
+    def read_stream_batch(
+        self, workflow_uuid: str, key: str, offset: int, limit: int
+    ) -> Tuple[Optional[str], List[Any]]:
+        """Read a stream reader's next values and the owning workflow's status in one round trip.
+
+        Returns (status, values), where status is None if the workflow does not exist and values
+        holds up to `limit` consecutive values starting at `offset` (empty if none are buffered).
+        Both come from one statement, so they share a snapshot: a terminal status is never
+        observed alongside a stale view of the stream.
+        """
+        # LEFT JOIN so a workflow with nothing buffered at offset still reports its status.
+        join = SystemSchema.workflow_status.outerjoin(
+            SystemSchema.streams,
+            sa.and_(
+                SystemSchema.streams.c.workflow_uuid
+                == SystemSchema.workflow_status.c.workflow_uuid,
+                SystemSchema.streams.c.key == key,
+                SystemSchema.streams.c.offset >= offset,
+            ),
+        )
+        # Polling read (listener-less clients poll the offset) under the limiter; inside db_retry so the permit frees across backoff.
+        with self.poll_limiter, self.engine.begin() as c:
+            rows = c.execute(
+                sa.select(
+                    SystemSchema.workflow_status.c.status,
+                    SystemSchema.streams.c.value,
+                    SystemSchema.streams.c.serialization,
+                    SystemSchema.streams.c.offset,
+                )
+                .select_from(join)
+                .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
+                .order_by(SystemSchema.streams.c.offset)
+                .limit(limit)
+            ).fetchall()
+
+        if not rows:
+            return None, []
+        values: List[Any] = []
+        # Stop at the first gap so this reports exactly what a per-offset read would: writers commit
+        # offsets contiguously, but reading across a hole would silently yield a later value as an earlier one.
+        for expected, row in enumerate(rows, start=offset):
+            if row[3] != expected:
+                break
+            values.append(deserialize_value(row[1], row[2], self.serializer))
+        return rows[0][0], values
 
     def garbage_collect(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4508,7 +4508,9 @@ class SystemDatabase(ABC):
 
         Returns (status, value). status is None if the workflow does not exist; value is
         _no_stream_value if nothing is written at offset. Both come from one statement, so they
-        share a snapshot: a terminal status is never observed alongside a stale view of the stream.
+        share a snapshot. A terminal status does not imply the stream is complete: cancel and
+        timeout set it out-of-band while the workflow is still running, so a caller that stops
+        reading must first drain to the first empty offset.
         """
         # LEFT JOIN so a workflow with nothing at offset still reports its status. Matching offset
         # exactly keeps this a single index lookup on the (workflow_uuid, key, offset) primary key.

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -387,6 +387,9 @@ class NotificationInfo(TypedDict):
 _dbos_null_topic = "__null__topic__"
 _dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
 
+# Returned by read_stream_value when nothing is written at the requested offset. Not None, which is itself a valid stream value.
+_no_stream_value = object()
+
 
 @dataclass
 class SendMessage:
@@ -509,9 +512,6 @@ DEFAULT_SYS_DB_POOL_SIZE = 20
 
 # Interval for coalescing stream-write notifications off the write path; caps the rate of notifying commits regardless of write throughput.
 DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC = 0.01
-
-# Values a stream reader fetches per round trip; amortizes the trip over a backlog while bounding how much it buffers at once.
-STREAM_READ_BATCH_SIZE = 100
 
 
 class SystemDatabase(ABC):
@@ -4501,29 +4501,29 @@ class SystemDatabase(ABC):
         self.streams_map.pop(payload)
 
     @db_retry()
-    def read_stream_batch(
-        self, workflow_uuid: str, key: str, offset: int, limit: int
-    ) -> Tuple[Optional[str], List[Any]]:
-        """Read a stream reader's next values and the owning workflow's status in one round trip.
+    def read_stream_value(
+        self, workflow_uuid: str, key: str, offset: int
+    ) -> Tuple[Optional[str], Any]:
+        """Read the stream value at offset and the owning workflow's status in one round trip.
 
-        Returns (status, values), where status is None if the workflow does not exist and values
-        holds up to `limit` consecutive values starting at `offset` (empty if none are buffered).
-        Both come from one statement, so they share a snapshot: a terminal status is never
-        observed alongside a stale view of the stream.
+        Returns (status, value). status is None if the workflow does not exist; value is
+        _no_stream_value if nothing is written at offset. Both come from one statement, so they
+        share a snapshot: a terminal status is never observed alongside a stale view of the stream.
         """
-        # LEFT JOIN so a workflow with nothing buffered at offset still reports its status.
+        # LEFT JOIN so a workflow with nothing at offset still reports its status. Matching offset
+        # exactly keeps this a single index lookup on the (workflow_uuid, key, offset) primary key.
         join = SystemSchema.workflow_status.outerjoin(
             SystemSchema.streams,
             sa.and_(
                 SystemSchema.streams.c.workflow_uuid
                 == SystemSchema.workflow_status.c.workflow_uuid,
                 SystemSchema.streams.c.key == key,
-                SystemSchema.streams.c.offset >= offset,
+                SystemSchema.streams.c.offset == offset,
             ),
         )
         # Polling read (listener-less clients poll the offset) under the limiter; inside db_retry so the permit frees across backoff.
         with self.poll_limiter, self.engine.begin() as c:
-            rows = c.execute(
+            row = c.execute(
                 sa.select(
                     SystemSchema.workflow_status.c.status,
                     SystemSchema.streams.c.value,
@@ -4532,20 +4532,14 @@ class SystemDatabase(ABC):
                 )
                 .select_from(join)
                 .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
-                .order_by(SystemSchema.streams.c.offset)
-                .limit(limit)
-            ).fetchall()
+            ).fetchone()
 
-        if not rows:
-            return None, []
-        values: List[Any] = []
-        # Stop at the first gap so this reports exactly what a per-offset read would: writers commit
-        # offsets contiguously, but reading across a hole would silently yield a later value as an earlier one.
-        for expected, row in enumerate(rows, start=offset):
-            if row[3] != expected:
-                break
-            values.append(deserialize_value(row[1], row[2], self.serializer))
-        return rows[0][0], values
+        if row is None:
+            return None, _no_stream_value
+        # streams.offset is non-nullable, so a NULL here means the join matched nothing at offset.
+        if row[3] is None:
+            return row[0], _no_stream_value
+        return row[0], deserialize_value(row[1], row[2], self.serializer)
 
     def garbage_collect(
         self,

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -232,7 +232,7 @@ class PostgresSystemDatabase(SystemDatabase):
         self._flush_stream_notifications()
 
     def _flush_stream_notifications(self) -> None:
-        """Emit one coalesced notifying transaction for all pending payloads."""
+        """Emit one coalesced notifying transaction for all pending payloads; drop the batch if it fails."""
         with self._stream_notifier_lock:
             if not self._pending_stream_notifications:
                 return
@@ -247,8 +247,6 @@ class PostgresSystemDatabase(SystemDatabase):
                         {"payload": payload},
                     )
         except Exception as e:
-            # Requeue on failure so the wakeup retries next interval; a duplicate notify is harmless.
-            with self._stream_notifier_lock:
-                self._pending_stream_notifications |= batch
+            # Drop the batch (do not requeue) on failure, e.g. a payload over pg_notify's 8000-byte limit; readers' polling fallback delivers these values, so one poison payload can't stall the notifier forever.
             if self._run_background_processes:
                 dbos_logger.warning(f"Stream notifier flush error: {e}")

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -212,3 +212,60 @@ class PostgresSystemDatabase(SystemDatabase):
                     # Then the loop will try to reconnect and restart the listener
             finally:
                 self._cleanup_connections()
+
+    def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
+        """Coalesce a wakeup for readers of (workflow_uuid, key).
+
+        The stream write itself no longer fires pg_notify (the per-row trigger
+        was dropped); instead we accumulate the payload and let
+        run_stream_notifier push it off the write path. Without L/N, readers
+        poll, so there is nothing to push.
+        """
+        if not self.use_listen_notify:
+            return
+        payload = f"{workflow_uuid}::{key}"
+        with self._stream_notifier_lock:
+            self._pending_stream_notifications.add(payload)
+
+    def run_stream_notifier(self) -> None:
+        """Flush coalesced stream-write notifications on a short debounce.
+
+        Firing pg_notify from a dedicated loop rather than inside each write's
+        commit keeps the async-notify queue lock (which serializes every
+        notifying commit) off the hot write path: its acquisition rate is
+        bounded by the debounce interval, not the stream write rate. Read
+        latency is bounded by the debounce interval.
+        """
+        if not self.use_listen_notify:
+            return
+        while self._run_background_processes:
+            time.sleep(self._stream_notification_debounce_sec)
+            self._flush_stream_notifications()
+        # Best-effort final flush so values written just before shutdown still
+        # wake readers promptly rather than waiting out their fallback interval.
+        self._flush_stream_notifications()
+
+    def _flush_stream_notifications(self) -> None:
+        """Emit one coalesced notifying transaction for all pending payloads."""
+        with self._stream_notifier_lock:
+            if not self._pending_stream_notifications:
+                return
+            batch = self._pending_stream_notifications
+            self._pending_stream_notifications = set()
+        try:
+            # One transaction, one commit: every payload's notification is
+            # appended under a single acquisition of the async-notify queue
+            # lock, no matter how many distinct streams changed this interval.
+            with self.engine.begin() as c:
+                for payload in batch:
+                    c.execute(
+                        sa.text("SELECT pg_notify('dbos_streams_channel', :payload)"),
+                        {"payload": payload},
+                    )
+        except Exception as e:
+            # Requeue on failure so the wakeup is retried next interval rather
+            # than lost; a duplicate notify is harmless (readers re-read anyway).
+            with self._stream_notifier_lock:
+                self._pending_stream_notifications |= batch
+            if self._run_background_processes:
+                dbos_logger.warning(f"Stream notifier flush error: {e}")

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -249,13 +249,14 @@ class PostgresSystemDatabase(SystemDatabase):
             batch = self._pending_stream_notifications
             self._pending_stream_notifications = set()
         try:
-            # One transaction: all payloads share a single acquisition of the async-notify queue lock.
+            # One statement, one transaction: one round trip and one acquisition of the async-notify queue lock; unnest emits one notification per payload.
             with self.engine.begin() as c:
-                for payload in batch:
-                    c.execute(
-                        sa.text("SELECT pg_notify('dbos_streams_channel', :payload)"),
-                        {"payload": payload},
-                    )
+                c.execute(
+                    sa.text(
+                        "SELECT pg_notify('dbos_streams_channel', p) FROM unnest(CAST(:payloads AS text[])) AS p"
+                    ),
+                    {"payloads": list(batch)},
+                )
         except Exception as e:
             # Drop the batch (do not requeue) on failure, e.g. a payload over pg_notify's 8000-byte limit; readers' polling fallback delivers these values, so one poison payload can't stall the notifier forever.
             if self._run_background_processes:

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -226,10 +226,20 @@ class PostgresSystemDatabase(SystemDatabase):
         if not self.use_listen_notify:
             return
         while self._run_background_processes:
-            time.sleep(self._stream_notification_coalesce_sec)
-            self._flush_stream_notifications()
+            try:
+                time.sleep(self._stream_notification_coalesce_sec)
+                self._flush_stream_notifications()
+            except Exception as e:
+                # Never let an unexpected error kill the sole push path; log and back off, matching _notification_listener.
+                if self._run_background_processes:
+                    dbos_logger.warning(f"Stream notifier error: {e}")
+                    time.sleep(1)
         # Final flush so values written just before shutdown still wake readers promptly.
-        self._flush_stream_notifications()
+        try:
+            self._flush_stream_notifications()
+        except Exception as e:
+            if self._run_background_processes:
+                dbos_logger.warning(f"Stream notifier final flush error: {e}")
 
     def _flush_stream_notifications(self) -> None:
         """Emit one coalesced notifying transaction for all pending payloads; drop the batch if it fails."""

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -214,13 +214,7 @@ class PostgresSystemDatabase(SystemDatabase):
                 self._cleanup_connections()
 
     def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
-        """Coalesce a wakeup for readers of (workflow_uuid, key).
-
-        The stream write itself no longer fires pg_notify (the per-row trigger
-        was dropped); instead we accumulate the payload and let
-        run_stream_notifier push it off the write path. Without L/N, readers
-        poll, so there is nothing to push.
-        """
+        """Accumulate a coalesced wakeup for readers of (workflow_uuid, key); run_stream_notifier pushes it off the write path (no-op without L/N)."""
         if not self.use_listen_notify:
             return
         payload = f"{workflow_uuid}::{key}"
@@ -228,21 +222,13 @@ class PostgresSystemDatabase(SystemDatabase):
             self._pending_stream_notifications.add(payload)
 
     def run_stream_notifier(self) -> None:
-        """Flush coalesced stream-write notifications on a short debounce.
-
-        Firing pg_notify from a dedicated loop rather than inside each write's
-        commit keeps the async-notify queue lock (which serializes every
-        notifying commit) off the hot write path: its acquisition rate is
-        bounded by the debounce interval, not the stream write rate. Read
-        latency is bounded by the debounce interval.
-        """
+        """Periodically flush coalesced stream-write notifications, keeping the async-notify queue lock (which serializes notifying commits) off the write path."""
         if not self.use_listen_notify:
             return
         while self._run_background_processes:
-            time.sleep(self._stream_notification_debounce_sec)
+            time.sleep(self._stream_notification_coalesce_sec)
             self._flush_stream_notifications()
-        # Best-effort final flush so values written just before shutdown still
-        # wake readers promptly rather than waiting out their fallback interval.
+        # Final flush so values written just before shutdown still wake readers promptly.
         self._flush_stream_notifications()
 
     def _flush_stream_notifications(self) -> None:
@@ -253,9 +239,7 @@ class PostgresSystemDatabase(SystemDatabase):
             batch = self._pending_stream_notifications
             self._pending_stream_notifications = set()
         try:
-            # One transaction, one commit: every payload's notification is
-            # appended under a single acquisition of the async-notify queue
-            # lock, no matter how many distinct streams changed this interval.
+            # One transaction: all payloads share a single acquisition of the async-notify queue lock.
             with self.engine.begin() as c:
                 for payload in batch:
                     c.execute(
@@ -263,8 +247,7 @@ class PostgresSystemDatabase(SystemDatabase):
                         {"payload": payload},
                     )
         except Exception as e:
-            # Requeue on failure so the wakeup is retried next interval rather
-            # than lost; a duplicate notify is harmless (readers re-read anyway).
+            # Requeue on failure so the wakeup retries next interval; a duplicate notify is harmless.
             with self._stream_notifier_lock:
                 self._pending_stream_notifications |= batch
             if self._run_background_processes:

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -230,7 +230,7 @@ class PostgresSystemDatabase(SystemDatabase):
                 time.sleep(self._stream_notification_coalesce_sec)
                 self._flush_stream_notifications()
             except Exception as e:
-                # Never let an unexpected error kill the sole push path; log and back off, matching _notification_listener.
+                # Last resort: a failing flush logs and drops its batch internally, so this catches only unexpected errors, which must not kill the sole push path.
                 if self._run_background_processes:
                     dbos_logger.warning(f"Stream notifier error: {e}")
                     time.sleep(1)
@@ -238,8 +238,7 @@ class PostgresSystemDatabase(SystemDatabase):
         try:
             self._flush_stream_notifications()
         except Exception as e:
-            if self._run_background_processes:
-                dbos_logger.warning(f"Stream notifier final flush error: {e}")
+            dbos_logger.warning(f"Stream notifier final flush error: {e}")
 
     def _flush_stream_notifications(self) -> None:
         """Emit one coalesced notifying transaction for all pending payloads; drop the batch if it fails."""
@@ -259,5 +258,4 @@ class PostgresSystemDatabase(SystemDatabase):
                 )
         except Exception as e:
             # Drop the batch (do not requeue) on failure, e.g. a payload over pg_notify's 8000-byte limit; readers' polling fallback delivers these values, so one poison payload can't stall the notifier forever.
-            if self._run_background_processes:
-                dbos_logger.warning(f"Stream notifier flush error: {e}")
+            dbos_logger.warning(f"Stream notifier flush error: {e}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -654,6 +654,22 @@ def test_translate_dbosconfig_full_input():
     assert "env" not in translated_config
 
 
+def test_translate_dbosconfig_stream_notification_coalesce_sec():
+    # A valid value is threaded into runtimeConfig.
+    ok: DBOSConfig = {"name": "test-app", "stream_notification_coalesce_sec": 0.001}
+    translated = translate_dbos_config_to_config_file(ok)
+    assert translated["runtimeConfig"]["stream_notification_coalesce_sec"] == 0.001
+
+    # Invalid values are rejected, including NaN/inf which slip past a bare < 0.001 check
+    # and would otherwise crash run_stream_notifier's time.sleep.
+    for bad in [0.0005, 0.0, -1.0, float("nan"), float("inf")]:
+        with pytest.raises(DBOSInitializationError) as exc_info:
+            translate_dbos_config_to_config_file(
+                {"name": "test-app", "stream_notification_coalesce_sec": bad}
+            )
+        assert "stream_notification_coalesce_sec" in str(exc_info.value)
+
+
 def test_translate_dbosconfig_minimal_input():
     config: DBOSConfig = {
         "name": "test-app",

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,12 +1,14 @@
 import time
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._client import DBOSClient
+from dbos._sys_db_postgres import PostgresSystemDatabase
+from tests.conftest import retry_until_success
 
 
 def test_basic_stream_write_read(dbos: DBOS) -> None:
@@ -429,7 +431,7 @@ def test_stream_notifier_drops_unsendable_payload(
     dbos: DBOS, skip_with_sqlite: None
 ) -> None:
     """A batch pg_notify rejects (e.g. a payload over the 8000-byte limit) is dropped, not requeued, so a poison payload can't permanently stall the notifier (H1); the notifier keeps delivering afterward and polling covers the dropped values."""
-    sys_db = dbos._sys_db
+    sys_db = cast(PostgresSystemDatabase, dbos._sys_db)
     # A stream key past pg_notify's 8000-byte payload limit makes its batch unsendable.
     poison_payload = f"{uuid.uuid4()}::{'x' * 9000}"
 
@@ -453,6 +455,45 @@ def test_stream_notifier_drops_unsendable_payload(
         assert event.wait(
             timeout=10
         ), "notifier stopped delivering after a poison batch"
+    finally:
+        sys_db.unregister_stream_listener(payload_key)
+
+
+def test_stream_notifier_survives_flush_error(
+    dbos: DBOS, skip_with_sqlite: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exception escaping a flush must not kill the notifier thread (M1): it logs, backs off, and resumes delivering. Without the loop guard the thread would die and stop all stream push notifications for the process."""
+    sys_db = cast(PostgresSystemDatabase, dbos._sys_db)
+    real_flush = sys_db._flush_stream_notifications
+    state = {"raised": False}
+
+    def flaky_flush() -> None:
+        # Raise once (even on an empty batch) to simulate an unexpected error; then behave normally.
+        if not state["raised"]:
+            state["raised"] = True
+            raise RuntimeError("simulated flush failure")
+        real_flush()
+
+    monkeypatch.setattr(sys_db, "_flush_stream_notifications", flaky_flush)
+
+    # Wait until the running notifier thread has hit the injected failure.
+    def failure_injected() -> bool:
+        assert state["raised"], "notifier has not called flush yet"
+        return True
+
+    retry_until_success(failure_injected)
+
+    # The thread must have survived it and still deliver a subsequently signaled stream.
+    good_wf = str(uuid.uuid4())
+    good_key = "post_error"
+    event, payload_key = sys_db.register_stream_listener(good_wf, good_key)
+    try:
+        event.clear()
+        with sys_db._stream_notifier_lock:
+            sys_db._pending_stream_notifications.add(f"{good_wf}::{good_key}")
+        assert event.wait(
+            timeout=10
+        ), "notifier did not resume delivering after a flush error"
     finally:
         sys_db.unregister_stream_listener(payload_key)
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -425,6 +425,38 @@ def test_stream_notifier_delivers_without_trigger(
     assert second_latency < 10.0, f"second value took {second_latency:.3f}s to arrive"
 
 
+def test_stream_notifier_drops_unsendable_payload(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """A batch pg_notify rejects (e.g. a payload over the 8000-byte limit) is dropped, not requeued, so a poison payload can't permanently stall the notifier (H1); the notifier keeps delivering afterward and polling covers the dropped values."""
+    sys_db = dbos._sys_db
+    # A stream key past pg_notify's 8000-byte payload limit makes its batch unsendable.
+    poison_payload = f"{uuid.uuid4()}::{'x' * 9000}"
+
+    with sys_db._stream_notifier_lock:
+        sys_db._pending_stream_notifications = {poison_payload}
+    sys_db._flush_stream_notifications()
+
+    # The poison batch is dropped, not requeued (requeuing would loop forever).
+    with sys_db._stream_notifier_lock:
+        assert sys_db._pending_stream_notifications == set()
+
+    # The notifier still works afterward: a subsequent good payload is delivered.
+    good_wf = str(uuid.uuid4())
+    good_key = "deliverable"
+    event, payload_key = sys_db.register_stream_listener(good_wf, good_key)
+    try:
+        event.clear()
+        with sys_db._stream_notifier_lock:
+            sys_db._pending_stream_notifications = {f"{good_wf}::{good_key}"}
+        sys_db._flush_stream_notifications()
+        assert event.wait(
+            timeout=10
+        ), "notifier stopped delivering after a poison batch"
+    finally:
+        sys_db.unregister_stream_listener(payload_key)
+
+
 def test_stream_multiple_keys(dbos: DBOS) -> None:
     """Test multiple streams with different keys in the same workflow."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,10 +3,12 @@ import uuid
 from typing import Any, cast
 
 import pytest
+import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._client import DBOSClient
+from dbos._sys_db import STREAM_READ_BATCH_SIZE
 from dbos._sys_db_postgres import PostgresSystemDatabase
 from tests.conftest import retry_until_success
 
@@ -86,6 +88,108 @@ async def test_stream_read_offset_async(dbos: DBOS) -> None:
 
     values = [v async for v in DBOS.read_stream_async(wfid, stream_key, offset=3)]
     assert values == [3, 4]
+
+
+@pytest.mark.parametrize(
+    "n",
+    [
+        0,
+        1,
+        STREAM_READ_BATCH_SIZE - 1,
+        STREAM_READ_BATCH_SIZE,
+        STREAM_READ_BATCH_SIZE + 1,
+        2 * STREAM_READ_BATCH_SIZE + 1,
+    ],
+)
+def test_stream_read_batch_boundaries(dbos: DBOS, n: int) -> None:
+    """Reads are fetched in batches of STREAM_READ_BATCH_SIZE, so a stream whose length lands on a batch edge must still deliver every value exactly once, in order."""
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for i in range(n):
+            DBOS.write_stream("s", i)
+        DBOS.close_stream("s")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        DBOS.start_workflow(writer_workflow).get_result()
+
+    assert list(DBOS.read_stream(wfid, "s")) == list(range(n))
+
+
+def test_stream_read_batch_returns_status_and_values(dbos: DBOS) -> None:
+    """read_stream_batch answers both questions a reader tick asks -- 'any new values?' and 'is the workflow still running?' -- in one round trip, from one snapshot."""
+    sys_db = dbos._sys_db
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for i in range(3):
+            DBOS.write_stream("s", i)
+        DBOS.close_stream("s")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        DBOS.start_workflow(writer_workflow).get_result()
+
+    # Status plus the values at the requested offset, together.
+    status, values = sys_db.read_stream_batch(wfid, "s", 0, STREAM_READ_BATCH_SIZE)
+    assert status == "SUCCESS"
+    assert values[:3] == [0, 1, 2]
+
+    # Past the end: still reports status, so the reader can tell "not yet" from "never".
+    status, values = sys_db.read_stream_batch(wfid, "s", 99, STREAM_READ_BATCH_SIZE)
+    assert status == "SUCCESS"
+    assert values == []
+
+    # The limit is respected.
+    _, values = sys_db.read_stream_batch(wfid, "s", 0, 2)
+    assert values == [0, 1]
+
+    # A non-existent workflow is distinguishable from one with no values.
+    status, values = sys_db.read_stream_batch(str(uuid.uuid4()), "s", 0, 10)
+    assert status is None
+    assert values == []
+
+
+def test_stream_read_is_one_round_trip_per_batch(dbos: DBOS) -> None:
+    """Draining N values costs ~N/STREAM_READ_BATCH_SIZE queries rather than N, and each tick reads the stream and the workflow status in a single joined statement rather than two."""
+    n = 2 * STREAM_READ_BATCH_SIZE + 5
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for i in range(n):
+            DBOS.write_stream("s", i)
+        DBOS.close_stream("s")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        DBOS.start_workflow(writer_workflow).get_result()
+
+    # Only the reader joins streams to workflow_status, so background threads sharing the engine cannot match.
+    # Matched loosely rather than by table name, which is schema-qualified.
+    reads = []
+
+    def count(
+        conn: Any, cursor: Any, statement: str, params: Any, context: Any, many: bool
+    ) -> None:
+        s = " ".join(statement.lower().split())
+        if "outer join" in s and "streams" in s and "workflow_status" in s:
+            reads.append(statement)
+
+    engine = dbos._sys_db.engine
+    sa.event.listen(engine, "before_cursor_execute", count)
+    try:
+        values = list(DBOS.read_stream(wfid, "s"))
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", count)
+
+    assert values == list(range(n))
+    # Guards against passing vacuously: a per-offset read issues no joined query at all.
+    assert reads, "reader did not fetch values and status in one joined query"
+    # 3 batches cover 205 values + the sentinel's batch + one final re-read; well under one query per value.
+    assert (
+        len(reads) <= 6
+    ), f"expected ~4 batched reads for {n} values, got {len(reads)}"
 
 
 def test_client_read_stream_offset(dbos: DBOS, client: DBOSClient) -> None:
@@ -1005,6 +1109,51 @@ async def test_client_read_stream_async(dbos: DBOS, client: DBOSClient) -> None:
         assert read_values == test_values
     finally:
         client.destroy()
+
+
+def test_client_read_stream_batches(dbos: DBOS, client: DBOSClient) -> None:
+    """The client reader batches like the in-process one: draining N values costs ~N/STREAM_READ_BATCH_SIZE joined queries rather than N, each reading values and status together."""
+    n = 2 * STREAM_READ_BATCH_SIZE + 5
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for i in range(n):
+            DBOS.write_stream("s", i)
+        DBOS.close_stream("s")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        DBOS.start_workflow(writer_workflow).get_result()
+
+    reads = []
+
+    def count(
+        conn: Any, cursor: Any, statement: str, params: Any, context: Any, many: bool
+    ) -> None:
+        s = " ".join(statement.lower().split())
+        if "outer join" in s and "streams" in s and "workflow_status" in s:
+            reads.append(statement)
+
+    engine = client._sys_db.engine
+    sa.event.listen(engine, "before_cursor_execute", count)
+    try:
+        values = list(client.read_stream(wfid, "s"))
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", count)
+
+    assert values == list(range(n))
+    # Guards against passing vacuously: a per-offset read issues no joined query at all.
+    assert reads, "client did not fetch values and status in one joined query"
+    assert (
+        len(reads) <= 6
+    ), f"expected ~4 batched reads for {n} values, got {len(reads)}"
+
+
+def test_client_read_stream_nonexistent_workflow(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    """A stream on an unknown workflow ends the client's generator quietly, where the in-process reader raises. Preserved deliberately: the batch read reports a missing workflow the same way as a workflow with nothing buffered."""
+    assert list(client.read_stream(str(uuid.uuid4()), "s")) == []
 
 
 def test_client_read_stream_workflow_termination(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -7,6 +7,7 @@ from sqlalchemy import event as sa_event
 
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
+from dbos import _dbos as dbos_module
 from dbos._client import DBOSClient
 from dbos._sys_db import _no_stream_value
 from dbos._sys_db_postgres import PostgresSystemDatabase
@@ -123,6 +124,49 @@ def test_stream_read_value_returns_status_and_value(dbos: DBOS) -> None:
     status, value = sys_db.read_stream_value(str(uuid.uuid4()), "s", 0)
     assert status is None
     assert value is _no_stream_value
+
+
+@pytest.mark.asyncio
+async def test_stream_read_async_sub_poll_observes_notifications(
+    dbos: DBOS, skip_with_sqlite: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """read_stream_async waits on the notification event by sub-polling it, tightly at first and
+    relaxed once a value has been awaited a while. Both branches must observe the event promptly.
+
+    This passes a long polling_interval_sec on purpose. The suite's default (0.01s, conftest.py)
+    makes `min(remaining, sub_poll) == remaining` whichever branch is taken, so under it the sub-poll
+    constants have no effect and a regression in either is invisible.
+    """
+    # Relax after 0.2s rather than the real 10s, so the test need not idle for the full window.
+    monkeypatch.setattr(dbos_module, "_STREAM_EVENT_FAST_POLL_WINDOW_SEC", 0.2)
+    # First gap stays inside the window (fast branch); the rest exceed it (relaxed branch).
+    gaps = [0.1, 0.5, 0.5]
+    written: dict[int, float] = {}
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        for i, gap in enumerate(gaps):
+            DBOS.sleep(gap)
+            written[i] = time.time()
+            DBOS.write_stream("s", i)
+        DBOS.close_stream("s")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        DBOS.start_workflow(writer_workflow)
+
+    # A fallback re-read interval far longer than any gap: prompt delivery can only come from the
+    # sub-poll observing the notification, never from the fallback.
+    latencies = []
+    async for value in DBOS.read_stream_async(wfid, "s", polling_interval_sec=30.0):
+        latencies.append(time.time() - written[value])
+
+    assert len(latencies) == len(gaps)
+    # Fast branch: sub-polls at 0.01s, so the value lands almost immediately.
+    assert latencies[0] < 0.15, f"fast-branch latency {latencies[0]:.3f}s"
+    # Relaxed branch: sub-polls at 0.1s. Raising it to the 1.0s default fallback interval would make
+    # the reader sleep clean past each write and land near 0.7s here.
+    assert max(latencies[1:]) < 0.3, f"relaxed-branch latencies {latencies[1:]}"
 
 
 def test_stream_read_is_one_round_trip_per_value(dbos: DBOS) -> None:
@@ -339,10 +383,18 @@ def test_stream_low_latency_delivery(
     # In-process DBOS reader: woken by LISTEN/NOTIFY, so delivery is single-digit
     # milliseconds. The threshold leaves headroom for CI stalls while staying
     # well below what a broken wakeup path would produce.
+    # The fallback re-read interval is raised for this phase so that a working notification is the
+    # only thing that can deliver within the threshold; at the suite default (0.01s, conftest.py)
+    # the fallback delivers every value in ~10ms and this phase passes even with no notifier at all.
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         handle = DBOS.start_workflow(writer_workflow)
-    count, max_latency = measure(DBOS.read_stream(wfid, stream_key))
+    original_interval = dbos._sys_db._notification_listener_polling_interval_sec
+    dbos._sys_db._notification_listener_polling_interval_sec = 10.0
+    try:
+        count, max_latency = measure(DBOS.read_stream(wfid, stream_key))
+    finally:
+        dbos._sys_db._notification_listener_polling_interval_sec = original_interval
     handle.get_result()
     assert count == num_values
     assert max_latency < 2.0, f"DBOS delivery latency {max_latency:.3f}s too high"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -279,10 +279,7 @@ def test_stream_low_latency_delivery(
     assert count == num_values
     assert max_latency < 5.0, f"client delivery latency {max_latency:.3f}s too high"
 
-    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
-    # reader still receives every value via the polling fallback. With L/N off
-    # the app-side stream notifier stays idle, so no notifications fire at all;
-    # the reader is woken by the polling listener thread instead.
+    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled: the app-side notifier stays idle and no notifications fire, so the reader is woken by the polling listener thread instead.
     DBOS.destroy(destroy_registry=False)
     config["use_listen_notify"] = False
     DBOS(config=config)
@@ -357,10 +354,7 @@ async def test_stream_low_latency_delivery_async(
     assert count == num_values
     assert max_latency < 5.0, f"client delivery latency {max_latency:.3f}s too high"
 
-    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
-    # reader still receives every value via the polling fallback. With L/N off
-    # the app-side stream notifier stays idle, so no notifications fire at all;
-    # the reader is woken by the polling listener thread instead.
+    # Recreate the in-process DBOS with LISTEN/NOTIFY disabled: the app-side notifier stays idle and no notifications fire, so the reader is woken by the polling listener thread instead.
     DBOS.destroy(destroy_registry=False)
     config["use_listen_notify"] = False
     DBOS(config=config)
@@ -380,17 +374,12 @@ async def test_stream_low_latency_delivery_async(
 def test_stream_notifier_delivers_without_trigger(
     dbos: DBOS, skip_with_sqlite: None
 ) -> None:
-    """Stream writes no longer fire pg_notify inside their own commit: the
-    per-row NOTIFY trigger is dropped (migration 43) so high-throughput writers
-    don't serialize on the async-notify queue lock. Wakeups are instead pushed
-    by the coalescing app-side notifier. Assert the trigger is gone and that a
-    reader blocked with a long polling fallback is still woken by the notifier
-    rather than the poll."""
+    """The per-row NOTIFY trigger is dropped (migration 43) and wakeups come from the coalescing app-side notifier: assert the trigger is gone and a reader on a long poll fallback is still woken by the notifier."""
     import sqlalchemy as sa
 
     sys_db = dbos._sys_db
 
-    # No per-row trigger or its function may remain on the streams table.
+    # No per-row trigger may remain on the streams table.
     with sys_db.engine.begin() as c:
         trigger = c.execute(
             sa.text(
@@ -409,8 +398,7 @@ def test_stream_notifier_delivers_without_trigger(
     @DBOS.workflow()
     def writer_workflow() -> None:
         DBOS.write_stream(stream_key, "first")
-        # Keep the stream open and the reader genuinely blocked, then write a
-        # second value that can only reach the reader via a notification.
+        # Keep the stream open so the reader blocks, then write a value it can only get via a notification.
         DBOS.sleep(2.0)
         DBOS.write_stream(stream_key, "second")
         DBOS.close_stream(stream_key)
@@ -419,8 +407,7 @@ def test_stream_notifier_delivers_without_trigger(
     with SetWorkflowID(wfid):
         handle = DBOS.start_workflow(writer_workflow)
 
-    # Force a fallback poll interval far longer than the write gap so any
-    # timely delivery must come from the notifier, not the poll.
+    # Force a poll interval far longer than the write gap so timely delivery must come from the notifier, not the poll.
     original_interval = sys_db._notification_listener_polling_interval_sec
     sys_db._notification_listener_polling_interval_sec = 30.0
     try:
@@ -433,8 +420,7 @@ def test_stream_notifier_delivers_without_trigger(
         sys_db._notification_listener_polling_interval_sec = original_interval
 
     assert [v for v, _ in received] == ["first", "second"]
-    # The second value is written ~2s in; the reader blocks on it and must be
-    # woken by the notifier well before the 30s poll would fire.
+    # The second value is written ~2s in; the notifier must wake the reader well before the 30s poll would.
     second_latency = received[1][1]
     assert second_latency < 10.0, f"second value took {second_latency:.3f}s to arrive"
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -8,7 +8,7 @@ from sqlalchemy import event as sa_event
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._client import DBOSClient
-from dbos._sys_db import STREAM_READ_BATCH_SIZE
+from dbos._sys_db import _no_stream_value
 from dbos._sys_db_postgres import PostgresSystemDatabase
 from tests.conftest import retry_until_success
 
@@ -90,70 +90,44 @@ async def test_stream_read_offset_async(dbos: DBOS) -> None:
     assert values == [3, 4]
 
 
-@pytest.mark.parametrize(
-    "n",
-    [
-        0,
-        1,
-        STREAM_READ_BATCH_SIZE - 1,
-        STREAM_READ_BATCH_SIZE,
-        STREAM_READ_BATCH_SIZE + 1,
-        2 * STREAM_READ_BATCH_SIZE + 1,
-    ],
-)
-def test_stream_read_batch_boundaries(dbos: DBOS, n: int) -> None:
-    """Reads are fetched in batches of STREAM_READ_BATCH_SIZE, so a stream whose length lands on a batch edge must still deliver every value exactly once, in order."""
-
-    @DBOS.workflow()
-    def writer_workflow() -> None:
-        for i in range(n):
-            DBOS.write_stream("s", i)
-        DBOS.close_stream("s")
-
-    wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        DBOS.start_workflow(writer_workflow).get_result()
-
-    assert list(DBOS.read_stream(wfid, "s")) == list(range(n))
-
-
-def test_stream_read_batch_returns_status_and_values(dbos: DBOS) -> None:
-    """read_stream_batch answers both questions a reader tick asks -- 'any new values?' and 'is the workflow still running?' -- in one round trip, from one snapshot."""
+def test_stream_read_value_returns_status_and_value(dbos: DBOS) -> None:
+    """read_stream_value answers both questions a reader tick asks -- 'is there a value at this offset?' and 'is the workflow still running?' -- in one round trip, from one snapshot."""
     sys_db = dbos._sys_db
 
     @DBOS.workflow()
     def writer_workflow() -> None:
-        for i in range(3):
-            DBOS.write_stream("s", i)
+        DBOS.write_stream("s", 0)
+        DBOS.write_stream("s", None)
         DBOS.close_stream("s")
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         DBOS.start_workflow(writer_workflow).get_result()
 
-    # Status plus the values at the requested offset, together.
-    status, values = sys_db.read_stream_batch(wfid, "s", 0, STREAM_READ_BATCH_SIZE)
+    # The value at the offset and the status, together.
+    status, value = sys_db.read_stream_value(wfid, "s", 0)
     assert status == "SUCCESS"
-    assert values[:3] == [0, 1, 2]
+    assert value == 0
+
+    # A written None is a value, not an absence -- which is why absence needs its own sentinel.
+    status, value = sys_db.read_stream_value(wfid, "s", 1)
+    assert status == "SUCCESS"
+    assert value is None
 
     # Past the end: still reports status, so the reader can tell "not yet" from "never".
-    status, values = sys_db.read_stream_batch(wfid, "s", 99, STREAM_READ_BATCH_SIZE)
+    status, value = sys_db.read_stream_value(wfid, "s", 99)
     assert status == "SUCCESS"
-    assert values == []
+    assert value is _no_stream_value
 
-    # The limit is respected.
-    _, values = sys_db.read_stream_batch(wfid, "s", 0, 2)
-    assert values == [0, 1]
-
-    # A non-existent workflow is distinguishable from one with no values.
-    status, values = sys_db.read_stream_batch(str(uuid.uuid4()), "s", 0, 10)
+    # A non-existent workflow is distinguishable from a workflow with no value at the offset.
+    status, value = sys_db.read_stream_value(str(uuid.uuid4()), "s", 0)
     assert status is None
-    assert values == []
+    assert value is _no_stream_value
 
 
-def test_stream_read_is_one_round_trip_per_batch(dbos: DBOS) -> None:
-    """Draining N values costs ~N/STREAM_READ_BATCH_SIZE queries rather than N, and each tick reads the stream and the workflow status in a single joined statement rather than two."""
-    n = 2 * STREAM_READ_BATCH_SIZE + 5
+def test_stream_read_is_one_round_trip_per_value(dbos: DBOS) -> None:
+    """Each reader tick issues a single query fetching the value and the workflow status together, rather than reading the stream and then looking the status up separately."""
+    n = 25
 
     @DBOS.workflow()
     def writer_workflow() -> None:
@@ -184,12 +158,13 @@ def test_stream_read_is_one_round_trip_per_batch(dbos: DBOS) -> None:
         sa_event.remove(engine, "before_cursor_execute", count)
 
     assert values == list(range(n))
-    # Guards against passing vacuously: a per-offset read issues no joined query at all.
-    assert reads, "reader did not fetch values and status in one joined query"
-    # 3 batches cover 205 values + the sentinel's batch + one final re-read; well under one query per value.
+    # Guards against passing vacuously: reading the status separately issues no joined query at all.
+    assert reads, "reader did not fetch value and status in one joined query"
+    # One query per delivered value, plus the one that finds the close sentinel. Two queries per
+    # tick (a read then a status lookup) would double this.
     assert (
-        len(reads) <= 6
-    ), f"expected ~4 batched reads for {n} values, got {len(reads)}"
+        len(reads) == n + 1
+    ), f"expected {n + 1} reads for {n} values, got {len(reads)}"
 
 
 def test_client_read_stream_offset(dbos: DBOS, client: DBOSClient) -> None:
@@ -1111,9 +1086,11 @@ async def test_client_read_stream_async(dbos: DBOS, client: DBOSClient) -> None:
         client.destroy()
 
 
-def test_client_read_stream_batches(dbos: DBOS, client: DBOSClient) -> None:
-    """The client reader batches like the in-process one: draining N values costs ~N/STREAM_READ_BATCH_SIZE joined queries rather than N, each reading values and status together."""
-    n = 2 * STREAM_READ_BATCH_SIZE + 5
+def test_client_read_stream_is_one_round_trip_per_value(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    """The client reader fetches value and status in one joined query per tick, like the in-process one."""
+    n = 25
 
     @DBOS.workflow()
     def writer_workflow() -> None:
@@ -1142,11 +1119,12 @@ def test_client_read_stream_batches(dbos: DBOS, client: DBOSClient) -> None:
         sa_event.remove(engine, "before_cursor_execute", count)
 
     assert values == list(range(n))
-    # Guards against passing vacuously: a per-offset read issues no joined query at all.
-    assert reads, "client did not fetch values and status in one joined query"
+    # Guards against passing vacuously: reading the status separately issues no joined query at all.
+    assert reads, "client did not fetch value and status in one joined query"
+    # One query per delivered value, plus the one that finds the close sentinel.
     assert (
-        len(reads) <= 6
-    ), f"expected ~4 batched reads for {n} values, got {len(reads)}"
+        len(reads) == n + 1
+    ), f"expected {n + 1} reads for {n} values, got {len(reads)}"
 
 
 def test_client_read_stream_nonexistent_workflow(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -280,8 +280,8 @@ def test_stream_low_latency_delivery(
     assert max_latency < 5.0, f"client delivery latency {max_latency:.3f}s too high"
 
     # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
-    # reader still receives every value via the polling fallback. The trigger
-    # installed earlier harmlessly fires notifications that nobody listens for;
+    # reader still receives every value via the polling fallback. With L/N off
+    # the app-side stream notifier stays idle, so no notifications fire at all;
     # the reader is woken by the polling listener thread instead.
     DBOS.destroy(destroy_registry=False)
     config["use_listen_notify"] = False
@@ -358,8 +358,8 @@ async def test_stream_low_latency_delivery_async(
     assert max_latency < 5.0, f"client delivery latency {max_latency:.3f}s too high"
 
     # Recreate the in-process DBOS with LISTEN/NOTIFY disabled and confirm the
-    # reader still receives every value via the polling fallback. The trigger
-    # installed earlier harmlessly fires notifications that nobody listens for;
+    # reader still receives every value via the polling fallback. With L/N off
+    # the app-side stream notifier stays idle, so no notifications fire at all;
     # the reader is woken by the polling listener thread instead.
     DBOS.destroy(destroy_registry=False)
     config["use_listen_notify"] = False
@@ -375,6 +375,68 @@ async def test_stream_low_latency_delivery_async(
     assert (
         max_latency < 20.0
     ), f"polling DBOS delivery latency {max_latency:.3f}s too high"
+
+
+def test_stream_notifier_delivers_without_trigger(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """Stream writes no longer fire pg_notify inside their own commit: the
+    per-row NOTIFY trigger is dropped (migration 43) so high-throughput writers
+    don't serialize on the async-notify queue lock. Wakeups are instead pushed
+    by the coalescing app-side notifier. Assert the trigger is gone and that a
+    reader blocked with a long polling fallback is still woken by the notifier
+    rather than the poll."""
+    import sqlalchemy as sa
+
+    sys_db = dbos._sys_db
+
+    # No per-row trigger or its function may remain on the streams table.
+    with sys_db.engine.begin() as c:
+        trigger = c.execute(
+            sa.text(
+                "SELECT 1 FROM pg_trigger t "
+                "JOIN pg_class cl ON t.tgrelid = cl.oid "
+                "JOIN pg_namespace n ON cl.relnamespace = n.oid "
+                "WHERE n.nspname = :schema AND cl.relname = 'streams' "
+                "AND t.tgname = 'dbos_streams_trigger'"
+            ),
+            {"schema": sys_db.schema},
+        ).fetchone()
+    assert trigger is None, "dbos_streams_trigger should have been dropped"
+
+    stream_key = "notifier_stream"
+
+    @DBOS.workflow()
+    def writer_workflow() -> None:
+        DBOS.write_stream(stream_key, "first")
+        # Keep the stream open and the reader genuinely blocked, then write a
+        # second value that can only reach the reader via a notification.
+        DBOS.sleep(2.0)
+        DBOS.write_stream(stream_key, "second")
+        DBOS.close_stream(stream_key)
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = DBOS.start_workflow(writer_workflow)
+
+    # Force a fallback poll interval far longer than the write gap so any
+    # timely delivery must come from the notifier, not the poll.
+    original_interval = sys_db._notification_listener_polling_interval_sec
+    sys_db._notification_listener_polling_interval_sec = 30.0
+    try:
+        received = []
+        start = time.time()
+        for value in DBOS.read_stream(wfid, stream_key):
+            received.append((value, time.time() - start))
+        handle.get_result()
+    finally:
+        sys_db._notification_listener_polling_interval_sec = original_interval
+
+    assert [v for v, _ in received] == ["first", "second"]
+    # The second value is written ~2s in; the reader blocks on it and must be
+    # woken by the notifier well before the 30s poll would fire.
+    second_latency = received[1][1]
+    assert second_latency < 10.0, f"second value took {second_latency:.3f}s to arrive"
 
 
 def test_stream_multiple_keys(dbos: DBOS) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Any, cast
 
 import pytest
-import sqlalchemy as sa
+from sqlalchemy import event as sa_event
 
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
@@ -177,11 +177,11 @@ def test_stream_read_is_one_round_trip_per_batch(dbos: DBOS) -> None:
             reads.append(statement)
 
     engine = dbos._sys_db.engine
-    sa.event.listen(engine, "before_cursor_execute", count)
+    sa_event.listen(engine, "before_cursor_execute", count)
     try:
         values = list(DBOS.read_stream(wfid, "s"))
     finally:
-        sa.event.remove(engine, "before_cursor_execute", count)
+        sa_event.remove(engine, "before_cursor_execute", count)
 
     assert values == list(range(n))
     # Guards against passing vacuously: a per-offset read issues no joined query at all.
@@ -1135,11 +1135,11 @@ def test_client_read_stream_batches(dbos: DBOS, client: DBOSClient) -> None:
             reads.append(statement)
 
     engine = client._sys_db.engine
-    sa.event.listen(engine, "before_cursor_execute", count)
+    sa_event.listen(engine, "before_cursor_execute", count)
     try:
         values = list(client.read_stream(wfid, "s"))
     finally:
-        sa.event.remove(engine, "before_cursor_execute", count)
+        sa_event.remove(engine, "before_cursor_execute", count)
 
     assert values == list(range(n))
     # Guards against passing vacuously: a per-offset read issues no joined query at all.


### PR DESCRIPTION
A transaction that sends a notification in Postgres must grab a global lock. To improve the performance of streams at scale, instead of sending a notification as part of the `write_stream` transaction, send batches of notifications every 10ms (configurable). This minimizes Postgres lock contention while keeping latency low (bounded at 10ms). 

In benchmarks, maximum stream throughput with concurrent readers improves from ~3K QPS to ~55K QPS.