### PR TITLE
Optimize NOTIFY

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -99,7 +99,7 @@ from ._scheduler import (
 )
 from ._scheduler_decorator import DecoratedScheduledWorkflow, scheduled
 from ._sys_db import (
-    DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
+    DEFAULT_NOTIFICATION_COALESCE_SEC,
     GetEventWorkflowContext,
     SendMessage,
     StepInfo,
@@ -569,11 +569,9 @@ class DBOS:
                 )
                 or 1.0
             )
-            stream_notification_coalesce_sec = (
-                self._config.get("runtimeConfig", {}).get(
-                    "stream_notification_coalesce_sec"
-                )
-                or DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC
+            notification_coalesce_sec = (
+                self._config.get("runtimeConfig", {}).get("notification_coalesce_sec")
+                or DEFAULT_NOTIFICATION_COALESCE_SEC
             )
             self._sys_db_field = SystemDatabase.create(
                 system_database_url=get_system_database_url(self._config),
@@ -584,7 +582,7 @@ class DBOS:
                 use_listen_notify=self._config["use_listen_notify"],
                 executor_id=GlobalParams.executor_id,
                 notification_listener_polling_interval_sec=self._notification_listener_polling_interval_sec,
-                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
+                notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=self._config["database"].get(
                     "sys_db_polling_concurrency"
                 ),
@@ -659,14 +657,14 @@ class DBOS:
             notification_listener_thread.start()
             self._background_threads.append(notification_listener_thread)
 
-            # Push coalesced stream-write notifications off the write path (no-op unless Postgres + L/N).
-            dbos_logger.debug("Starting stream notifier thread")
-            stream_notifier_thread = threading.Thread(
-                target=self._sys_db.run_stream_notifier,
+            # Push coalesced NOTIFY payloads off the write path (no-op unless Postgres + L/N).
+            dbos_logger.debug("Starting notifier thread")
+            notifier_thread = threading.Thread(
+                target=self._sys_db.run_notifier,
                 daemon=True,
             )
-            stream_notifier_thread.start()
-            self._background_threads.append(stream_notifier_thread)
+            notifier_thread.start()
+            self._background_threads.append(notifier_thread)
 
             # Create the internal queue if it has not yet been created
             self._registry.get_internal_queue()

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -48,7 +48,7 @@ class DBOSConfig(TypedDict, total=False):
         serializer (Serializer): A custom serializer and deserializer DBOS uses when storing program data in the system database
         use_listen_notify (bool): Whether to use LISTEN/NOTIFY or polling to listen for notifications and events.  Defaults to True. As this affects migrations, may not be changed after the system database is first created.
         notification_listener_polling_interval_sec (float): Polling interval in seconds for the notification listener background process. Defaults to 1.0. Minimum value is 0.001. Lower values can speed up test execution.
-        stream_notification_coalesce_sec (float): Interval in seconds for coalescing stream-write notifications pushed via LISTEN/NOTIFY. Bounds stream read latency and caps the rate of notifying commits independent of write throughput. Defaults to 0.01. Minimum value is 0.001.
+        notification_coalesce_sec (float): Interval in seconds for coalescing LISTEN/NOTIFY notifications (streams, messages, and events) pushed off the write path. Bounds read latency and caps the rate of notifying commits independent of write throughput. Defaults to 0.01. Minimum value is 0.001.
         scheduler_polling_interval_sec (float): Polling interval in seconds for the scheduler thread to detect new workflow schedules. Defaults to 30.0.
         otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
             "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward
@@ -85,7 +85,7 @@ class DBOSConfig(TypedDict, total=False):
     use_listen_notify: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
-    stream_notification_coalesce_sec: Optional[float]
+    notification_coalesce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
     otel_attribute_format: Optional[Literal["legacy", "semconv"]]
 
@@ -97,7 +97,7 @@ class RuntimeConfig(TypedDict, total=False):
     run_admin_server: Optional[bool]
     max_executor_threads: Optional[int]
     notification_listener_polling_interval_sec: Optional[float]
-    stream_notification_coalesce_sec: Optional[float]
+    notification_coalesce_sec: Optional[float]
     scheduler_polling_interval_sec: Optional[float]
 
 
@@ -201,16 +201,14 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         translated_config["runtimeConfig"][
             "notification_listener_polling_interval_sec"
         ] = interval
-    if "stream_notification_coalesce_sec" in config:
-        coalesce = config["stream_notification_coalesce_sec"]
-        # Reject NaN/inf too (they slip past a bare < 0.001) so run_stream_notifier's time.sleep can't crash.
+    if "notification_coalesce_sec" in config:
+        coalesce = config["notification_coalesce_sec"]
+        # Reject NaN/inf too (they slip past a bare < 0.001) so run_notifier's time.sleep can't crash.
         if coalesce is not None and (not math.isfinite(coalesce) or coalesce < 0.001):
             raise DBOSInitializationError(
-                f"stream_notification_coalesce_sec must be a finite number at least 0.001 seconds, got {coalesce}"
+                f"notification_coalesce_sec must be a finite number at least 0.001 seconds, got {coalesce}"
             )
-        translated_config["runtimeConfig"][
-            "stream_notification_coalesce_sec"
-        ] = coalesce
+        translated_config["runtimeConfig"]["notification_coalesce_sec"] = coalesce
     if "scheduler_polling_interval_sec" in config:
         translated_config["runtimeConfig"]["scheduler_polling_interval_sec"] = config[
             "scheduler_polling_interval_sec"

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -48,7 +48,7 @@ class DBOSConfig(TypedDict, total=False):
         serializer (Serializer): A custom serializer and deserializer DBOS uses when storing program data in the system database
         use_listen_notify (bool): Whether to use LISTEN/NOTIFY or polling to listen for notifications and events.  Defaults to True. As this affects migrations, may not be changed after the system database is first created.
         notification_listener_polling_interval_sec (float): Polling interval in seconds for the notification listener background process. Defaults to 1.0. Minimum value is 0.001. Lower values can speed up test execution.
-        notification_coalesce_sec (float): Interval in seconds for coalescing LISTEN/NOTIFY notifications (streams, messages, and events) pushed off the write path. Bounds read latency and caps the rate of notifying commits independent of write throughput. Defaults to 0.01. Minimum value is 0.001.
+        notification_coalesce_sec (float): Interval in seconds for coalescing LISTEN/NOTIFY notifications (streams and events) pushed off the write path. Bounds read latency and caps the rate of notifying commits independent of write throughput. Defaults to 0.01. Minimum value is 0.001.
         scheduler_polling_interval_sec (float): Polling interval in seconds for the scheduler thread to detect new workflow schedules. Defaults to 30.0.
         otel_attribute_format (Literal["legacy", "semconv"]): How span attribute names are emitted to OTLP.
             "legacy" (default) keeps DBOS's original names (e.g. operationUUID, applicationID) for backward

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -893,12 +893,11 @@ DROP FUNCTION IF EXISTS "{schema}".streams_function();
 
 
 def get_dbos_migration_fortyfour(schema: str, use_listen_notify: bool) -> str:
-    # Drop the per-row notifications and workflow_events NOTIFY triggers (migration 1): like streams, these are now coalesced and pushed by run_notifier off the write path. Gated to match migration 1.
+    # Drop the per-row workflow_events NOTIFY trigger (migration 1): like streams, events are now coalesced and pushed by run_notifier off the write path. Gated to match migration 1.
+    # The notifications trigger is deliberately kept: recv destructively consumes on wakeup, so it must not be woken before the message row commits, which the in-transaction trigger guarantees but a batched app-side notify does not.
     if not use_listen_notify:
         return ""
     return f"""
-DROP TRIGGER IF EXISTS dbos_notifications_trigger ON "{schema}".notifications;
-DROP FUNCTION IF EXISTS "{schema}".notifications_function();
 DROP TRIGGER IF EXISTS dbos_workflow_events_trigger ON "{schema}".workflow_events;
 DROP FUNCTION IF EXISTS "{schema}".workflow_events_function();
 """

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -883,7 +883,7 @@ ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced"
 
 
 def get_dbos_migration_fortythree(schema: str, use_listen_notify: bool) -> str:
-    # Drop the per-row streams NOTIFY trigger (migration 39): notifications are now coalesced and pushed by run_notifier off the write path. Gated to match migration 39.
+    # Drop the streams NOTIFY trigger; stream writes are pushed by run_notifier off the write path.
     if not use_listen_notify:
         return ""
     return f"""
@@ -893,8 +893,7 @@ DROP FUNCTION IF EXISTS "{schema}".streams_function();
 
 
 def get_dbos_migration_fortyfour(schema: str, use_listen_notify: bool) -> str:
-    # Drop the per-row workflow_events NOTIFY trigger (migration 1): like streams, events are now coalesced and pushed by run_notifier off the write path. Gated to match migration 1.
-    # The notifications trigger is deliberately kept: recv destructively consumes on wakeup, so it must not be woken before the message row commits, which the in-transaction trigger guarantees but a batched app-side notify does not.
+    # Drop the workflow_events NOTIFY trigger (events are pushed by run_notifier); keep the notifications trigger since recv consumes destructively on wakeup and must not fire before the row commits.
     if not use_listen_notify:
         return ""
     return f"""

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -883,12 +883,24 @@ ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced"
 
 
 def get_dbos_migration_fortythree(schema: str, use_listen_notify: bool) -> str:
-    # Drop the per-row streams NOTIFY trigger (migration 39): notifications are now coalesced and pushed by run_stream_notifier off the write path. Gated to match migration 39.
+    # Drop the per-row streams NOTIFY trigger (migration 39): notifications are now coalesced and pushed by run_notifier off the write path. Gated to match migration 39.
     if not use_listen_notify:
         return ""
     return f"""
 DROP TRIGGER IF EXISTS dbos_streams_trigger ON "{schema}".streams;
 DROP FUNCTION IF EXISTS "{schema}".streams_function();
+"""
+
+
+def get_dbos_migration_fortyfour(schema: str, use_listen_notify: bool) -> str:
+    # Drop the per-row notifications and workflow_events NOTIFY triggers (migration 1): like streams, these are now coalesced and pushed by run_notifier off the write path. Gated to match migration 1.
+    if not use_listen_notify:
+        return ""
+    return f"""
+DROP TRIGGER IF EXISTS dbos_notifications_trigger ON "{schema}".notifications;
+DROP FUNCTION IF EXISTS "{schema}".notifications_function();
+DROP TRIGGER IF EXISTS dbos_workflow_events_trigger ON "{schema}".workflow_events;
+DROP FUNCTION IF EXISTS "{schema}".workflow_events_function();
 """
 
 
@@ -939,6 +951,7 @@ def get_dbos_migrations(
         get_dbos_migration_fortyone(schema),
         get_dbos_migration_fortytwo(schema),
         get_dbos_migration_fortythree(schema, use_listen_notify),
+        get_dbos_migration_fortyfour(schema, use_listen_notify),
     ]
 
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -893,7 +893,7 @@ DROP FUNCTION IF EXISTS "{schema}".streams_function();
 
 
 def get_dbos_migration_fortyfour(schema: str, use_listen_notify: bool) -> str:
-    # Drop the workflow_events NOTIFY trigger (events are pushed by run_notifier); keep the notifications trigger since recv consumes destructively on wakeup and must not fire before the row commits.
+    # Drop the workflow_events NOTIFY trigger (events are pushed by run_notifier)
     if not use_listen_notify:
         return ""
     return f"""

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -388,7 +388,10 @@ class NotificationInfo(TypedDict):
 _dbos_null_topic = "__null__topic__"
 _dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
 
-# LISTEN/NOTIFY channels. Writers coalesce payloads per channel and the notifier pushes them off the write path; the listener fans each channel's payload back to its waiting event.
+# LISTEN/NOTIFY channels; the listener fans each channel's payload back to its waiting event.
+# streams and workflow_events are coalesced and pushed off the write path by run_notifier; notifications
+# still fires from an in-transaction DB trigger, because recv destructively consumes on wakeup and must
+# not be woken before the message row commits (which the trigger guarantees but a batched notify does not).
 _dbos_notifications_channel = "dbos_notifications_channel"
 _dbos_workflow_events_channel = "dbos_workflow_events_channel"
 _dbos_streams_channel = "dbos_streams_channel"
@@ -2772,7 +2775,7 @@ class SystemDatabase(ABC):
         (forks, forks of forks, ...) that exists at send time.
         """
         with self.engine.begin() as c:
-            payloads = self._send_bulk_txn(
+            self._send_bulk_txn(
                 messages,
                 c,
                 serialization_type=serialization_type,
@@ -2781,9 +2784,6 @@ class SystemDatabase(ABC):
                 function_name=function_name,
                 send_to_forks=send_to_forks,
             )
-        # Notify only after commit, so a woken recv sees the rows.
-        for payload in payloads:
-            self._signal_notification(_dbos_notifications_channel, payload)
 
     def send_bulk_with_connection(
         self,
@@ -2803,7 +2803,7 @@ class SystemDatabase(ABC):
         database.
         """
         self._apply_caller_schema(conn)
-        payloads = self._send_bulk_txn(
+        self._send_bulk_txn(
             messages,
             conn,
             serialization_type=serialization_type,
@@ -2812,10 +2812,6 @@ class SystemDatabase(ABC):
             function_name=function_name,
             send_to_forks=send_to_forks,
         )
-        # The caller owns the commit, so this may notify slightly before the rows
-        # are visible; the recv listener's periodic recheck covers that window.
-        for payload in payloads:
-            self._signal_notification(_dbos_notifications_channel, payload)
 
     def _send_bulk_txn(
         self,
@@ -2827,10 +2823,7 @@ class SystemDatabase(ABC):
         function_id: Optional[int],
         function_name: str,
         send_to_forks: bool,
-    ) -> Set[str]:
-        """Insert the messages within `conn`'s transaction and return the set of
-        `destination_uuid::topic` payloads to notify once it commits (empty on replay).
-        """
+    ) -> None:
         start_time = int(time.time() * 1000)
 
         # Reject duplicate idempotency keys
@@ -2859,7 +2852,7 @@ class SystemDatabase(ABC):
                 dbos_logger.debug(
                     f"Replaying {function_name}, id: {function_id}, messages: {len(messages)}"
                 )
-                return set()  # Already sent before
+                return  # Already sent before
             else:
                 dbos_logger.debug(
                     f"Running {function_name}, id: {function_id}, messages: {len(messages)}"
@@ -2936,9 +2929,6 @@ class SystemDatabase(ABC):
             self._record_operation_result_txn(
                 output, int(time.time() * 1000), conn=conn
             )
-
-        # One notification per (destination, topic) a recv listener registers on.
-        return {f"{r['destination_uuid']}::{r['topic']}" for r in rows}
 
     @db_retry()
     def recv_setup(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -388,10 +388,7 @@ class NotificationInfo(TypedDict):
 _dbos_null_topic = "__null__topic__"
 _dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
 
-# LISTEN/NOTIFY channels; the listener fans each channel's payload back to its waiting event.
-# streams and workflow_events are coalesced and pushed off the write path by run_notifier; notifications
-# still fires from an in-transaction DB trigger, because recv destructively consumes on wakeup and must
-# not be woken before the message row commits (which the trigger guarantees but a batched notify does not).
+# LISTEN/NOTIFY channels; streams and workflow_events are pushed by run_notifier, while notifications fires from an in-transaction DB trigger so recv is never woken before its row commits.
 _dbos_notifications_channel = "dbos_notifications_channel"
 _dbos_workflow_events_channel = "dbos_workflow_events_channel"
 _dbos_streams_channel = "dbos_streams_channel"

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -388,6 +388,11 @@ class NotificationInfo(TypedDict):
 _dbos_null_topic = "__null__topic__"
 _dbos_stream_closed_sentinel = "__DBOS_STREAM_CLOSED__"
 
+# LISTEN/NOTIFY channels. Writers coalesce payloads per channel and the notifier pushes them off the write path; the listener fans each channel's payload back to its waiting event.
+_dbos_notifications_channel = "dbos_notifications_channel"
+_dbos_workflow_events_channel = "dbos_workflow_events_channel"
+_dbos_streams_channel = "dbos_streams_channel"
+
 # Returned by read_stream_value when nothing is written at the requested offset. Not None, which is itself a valid stream value.
 _no_stream_value = object()
 
@@ -511,8 +516,8 @@ def db_retry(
 # Fallback pool size for defaulting polling concurrency when the engine's is unknown (mirrors configure_db_engine_parameters).
 DEFAULT_SYS_DB_POOL_SIZE = 20
 
-# Interval for coalescing stream-write notifications off the write path; caps the rate of notifying commits regardless of write throughput.
-DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC = 0.01
+# Interval for coalescing LISTEN/NOTIFY notifications off the write path; caps the rate of notifying commits regardless of write throughput.
+DEFAULT_NOTIFICATION_COALESCE_SEC = 0.01
 
 
 class SystemDatabase(ABC):
@@ -527,7 +532,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
-        stream_notification_coalesce_sec: float = DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
+        notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
@@ -543,7 +548,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
-                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
+                notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
             )
         else:
@@ -558,7 +563,7 @@ class SystemDatabase(ABC):
                 executor_id=executor_id,
                 use_listen_notify=use_listen_notify,
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
-                stream_notification_coalesce_sec=stream_notification_coalesce_sec,
+                notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
             )
 
@@ -573,7 +578,7 @@ class SystemDatabase(ABC):
         executor_id: Optional[str],
         use_listen_notify: bool = True,
         notification_listener_polling_interval_sec: float = 1.0,
-        stream_notification_coalesce_sec: float = DEFAULT_STREAM_NOTIFICATION_COALESCE_SEC,
+        notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
     ):
         import sqlalchemy.dialects.postgresql as pg
@@ -639,11 +644,11 @@ class SystemDatabase(ABC):
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
         )
-        self._stream_notification_coalesce_sec = stream_notification_coalesce_sec
+        self._notification_coalesce_sec = notification_coalesce_sec
 
-        # Coalesced stream-write notification payloads, flushed off the write path by run_stream_notifier (Postgres + L/N only).
-        self._pending_stream_notifications: Set[str] = set()
-        self._stream_notifier_lock = threading.Lock()
+        # Coalesced NOTIFY payloads keyed by channel, flushed off the write path by run_notifier (Postgres + L/N only).
+        self._pending_notifications: Dict[str, Set[str]] = {}
+        self._notifier_lock = threading.Lock()
 
         self._listener_thread_lock = threading.Lock()
         self._listener_running = False
@@ -2767,7 +2772,7 @@ class SystemDatabase(ABC):
         (forks, forks of forks, ...) that exists at send time.
         """
         with self.engine.begin() as c:
-            self._send_bulk_txn(
+            payloads = self._send_bulk_txn(
                 messages,
                 c,
                 serialization_type=serialization_type,
@@ -2776,6 +2781,9 @@ class SystemDatabase(ABC):
                 function_name=function_name,
                 send_to_forks=send_to_forks,
             )
+        # Notify only after commit, so a woken recv sees the rows.
+        for payload in payloads:
+            self._signal_notification(_dbos_notifications_channel, payload)
 
     def send_bulk_with_connection(
         self,
@@ -2795,7 +2803,7 @@ class SystemDatabase(ABC):
         database.
         """
         self._apply_caller_schema(conn)
-        self._send_bulk_txn(
+        payloads = self._send_bulk_txn(
             messages,
             conn,
             serialization_type=serialization_type,
@@ -2804,6 +2812,10 @@ class SystemDatabase(ABC):
             function_name=function_name,
             send_to_forks=send_to_forks,
         )
+        # The caller owns the commit, so this may notify slightly before the rows
+        # are visible; the recv listener's periodic recheck covers that window.
+        for payload in payloads:
+            self._signal_notification(_dbos_notifications_channel, payload)
 
     def _send_bulk_txn(
         self,
@@ -2815,7 +2827,10 @@ class SystemDatabase(ABC):
         function_id: Optional[int],
         function_name: str,
         send_to_forks: bool,
-    ) -> None:
+    ) -> Set[str]:
+        """Insert the messages within `conn`'s transaction and return the set of
+        `destination_uuid::topic` payloads to notify once it commits (empty on replay).
+        """
         start_time = int(time.time() * 1000)
 
         # Reject duplicate idempotency keys
@@ -2844,7 +2859,7 @@ class SystemDatabase(ABC):
                 dbos_logger.debug(
                     f"Replaying {function_name}, id: {function_id}, messages: {len(messages)}"
                 )
-                return  # Already sent before
+                return set()  # Already sent before
             else:
                 dbos_logger.debug(
                     f"Running {function_name}, id: {function_id}, messages: {len(messages)}"
@@ -2921,6 +2936,9 @@ class SystemDatabase(ABC):
             self._record_operation_result_txn(
                 output, int(time.time() * 1000), conn=conn
             )
+
+        # One notification per (destination, topic) a recv listener registers on.
+        return {f"{r['destination_uuid']}::{r['topic']}" for r in rows}
 
     @db_retry()
     def recv_setup(
@@ -3110,12 +3128,12 @@ class SystemDatabase(ABC):
         self._listener_running = True
         self._notification_listener()
 
-    def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
-        """Hint that (workflow_uuid, key) was written; push-notification backends override to coalesce a wakeup, pollers ignore it."""
+    def _signal_notification(self, channel: str, payload: str) -> None:
+        """Hint that `payload` was written on `channel`; push-notification backends override to coalesce a wakeup, pollers ignore it."""
         pass
 
-    def run_stream_notifier(self) -> None:
-        """Background loop flushing coalesced stream-write notifications; no-op except on push-notification backends (Postgres + L/N)."""
+    def run_notifier(self) -> None:
+        """Background loop flushing coalesced NOTIFY payloads across all channels; no-op except on push-notification backends (Postgres + L/N)."""
         pass
 
     def recv(
@@ -3445,6 +3463,10 @@ class SystemDatabase(ABC):
                 "serialization": None,
             }
             self._record_operation_result_txn(output, int(time.time() * 1000), conn=c)
+        # Notify only after commit, so a woken get_event sees the value.
+        self._signal_notification(
+            _dbos_workflow_events_channel, f"{workflow_uuid}::{key}"
+        )
 
     def set_event_from_step(
         self,
@@ -3495,6 +3517,10 @@ class SystemDatabase(ABC):
                     },
                 )
             )
+        # Notify only after commit, so a woken get_event sees the value.
+        self._signal_notification(
+            _dbos_workflow_events_channel, f"{workflow_uuid}::{key}"
+        )
 
     def get_all_events(self, workflow_id: str) -> Dict[str, Any]:
         """
@@ -4388,7 +4414,9 @@ class SystemDatabase(ABC):
             try:
                 with self.engine.begin() as c:
                     c.execute(stmt)
-                self._signal_stream_write(workflow_uuid, key)
+                self._signal_notification(
+                    _dbos_streams_channel, f"{workflow_uuid}::{key}"
+                )
                 return
             except sa.exc.IntegrityError:
                 dbos_logger.warning(
@@ -4462,7 +4490,7 @@ class SystemDatabase(ABC):
                 self._record_operation_result_txn(
                     output, int(time.time() * 1000), conn=c
                 )
-            self._signal_stream_write(workflow_uuid, key)
+            self._signal_notification(_dbos_streams_channel, f"{workflow_uuid}::{key}")
             return
 
     def close_stream(self, workflow_uuid: str, function_id: int, key: str) -> None:

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -10,7 +10,12 @@ from dbos._migration import ensure_dbos_schema, run_dbos_migrations, should_migr
 
 from ._logger import dbos_logger
 from ._schemas.system_database import SystemSchema
-from ._sys_db import SystemDatabase
+from ._sys_db import (
+    SystemDatabase,
+    _dbos_notifications_channel,
+    _dbos_streams_channel,
+    _dbos_workflow_events_channel,
+)
 
 
 class PostgresSystemDatabase(SystemDatabase):
@@ -166,9 +171,9 @@ class PostgresSystemDatabase(SystemDatabase):
                     )
                     psycopg_conn.set_autocommit(True)
 
-                    psycopg_conn.execute("LISTEN dbos_notifications_channel")
-                    psycopg_conn.execute("LISTEN dbos_workflow_events_channel")
-                    psycopg_conn.execute("LISTEN dbos_streams_channel")
+                    psycopg_conn.execute(f"LISTEN {_dbos_notifications_channel}")
+                    psycopg_conn.execute(f"LISTEN {_dbos_workflow_events_channel}")
+                    psycopg_conn.execute(f"LISTEN {_dbos_streams_channel}")
                 while self._run_background_processes:
                     gen = psycopg_conn.notifies()
                     for notify in gen:
@@ -176,7 +181,7 @@ class PostgresSystemDatabase(SystemDatabase):
                         dbos_logger.debug(
                             f"Received notification on channel: {channel}, payload: {notify.payload}"
                         )
-                        if channel == "dbos_notifications_channel":
+                        if channel == _dbos_notifications_channel:
                             if notify.payload:
                                 event = self.notifications_map.get(notify.payload)
                                 if event is None:
@@ -185,7 +190,7 @@ class PostgresSystemDatabase(SystemDatabase):
                                 dbos_logger.debug(
                                     f"Signaled notifications event for {notify.payload}"
                                 )
-                        elif channel == "dbos_workflow_events_channel":
+                        elif channel == _dbos_workflow_events_channel:
                             if notify.payload:
                                 event = self.workflow_events_map.get(notify.payload)
                                 if event is None:
@@ -194,7 +199,7 @@ class PostgresSystemDatabase(SystemDatabase):
                                 dbos_logger.debug(
                                     f"Signaled workflow_events event for {notify.payload}"
                                 )
-                        elif channel == "dbos_streams_channel":
+                        elif channel == _dbos_streams_channel:
                             if notify.payload:
                                 event = self.streams_map.get(notify.payload)
                                 if event is None:
@@ -213,49 +218,52 @@ class PostgresSystemDatabase(SystemDatabase):
             finally:
                 self._cleanup_connections()
 
-    def _signal_stream_write(self, workflow_uuid: str, key: str) -> None:
-        """Accumulate a coalesced wakeup for readers of (workflow_uuid, key); run_stream_notifier pushes it off the write path (no-op without L/N)."""
+    def _signal_notification(self, channel: str, payload: str) -> None:
+        """Accumulate a coalesced wakeup on `channel` for `payload`; run_notifier pushes it off the write path (no-op without L/N)."""
         if not self.use_listen_notify:
             return
-        payload = f"{workflow_uuid}::{key}"
-        with self._stream_notifier_lock:
-            self._pending_stream_notifications.add(payload)
+        with self._notifier_lock:
+            self._pending_notifications.setdefault(channel, set()).add(payload)
 
-    def run_stream_notifier(self) -> None:
-        """Periodically flush coalesced stream-write notifications, keeping the async-notify queue lock (which serializes notifying commits) off the write path."""
+    def run_notifier(self) -> None:
+        """Periodically flush coalesced notifications across all channels, keeping the async-notify queue lock (which serializes notifying commits) off the write path."""
         if not self.use_listen_notify:
             return
         while self._run_background_processes:
             try:
-                time.sleep(self._stream_notification_coalesce_sec)
-                self._flush_stream_notifications()
+                time.sleep(self._notification_coalesce_sec)
+                self._flush_notifications()
             except Exception as e:
                 # Last resort: a failing flush logs and drops its batch internally, so this catches only unexpected errors, which must not kill the sole push path.
                 if self._run_background_processes:
-                    dbos_logger.warning(f"Stream notifier error: {e}")
+                    dbos_logger.warning(f"Notifier error: {e}")
                     time.sleep(1)
         # Final flush so values written just before shutdown still wake readers promptly.
         try:
-            self._flush_stream_notifications()
+            self._flush_notifications()
         except Exception as e:
-            dbos_logger.warning(f"Stream notifier final flush error: {e}")
+            dbos_logger.warning(f"Notifier final flush error: {e}")
 
-    def _flush_stream_notifications(self) -> None:
-        """Emit one coalesced notifying transaction for all pending payloads; drop the batch if it fails."""
-        with self._stream_notifier_lock:
-            if not self._pending_stream_notifications:
+    def _flush_notifications(self) -> None:
+        """Emit one coalesced notifying transaction per channel for all pending payloads; drop a channel's batch if it fails."""
+        with self._notifier_lock:
+            if not any(self._pending_notifications.values()):
                 return
-            batch = self._pending_stream_notifications
-            self._pending_stream_notifications = set()
-        try:
-            # One statement, one transaction: one round trip and one acquisition of the async-notify queue lock; unnest emits one notification per payload.
-            with self.engine.begin() as c:
-                c.execute(
-                    sa.text(
-                        "SELECT pg_notify('dbos_streams_channel', p) FROM unnest(CAST(:payloads AS text[])) AS p"
-                    ),
-                    {"payloads": list(batch)},
-                )
-        except Exception as e:
-            # Drop the batch (do not requeue) on failure, e.g. a payload over pg_notify's 8000-byte limit; readers' polling fallback delivers these values, so one poison payload can't stall the notifier forever.
-            dbos_logger.warning(f"Stream notifier flush error: {e}")
+            batches = self._pending_notifications
+            self._pending_notifications = {}
+        # One transaction per channel so an unsendable payload on one channel drops only its own batch.
+        for channel, batch in batches.items():
+            if not batch:
+                continue
+            try:
+                # One statement, one transaction: one round trip and one acquisition of the async-notify queue lock; unnest emits one notification per payload.
+                with self.engine.begin() as c:
+                    c.execute(
+                        sa.text(
+                            "SELECT pg_notify(:channel, p) FROM unnest(CAST(:payloads AS text[])) AS p"
+                        ),
+                        {"channel": channel, "payloads": list(batch)},
+                    )
+            except Exception as e:
+                # Drop the batch (do not requeue) on failure, e.g. a payload over pg_notify's 8000-byte limit; readers' polling fallback delivers these values, so one poison payload can't stall the notifier forever.
+                dbos_logger.warning(f"Notifier flush error on {channel}: {e}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -660,8 +660,7 @@ def test_translate_dbosconfig_notification_coalesce_sec():
     translated = translate_dbos_config_to_config_file(ok)
     assert translated["runtimeConfig"]["notification_coalesce_sec"] == 0.001
 
-    # Invalid values are rejected, including NaN/inf which slip past a bare < 0.001 check
-    # and would otherwise crash run_notifier's time.sleep.
+    # Invalid values are rejected, including NaN/inf which would otherwise crash run_notifier's time.sleep.
     for bad in [0.0005, 0.0, -1.0, float("nan"), float("inf")]:
         with pytest.raises(DBOSInitializationError) as exc_info:
             translate_dbos_config_to_config_file(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -654,20 +654,20 @@ def test_translate_dbosconfig_full_input():
     assert "env" not in translated_config
 
 
-def test_translate_dbosconfig_stream_notification_coalesce_sec():
+def test_translate_dbosconfig_notification_coalesce_sec():
     # A valid value is threaded into runtimeConfig.
-    ok: DBOSConfig = {"name": "test-app", "stream_notification_coalesce_sec": 0.001}
+    ok: DBOSConfig = {"name": "test-app", "notification_coalesce_sec": 0.001}
     translated = translate_dbos_config_to_config_file(ok)
-    assert translated["runtimeConfig"]["stream_notification_coalesce_sec"] == 0.001
+    assert translated["runtimeConfig"]["notification_coalesce_sec"] == 0.001
 
     # Invalid values are rejected, including NaN/inf which slip past a bare < 0.001 check
-    # and would otherwise crash run_stream_notifier's time.sleep.
+    # and would otherwise crash run_notifier's time.sleep.
     for bad in [0.0005, 0.0, -1.0, float("nan"), float("inf")]:
         with pytest.raises(DBOSInitializationError) as exc_info:
             translate_dbos_config_to_config_file(
-                {"name": "test-app", "stream_notification_coalesce_sec": bad}
+                {"name": "test-app", "notification_coalesce_sec": bad}
             )
-        assert "stream_notification_coalesce_sec" in str(exc_info.value)
+        assert "notification_coalesce_sec" in str(exc_info.value)
 
 
 def test_translate_dbosconfig_minimal_input():

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -3062,14 +3062,10 @@ def test_notification_fallback_polling(dbos: DBOS) -> None:
 
 
 def test_recv_wakeup_trigger_is_kept(dbos: DBOS, skip_with_sqlite: None) -> None:
-    """The notifications NOTIFY trigger is deliberately NOT dropped: recv destructively
-    consumes on wakeup, so it must only be woken after the message row commits, which the
-    in-transaction trigger guarantees but a batched app-side notify does not. Assert the
-    trigger is present and that with the fallback recheck forced far out, a send still wakes
-    a blocked recv promptly -- which can only come from the trigger's NOTIFY."""
+    """The notifications trigger must wake a blocked recv: assert it exists and that, with the fallback recheck forced far out, a send still delivers promptly via the trigger's NOTIFY."""
     sys_db = dbos._sys_db
 
-    # The per-row trigger on the notifications table must still exist.
+    # The trigger on the notifications table must exist.
     with sys_db.engine.begin() as c:
         trigger = c.execute(
             sa.text(
@@ -3089,16 +3085,14 @@ def test_recv_wakeup_trigger_is_kept(dbos: DBOS, skip_with_sqlite: None) -> None
     def recv_workflow() -> str:
         return str(DBOS.recv(timeout_seconds=30))
 
-    # Force the fallback recheck far longer than the delivery we expect, so a timely
-    # wakeup must come from the trigger's NOTIFY, not the periodic recheck.
+    # Force the fallback recheck far out so a timely wakeup must come from the trigger's NOTIFY.
     original = sys_db._notification_fallback_polling_interval
     sys_db._notification_fallback_polling_interval = 30.0
     try:
         with SetWorkflowID(dest_uuid):
             handle = DBOS.start_workflow(recv_workflow)
 
-        # Wait until the recv is actually blocked (registered its listener) before sending,
-        # so delivery exercises the notification wakeup path rather than recv's initial check.
+        # Wait until the recv is blocked (listener registered) so delivery exercises the wakeup path.
         payload = f"{dest_uuid}::{_dbos_null_topic}"
 
         def recv_blocked() -> None:
@@ -3121,10 +3115,10 @@ def test_recv_wakeup_trigger_is_kept(dbos: DBOS, skip_with_sqlite: None) -> None
 def test_get_event_delivered_by_notifier_without_trigger(
     dbos: DBOS, skip_with_sqlite: None
 ) -> None:
-    """The per-row workflow_events NOTIFY trigger is dropped (migration 44); a blocked get_event is woken by the coalescing app-side notifier instead. Assert the trigger is gone and that with the fallback recheck forced far out, a set_event still wakes the get_event promptly."""
+    """get_event is woken by the app-side notifier: assert no workflow_events trigger exists and that, with the fallback recheck forced far out, a set_event still wakes a blocked get_event promptly."""
     sys_db = dbos._sys_db
 
-    # No per-row trigger may remain on the workflow_events table.
+    # No trigger may exist on the workflow_events table.
     with sys_db.engine.begin() as c:
         trigger = c.execute(
             sa.text(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -3061,13 +3061,15 @@ def test_notification_fallback_polling(dbos: DBOS) -> None:
     assert duration < 5.0
 
 
-def test_recv_delivered_by_notifier_without_trigger(
-    dbos: DBOS, skip_with_sqlite: None
-) -> None:
-    """The per-row notifications NOTIFY trigger is dropped (migration 44); a blocked recv is woken by the coalescing app-side notifier instead. Assert the trigger is gone and that with the fallback recheck forced far out, a send still wakes the recv promptly -- which can only happen via the notifier."""
+def test_recv_wakeup_trigger_is_kept(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """The notifications NOTIFY trigger is deliberately NOT dropped: recv destructively
+    consumes on wakeup, so it must only be woken after the message row commits, which the
+    in-transaction trigger guarantees but a batched app-side notify does not. Assert the
+    trigger is present and that with the fallback recheck forced far out, a send still wakes
+    a blocked recv promptly -- which can only come from the trigger's NOTIFY."""
     sys_db = dbos._sys_db
 
-    # No per-row trigger may remain on the notifications table.
+    # The per-row trigger on the notifications table must still exist.
     with sys_db.engine.begin() as c:
         trigger = c.execute(
             sa.text(
@@ -3079,7 +3081,7 @@ def test_recv_delivered_by_notifier_without_trigger(
             ),
             {"schema": sys_db.schema},
         ).fetchone()
-    assert trigger is None, "dbos_notifications_trigger should have been dropped"
+    assert trigger is not None, "dbos_notifications_trigger must be kept"
 
     dest_uuid = str(uuid.uuid4())
 
@@ -3088,7 +3090,7 @@ def test_recv_delivered_by_notifier_without_trigger(
         return str(DBOS.recv(timeout_seconds=30))
 
     # Force the fallback recheck far longer than the delivery we expect, so a timely
-    # wakeup must come from the notifier, not the periodic recheck.
+    # wakeup must come from the trigger's NOTIFY, not the periodic recheck.
     original = sys_db._notification_fallback_polling_interval
     sys_db._notification_fallback_polling_interval = 30.0
     try:
@@ -3105,15 +3107,15 @@ def test_recv_delivered_by_notifier_without_trigger(
         retry_until_success(recv_blocked, interval=0.05, max_attempts=200)
 
         begin_time = time.time()
-        DBOS.send(dest_uuid, "hello_notifier")
+        DBOS.send(dest_uuid, "hello_trigger")
         result = handle.get_result()
         duration = time.time() - begin_time
     finally:
         sys_db._notification_fallback_polling_interval = original
 
-    assert result == "hello_notifier"
-    # Well under the 30s fallback: delivery came from the notifier, not the recheck.
-    assert duration < 10.0, f"recv took {duration:.3f}s, notifier did not wake it"
+    assert result == "hello_trigger"
+    # Well under the 30s fallback: delivery came from the trigger's NOTIFY, not the recheck.
+    assert duration < 10.0, f"recv took {duration:.3f}s, trigger did not wake it"
 
 
 def test_get_event_delivered_by_notifier_without_trigger(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -38,6 +38,7 @@ from dbos._error import (
     DBOSRecoveryError,
 )
 from dbos._schemas.system_database import SystemSchema
+from dbos._sys_db import _dbos_null_topic
 from dbos._utils import GlobalParams
 from tests.conftest import retry_until_success, set_workflow_status, using_sqlite
 
@@ -3058,6 +3059,108 @@ def test_notification_fallback_polling(dbos: DBOS) -> None:
     duration = time.time() - begin_time
     assert event_result == "fallback_value"
     assert duration < 5.0
+
+
+def test_recv_delivered_by_notifier_without_trigger(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """The per-row notifications NOTIFY trigger is dropped (migration 44); a blocked recv is woken by the coalescing app-side notifier instead. Assert the trigger is gone and that with the fallback recheck forced far out, a send still wakes the recv promptly -- which can only happen via the notifier."""
+    sys_db = dbos._sys_db
+
+    # No per-row trigger may remain on the notifications table.
+    with sys_db.engine.begin() as c:
+        trigger = c.execute(
+            sa.text(
+                "SELECT 1 FROM pg_trigger t "
+                "JOIN pg_class cl ON t.tgrelid = cl.oid "
+                "JOIN pg_namespace n ON cl.relnamespace = n.oid "
+                "WHERE n.nspname = :schema AND cl.relname = 'notifications' "
+                "AND t.tgname = 'dbos_notifications_trigger'"
+            ),
+            {"schema": sys_db.schema},
+        ).fetchone()
+    assert trigger is None, "dbos_notifications_trigger should have been dropped"
+
+    dest_uuid = str(uuid.uuid4())
+
+    @DBOS.workflow()
+    def recv_workflow() -> str:
+        return str(DBOS.recv(timeout_seconds=30))
+
+    # Force the fallback recheck far longer than the delivery we expect, so a timely
+    # wakeup must come from the notifier, not the periodic recheck.
+    original = sys_db._notification_fallback_polling_interval
+    sys_db._notification_fallback_polling_interval = 30.0
+    try:
+        with SetWorkflowID(dest_uuid):
+            handle = DBOS.start_workflow(recv_workflow)
+
+        # Wait until the recv is actually blocked (registered its listener) before sending,
+        # so delivery exercises the notification wakeup path rather than recv's initial check.
+        payload = f"{dest_uuid}::{_dbos_null_topic}"
+
+        def recv_blocked() -> None:
+            assert sys_db.notifications_map.get(payload) is not None
+
+        retry_until_success(recv_blocked, interval=0.05, max_attempts=200)
+
+        begin_time = time.time()
+        DBOS.send(dest_uuid, "hello_notifier")
+        result = handle.get_result()
+        duration = time.time() - begin_time
+    finally:
+        sys_db._notification_fallback_polling_interval = original
+
+    assert result == "hello_notifier"
+    # Well under the 30s fallback: delivery came from the notifier, not the recheck.
+    assert duration < 10.0, f"recv took {duration:.3f}s, notifier did not wake it"
+
+
+def test_get_event_delivered_by_notifier_without_trigger(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """The per-row workflow_events NOTIFY trigger is dropped (migration 44); a blocked get_event is woken by the coalescing app-side notifier instead. Assert the trigger is gone and that with the fallback recheck forced far out, a set_event still wakes the get_event promptly."""
+    sys_db = dbos._sys_db
+
+    # No per-row trigger may remain on the workflow_events table.
+    with sys_db.engine.begin() as c:
+        trigger = c.execute(
+            sa.text(
+                "SELECT 1 FROM pg_trigger t "
+                "JOIN pg_class cl ON t.tgrelid = cl.oid "
+                "JOIN pg_namespace n ON cl.relnamespace = n.oid "
+                "WHERE n.nspname = :schema AND cl.relname = 'workflow_events' "
+                "AND t.tgname = 'dbos_workflow_events_trigger'"
+            ),
+            {"schema": sys_db.schema},
+        ).fetchone()
+    assert trigger is None, "dbos_workflow_events_trigger should have been dropped"
+
+    target_uuid = str(uuid.uuid4())
+    key = "notifier_key"
+
+    @DBOS.workflow()
+    def setter_workflow() -> None:
+        DBOS.sleep(2.0)
+        DBOS.set_event(key, "notifier_value")
+
+    original = sys_db._notification_fallback_polling_interval
+    sys_db._notification_fallback_polling_interval = 30.0
+    try:
+        with SetWorkflowID(target_uuid):
+            handle = DBOS.start_workflow(setter_workflow)
+
+        # get_event blocks (the value is set ~2s in); prompt delivery must come from the notifier.
+        begin_time = time.time()
+        value = DBOS.get_event(target_uuid, key, timeout_seconds=30)
+        duration = time.time() - begin_time
+        handle.get_result()
+    finally:
+        sys_db._notification_fallback_polling_interval = original
+
+    assert value == "notifier_value"
+    # Well under the 30s fallback: delivery came from the notifier, not the recheck.
+    assert duration < 10.0, f"get_event took {duration:.3f}s, notifier did not wake it"
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -8,7 +8,7 @@ from sqlalchemy import event as sa_event
 # Public API
 from dbos import DBOS, DBOSConfig, SetWorkflowID
 from dbos._client import DBOSClient
-from dbos._sys_db import _no_stream_value
+from dbos._sys_db import _dbos_streams_channel, _no_stream_value
 from dbos._sys_db_postgres import PostgresSystemDatabase
 from tests.conftest import (
     retry_until_success,
@@ -563,13 +563,13 @@ def test_stream_notifier_drops_unsendable_payload(
     # A stream key past pg_notify's 8000-byte payload limit makes its batch unsendable.
     poison_payload = f"{uuid.uuid4()}::{'x' * 9000}"
 
-    with sys_db._stream_notifier_lock:
-        sys_db._pending_stream_notifications = {poison_payload}
-    sys_db._flush_stream_notifications()
+    with sys_db._notifier_lock:
+        sys_db._pending_notifications = {_dbos_streams_channel: {poison_payload}}
+    sys_db._flush_notifications()
 
     # The poison batch is dropped, not requeued (requeuing would loop forever).
-    with sys_db._stream_notifier_lock:
-        assert sys_db._pending_stream_notifications == set()
+    with sys_db._notifier_lock:
+        assert sys_db._pending_notifications.get(_dbos_streams_channel, set()) == set()
 
     # The notifier still works afterward: a subsequent good payload is delivered.
     good_wf = str(uuid.uuid4())
@@ -577,9 +577,11 @@ def test_stream_notifier_drops_unsendable_payload(
     event, payload_key = sys_db.register_stream_listener(good_wf, good_key)
     try:
         event.clear()
-        with sys_db._stream_notifier_lock:
-            sys_db._pending_stream_notifications = {f"{good_wf}::{good_key}"}
-        sys_db._flush_stream_notifications()
+        with sys_db._notifier_lock:
+            sys_db._pending_notifications = {
+                _dbos_streams_channel: {f"{good_wf}::{good_key}"}
+            }
+        sys_db._flush_notifications()
         assert event.wait(
             timeout=10
         ), "notifier stopped delivering after a poison batch"
@@ -592,7 +594,7 @@ def test_stream_notifier_survives_flush_error(
 ) -> None:
     """An exception escaping a flush must not kill the notifier thread (M1): it logs, backs off, and resumes delivering. Without the loop guard the thread would die and stop all stream push notifications for the process."""
     sys_db = cast(PostgresSystemDatabase, dbos._sys_db)
-    real_flush = sys_db._flush_stream_notifications
+    real_flush = sys_db._flush_notifications
     state = {"raised": False}
 
     def flaky_flush() -> None:
@@ -602,7 +604,7 @@ def test_stream_notifier_survives_flush_error(
             raise RuntimeError("simulated flush failure")
         real_flush()
 
-    monkeypatch.setattr(sys_db, "_flush_stream_notifications", flaky_flush)
+    monkeypatch.setattr(sys_db, "_flush_notifications", flaky_flush)
 
     # Wait until the running notifier thread has hit the injected failure.
     def failure_injected() -> bool:
@@ -617,8 +619,10 @@ def test_stream_notifier_survives_flush_error(
     event, payload_key = sys_db.register_stream_listener(good_wf, good_key)
     try:
         event.clear()
-        with sys_db._stream_notifier_lock:
-            sys_db._pending_stream_notifications.add(f"{good_wf}::{good_key}")
+        with sys_db._notifier_lock:
+            sys_db._pending_notifications.setdefault(_dbos_streams_channel, set()).add(
+                f"{good_wf}::{good_key}"
+            )
         assert event.wait(
             timeout=10
         ), "notifier did not resume delivering after a flush error"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -162,8 +162,12 @@ async def test_stream_read_async_wakes_on_notification(
         latencies.append(time.time() - written[value])
 
     assert len(latencies) == len(gaps)
-    # Without the wakeup the reader sleeps to the 30s deadline, drains all three at once, and fails here with ~30s latencies.
-    assert max(latencies) < 0.15, f"notification latencies {latencies}"
+    # Without the wakeup the reader sleeps to the 30s deadline, drains all three at once, and shows ~30s latencies.
+    # Each value should arrive within a notification cycle, but the post-wakeup path hops through a thread pool and a
+    # DB re-read, so tolerate a single CI stall: the rest must stay prompt, and none may approach the 30s fallback.
+    ordered = sorted(latencies)
+    assert ordered[1] < 0.15, f"notification latencies {latencies}"
+    assert ordered[-1] < 2.0, f"notification latencies {latencies}"
 
 
 def test_stream_read_is_one_round_trip_per_value(dbos: DBOS) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -162,9 +162,7 @@ async def test_stream_read_async_wakes_on_notification(
         latencies.append(time.time() - written[value])
 
     assert len(latencies) == len(gaps)
-    # Without the wakeup the reader sleeps to the 30s deadline, drains all three at once, and shows ~30s latencies.
-    # Each value should arrive within a notification cycle, but the post-wakeup path hops through a thread pool and a
-    # DB re-read, so tolerate a single CI stall: the rest must stay prompt, and none may approach the 30s fallback.
+    # Each value should arrive within a notification cycle; tolerate one CI stall but keep the rest prompt and none near the 30s fallback (a broken wakeup drains all three at ~30s).
     ordered = sorted(latencies)
     assert ordered[1] < 0.15, f"notification latencies {latencies}"
     assert ordered[-1] < 2.0, f"notification latencies {latencies}"


### PR DESCRIPTION
Apply the optimizations from https://github.com/dbos-inc/dbos-transact-py/pull/774 to workflow events. For now, we'll keep the trigger on workflow messages (`DBOS.send`) because messages can be sent from anywhere, including environments that don't have a background process to buffer/batch notifications.