### PR TITLE
Add print only flags to dbos migrate

### DIFF
--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -13,7 +13,8 @@ import typer
 
 from dbos._context import SetWorkflowID
 from dbos.cli.migration import (
-    print_dbos_database_migrations,
+    print_dbos_migrations,
+    print_dbos_user_role_sql,
     run_dbos_database_migrations,
 )
 
@@ -284,11 +285,19 @@ def migrate(
             help='Schema name for DBOS system tables. Defaults to "dbos".',
         ),
     ] = "dbos",
-    print_only: Annotated[
+    print_migrations: Annotated[
+        typing.Optional[str],
+        typer.Option(
+            "--print-migrations",
+            metavar="[all|NUMBER]",
+            help="Print the SQL of one migration ('--print-migrations 3') or all of them ('--print-migrations all') instead of running them",
+        ),
+    ] = None,
+    print_user_role: Annotated[
         bool,
         typer.Option(
-            "--print-only",
-            help="Print the migration SQL without executing anything against the database",
+            "--print-user-role",
+            help="Print the SQL granting the application role (--app-role) access to DBOS system tables instead of executing it",
         ),
     ] = False,
 ) -> None:
@@ -299,17 +308,24 @@ def migrate(
     if schema is None:
         schema = "dbos"
 
-    if print_only:
-        print_dbos_database_migrations(
-            system_database_url=system_database_url,
-            schema=schema,
-            application_role=application_role,
-        )
+    if print_migrations is not None or print_user_role:
+        if print_user_role and application_role is None:
+            typer.echo("--print-user-role requires --app-role", err=True)
+            raise typer.Exit(code=1)
+        if print_migrations is not None:
+            print_dbos_migrations(
+                system_database_url=system_database_url,
+                schema=schema,
+                migration=print_migrations,
+            )
+        if print_user_role:
+            assert application_role is not None
+            print_dbos_user_role_sql(schema=schema, role_name=application_role)
         if os.path.exists("dbos-config.yaml"):
             config = load_config(silent=True)
             if "database" in config and config["database"].get("migrate"):
                 typer.echo(
-                    "Warning: skipping migration commands from 'dbos-config.yaml' in --print-only mode",
+                    "Warning: skipping migration commands from 'dbos-config.yaml' in print mode",
                     err=True,
                 )
         return

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -309,6 +309,11 @@ def migrate(
         schema = "dbos"
 
     if print_migrations is not None or print_user_role:
+        if print_migrations is not None and print_user_role:
+            typer.echo(
+                "--print-user-role cannot be combined with --print-migrations", err=True
+            )
+            raise typer.Exit(code=1)
         if print_user_role and application_role is None:
             typer.echo("--print-user-role requires --app-role", err=True)
             raise typer.Exit(code=1)
@@ -321,13 +326,6 @@ def migrate(
         if print_user_role:
             assert application_role is not None
             print_dbos_user_role_sql(schema=schema, role_name=application_role)
-        if os.path.exists("dbos-config.yaml"):
-            config = load_config(silent=True)
-            if "database" in config and config["database"].get("migrate"):
-                typer.echo(
-                    "Warning: skipping migration commands from 'dbos-config.yaml' in print mode",
-                    err=True,
-                )
         return
 
     # Emit INFO logs from migrations

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -290,7 +290,7 @@ def migrate(
         typer.Option(
             "--print-migrations",
             metavar="[all|NUMBER]",
-            help="Print the SQL of one migration ('--print-migrations 3') or all of them ('--print-migrations all') instead of running them",
+            help="Print the SQL of all migrations ('--print-migrations all') or of migrations from a number onward ('--print-migrations 3') instead of running them",
         ),
     ] = None,
     print_user_role: Annotated[

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -302,7 +302,6 @@ def migrate(
     if print_only:
         print_dbos_database_migrations(
             system_database_url=system_database_url,
-            app_database_url=application_database_url,
             schema=schema,
             application_role=application_role,
         )

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -12,7 +12,10 @@ import sqlalchemy as sa
 import typer
 
 from dbos._context import SetWorkflowID
-from dbos.cli.migration import run_dbos_database_migrations
+from dbos.cli.migration import (
+    print_dbos_database_migrations,
+    run_dbos_database_migrations,
+)
 
 from .._client import DBOSClient
 from .._dbos_config import (
@@ -281,11 +284,37 @@ def migrate(
             help='Schema name for DBOS system tables. Defaults to "dbos".',
         ),
     ] = "dbos",
+    print_only: Annotated[
+        bool,
+        typer.Option(
+            "--print-only",
+            help="Print the migration SQL without executing anything against the database",
+        ),
+    ] = False,
 ) -> None:
     system_database_url, application_database_url = _get_db_url(
         system_database_url=system_database_url,
         application_database_url=application_database_url,
     )
+    if schema is None:
+        schema = "dbos"
+
+    if print_only:
+        print_dbos_database_migrations(
+            system_database_url=system_database_url,
+            app_database_url=application_database_url,
+            schema=schema,
+            application_role=application_role,
+        )
+        if os.path.exists("dbos-config.yaml"):
+            config = load_config(silent=True)
+            if "database" in config and config["database"].get("migrate"):
+                typer.echo(
+                    "Warning: skipping migration commands from 'dbos-config.yaml' in --print-only mode",
+                    err=True,
+                )
+        return
+
     # Emit INFO logs from migrations
     init_logger()
     dbos_logger.setLevel(logging.INFO)
@@ -293,8 +322,6 @@ def migrate(
     if application_database_url:
         typer.echo(f"Application database: {sa.make_url(application_database_url)}")
     typer.echo(f"System database: {sa.make_url(system_database_url)}")
-    if schema is None:
-        schema = "dbos"
     typer.echo(f"DBOS system schema: {schema}")
 
     run_dbos_database_migrations(

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -5,7 +5,6 @@ import typer
 
 from dbos._app_db import ApplicationDatabase
 from dbos._migration import get_dbos_migrations
-from dbos._schemas.application_database import ApplicationSchema
 from dbos._serialization import DefaultSerializer
 from dbos._sys_db import SystemDatabase
 
@@ -160,7 +159,6 @@ def _get_current_dbos_schema_version(
 def print_dbos_database_migrations(
     system_database_url: str,
     *,
-    app_database_url: Optional[str] = None,
     schema: str = "dbos",
     application_role: Optional[str] = None,
 ) -> None:
@@ -168,9 +166,7 @@ def print_dbos_database_migrations(
     writing to any database. If the system database is reachable, only the
     migrations past its current version are printed; otherwise a full
     fresh-database script is printed. Stdout is pure SQL and comments."""
-    if system_database_url.startswith("sqlite") or (
-        app_database_url and app_database_url.startswith("sqlite")
-    ):
+    if system_database_url.startswith("sqlite"):
         typer.echo("--print-only is only supported for Postgres databases", err=True)
         raise typer.Exit(code=1)
     # The execute path interpolates the schema into quoted identifiers and
@@ -272,33 +268,3 @@ END $$""")
         typer.echo(f"-- Permissions for role {application_role}")
         for sql in get_dbos_schema_permissions_sql(schema, application_role):
             emit(sql)
-
-    if app_database_url:
-        typer.echo(
-            f"-- DBOS application database migrations for {sa.make_url(app_database_url)}: run these against the application database"
-        )
-        dialect = sa.make_url("postgresql+psycopg://").get_dialect()()
-        emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
-        # Clone the table into the real schema (it is defined with a placeholder schema)
-        table = ApplicationSchema.transaction_outputs.to_metadata(
-            sa.MetaData(), schema=schema
-        )
-        emit(
-            str(
-                sa.schema.CreateTable(table, if_not_exists=True).compile(
-                    dialect=dialect
-                )
-            )
-        )
-        for index in table.indexes:
-            emit(
-                str(
-                    sa.schema.CreateIndex(index, if_not_exists=True).compile(
-                        dialect=dialect
-                    )
-                )
-            )
-        if application_role:
-            typer.echo(f"-- Permissions for role {application_role}")
-            for sql in get_dbos_schema_permissions_sql(schema, application_role):
-                emit(sql)

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -203,7 +203,7 @@ def print_dbos_database_migrations(
         f"-- DBOS system database migrations for {sa.make_url(system_database_url)}"
     )
     typer.echo(
-        "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql -1)."
+        "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction)."
     )
     if current_version == 0:
         typer.echo(

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -171,6 +171,12 @@ def print_dbos_migrations(
                 err=True,
             )
             raise typer.Exit(code=1)
+        if start == 10:
+            typer.echo(
+                "Migration 10 is not applicable: it backfills the notifications primary key, which migration 1 already creates on a fresh database",
+                err=True,
+            )
+            raise typer.Exit(code=1)
         end = start
 
     typer.echo(
@@ -180,55 +186,22 @@ def print_dbos_migrations(
         "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction)."
     )
     if start == 1:
-        typer.echo(
-            "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied."
-        )
+        typer.echo("-- This script is for FRESH databases only.")
         _emit_sql(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
         _emit_sql(
             f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
         )
-        typer.echo("-- Abort if this is not a fresh database")
-        _emit_sql(f"""DO $$
-DECLARE
-    existing_version BIGINT;
-BEGIN
-    SELECT version INTO existing_version FROM "{schema}".dbos_migrations LIMIT 1;
-    IF existing_version IS NOT NULL THEN
-        RAISE EXCEPTION 'DBOS schema % is already at version %; this script is for fresh databases only. Use dbos migrate instead.', '{schema}', existing_version;
-    END IF;
-END $$""")
-    else:
-        typer.echo(f"-- Abort unless the database is exactly at version {start - 1}")
-        _emit_sql(f"""DO $$
-DECLARE
-    v BIGINT;
-BEGIN
-    SELECT version INTO v FROM "{schema}".dbos_migrations LIMIT 1;
-    IF v IS DISTINCT FROM {start - 1} THEN
-        RAISE EXCEPTION 'expected DBOS schema version {start - 1}, found %', v;
-    END IF;
-END $$""")
 
     version_row_exists = start > 1
     for i in range(start, end + 1):
         migration_sql = migrations[i - 1]
-        if migration_sql.strip():
+        if i == 10:
+            # Migration 10 backfills the notifications primary key, which
+            # migration 1 already creates on a fresh database.
+            typer.echo("-- Migration 10 skipped: not applicable on fresh databases")
+        elif migration_sql.strip():
             typer.echo(f"-- Migration {i}")
-            if i == 10:
-                # Mirrors the runner's guard in run_dbos_migrations: migration
-                # 10 backfills the notifications primary key, which migration
-                # 1 already creates on a fresh database.
-                typer.echo(
-                    "-- Applied only if the notifications table has no primary key, mirroring the migration runner's guard"
-                )
-                _emit_sql(f"""DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE table_schema = '{schema}' AND table_name = 'notifications' AND constraint_type = 'PRIMARY KEY') THEN
-        {migration_sql.strip()}
-    END IF;
-END $$""")
-            else:
-                _emit_sql(migration_sql)
+            _emit_sql(migration_sql)
         # Per-migration version bookkeeping, mirroring the runner: an
         # interrupted apply can be resumed from the next migration number.
         if version_row_exists:

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -1,9 +1,11 @@
-from typing import Optional
+from typing import List, Optional
 
 import sqlalchemy as sa
 import typer
 
 from dbos._app_db import ApplicationDatabase
+from dbos._migration import get_dbos_migrations
+from dbos._schemas.application_database import ApplicationSchema
 from dbos._serialization import DefaultSerializer
 from dbos._sys_db import SystemDatabase
 
@@ -76,6 +78,24 @@ def migrate_dbos_databases(
             app_db.destroy()
 
 
+def get_dbos_schema_permissions_sql(schema: str, role_name: str) -> List[str]:
+    """The statements granting permissions on all entities in the system schema to a role."""
+    return [
+        # Grant usage on the system schema
+        f'GRANT USAGE ON SCHEMA "{schema}" TO "{role_name}"',
+        # Grant all privileges on all existing tables in the system schema (includes views)
+        f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{schema}" TO "{role_name}"',
+        # Grant all privileges on all sequences in the system schema
+        f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role_name}"',
+        # Grant execute on all functions and procedures in the system schema
+        f'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA "{schema}" TO "{role_name}"',
+        # Grant default privileges for future objects in the system schema
+        f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT ALL ON TABLES TO "{role_name}"',
+        f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT ALL ON SEQUENCES TO "{role_name}"',
+        f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT EXECUTE ON FUNCTIONS TO "{role_name}"',
+    ]
+
+
 def grant_dbos_schema_permissions(
     database_url: str, role_name: str, schema: str
 ) -> None:
@@ -92,45 +112,92 @@ def grant_dbos_schema_permissions(
         )
         with engine.connect() as connection:
             connection.execution_options(isolation_level="AUTOCOMMIT")
-
-            # Grant usage on the system schema
-            sql = f'GRANT USAGE ON SCHEMA "{schema}" TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            # Grant all privileges on all existing tables in the system schema (includes views)
-            sql = f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{schema}" TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            # Grant all privileges on all sequences in the system schema
-            sql = f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            # Grant execute on all functions and procedures in the system schema
-            sql = (
-                f'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA "{schema}" TO "{role_name}"'
-            )
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            # Grant default privileges for future objects in the system schema
-            sql = f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT ALL ON TABLES TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            sql = f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT ALL ON SEQUENCES TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
-            sql = f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT EXECUTE ON FUNCTIONS TO "{role_name}"'
-            typer.echo(sql)
-            connection.execute(sa.text(sql))
-
+            for sql in get_dbos_schema_permissions_sql(schema, role_name):
+                typer.echo(sql)
+                connection.execute(sa.text(sql))
     except Exception as e:
         typer.echo(f"Failed to grant permissions to role {role_name}: {e}")
         raise typer.Exit(code=1)
     finally:
         if engine:
             engine.dispose()
+
+
+def print_dbos_database_migrations(
+    system_database_url: str,
+    *,
+    app_database_url: Optional[str] = None,
+    schema: str = "dbos",
+    application_role: Optional[str] = None,
+) -> None:
+    """Print to stdout the SQL that DBOS migrations would execute on a fresh database,
+    without connecting to any database."""
+    if system_database_url.startswith("sqlite") or (
+        app_database_url and app_database_url.startswith("sqlite")
+    ):
+        typer.echo("--print-only is only supported for Postgres databases", err=True)
+        raise typer.Exit(code=1)
+
+    def emit(sql: str) -> None:
+        sql = sql.strip()
+        if sql:
+            typer.echo(sql if sql.endswith(";") else sql + ";")
+
+    typer.echo(
+        f"-- DBOS system database migrations for {sa.make_url(system_database_url)}"
+    )
+    typer.echo(
+        "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql -1)."
+    )
+    emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+    emit(
+        f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
+    )
+    migrations = get_dbos_migrations(schema, use_listen_notify=True)
+    for i, migration_sql in enumerate(migrations, 1):
+        if i == 10:
+            # Migration 10 backfills the notifications primary key, which
+            # migration 1 already creates on a fresh database.
+            typer.echo(
+                "-- Migration 10 skipped: the notifications primary key is created in migration 1"
+            )
+            continue
+        if not migration_sql.strip():
+            continue
+        typer.echo(f"-- Migration {i}")
+        emit(migration_sql)
+    emit(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({len(migrations)})')
+    if application_role:
+        typer.echo(f"-- Permissions for role {application_role}")
+        for sql in get_dbos_schema_permissions_sql(schema, application_role):
+            emit(sql)
+
+    if app_database_url:
+        typer.echo(
+            f"-- DBOS application database migrations for {sa.make_url(app_database_url)}: run these against the application database"
+        )
+        dialect = sa.make_url("postgresql+psycopg://").get_dialect()()
+        emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+        # Clone the table into the real schema (it is defined with a placeholder schema)
+        table = ApplicationSchema.transaction_outputs.to_metadata(
+            sa.MetaData(), schema=schema
+        )
+        emit(
+            str(
+                sa.schema.CreateTable(table, if_not_exists=True).compile(
+                    dialect=dialect
+                )
+            )
+        )
+        for index in table.indexes:
+            emit(
+                str(
+                    sa.schema.CreateIndex(index, if_not_exists=True).compile(
+                        dialect=dialect
+                    )
+                )
+            )
+        if application_role:
+            typer.echo(f"-- Permissions for role {application_role}")
+            for sql in get_dbos_schema_permissions_sql(schema, application_role):
+                emit(sql)

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -142,9 +142,9 @@ def print_dbos_migrations(
     schema: str = "dbos",
     migration: str = "all",
 ) -> None:
-    """Print to stdout the SQL of one DBOS system database migration
-    (migration is a number) or all of them (migration is "all"), without
-    touching any database. Stdout is pure SQL and comments."""
+    """Print to stdout the SQL of the DBOS system database migrations, all of
+    them (migration is "all") or starting from a number (migration is N),
+    without touching any database. Stdout is pure SQL and comments."""
     if system_database_url.startswith("sqlite"):
         typer.echo(
             "--print-migrations is only supported for Postgres databases", err=True
@@ -155,7 +155,7 @@ def print_dbos_migrations(
     migrations = get_dbos_migrations(schema, use_listen_notify=True)
     latest_version = len(migrations)
     if migration == "all":
-        start, end = 1, latest_version
+        start = 1
     else:
         try:
             start = int(migration)
@@ -171,13 +171,6 @@ def print_dbos_migrations(
                 err=True,
             )
             raise typer.Exit(code=1)
-        if start == 10:
-            typer.echo(
-                "Migration 10 is not applicable: it backfills the notifications primary key, which migration 1 already creates on a fresh database",
-                err=True,
-            )
-            raise typer.Exit(code=1)
-        end = start
 
     typer.echo(
         f"-- DBOS system database migrations for {sa.make_url(system_database_url)}"
@@ -193,7 +186,7 @@ def print_dbos_migrations(
         )
 
     version_row_exists = start > 1
-    for i in range(start, end + 1):
+    for i in range(start, latest_version + 1):
         migration_sql = migrations[i - 1]
         if i == 10:
             # Migration 10 backfills the notifications primary key, which

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -123,6 +123,40 @@ def grant_dbos_schema_permissions(
             engine.dispose()
 
 
+def _get_current_dbos_schema_version(
+    system_database_url: str, schema: str
+) -> Optional[int]:
+    """Read the current DBOS schema version with read-only queries.
+
+    Returns 0 if the schema or dbos_migrations table is missing or empty
+    (fresh database), and None if no connection could be established."""
+    engine = None
+    try:
+        engine = sa.create_engine(
+            sa.make_url(system_database_url).set(drivername="postgresql+psycopg"),
+            connect_args={"connect_timeout": 10},
+        )
+        with engine.connect() as conn:
+            table_exists = conn.execute(
+                sa.text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = :schema AND table_name = 'dbos_migrations'"
+                ),
+                {"schema": schema},
+            ).fetchone()
+            if table_exists is None:
+                return 0
+            row = conn.execute(
+                sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+            ).fetchone()
+            return int(row[0]) if row else 0
+    except Exception:
+        return None
+    finally:
+        if engine:
+            engine.dispose()
+
+
 def print_dbos_database_migrations(
     system_database_url: str,
     *,
@@ -130,8 +164,10 @@ def print_dbos_database_migrations(
     schema: str = "dbos",
     application_role: Optional[str] = None,
 ) -> None:
-    """Print to stdout the SQL that DBOS migrations would execute on a fresh database,
-    without connecting to any database."""
+    """Print to stdout the SQL that DBOS migrations would execute, without
+    writing to any database. If the system database is reachable, only the
+    migrations past its current version are printed; otherwise a full
+    fresh-database script is printed. Stdout is pure SQL and comments."""
     if system_database_url.startswith("sqlite") or (
         app_database_url and app_database_url.startswith("sqlite")
     ):
@@ -142,6 +178,21 @@ def print_dbos_database_migrations(
     if '"' in schema or "'" in schema:
         typer.echo("Schema names containing quotes are not supported", err=True)
         raise typer.Exit(code=1)
+
+    migrations = get_dbos_migrations(schema, use_listen_notify=True)
+    latest_version = len(migrations)
+
+    # If the database is unreachable, silently fall back to a fresh-database
+    # script: the apply-time guard below protects against misuse.
+    current_version = _get_current_dbos_schema_version(system_database_url, schema)
+    if current_version is None:
+        current_version = 0
+
+    if current_version >= latest_version:
+        typer.echo(
+            f"-- Database is already at the latest DBOS schema version ({current_version}); nothing to do."
+        )
+        return
 
     def emit(sql: str) -> None:
         sql = sql.strip()
@@ -154,15 +205,16 @@ def print_dbos_database_migrations(
     typer.echo(
         "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql -1)."
     )
-    typer.echo(
-        "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied. Use `dbos migrate` to upgrade an existing database."
-    )
-    emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
-    emit(
-        f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
-    )
-    typer.echo("-- Abort if this is not a fresh database")
-    emit(f"""DO $$
+    if current_version == 0:
+        typer.echo(
+            "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied. Use `dbos migrate` to upgrade an existing database."
+        )
+        emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+        emit(
+            f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
+        )
+        typer.echo("-- Abort if this is not a fresh database")
+        emit(f"""DO $$
 DECLARE
     existing_version BIGINT;
 BEGIN
@@ -171,27 +223,51 @@ BEGIN
         RAISE EXCEPTION 'DBOS schema % is already at version %; this script is for fresh databases only. Use dbos migrate instead.', '{schema}', existing_version;
     END IF;
 END $$""")
-    migrations = get_dbos_migrations(schema, use_listen_notify=True)
+    else:
+        typer.echo(
+            f"-- Delta script: migrations {current_version + 1} through {latest_version}, generated for a database at version {current_version}."
+        )
+        typer.echo(
+            f"-- Abort unless the database is exactly at version {current_version}"
+        )
+        emit(f"""DO $$
+DECLARE
+    v BIGINT;
+BEGIN
+    SELECT version INTO v FROM "{schema}".dbos_migrations LIMIT 1;
+    IF v IS DISTINCT FROM {current_version} THEN
+        RAISE EXCEPTION 'expected DBOS schema version {current_version}, found %; regenerate this script with dbos migrate --print-only', v;
+    END IF;
+END $$""")
+
+    version_row_exists = current_version > 0
     for i, migration_sql in enumerate(migrations, 1):
-        if not migration_sql.strip():
+        if i <= current_version:
             continue
-        typer.echo(f"-- Migration {i}")
-        if i == 10:
-            # Mirrors the runner's guard in run_dbos_migrations: migration 10
-            # backfills the notifications primary key, which migration 1
-            # already creates on a fresh database.
-            typer.echo(
-                "-- Applied only if the notifications table has no primary key, mirroring the migration runner's guard"
-            )
-            emit(f"""DO $$
+        if migration_sql.strip():
+            typer.echo(f"-- Migration {i}")
+            if i == 10:
+                # Mirrors the runner's guard in run_dbos_migrations: migration
+                # 10 backfills the notifications primary key, which migration
+                # 1 already creates on a fresh database.
+                typer.echo(
+                    "-- Applied only if the notifications table has no primary key, mirroring the migration runner's guard"
+                )
+                emit(f"""DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE table_schema = '{schema}' AND table_name = 'notifications' AND constraint_type = 'PRIMARY KEY') THEN
         {migration_sql.strip()}
     END IF;
 END $$""")
-            continue
-        emit(migration_sql)
-    emit(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({len(migrations)})')
+            else:
+                emit(migration_sql)
+        # Per-migration version bookkeeping, mirroring the runner: an
+        # interrupted apply can be resumed by regenerating the delta.
+        if version_row_exists:
+            emit(f'UPDATE "{schema}".dbos_migrations SET version = {i}')
+        else:
+            emit(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({i})')
+            version_row_exists = True
     if application_role:
         typer.echo(f"-- Permissions for role {application_role}")
         for sql in get_dbos_schema_permissions_sql(schema, application_role):

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -207,7 +207,7 @@ def print_dbos_database_migrations(
     )
     if current_version == 0:
         typer.echo(
-            "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied. Use `dbos migrate` to upgrade an existing database."
+            "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied."
         )
         emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
         emit(

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -122,78 +122,56 @@ def grant_dbos_schema_permissions(
             engine.dispose()
 
 
-def _get_current_dbos_schema_version(
-    system_database_url: str, schema: str
-) -> Optional[int]:
-    """Read the current DBOS schema version with read-only queries.
-
-    Returns 0 if the schema or dbos_migrations table is missing or empty
-    (fresh database), and None if no connection could be established."""
-    engine = None
-    try:
-        engine = sa.create_engine(
-            sa.make_url(system_database_url).set(drivername="postgresql+psycopg"),
-            connect_args={"connect_timeout": 10},
-        )
-        with engine.connect() as conn:
-            table_exists = conn.execute(
-                sa.text(
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = :schema AND table_name = 'dbos_migrations'"
-                ),
-                {"schema": schema},
-            ).fetchone()
-            if table_exists is None:
-                return 0
-            row = conn.execute(
-                sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
-            ).fetchone()
-            return int(row[0]) if row else 0
-    except Exception:
-        return None
-    finally:
-        if engine:
-            engine.dispose()
+def _check_printable_identifier(name: str, kind: str) -> None:
+    # The execute path interpolates these names into quoted identifiers and
+    # string literals, so names containing quotes fail there too.
+    if '"' in name or "'" in name:
+        typer.echo(f"{kind} names containing quotes are not supported", err=True)
+        raise typer.Exit(code=1)
 
 
-def print_dbos_database_migrations(
+def _emit_sql(sql: str) -> None:
+    sql = sql.strip()
+    if sql:
+        typer.echo(sql if sql.endswith(";") else sql + ";")
+
+
+def print_dbos_migrations(
     system_database_url: str,
     *,
     schema: str = "dbos",
-    application_role: Optional[str] = None,
+    migration: str = "all",
 ) -> None:
-    """Print to stdout the SQL that DBOS migrations would execute, without
-    writing to any database. If the system database is reachable, only the
-    migrations past its current version are printed; otherwise a full
-    fresh-database script is printed. Stdout is pure SQL and comments."""
+    """Print to stdout the SQL of one DBOS system database migration
+    (migration is a number) or all of them (migration is "all"), without
+    touching any database. Stdout is pure SQL and comments."""
     if system_database_url.startswith("sqlite"):
-        typer.echo("--print-only is only supported for Postgres databases", err=True)
+        typer.echo(
+            "--print-migrations is only supported for Postgres databases", err=True
+        )
         raise typer.Exit(code=1)
-    # The execute path interpolates the schema into quoted identifiers and
-    # string literals, so names containing quotes fail there too.
-    if '"' in schema or "'" in schema:
-        typer.echo("Schema names containing quotes are not supported", err=True)
-        raise typer.Exit(code=1)
+    _check_printable_identifier(schema, "Schema")
 
     migrations = get_dbos_migrations(schema, use_listen_notify=True)
     latest_version = len(migrations)
-
-    # If the database is unreachable, silently fall back to a fresh-database
-    # script: the apply-time guard below protects against misuse.
-    current_version = _get_current_dbos_schema_version(system_database_url, schema)
-    if current_version is None:
-        current_version = 0
-
-    if current_version >= latest_version:
-        typer.echo(
-            f"-- Database is already at the latest DBOS schema version ({current_version}); nothing to do."
-        )
-        return
-
-    def emit(sql: str) -> None:
-        sql = sql.strip()
-        if sql:
-            typer.echo(sql if sql.endswith(";") else sql + ";")
+    if migration == "all":
+        start, end = 1, latest_version
+    else:
+        try:
+            start = int(migration)
+        except ValueError:
+            typer.echo(
+                f"Invalid --print-migrations value '{migration}': expected 'all' or a migration number",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        if not 1 <= start <= latest_version:
+            typer.echo(
+                f"Migration {start} does not exist: valid migrations are 1 through {latest_version}",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        end = start
 
     typer.echo(
         f"-- DBOS system database migrations for {sa.make_url(system_database_url)}"
@@ -201,16 +179,16 @@ def print_dbos_database_migrations(
     typer.echo(
         "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction)."
     )
-    if current_version == 0:
+    if start == 1:
         typer.echo(
             "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied."
         )
-        emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
-        emit(
+        _emit_sql(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+        _emit_sql(
             f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
         )
         typer.echo("-- Abort if this is not a fresh database")
-        emit(f"""DO $$
+        _emit_sql(f"""DO $$
 DECLARE
     existing_version BIGINT;
 BEGIN
@@ -220,26 +198,20 @@ BEGIN
     END IF;
 END $$""")
     else:
-        typer.echo(
-            f"-- Delta script: migrations {current_version + 1} through {latest_version}, generated for a database at version {current_version}."
-        )
-        typer.echo(
-            f"-- Abort unless the database is exactly at version {current_version}"
-        )
-        emit(f"""DO $$
+        typer.echo(f"-- Abort unless the database is exactly at version {start - 1}")
+        _emit_sql(f"""DO $$
 DECLARE
     v BIGINT;
 BEGIN
     SELECT version INTO v FROM "{schema}".dbos_migrations LIMIT 1;
-    IF v IS DISTINCT FROM {current_version} THEN
-        RAISE EXCEPTION 'expected DBOS schema version {current_version}, found %; regenerate this script with dbos migrate --print-only', v;
+    IF v IS DISTINCT FROM {start - 1} THEN
+        RAISE EXCEPTION 'expected DBOS schema version {start - 1}, found %', v;
     END IF;
 END $$""")
 
-    version_row_exists = current_version > 0
-    for i, migration_sql in enumerate(migrations, 1):
-        if i <= current_version:
-            continue
+    version_row_exists = start > 1
+    for i in range(start, end + 1):
+        migration_sql = migrations[i - 1]
         if migration_sql.strip():
             typer.echo(f"-- Migration {i}")
             if i == 10:
@@ -249,22 +221,28 @@ END $$""")
                 typer.echo(
                     "-- Applied only if the notifications table has no primary key, mirroring the migration runner's guard"
                 )
-                emit(f"""DO $$
+                _emit_sql(f"""DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE table_schema = '{schema}' AND table_name = 'notifications' AND constraint_type = 'PRIMARY KEY') THEN
         {migration_sql.strip()}
     END IF;
 END $$""")
             else:
-                emit(migration_sql)
+                _emit_sql(migration_sql)
         # Per-migration version bookkeeping, mirroring the runner: an
-        # interrupted apply can be resumed by regenerating the delta.
+        # interrupted apply can be resumed from the next migration number.
         if version_row_exists:
-            emit(f'UPDATE "{schema}".dbos_migrations SET version = {i}')
+            _emit_sql(f'UPDATE "{schema}".dbos_migrations SET version = {i}')
         else:
-            emit(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({i})')
+            _emit_sql(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({i})')
             version_row_exists = True
-    if application_role:
-        typer.echo(f"-- Permissions for role {application_role}")
-        for sql in get_dbos_schema_permissions_sql(schema, application_role):
-            emit(sql)
+
+
+def print_dbos_user_role_sql(*, schema: str = "dbos", role_name: str) -> None:
+    """Print to stdout the SQL granting an application role access to the DBOS
+    system schema, without touching any database."""
+    _check_printable_identifier(schema, "Schema")
+    _check_printable_identifier(role_name, "Role")
+    typer.echo(f"-- Permissions on DBOS schema {schema} for role {role_name}")
+    for sql in get_dbos_schema_permissions_sql(schema, role_name):
+        _emit_sql(sql)

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -137,6 +137,11 @@ def print_dbos_database_migrations(
     ):
         typer.echo("--print-only is only supported for Postgres databases", err=True)
         raise typer.Exit(code=1)
+    # The execute path interpolates the schema into quoted identifiers and
+    # string literals, so names containing quotes fail there too.
+    if '"' in schema or "'" in schema:
+        typer.echo("Schema names containing quotes are not supported", err=True)
+        raise typer.Exit(code=1)
 
     def emit(sql: str) -> None:
         sql = sql.strip()
@@ -149,22 +154,42 @@ def print_dbos_database_migrations(
     typer.echo(
         "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql -1)."
     )
+    typer.echo(
+        "-- This script is for FRESH databases only and aborts if DBOS migrations were already applied. Use `dbos migrate` to upgrade an existing database."
+    )
     emit(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
     emit(
         f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY)'
     )
+    typer.echo("-- Abort if this is not a fresh database")
+    emit(f"""DO $$
+DECLARE
+    existing_version BIGINT;
+BEGIN
+    SELECT version INTO existing_version FROM "{schema}".dbos_migrations LIMIT 1;
+    IF existing_version IS NOT NULL THEN
+        RAISE EXCEPTION 'DBOS schema % is already at version %; this script is for fresh databases only. Use dbos migrate instead.', '{schema}', existing_version;
+    END IF;
+END $$""")
     migrations = get_dbos_migrations(schema, use_listen_notify=True)
     for i, migration_sql in enumerate(migrations, 1):
-        if i == 10:
-            # Migration 10 backfills the notifications primary key, which
-            # migration 1 already creates on a fresh database.
-            typer.echo(
-                "-- Migration 10 skipped: the notifications primary key is created in migration 1"
-            )
-            continue
         if not migration_sql.strip():
             continue
         typer.echo(f"-- Migration {i}")
+        if i == 10:
+            # Mirrors the runner's guard in run_dbos_migrations: migration 10
+            # backfills the notifications primary key, which migration 1
+            # already creates on a fresh database.
+            typer.echo(
+                "-- Applied only if the notifications table has no primary key, mirroring the migration runner's guard"
+            )
+            emit(f"""DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE table_schema = '{schema}' AND table_name = 'notifications' AND constraint_type = 'PRIMARY KEY') THEN
+        {migration_sql.strip()}
+    END IF;
+END $$""")
+            continue
         emit(migration_sql)
     emit(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({len(migrations)})')
     if application_role:

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1081,7 +1081,7 @@ def test_migrate_print_user_role(
         print_dbos_user_role_sql(schema="dbos", role_name='bad"role')
     capsys.readouterr()
 
-    # Combined with --print-migrations, migrations come first, then grants
+    # --print-user-role cannot be combined with --print-migrations
     result = subprocess.run(
         [
             "dbos",
@@ -1097,8 +1097,6 @@ def test_migrate_print_user_role(
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0
-    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
-    assert result.stdout.index('CREATE SCHEMA IF NOT EXISTS "dbos";') < (
-        result.stdout.index('GRANT USAGE ON SCHEMA "dbos" TO "my-app-role";')
-    )
+    assert result.returncode != 0
+    assert "cannot be combined" in result.stderr
+    assert result.stdout == ""

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -744,7 +744,9 @@ def test_migrate_print_migrations_all(
     print_dbos_migrations(db_url_string, schema="dbos", migration="all")
     sql = capsys.readouterr().out
     assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in sql
-    assert "-- Abort if this is not a fresh database" in sql
+    assert "DO $$" not in sql
+    assert "-- Migration 10 skipped: not applicable on fresh databases" in sql
+    assert "ADD PRIMARY KEY (message_uuid)" not in sql
     assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in sql
     assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in sql
     # Role grants are only printed by --print-user-role
@@ -791,16 +793,6 @@ def test_migrate_print_migrations_all(
     finally:
         engine.dispose()
 
-    # Re-applying the script to a non-fresh database must fail fast
-    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(sql)
-        f.flush()
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(
-                ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name],
-                stderr=subprocess.DEVNULL,
-            )
-
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(
@@ -833,11 +825,9 @@ def test_migrate_print_migrations_custom_schema(
         f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);'
         in sql
     )
-    # Migration 10's guard embeds the schema in a single-quoted literal
-    assert f"WHERE table_schema = '{schema}'" in sql
-    assert (
-        f'ALTER TABLE "{schema}".notifications ADD PRIMARY KEY (message_uuid);' in sql
-    )
+    # Migration 10 is skipped, but its version bump is still recorded
+    assert "ADD PRIMARY KEY (message_uuid)" not in sql
+    assert f'UPDATE "{schema}".dbos_migrations SET version = 10;' in sql
     assert f'INSERT INTO "{schema}".dbos_migrations (version) VALUES (1);' in sql
     assert f'UPDATE "{schema}".dbos_migrations SET version = {latest_version};' in sql
     # The unquoted schema name must never appear outside quotes or literals
@@ -900,7 +890,7 @@ def test_migrate_print_migrations_custom_schema(
             ).scalar()
             assert version == latest_version
             # The notifications primary key exists (created by migration 1;
-            # migration 10's guarded backfill was a no-op)
+            # migration 10 is skipped in the printed script)
             assert (
                 conn.execute(
                     sa.text(
@@ -927,7 +917,7 @@ def test_migrate_print_single_migration(
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """--print-migrations N emits one migration, guarded on version N-1."""
+    """--print-migrations N emits one migration."""
     database_name = "print_single_migration_test"
     db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
     db_url_string = db_url.render_as_string(hide_password=False)
@@ -947,24 +937,26 @@ def test_migrate_print_single_migration(
     assert result.returncode != 0
     assert "expected 'all' or a migration number" in result.stderr
 
-    # Migration 1 includes the fresh-database prelude and abort guard
+    # Migration 1 includes the fresh-database prelude
     print_dbos_migrations(db_url_string, schema="dbos", migration="1")
     out = capsys.readouterr().out
     assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
-    assert "-- Abort if this is not a fresh database" in out
     assert "-- Migration 1" in out.splitlines()
     assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
     assert "-- Migration 2" not in out
+    assert "DO $$" not in out
 
-    # Migration 10 keeps the runner's primary-key guard and a version guard
-    print_dbos_migrations(db_url_string, schema="dbos", migration="10")
-    out = capsys.readouterr().out
-    assert "IF v IS DISTINCT FROM 9 THEN" in out
-    assert "table_constraints" in out
-    assert 'UPDATE "dbos".dbos_migrations SET version = 10;' in out
-    assert "CREATE SCHEMA" not in out
-    assert "-- Migration 9" not in out
-    assert "-- Migration 11" not in out
+    # Migration 10 is not applicable on fresh databases
+    with pytest.raises(typer.Exit):
+        print_dbos_migrations(db_url_string, schema="dbos", migration="10")
+    capsys.readouterr()
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", db_url_string, "--print-migrations", "10"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "not applicable" in result.stderr
 
     if shutil.which("psql") is None:
         pytest.skip("psql not available")
@@ -1000,8 +992,8 @@ def test_migrate_print_single_migration(
         ],
         text=True,
     )
-    assert f"IF v IS DISTINCT FROM {latest_version - 1} THEN" in single
     assert "CREATE SCHEMA" not in single
+    assert "DO $$" not in single
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
         f.write(single)
         f.flush()
@@ -1019,16 +1011,6 @@ def test_migrate_print_single_migration(
             assert version == latest_version
     finally:
         engine.dispose()
-
-    # Its guard makes re-applying it fail fast
-    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(single)
-        f.flush()
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(
-                ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name],
-                stderr=subprocess.DEVNULL,
-            )
 
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -742,7 +742,6 @@ def test_migrate_print_only(
     # Printing works without a reachable database and includes grants for the role
     print_dbos_database_migrations(
         db_url_string,
-        app_database_url=db_url_string,
         schema="dbos",
         application_role="print-only-role",
     )
@@ -751,7 +750,6 @@ def test_migrate_print_only(
     assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
     assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in out
     assert 'GRANT USAGE ON SCHEMA "dbos" TO "print-only-role";' in out
-    assert "transaction_outputs" in out
     for line in out.splitlines():
         assert line.startswith("--") or not line.startswith(
             ("Starting", "Granting", "System database")
@@ -761,7 +759,7 @@ def test_migrate_print_only(
         pytest.skip("psql not available")
 
     # Print without a role (the role does not exist) and apply the SQL to a fresh database
-    print_dbos_database_migrations(db_url_string, app_database_url=None, schema="dbos")
+    print_dbos_database_migrations(db_url_string, schema="dbos")
     sql = capsys.readouterr().out
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
@@ -824,7 +822,7 @@ def test_migrate_print_only_custom_schema(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
 
-    print_dbos_database_migrations(db_url_string, app_database_url=None, schema=schema)
+    print_dbos_database_migrations(db_url_string, schema=schema)
     sql = capsys.readouterr().out
     assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in sql
     assert (
@@ -843,9 +841,7 @@ def test_migrate_print_only_custom_schema(
 
     # Schema names containing quotes are rejected
     with pytest.raises(Exception):
-        print_dbos_database_migrations(
-            db_url_string, app_database_url=None, schema='bad"schema'
-        )
+        print_dbos_database_migrations(db_url_string, schema='bad"schema')
     capsys.readouterr()
 
     # The CLI flag path accepts the funny schema name
@@ -963,7 +959,7 @@ def test_migrate_print_only_delta(
         connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
 
     # The database is reachable but empty, so this still prints the fresh script
-    print_dbos_database_migrations(db_url_string, app_database_url=None, schema=schema)
+    print_dbos_database_migrations(db_url_string, schema=schema)
     sql = capsys.readouterr().out
     assert "FRESH databases only" in sql
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -8,12 +9,13 @@ import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
-from dbos._migration import get_dbos_migrations, sqlite_migrations
+from dbos._migration import get_dbos_migrations, should_migrate, sqlite_migrations
 
 # Private API because this is a unit test
 from dbos._schemas.system_database import SystemSchema
 from dbos._serialization import DefaultSerializer
 from dbos._sys_db import SystemDatabase
+from dbos.cli.migration import print_dbos_database_migrations
 
 
 def test_systemdb_migration(dbos: DBOS, skip_with_sqlite: None) -> None:
@@ -718,3 +720,73 @@ def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) 
             sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
         ).scalar()
         assert version == final_version
+
+
+def test_migrate_print_only(
+    db_engine: sa.Engine,
+    skip_with_sqlite: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that --print-only emits complete SQL that psql can apply to a fresh database."""
+    database_name = "print_only_test"
+    db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
+    db_url_string = db_url.render_as_string(hide_password=False)
+    latest_version = len(get_dbos_migrations("dbos", True))
+
+    # Printing requires no database connection and includes grants for the role
+    print_dbos_database_migrations(
+        db_url_string,
+        app_database_url=db_url_string,
+        schema="dbos",
+        application_role="print-only-role",
+    )
+    out = capsys.readouterr().out
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
+    assert (
+        f'INSERT INTO "dbos".dbos_migrations (version) VALUES ({latest_version});'
+        in out
+    )
+    assert 'GRANT USAGE ON SCHEMA "dbos" TO "print-only-role";' in out
+    assert "transaction_outputs" in out
+    for line in out.splitlines():
+        assert line.startswith("--") or not line.startswith(
+            ("Starting", "Granting", "System database")
+        )
+
+    if shutil.which("psql") is None:
+        pytest.skip("psql not available")
+
+    # Print without a role (the role does not exist) and apply the SQL to a fresh database
+    print_dbos_database_migrations(db_url_string, app_database_url=None, schema="dbos")
+    sql = capsys.readouterr().out
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+        connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(sql)
+        f.flush()
+        subprocess.check_call(
+            ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+        )
+
+    # A real migration now considers the database up to date
+    engine = sa.create_engine(db_url.set(drivername="postgresql+psycopg"))
+    try:
+        assert should_migrate(engine, "dbos", True) is False
+        with engine.connect() as conn:
+            version = conn.execute(
+                sa.text('SELECT version FROM "dbos".dbos_migrations')
+            ).scalar()
+            assert version == latest_version
+    finally:
+        engine.dispose()
+
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -765,7 +765,7 @@ def test_migrate_print_migrations_all(
     )
     assert result.returncode == 0
     assert result.stderr == ""
-    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
+    assert result.stdout == sql
 
     if shutil.which("psql") is None:
         pytest.skip("psql not available")
@@ -800,12 +800,12 @@ def test_migrate_print_migrations_all(
         )
 
 
-def test_migrate_print_migrations_custom_schema(
+def test_migrate_print_custom_schema(
     db_engine: sa.Engine,
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """--print-migrations must quote identifiers correctly for unusual schema names."""
+    """--print-migrations and --print-user-role handle unusual schema names."""
     database_name = "print_migrations_schema_test"
     schema = "F8nny_sCHem@-n@m3"
     db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
@@ -821,15 +821,6 @@ def test_migrate_print_migrations_custom_schema(
     print_dbos_migrations(db_url_string, schema=schema, migration="all")
     sql = capsys.readouterr().out
     assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in sql
-    assert (
-        f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);'
-        in sql
-    )
-    # Migration 10 is skipped, but its version bump is still recorded
-    assert "ADD PRIMARY KEY (message_uuid)" not in sql
-    assert f'UPDATE "{schema}".dbos_migrations SET version = 10;' in sql
-    assert f'INSERT INTO "{schema}".dbos_migrations (version) VALUES (1);' in sql
-    assert f'UPDATE "{schema}".dbos_migrations SET version = {latest_version};' in sql
     # The unquoted schema name must never appear outside quotes or literals
     assert f"CREATE TABLE {schema}." not in sql
 
@@ -838,8 +829,17 @@ def test_migrate_print_migrations_custom_schema(
         print_dbos_migrations(db_url_string, schema='bad"schema', migration="all")
     capsys.readouterr()
 
-    # The CLI flag path accepts the funny schema name
-    cli_out = subprocess.check_output(
+    # --print-user-role requires --app-role
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", db_url_string, "--print-user-role"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--app-role" in result.stderr
+
+    # --print-user-role emits only grant statements, quoting schema and role
+    result = subprocess.run(
         [
             "dbos",
             "migrate",
@@ -847,69 +847,92 @@ def test_migrate_print_migrations_custom_schema(
             db_url_string,
             "--schema",
             schema,
-            "--print-migrations",
-            "all",
+            "--print-user-role",
+            "-r",
+            "my-app-role",
         ],
+        capture_output=True,
         text=True,
     )
-    assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in cli_out
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert f'GRANT USAGE ON SCHEMA "{schema}" TO "my-app-role";' in result.stdout
+    for line in result.stdout.splitlines():
+        assert line.startswith(("--", "GRANT", "ALTER"))
+    role_sql = result.stdout
+
+    # Role names containing quotes are rejected
+    with pytest.raises(typer.Exit):
+        print_dbos_user_role_sql(schema=schema, role_name='bad"role')
+    capsys.readouterr()
+
+    # --print-user-role cannot be combined with --print-migrations
+    result = subprocess.run(
+        [
+            "dbos",
+            "migrate",
+            "-s",
+            db_url_string,
+            "--print-migrations",
+            "all",
+            "--print-user-role",
+            "-r",
+            "my-app-role",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "cannot be combined" in result.stderr
+    assert result.stdout == ""
 
     if shutil.which("psql") is None:
         pytest.skip("psql not available")
 
+    # The printed scripts work on a fresh database
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
-
-    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(sql)
-        f.flush()
-        subprocess.check_call(
-            ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+        connection.execute(sa.text('DROP ROLE IF EXISTS "my-app-role"'))
+        connection.execute(
+            sa.text("CREATE ROLE \"my-app-role\" LOGIN PASSWORD 'app_role_pwd'")
         )
+
+    for script in [sql, role_sql]:
+        with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+            f.write(script)
+            f.flush()
+            subprocess.check_call(
+                ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+            )
 
     engine = sa.create_engine(db_url.set(drivername="postgresql+psycopg"))
     try:
         assert should_migrate(engine, schema, True) is False
-        with engine.connect() as conn:
-            assert (
-                conn.execute(
-                    sa.text(
-                        "SELECT 1 FROM information_schema.schemata WHERE schema_name = :s"
-                    ),
-                    {"s": schema},
-                ).scalar()
-                == 1
-            )
-            for table in ["workflow_status", "notifications", "dbos_migrations"]:
-                assert conn.execute(
-                    sa.text(f'SELECT COUNT(*) FROM "{schema}".{table}')
-                ).scalar() in (0, 1)
+    finally:
+        engine.dispose()
+
+    # The app role can query the DBOS schema
+    app_engine = sa.create_engine(
+        db_url.set(drivername="postgresql+psycopg")
+        .set(username="my-app-role")
+        .set(password="app_role_pwd")
+    )
+    try:
+        with app_engine.connect() as conn:
             version = conn.execute(
                 sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
             ).scalar()
             assert version == latest_version
-            # The notifications primary key exists (created by migration 1;
-            # migration 10 is skipped in the printed script)
-            assert (
-                conn.execute(
-                    sa.text(
-                        "SELECT COUNT(*) FROM information_schema.table_constraints "
-                        "WHERE table_schema = :s AND table_name = 'notifications' "
-                        "AND constraint_type = 'PRIMARY KEY'"
-                    ),
-                    {"s": schema},
-                ).scalar()
-                == 1
-            )
     finally:
-        engine.dispose()
+        app_engine.dispose()
 
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
+        connection.execute(sa.text('DROP ROLE IF EXISTS "my-app-role"'))
 
 
 def test_migrate_print_from_migration(
@@ -1013,68 +1036,3 @@ def test_migrate_print_from_migration(
         connection.execute(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
-
-
-def test_migrate_print_user_role(
-    skip_with_sqlite: None,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """--print-user-role prints the role grant SQL and requires --app-role."""
-    # No database is contacted, so an unreachable URL works
-    unreachable_url = "postgresql://postgres:x@127.0.0.1:1/no_such_db"
-
-    result = subprocess.run(
-        ["dbos", "migrate", "-s", unreachable_url, "--print-user-role"],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "--app-role" in result.stderr
-
-    result = subprocess.run(
-        [
-            "dbos",
-            "migrate",
-            "-s",
-            unreachable_url,
-            "--print-user-role",
-            "-r",
-            "my-app-role",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert result.stderr == ""
-    assert 'GRANT USAGE ON SCHEMA "dbos" TO "my-app-role";' in result.stdout
-    assert (
-        'ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT EXECUTE ON FUNCTIONS TO "my-app-role";'
-        in result.stdout
-    )
-    for line in result.stdout.splitlines():
-        assert line.startswith(("--", "GRANT", "ALTER"))
-
-    # Role names containing quotes are rejected
-    with pytest.raises(typer.Exit):
-        print_dbos_user_role_sql(schema="dbos", role_name='bad"role')
-    capsys.readouterr()
-
-    # --print-user-role cannot be combined with --print-migrations
-    result = subprocess.run(
-        [
-            "dbos",
-            "migrate",
-            "-s",
-            unreachable_url,
-            "--print-migrations",
-            "all",
-            "--print-user-role",
-            "-r",
-            "my-app-role",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "cannot be combined" in result.stderr
-    assert result.stdout == ""

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 import sqlalchemy as sa
+import typer
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
@@ -15,7 +16,7 @@ from dbos._migration import get_dbos_migrations, should_migrate, sqlite_migratio
 from dbos._schemas.system_database import SystemSchema
 from dbos._serialization import DefaultSerializer
 from dbos._sys_db import SystemDatabase
-from dbos.cli.migration import print_dbos_database_migrations
+from dbos.cli.migration import print_dbos_migrations, print_dbos_user_role_sql
 
 
 def test_systemdb_migration(dbos: DBOS, skip_with_sqlite: None) -> None:
@@ -722,13 +723,13 @@ def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) 
         assert version == final_version
 
 
-def test_migrate_print_only(
+def test_migrate_print_migrations_all(
     db_engine: sa.Engine,
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Test that --print-only emits complete SQL that psql can apply to a fresh database."""
-    database_name = "print_only_test"
+    """--print-migrations all emits a complete fresh-database script that psql can apply."""
+    database_name = "print_migrations_test"
     db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
     db_url_string = db_url.render_as_string(hide_password=False)
     latest_version = len(get_dbos_migrations("dbos", True))
@@ -739,33 +740,36 @@ def test_migrate_print_only(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
 
-    # Printing works without a reachable database and includes grants for the role
-    print_dbos_database_migrations(
-        db_url_string,
-        schema="dbos",
-        application_role="print-only-role",
-    )
-    out = capsys.readouterr().out
-    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
-    assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
-    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in out
-    assert 'GRANT USAGE ON SCHEMA "dbos" TO "print-only-role";' in out
-    for line in out.splitlines():
+    # Printing needs no reachable database; stdout is pure SQL and comments
+    print_dbos_migrations(db_url_string, schema="dbos", migration="all")
+    sql = capsys.readouterr().out
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in sql
+    assert "-- Abort if this is not a fresh database" in sql
+    assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in sql
+    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in sql
+    # Role grants are only printed by --print-user-role
+    assert "GRANT" not in sql
+    for line in sql.splitlines():
         assert line.startswith("--") or not line.startswith(
             ("Starting", "Granting", "System database")
         )
 
+    # The CLI path prints the same script and exits cleanly, even though the
+    # database is unreachable
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", db_url_string, "--print-migrations", "all"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
+
     if shutil.which("psql") is None:
         pytest.skip("psql not available")
 
-    # Print without a role (the role does not exist) and apply the SQL to a fresh database
-    print_dbos_database_migrations(db_url_string, schema="dbos")
-    sql = capsys.readouterr().out
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
-        connection.execute(
-            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
-        )
         connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
 
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
@@ -804,13 +808,13 @@ def test_migrate_print_only(
         )
 
 
-def test_migrate_print_only_custom_schema(
+def test_migrate_print_migrations_custom_schema(
     db_engine: sa.Engine,
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """--print-only must quote identifiers correctly for unusual schema names."""
-    database_name = "print_only_schema_test"
+    """--print-migrations must quote identifiers correctly for unusual schema names."""
+    database_name = "print_migrations_schema_test"
     schema = "F8nny_sCHem@-n@m3"
     db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
     db_url_string = db_url.render_as_string(hide_password=False)
@@ -822,7 +826,7 @@ def test_migrate_print_only_custom_schema(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
 
-    print_dbos_database_migrations(db_url_string, schema=schema)
+    print_dbos_migrations(db_url_string, schema=schema, migration="all")
     sql = capsys.readouterr().out
     assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in sql
     assert (
@@ -841,12 +845,21 @@ def test_migrate_print_only_custom_schema(
 
     # Schema names containing quotes are rejected
     with pytest.raises(Exception):
-        print_dbos_database_migrations(db_url_string, schema='bad"schema')
+        print_dbos_migrations(db_url_string, schema='bad"schema', migration="all")
     capsys.readouterr()
 
     # The CLI flag path accepts the funny schema name
     cli_out = subprocess.check_output(
-        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
+        [
+            "dbos",
+            "migrate",
+            "-s",
+            db_url_string,
+            "--schema",
+            schema,
+            "--print-migrations",
+            "all",
+        ],
         text=True,
     )
     assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in cli_out
@@ -856,9 +869,6 @@ def test_migrate_print_only_custom_schema(
 
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
-        connection.execute(
-            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
-        )
         connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
 
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
@@ -912,44 +922,58 @@ def test_migrate_print_only_custom_schema(
         )
 
 
-def test_migrate_print_only_connection_failure(skip_with_sqlite: None) -> None:
-    """An unreachable database silently falls back to the full fresh script:
-    stdout is pure SQL/comments, stderr is empty, and the exit code is 0."""
-    unreachable_url = "postgresql://postgres:x@127.0.0.1:1/no_such_db"
-    result = subprocess.run(
-        ["dbos", "migrate", "-s", unreachable_url, "--print-only"],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert result.stderr == ""
-    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
-    assert "-- Abort if this is not a fresh database" in result.stdout
-    latest_version = len(get_dbos_migrations("dbos", True))
-    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in (
-        result.stdout
-    )
-    for line in result.stdout.splitlines():
-        assert not line.startswith(("Starting", "Granting", "System database"))
-
-
-def test_migrate_print_only_delta(
+def test_migrate_print_single_migration(
     db_engine: sa.Engine,
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Against a reachable database at version N, --print-only emits a delta
-    script covering only migrations N+1..latest, guarded on version N."""
+    """--print-migrations N emits one migration, guarded on version N-1."""
+    database_name = "print_single_migration_test"
+    db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
+    db_url_string = db_url.render_as_string(hide_password=False)
+    migrations = get_dbos_migrations("dbos", True)
+    latest_version = len(migrations)
+
+    # Invalid selections are rejected
+    for bad in ["0", str(latest_version + 1), "-1", "foo"]:
+        with pytest.raises(typer.Exit):
+            print_dbos_migrations(db_url_string, schema="dbos", migration=bad)
+    capsys.readouterr()
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", db_url_string, "--print-migrations", "nope"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "expected 'all' or a migration number" in result.stderr
+
+    # Migration 1 includes the fresh-database prelude and abort guard
+    print_dbos_migrations(db_url_string, schema="dbos", migration="1")
+    out = capsys.readouterr().out
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
+    assert "-- Abort if this is not a fresh database" in out
+    assert "-- Migration 1" in out.splitlines()
+    assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
+    assert "-- Migration 2" not in out
+
+    # Migration 10 keeps the runner's primary-key guard and a version guard
+    print_dbos_migrations(db_url_string, schema="dbos", migration="10")
+    out = capsys.readouterr().out
+    assert "IF v IS DISTINCT FROM 9 THEN" in out
+    assert "table_constraints" in out
+    assert 'UPDATE "dbos".dbos_migrations SET version = 10;' in out
+    assert "CREATE SCHEMA" not in out
+    assert "-- Migration 9" not in out
+    assert "-- Migration 11" not in out
+
     if shutil.which("psql") is None:
         pytest.skip("psql not available")
 
-    database_name = "print_only_delta_test"
-    schema = "F8nny_sCHem@-n@m3"
-    db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
-    db_url_string = db_url.render_as_string(hide_password=False)
-    migrations = get_dbos_migrations(schema, True)
-    latest_version = len(migrations)
-    delta_from = latest_version - 5
+    # Bring a fresh database to version latest-1 by truncating the full script
+    print_dbos_migrations(db_url_string, schema="dbos", migration="all")
+    full = capsys.readouterr().out
+    marker = f'UPDATE "dbos".dbos_migrations SET version = {latest_version - 1};'
+    partial = full[: full.index(marker) + len(marker)] + "\n"
 
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
@@ -957,44 +981,29 @@ def test_migrate_print_only_delta(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
         connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
-
-    # The database is reachable but empty, so this still prints the fresh script
-    print_dbos_database_migrations(db_url_string, schema=schema)
-    sql = capsys.readouterr().out
-    assert "FRESH databases only" in sql
-
-    # Build a genuinely partial database: apply the fresh script only up
-    # through migration delta_from's version bookkeeping
-    marker = f'UPDATE "{schema}".dbos_migrations SET version = {delta_from};'
-    partial_sql = sql[: sql.index(marker) + len(marker)] + "\n"
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(partial_sql)
+        f.write(partial)
         f.flush()
         subprocess.check_call(
             ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
         )
 
-    # The CLI now prints a delta script for migrations delta_from+1..latest
-    delta = subprocess.check_output(
-        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
+    # The last migration printed alone applies on top of version latest-1
+    single = subprocess.check_output(
+        [
+            "dbos",
+            "migrate",
+            "-s",
+            db_url_string,
+            "--print-migrations",
+            str(latest_version),
+        ],
         text=True,
     )
-    lines = delta.splitlines()
-    assert f"IF v IS DISTINCT FROM {delta_from} THEN" in delta
-    assert "CREATE SCHEMA" not in delta
-    assert f'INSERT INTO "{schema}".dbos_migrations' not in delta
-    # Migration 10's conditional block only appears when 10 is in range
-    assert "table_constraints" not in delta
-    for i in range(1, delta_from + 1):
-        assert f"-- Migration {i}" not in lines
-    for i in range(delta_from + 1, latest_version + 1):
-        if migrations[i - 1].strip():
-            assert f"-- Migration {i}" in lines
-        assert f'UPDATE "{schema}".dbos_migrations SET version = {i};' in lines
-
-    # Applying the delta brings the database to the latest version
+    assert f"IF v IS DISTINCT FROM {latest_version - 1} THEN" in single
+    assert "CREATE SCHEMA" not in single
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(delta)
+        f.write(single)
         f.flush()
         subprocess.check_call(
             ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
@@ -1002,31 +1011,18 @@ def test_migrate_print_only_delta(
 
     engine = sa.create_engine(db_url.set(drivername="postgresql+psycopg"))
     try:
-        assert should_migrate(engine, schema, True) is False
+        assert should_migrate(engine, "dbos", True) is False
         with engine.connect() as conn:
             version = conn.execute(
-                sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+                sa.text('SELECT version FROM "dbos".dbos_migrations')
             ).scalar()
             assert version == latest_version
     finally:
         engine.dispose()
 
-    # An up-to-date database prints only the nothing-to-do comment
-    up_to_date = subprocess.check_output(
-        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
-        text=True,
-    )
-    assert (
-        f"-- Database is already at the latest DBOS schema version ({latest_version}); nothing to do."
-        in up_to_date
-    )
-    assert "CREATE" not in up_to_date
-    assert "UPDATE" not in up_to_date
-
-    # A delta generated for version delta_from must fail fast against a
-    # database at a different version
+    # Its guard makes re-applying it fail fast
     with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
-        f.write(delta)
+        f.write(single)
         f.flush()
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_call(
@@ -1039,3 +1035,70 @@ def test_migrate_print_only_delta(
         connection.execute(
             sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
         )
+
+
+def test_migrate_print_user_role(
+    skip_with_sqlite: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--print-user-role prints the role grant SQL and requires --app-role."""
+    # No database is contacted, so an unreachable URL works
+    unreachable_url = "postgresql://postgres:x@127.0.0.1:1/no_such_db"
+
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", unreachable_url, "--print-user-role"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--app-role" in result.stderr
+
+    result = subprocess.run(
+        [
+            "dbos",
+            "migrate",
+            "-s",
+            unreachable_url,
+            "--print-user-role",
+            "-r",
+            "my-app-role",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert 'GRANT USAGE ON SCHEMA "dbos" TO "my-app-role";' in result.stdout
+    assert (
+        'ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT EXECUTE ON FUNCTIONS TO "my-app-role";'
+        in result.stdout
+    )
+    for line in result.stdout.splitlines():
+        assert line.startswith(("--", "GRANT", "ALTER"))
+
+    # Role names containing quotes are rejected
+    with pytest.raises(typer.Exit):
+        print_dbos_user_role_sql(schema="dbos", role_name='bad"role')
+    capsys.readouterr()
+
+    # Combined with --print-migrations, migrations come first, then grants
+    result = subprocess.run(
+        [
+            "dbos",
+            "migrate",
+            "-s",
+            unreachable_url,
+            "--print-migrations",
+            "all",
+            "--print-user-role",
+            "-r",
+            "my-app-role",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
+    assert result.stdout.index('CREATE SCHEMA IF NOT EXISTS "dbos";') < (
+        result.stdout.index('GRANT USAGE ON SCHEMA "dbos" TO "my-app-role";')
+    )

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -785,6 +785,122 @@ def test_migrate_print_only(
     finally:
         engine.dispose()
 
+    # Re-applying the script to a non-fresh database must fail fast
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(sql)
+        f.flush()
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(
+                ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name],
+                stderr=subprocess.DEVNULL,
+            )
+
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
+
+def test_migrate_print_only_custom_schema(
+    db_engine: sa.Engine,
+    skip_with_sqlite: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--print-only must quote identifiers correctly for unusual schema names."""
+    database_name = "print_only_schema_test"
+    schema = "F8nny_sCHem@-n@m3"
+    db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
+    db_url_string = db_url.render_as_string(hide_password=False)
+    latest_version = len(get_dbos_migrations(schema, True))
+
+    print_dbos_database_migrations(db_url_string, app_database_url=None, schema=schema)
+    sql = capsys.readouterr().out
+    assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in sql
+    assert (
+        f'CREATE TABLE IF NOT EXISTS "{schema}".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);'
+        in sql
+    )
+    # Migration 10's guard embeds the schema in a single-quoted literal
+    assert f"WHERE table_schema = '{schema}'" in sql
+    assert (
+        f'ALTER TABLE "{schema}".notifications ADD PRIMARY KEY (message_uuid);' in sql
+    )
+    assert (
+        f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({latest_version});'
+        in sql
+    )
+    # The unquoted schema name must never appear outside quotes or literals
+    assert f"CREATE TABLE {schema}." not in sql
+
+    # Schema names containing quotes are rejected
+    with pytest.raises(Exception):
+        print_dbos_database_migrations(
+            db_url_string, app_database_url=None, schema='bad"schema'
+        )
+    capsys.readouterr()
+
+    # The CLI flag path accepts the funny schema name
+    cli_out = subprocess.check_output(
+        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
+        text=True,
+    )
+    assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in cli_out
+
+    if shutil.which("psql") is None:
+        pytest.skip("psql not available")
+
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+        connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(sql)
+        f.flush()
+        subprocess.check_call(
+            ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+        )
+
+    engine = sa.create_engine(db_url.set(drivername="postgresql+psycopg"))
+    try:
+        assert should_migrate(engine, schema, True) is False
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    sa.text(
+                        "SELECT 1 FROM information_schema.schemata WHERE schema_name = :s"
+                    ),
+                    {"s": schema},
+                ).scalar()
+                == 1
+            )
+            for table in ["workflow_status", "notifications", "dbos_migrations"]:
+                assert conn.execute(
+                    sa.text(f'SELECT COUNT(*) FROM "{schema}".{table}')
+                ).scalar() in (0, 1)
+            version = conn.execute(
+                sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+            ).scalar()
+            assert version == latest_version
+            # The notifications primary key exists (created by migration 1;
+            # migration 10's guarded backfill was a no-op)
+            assert (
+                conn.execute(
+                    sa.text(
+                        "SELECT COUNT(*) FROM information_schema.table_constraints "
+                        "WHERE table_schema = :s AND table_name = 'notifications' "
+                        "AND constraint_type = 'PRIMARY KEY'"
+                    ),
+                    {"s": schema},
+                ).scalar()
+                == 1
+            )
+    finally:
+        engine.dispose()
+
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -733,7 +733,13 @@ def test_migrate_print_only(
     db_url_string = db_url.render_as_string(hide_password=False)
     latest_version = len(get_dbos_migrations("dbos", True))
 
-    # Printing requires no database connection and includes grants for the role
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
+    # Printing works without a reachable database and includes grants for the role
     print_dbos_database_migrations(
         db_url_string,
         app_database_url=db_url_string,
@@ -742,10 +748,8 @@ def test_migrate_print_only(
     )
     out = capsys.readouterr().out
     assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
-    assert (
-        f'INSERT INTO "dbos".dbos_migrations (version) VALUES ({latest_version});'
-        in out
-    )
+    assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
+    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in out
     assert 'GRANT USAGE ON SCHEMA "dbos" TO "print-only-role";' in out
     assert "transaction_outputs" in out
     for line in out.splitlines():
@@ -814,6 +818,12 @@ def test_migrate_print_only_custom_schema(
     db_url_string = db_url.render_as_string(hide_password=False)
     latest_version = len(get_dbos_migrations(schema, True))
 
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
     print_dbos_database_migrations(db_url_string, app_database_url=None, schema=schema)
     sql = capsys.readouterr().out
     assert f'CREATE SCHEMA IF NOT EXISTS "{schema}";' in sql
@@ -826,10 +836,8 @@ def test_migrate_print_only_custom_schema(
     assert (
         f'ALTER TABLE "{schema}".notifications ADD PRIMARY KEY (message_uuid);' in sql
     )
-    assert (
-        f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({latest_version});'
-        in sql
-    )
+    assert f'INSERT INTO "{schema}".dbos_migrations (version) VALUES (1);' in sql
+    assert f'UPDATE "{schema}".dbos_migrations SET version = {latest_version};' in sql
     # The unquoted schema name must never appear outside quotes or literals
     assert f"CREATE TABLE {schema}." not in sql
 
@@ -900,6 +908,135 @@ def test_migrate_print_only_custom_schema(
             )
     finally:
         engine.dispose()
+
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+
+
+def test_migrate_print_only_connection_failure(skip_with_sqlite: None) -> None:
+    """An unreachable database silently falls back to the full fresh script:
+    stdout is pure SQL/comments, stderr is empty, and the exit code is 0."""
+    unreachable_url = "postgresql://postgres:x@127.0.0.1:1/no_such_db"
+    result = subprocess.run(
+        ["dbos", "migrate", "-s", unreachable_url, "--print-only"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in result.stdout
+    assert "-- Abort if this is not a fresh database" in result.stdout
+    latest_version = len(get_dbos_migrations("dbos", True))
+    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in (
+        result.stdout
+    )
+    for line in result.stdout.splitlines():
+        assert not line.startswith(("Starting", "Granting", "System database"))
+
+
+def test_migrate_print_only_delta(
+    db_engine: sa.Engine,
+    skip_with_sqlite: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Against a reachable database at version N, --print-only emits a delta
+    script covering only migrations N+1..latest, guarded on version N."""
+    if shutil.which("psql") is None:
+        pytest.skip("psql not available")
+
+    database_name = "print_only_delta_test"
+    schema = "F8nny_sCHem@-n@m3"
+    db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
+    db_url_string = db_url.render_as_string(hide_password=False)
+    migrations = get_dbos_migrations(schema, True)
+    latest_version = len(migrations)
+    delta_from = latest_version - 5
+
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(f"DROP DATABASE IF EXISTS {database_name} WITH (FORCE)")
+        )
+        connection.execute(sa.text(f"CREATE DATABASE {database_name}"))
+
+    # The database is reachable but empty, so this still prints the fresh script
+    print_dbos_database_migrations(db_url_string, app_database_url=None, schema=schema)
+    sql = capsys.readouterr().out
+    assert "FRESH databases only" in sql
+
+    # Build a genuinely partial database: apply the fresh script only up
+    # through migration delta_from's version bookkeeping
+    marker = f'UPDATE "{schema}".dbos_migrations SET version = {delta_from};'
+    partial_sql = sql[: sql.index(marker) + len(marker)] + "\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(partial_sql)
+        f.flush()
+        subprocess.check_call(
+            ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+        )
+
+    # The CLI now prints a delta script for migrations delta_from+1..latest
+    delta = subprocess.check_output(
+        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
+        text=True,
+    )
+    lines = delta.splitlines()
+    assert f"IF v IS DISTINCT FROM {delta_from} THEN" in delta
+    assert "CREATE SCHEMA" not in delta
+    assert f'INSERT INTO "{schema}".dbos_migrations' not in delta
+    # Migration 10's conditional block only appears when 10 is in range
+    assert "table_constraints" not in delta
+    for i in range(1, delta_from + 1):
+        assert f"-- Migration {i}" not in lines
+    for i in range(delta_from + 1, latest_version + 1):
+        if migrations[i - 1].strip():
+            assert f"-- Migration {i}" in lines
+        assert f'UPDATE "{schema}".dbos_migrations SET version = {i};' in lines
+
+    # Applying the delta brings the database to the latest version
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(delta)
+        f.flush()
+        subprocess.check_call(
+            ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name]
+        )
+
+    engine = sa.create_engine(db_url.set(drivername="postgresql+psycopg"))
+    try:
+        assert should_migrate(engine, schema, True) is False
+        with engine.connect() as conn:
+            version = conn.execute(
+                sa.text(f'SELECT version FROM "{schema}".dbos_migrations')
+            ).scalar()
+            assert version == latest_version
+    finally:
+        engine.dispose()
+
+    # An up-to-date database prints only the nothing-to-do comment
+    up_to_date = subprocess.check_output(
+        ["dbos", "migrate", "-s", db_url_string, "--schema", schema, "--print-only"],
+        text=True,
+    )
+    assert (
+        f"-- Database is already at the latest DBOS schema version ({latest_version}); nothing to do."
+        in up_to_date
+    )
+    assert "CREATE" not in up_to_date
+    assert "UPDATE" not in up_to_date
+
+    # A delta generated for version delta_from must fail fast against a
+    # database at a different version
+    with tempfile.NamedTemporaryFile("w", suffix=".sql") as f:
+        f.write(delta)
+        f.flush()
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(
+                ["psql", db_url_string, "-v", "ON_ERROR_STOP=1", "-q", "-f", f.name],
+                stderr=subprocess.DEVNULL,
+            )
 
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -912,13 +912,13 @@ def test_migrate_print_migrations_custom_schema(
         )
 
 
-def test_migrate_print_single_migration(
+def test_migrate_print_from_migration(
     db_engine: sa.Engine,
     skip_with_sqlite: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """--print-migrations N emits one migration."""
-    database_name = "print_single_migration_test"
+    """--print-migrations N emits migrations N through latest."""
+    database_name = "print_from_migration_test"
     db_url = db_engine.url.set(database=database_name).set(drivername="postgresql")
     db_url_string = db_url.render_as_string(hide_password=False)
     migrations = get_dbos_migrations("dbos", True)
@@ -937,26 +937,22 @@ def test_migrate_print_single_migration(
     assert result.returncode != 0
     assert "expected 'all' or a migration number" in result.stderr
 
-    # Migration 1 includes the fresh-database prelude
+    # Starting from 1 is identical to "all"
     print_dbos_migrations(db_url_string, schema="dbos", migration="1")
-    out = capsys.readouterr().out
-    assert 'CREATE SCHEMA IF NOT EXISTS "dbos";' in out
-    assert "-- Migration 1" in out.splitlines()
-    assert 'INSERT INTO "dbos".dbos_migrations (version) VALUES (1);' in out
-    assert "-- Migration 2" not in out
-    assert "DO $$" not in out
+    from_one = capsys.readouterr().out
+    print_dbos_migrations(db_url_string, schema="dbos", migration="all")
+    assert capsys.readouterr().out == from_one
 
-    # Migration 10 is not applicable on fresh databases
-    with pytest.raises(typer.Exit):
-        print_dbos_migrations(db_url_string, schema="dbos", migration="10")
-    capsys.readouterr()
-    result = subprocess.run(
-        ["dbos", "migrate", "-s", db_url_string, "--print-migrations", "10"],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "not applicable" in result.stderr
+    # Starting mid-way omits the prelude and earlier migrations
+    print_dbos_migrations(db_url_string, schema="dbos", migration="10")
+    out = capsys.readouterr().out
+    assert "CREATE SCHEMA" not in out
+    assert "-- Migration 9" not in out
+    assert "-- Migration 10 skipped: not applicable on fresh databases" in out
+    assert 'UPDATE "dbos".dbos_migrations SET version = 10;' in out
+    assert "-- Migration 11" in out.splitlines()
+    assert f'UPDATE "dbos".dbos_migrations SET version = {latest_version};' in out
+    assert "DO $$" not in out
 
     if shutil.which("psql") is None:
         pytest.skip("psql not available")


### PR DESCRIPTION
`dbos migrate --print-migrations all # print all migrationns
`
`dbos migrate --print-migrations 10 # print migrations starting from 10
`
`dbos migrate --print-user-role -r my_app_role # print privileges SQL`

`--print-migrations` and `--print-user-role` are exclusive

<img width="996" height="151" alt="Screenshot 2026-07-20 at 12 48 25" src="https://github.com/user-attachments/assets/75c0e16f-9635-448a-a8a1-c85f2db58ad5" />

<img width="1029" height="968" alt="Screenshot 2026-07-21 at 09 54 20" src="https://github.com/user-attachments/assets/7a9f5a5f-4b5b-4bb1-82bf-715c5d444ca0" />

<img width="1059" height="642" alt="Screenshot 2026-07-21 at 09 49 38" src="https://github.com/user-attachments/assets/d9ae932a-3b23-4a40-bc42-7ba77f512d65" />
