### PR TITLE
Idempotent Recovery

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -2377,7 +2377,6 @@ def _validate_enqueue_only_options(
         for name, value in (
             ("deduplication_id", ctx.deduplication_id),
             ("priority", ctx.priority),
-            ("app_version", ctx.app_version),
             ("queue_partition_key", ctx.queue_partition_key),
             ("delay_seconds", ctx.delay_until_epoch_ms),
         )

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1104,6 +1104,7 @@ def start_workflow(
     }
 
     local_ctx = get_local_dbos_context()
+    _validate_enqueue_only_options(local_ctx, queue_name)
     workflow_timeout_ms, workflow_deadline_epoch_ms = _get_timeout_deadline(
         local_ctx, queue_name
     )
@@ -1231,6 +1232,7 @@ async def start_workflow_async(
         "kwargs": kwargs,
     }
 
+    _validate_enqueue_only_options(local_ctx, queue_name)
     workflow_timeout_ms, workflow_deadline_epoch_ms = _get_timeout_deadline(
         local_ctx, queue_name
     )
@@ -2362,6 +2364,30 @@ def close_stream(dbos: "DBOS", step_ctx: Optional["DBOSContext"], key: str) -> N
     else:
         # Cannot call it from outside of a workflow
         raise DBOSException("close_stream() must be called from within a workflow")
+
+
+def _validate_enqueue_only_options(
+    ctx: Optional[DBOSContext], queue: Optional[str]
+) -> None:
+    """Reject enqueue options on a workflow that is not being enqueued."""
+    if queue is not None or ctx is None:
+        return
+    set_options = [
+        name
+        for name, value in (
+            ("deduplication_id", ctx.deduplication_id),
+            ("priority", ctx.priority),
+            ("app_version", ctx.app_version),
+            ("queue_partition_key", ctx.queue_partition_key),
+            ("delay_seconds", ctx.delay_until_epoch_ms),
+        )
+        if value is not None
+    ]
+    if set_options:
+        raise DBOSException(
+            f"Enqueue option(s) {', '.join(set_options)} set on a workflow that is not being enqueued. "
+            "These options are only supported when enqueueing a workflow onto a queue."
+        )
 
 
 def _get_timeout_deadline(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1943,14 +1943,14 @@ class DBOS:
 
     @classmethod
     def _execute_workflow_id(cls, workflow_id: str) -> WorkflowHandle[Any]:
-        """Execute a workflow by ID directly. Used only in testing."""
+        """Execute a workflow by ID directly. Internal, used only for testing."""
         return execute_workflow_by_id(_get_dbos_instance(), workflow_id, True, False)
 
     @classmethod
     def _recover_pending_workflows(
         cls, executor_ids: List[str] = ["local"]
     ) -> List[WorkflowHandle[Any]]:
-        """Find all PENDING workflows and execute them."""
+        """Find all PENDING workflows and execute them. Internal, used only for testing."""
         return recover_pending_workflows(_get_dbos_instance(), executor_ids)
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1950,7 +1950,7 @@ class DBOS:
     def _recover_pending_workflows(
         cls, executor_ids: List[str] = ["local"]
     ) -> List[WorkflowHandle[Any]]:
-        """Find all PENDING workflows and execute them. Internal, used only for testing."""
+        """Find all PENDING workflows and recover them. Internal."""
         return recover_pending_workflows(_get_dbos_instance(), executor_ids)
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1943,7 +1943,7 @@ class DBOS:
 
     @classmethod
     def _execute_workflow_id(cls, workflow_id: str) -> WorkflowHandle[Any]:
-        """Execute a workflow by ID (for recovery)."""
+        """Execute a workflow by ID directly. Used only in testing."""
         return execute_workflow_by_id(_get_dbos_instance(), workflow_id, True, False)
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -57,6 +57,7 @@ from ._core import (
     StepOptions,
     WorkflowHandleAsyncPolling,
     WorkflowHandlePolling,
+    _validate_enqueue_only_options,
     close_stream,
     decorate_step,
     decorate_transaction,
@@ -1238,6 +1239,7 @@ class DBOS:
     ) -> WorkflowHandleAsync[R]:
         """Invoke a workflow function on the event loop, returning a handle to the ongoing execution."""
         ctx = get_local_dbos_context()
+        _validate_enqueue_only_options(ctx, None)
         parent_ctx_copy = copy.copy(ctx)
         child_ctx = DBOSContext.create_start_workflow_child(ctx)
         await cls._configure_asyncio_thread_pool()

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -12,7 +12,7 @@ from psycopg import errors
 from sqlalchemy.exc import OperationalError
 
 from dbos._context import DBOSContext, get_local_dbos_context
-from dbos._error import DBOSException
+from dbos._error import DBOSException, DBOSWorkflowFunctionNotFoundError
 from dbos._logger import dbos_logger
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
@@ -437,6 +437,21 @@ class Queue:
         )
 
 
+def _dispatch_dequeued_workflow(dbos: "DBOS", workflow_id: str) -> None:
+    """Start a workflow this thread just dequeued, returning it to the queue if
+    it cannot run yet.
+    """
+    try:
+        execute_workflow_by_id(dbos, workflow_id, False, True)
+    except DBOSWorkflowFunctionNotFoundError as e:
+        # The function may register later (e.g. a configured instance constructed
+        # after launch), so re-enqueue instead of leaving the row stuck PENDING.
+        dbos.logger.warning(f"Error executing workflow {workflow_id}: {e.message}")
+        dbos._sys_db.requeue_dequeued_workflow(workflow_id)
+    except Exception as e:
+        dbos.logger.error(f"Error executing workflow {workflow_id}: {e}")
+
+
 def queue_worker_thread(
     stop_event: threading.Event, dbos: "DBOS", queue: Queue
 ) -> None:
@@ -494,10 +509,7 @@ def queue_worker_thread(
                             continue
                         raise
                     for id in dequeued_workflows:
-                        try:
-                            execute_workflow_by_id(dbos, id, False, True)
-                        except Exception as e:
-                            dbos.logger.error(f"Error executing workflow {id}: {e}")
+                        _dispatch_dequeued_workflow(dbos, id)
             else:
                 local_running_count = dbos._active_workflows_set.count_for_queue(
                     queue.name, None
@@ -510,10 +522,7 @@ def queue_worker_thread(
                     local_running_count,
                 )
                 for id in dequeued_workflows:
-                    try:
-                        execute_workflow_by_id(dbos, id, False, True)
-                    except Exception as e:
-                        dbos.logger.error(f"Error executing workflow {id}: {e}")
+                    _dispatch_dequeued_workflow(dbos, id)
         except OperationalError as e:
             if isinstance(e.orig, errors.LockNotAvailable):
                 # Another worker is dequeueing this queue right now; retry next

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -12,7 +12,7 @@ from psycopg import errors
 from sqlalchemy.exc import OperationalError
 
 from dbos._context import DBOSContext, get_local_dbos_context
-from dbos._error import DBOSException, DBOSWorkflowFunctionNotFoundError
+from dbos._error import DBOSException
 from dbos._logger import dbos_logger
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
@@ -437,21 +437,6 @@ class Queue:
         )
 
 
-def _dispatch_dequeued_workflow(dbos: "DBOS", workflow_id: str) -> None:
-    """Start a workflow this thread just dequeued, returning it to the queue if
-    it cannot run yet.
-    """
-    try:
-        execute_workflow_by_id(dbos, workflow_id, False, True)
-    except DBOSWorkflowFunctionNotFoundError as e:
-        # The function may register later (e.g. a configured instance constructed
-        # after launch), so re-enqueue instead of leaving the row stuck PENDING.
-        dbos.logger.warning(f"Error executing workflow {workflow_id}: {e.message}")
-        dbos._sys_db.requeue_dequeued_workflow(workflow_id)
-    except Exception as e:
-        dbos.logger.error(f"Error executing workflow {workflow_id}: {e}")
-
-
 def queue_worker_thread(
     stop_event: threading.Event, dbos: "DBOS", queue: Queue
 ) -> None:
@@ -509,7 +494,10 @@ def queue_worker_thread(
                             continue
                         raise
                     for id in dequeued_workflows:
-                        _dispatch_dequeued_workflow(dbos, id)
+                        try:
+                            execute_workflow_by_id(dbos, id, False, True)
+                        except Exception as e:
+                            dbos.logger.error(f"Error executing workflow {id}: {e}")
             else:
                 local_running_count = dbos._active_workflows_set.count_for_queue(
                     queue.name, None
@@ -522,7 +510,10 @@ def queue_worker_thread(
                     local_running_count,
                 )
                 for id in dequeued_workflows:
-                    _dispatch_dequeued_workflow(dbos, id)
+                    try:
+                        execute_workflow_by_id(dbos, id, False, True)
+                    except Exception as e:
+                        dbos.logger.error(f"Error executing workflow {id}: {e}")
         except OperationalError as e:
             if isinstance(e.orig, errors.LockNotAvailable):
                 # Another worker is dequeueing this queue right now; retry next

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -1,12 +1,10 @@
 import threading
-import time
 from typing import TYPE_CHECKING, Any, List
 
 from dbos._context import UseLogAttributes
-from dbos._utils import GlobalParams
+from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
-from ._core import WorkflowHandlePolling, execute_workflow_by_id
-from ._error import DBOSWorkflowFunctionNotFoundError
+from ._core import WorkflowHandlePolling
 from ._sys_db import GetPendingWorkflowsOutput
 
 if TYPE_CHECKING:
@@ -14,13 +12,19 @@ if TYPE_CHECKING:
 
 
 def _recover_workflow(
-    dbos: "DBOS", workflow: GetPendingWorkflowsOutput
+    dbos: "DBOS", workflow: GetPendingWorkflowsOutput, executor_ids: List[str]
 ) -> "WorkflowHandle[Any]":
-    if workflow.queue_name:
-        # Queued workflows are dispatched by the queue, not run directly by recovery: just return the row to the queue.
-        dbos._sys_db.clear_queue_assignment(workflow.workflow_id)
-        return WorkflowHandlePolling(workflow.workflow_id, dbos)
-    return execute_workflow_by_id(dbos, workflow.workflow_id, True, False)
+    """Make a pending workflow eligible for execution again, and return a handle to it.
+
+    Recovery re-enqueues rather than executing directly, so that every recovered
+    workflow starts through the queue's atomic ENQUEUED->PENDING dequeue. That
+    handoff admits exactly one runner, which makes duplicate recovery requests
+    idempotent.
+    """
+    dbos._sys_db.reenqueue_for_recovery(
+        workflow.workflow_id, executor_ids, INTERNAL_QUEUE_NAME
+    )
+    return WorkflowHandlePolling(workflow.workflow_id, dbos)
 
 
 def startup_recovery_thread(
@@ -29,17 +33,12 @@ def startup_recovery_thread(
     """Attempt to recover local pending workflows on startup using a background thread."""
     stop_event = threading.Event()
     dbos.background_thread_stop_events.append(stop_event)
+    executor_ids = [GlobalParams.executor_id]
     while not stop_event.is_set() and len(pending_workflows) > 0:
         for pending_workflow in list(pending_workflows):
             try:
-                _recover_workflow(dbos, pending_workflow)
+                _recover_workflow(dbos, pending_workflow, executor_ids)
                 pending_workflows.remove(pending_workflow)
-            except DBOSWorkflowFunctionNotFoundError as e:
-                with UseLogAttributes(workflow_id=pending_workflow.workflow_id):
-                    dbos.logger.warning(
-                        f"Exception encountered when recovering workflow {pending_workflow.workflow_id}: {e.message}"
-                    )
-                time.sleep(1)
             except Exception as e:
                 with UseLogAttributes(workflow_id=pending_workflow.workflow_id):
                     dbos.logger.error(
@@ -60,7 +59,7 @@ def recover_pending_workflows(
         )
         for pending_workflow in pending_workflows:
             try:
-                handle = _recover_workflow(dbos, pending_workflow)
+                handle = _recover_workflow(dbos, pending_workflow, executor_ids)
                 workflow_handles.append(handle)
             except Exception as e:
                 with UseLogAttributes(workflow_id=pending_workflow.workflow_id):

--- a/dbos/_recovery.py
+++ b/dbos/_recovery.py
@@ -34,18 +34,17 @@ def startup_recovery_thread(
     stop_event = threading.Event()
     dbos.background_thread_stop_events.append(stop_event)
     executor_ids = [GlobalParams.executor_id]
-    while not stop_event.is_set() and len(pending_workflows) > 0:
-        for pending_workflow in list(pending_workflows):
-            try:
-                _recover_workflow(dbos, pending_workflow, executor_ids)
-                pending_workflows.remove(pending_workflow)
-            except Exception as e:
-                with UseLogAttributes(workflow_id=pending_workflow.workflow_id):
-                    dbos.logger.error(
-                        f"Exception encountered when recovering workflow {pending_workflow.workflow_id}:",
-                        exc_info=e,
-                    )
-                pending_workflows.remove(pending_workflow)
+    for pending_workflow in pending_workflows:
+        if stop_event.is_set():
+            return
+        try:
+            _recover_workflow(dbos, pending_workflow, executor_ids)
+        except Exception as e:
+            with UseLogAttributes(workflow_id=pending_workflow.workflow_id):
+                dbos.logger.error(
+                    f"Exception encountered when recovering workflow {pending_workflow.workflow_id}:",
+                    exc_info=e,
+                )
 
 
 def recover_pending_workflows(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -310,9 +310,8 @@ class ExportedWorkflow(TypedDict):
 
 
 class GetPendingWorkflowsOutput:
-    def __init__(self, *, workflow_id: str, queue_name: Optional[str] = None):
+    def __init__(self, *, workflow_id: str):
         self.workflow_id: str = workflow_id
-        self.queue_name: Optional[str] = queue_name
 
 
 class WorkflowSchedule(TypedDict):
@@ -1971,7 +1970,6 @@ class SystemDatabase(ABC):
             rows = c.execute(
                 sa.select(
                     SystemSchema.workflow_status.c.workflow_uuid,
-                    SystemSchema.workflow_status.c.queue_name,
                 ).where(
                     SystemSchema.workflow_status.c.status
                     == WorkflowStatusString.PENDING.value,
@@ -1981,11 +1979,7 @@ class SystemDatabase(ABC):
             ).fetchall()
 
             return [
-                GetPendingWorkflowsOutput(
-                    workflow_id=row.workflow_uuid,
-                    queue_name=row.queue_name,
-                )
-                for row in rows
+                GetPendingWorkflowsOutput(workflow_id=row.workflow_uuid) for row in rows
             ]
 
     def list_workflow_steps(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4062,25 +4062,6 @@ class SystemDatabase(ABC):
             )
             return res.rowcount > 0
 
-    @db_retry()
-    def requeue_dequeued_workflow(self, workflow_id: str) -> None:
-        """Return a workflow this executor just dequeued to its queue, to be
-        retried on a later poll.
-        """
-        with self.engine.begin() as c:
-            c.execute(
-                sa.update(SystemSchema.workflow_status)
-                .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
-                .where(SystemSchema.workflow_status.c.queue_name.isnot(None))
-                .where(
-                    SystemSchema.workflow_status.c.status
-                    == WorkflowStatusString.PENDING.value
-                )
-                .values(
-                    status=WorkflowStatusString.ENQUEUED.value, started_at_epoch_ms=None
-                )
-            )
-
     T = TypeVar("T")
 
     def call_function_as_step(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4035,9 +4035,45 @@ class SystemDatabase(ABC):
             return ret_ids
 
     @db_retry()
-    def clear_queue_assignment(self, workflow_id: str) -> None:
+    def reenqueue_for_recovery(
+        self, workflow_id: str, executor_ids: List[str], recovery_queue_name: str
+    ) -> bool:
+        """Return a PENDING workflow to a queue so it is re-dispatched. Returns
+        whether the row was re-enqueued.
+
+        The executor_ids predicate makes recovery idempotent. Recovery declares a
+        set of executors dead; once any live executor dequeues the workflow,
+        start_queued_workflows sets the workflow's executor ID on the row, so a
+        duplicate recovery request for the original (dead) executor matches
+        nothing instead of re-enqueueing a running workflow.
+        """
+        if not executor_ids:
+            return False
         with self.engine.begin() as c:
-            # Reset the task to "ENQUEUED" so the queue re-dispatches it; a no-op if the row is no longer PENDING-queued.
+            res = c.execute(
+                sa.update(SystemSchema.workflow_status)
+                .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
+                .where(
+                    SystemSchema.workflow_status.c.status
+                    == WorkflowStatusString.PENDING.value
+                )
+                .where(SystemSchema.workflow_status.c.executor_id.in_(executor_ids))
+                .values(
+                    status=WorkflowStatusString.ENQUEUED.value,
+                    started_at_epoch_ms=None,
+                    queue_name=sa.func.coalesce(
+                        SystemSchema.workflow_status.c.queue_name, recovery_queue_name
+                    ),
+                )
+            )
+            return res.rowcount > 0
+
+    @db_retry()
+    def requeue_dequeued_workflow(self, workflow_id: str) -> None:
+        """Return a workflow this executor just dequeued to its queue, to be
+        retried on a later poll.
+        """
+        with self.engine.begin() as c:
             c.execute(
                 sa.update(SystemSchema.workflow_status)
                 .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4055,6 +4055,7 @@ class SystemDatabase(ABC):
                 .values(
                     status=WorkflowStatusString.ENQUEUED.value,
                     started_at_epoch_ms=None,
+                    updated_at=self._now_ms_sql(),
                     queue_name=sa.func.coalesce(
                         SystemSchema.workflow_status.c.queue_name, recovery_queue_name
                     ),

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -914,10 +914,11 @@ def test_class_step_without_dbos(dbos: DBOS, config: DBOSConfig) -> None:
 def test_inst_recovery_missing_instance(
     dbos: DBOS, config: DBOSConfig, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Reproduces issue #645: when startup recovery runs for an instance-method
-    # workflow whose DBOSConfiguredInstance has not been registered, the lookup
-    # raises DBOSWorkflowFunctionNotFoundError but the recovery thread swallows
-    # it without any log or other indication to the user.
+    # Reproduces issue #645: when a recovered instance-method workflow's
+    # DBOSConfiguredInstance has not been registered, the lookup raises
+    # DBOSWorkflowFunctionNotFoundError, which was swallowed without any log or
+    # other indication to the user. The workflow does not run; it must at least
+    # be visible in the logs.
     wfid = str(uuid.uuid4())
     DBOS.destroy(destroy_registry=True)
     config["application_version"] = "1.0.0"
@@ -959,7 +960,7 @@ def test_inst_recovery_missing_instance(
     caplog.set_level(logging.WARNING, "dbos")
     try:
         DBOS.launch()
-        # Give startup_recovery_thread a moment to run and emit a warning.
+        # Recovery re-enqueues; the queue worker logs the failed lookup on dequeue.
         deadline = time.time() + 5
         while time.time() < deadline:
             if "is not registered" in caplog.text:
@@ -970,8 +971,6 @@ def test_inst_recovery_missing_instance(
 
     assert f"is not registered" in caplog.text
     assert "test_class" in caplog.text
-    inst = TestClass()
-    assert DBOS.retrieve_workflow(wfid).get_result()
 
 
 def test_class_with_only_steps(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -522,11 +522,12 @@ def test_recovery_reenqueue_is_ownership_conditional(dbos: DBOS) -> None:
 
 
 def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
-    """Repeatedly recovering an executor that is alive and running the workflow must not re-run its body.
+    """Recovery hands a running workflow back to the queue, and each sweep yields exactly one dequeue.
 
-    Recovery only re-enqueues, so each assertion has to wait for the queue to
-    actually dequeue the row: that dequeue is the point at which a missing
-    ownership check would start a second copy of the body.
+    This pins the mechanism this PR introduced rather than the pre-existing
+    in-process ownership guard: a workflow that was never enqueued acquires the
+    internal queue's name and is restarted by the queue, where before the sweep
+    executed it directly and the row's queue_name stayed None.
     """
     start_count = 0
     blocker = threading.Event()
@@ -551,12 +552,24 @@ def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
 
         retry_until_success(check_running)
 
+        # Started directly, so it carries no queue at all.
+        before = DBOS.get_workflow_status(wfuuid)
+        assert before is not None and before.queue_name is None
+
         # Each sweep re-enqueues the running workflow (recovering a live executor
-        # is not prevented); the dequeue that follows bumps recovery_attempts, so
-        # wait for it before asserting the body did not run a second time.
+        # is not prevented).
         for expected_attempts in (2, 3):
             DBOS._recover_pending_workflows([GlobalParams.executor_id])
 
+            # Recovery re-enqueued rather than executing: the row now belongs to
+            # the internal queue, which is what restarts it. queue_name is never
+            # cleared afterwards, so reading it here is not a race.
+            requeued = DBOS.get_workflow_status(wfuuid)
+            assert requeued is not None
+            assert requeued.queue_name == INTERNAL_QUEUE_NAME
+
+            # The queue restarts it exactly once per sweep: the ENQUEUED->PENDING
+            # dequeue admits a single runner, so recovery_attempts advances by one.
             def dequeued(expected: int = expected_attempts) -> None:
                 status = DBOS.get_workflow_status(wfuuid)
                 assert status is not None

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -452,13 +452,16 @@ def test_recovery_reenqueue_is_ownership_conditional(dbos: DBOS) -> None:
     must not yank the running workflow back to ENQUEUED.
     """
 
+    blocker = threading.Event()
+
     @DBOS.workflow()
-    def test_workflow(var: str) -> str:
+    def blocked_workflow(var: str) -> str:
+        blocker.wait()
         return var
 
     wfuuid = str(uuid.uuid4())
     with SetWorkflowID(wfuuid):
-        assert test_workflow("bob") == "bob"
+        handle = DBOS.start_workflow(blocked_workflow, "bob")
 
     # Orphan the workflow: PENDING, owned by an executor that is now dead.
     with dbos._sys_db.engine.begin() as c:
@@ -468,51 +471,62 @@ def test_recovery_reenqueue_is_ownership_conditional(dbos: DBOS) -> None:
             .where(SystemSchema.workflow_status.c.workflow_uuid == wfuuid)
         )
 
-    # A sweep naming a different executor must not touch the row.
-    assert (
-        dbos._sys_db.reenqueue_for_recovery(
-            wfuuid, ["someotherexecutor"], INTERNAL_QUEUE_NAME
+    # The workflow stays blocked for the whole check, so release it even on
+    # failure: an assertion that escapes with the workflow still running wedges
+    # DBOS.destroy() in fixture teardown and hangs the suite instead of failing.
+    try:
+        # A sweep naming a different executor must not touch the row.
+        assert (
+            dbos._sys_db.reenqueue_for_recovery(
+                wfuuid, ["someotherexecutor"], INTERNAL_QUEUE_NAME
+            )
+            is False
         )
-        is False
-    )
-    unchanged = DBOS.get_workflow_status(wfuuid)
-    assert unchanged and unchanged.status == "PENDING"
+        unchanged = DBOS.get_workflow_status(wfuuid)
+        assert unchanged and unchanged.status == "PENDING"
 
-    # A sweep naming the dead executor re-enqueues it onto the internal queue.
-    assert (
-        dbos._sys_db.reenqueue_for_recovery(
-            wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+        # A sweep naming the dead executor re-enqueues it onto the internal queue.
+        assert (
+            dbos._sys_db.reenqueue_for_recovery(
+                wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+            )
+            is True
         )
-        is True
-    )
 
-    # A duplicate sweep for the dead executor is a no-op, whether the row is
-    # still ENQUEUED or has since been dequeued and stamped with the live
-    # executor's ID. Either way the workflow starts exactly once.
-    assert (
-        dbos._sys_db.reenqueue_for_recovery(
-            wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+        # Wait for the queue to dequeue it. The row returns to PENDING, now
+        # stamped with this live executor's ID -- the state the claim rests on.
+        def dequeued_by_live_executor() -> None:
+            status = DBOS.get_workflow_status(wfuuid)
+            assert status is not None
+            assert status.status == WorkflowStatusString.PENDING.value
+            assert status.executor_id == GlobalParams.executor_id
+
+        retry_until_success(dequeued_by_live_executor)
+
+        # Because the row is PENDING again, only the executor predicate can
+        # reject this duplicate sweep. It must not yank the running workflow.
+        assert (
+            dbos._sys_db.reenqueue_for_recovery(
+                wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+            )
+            is False
         )
-        is False
-    )
+        still_running = DBOS.get_workflow_status(wfuuid)
+        assert (
+            still_running and still_running.status == WorkflowStatusString.PENDING.value
+        )
+    finally:
+        blocker.set()
 
-    assert DBOS.retrieve_workflow(wfuuid).get_result() == "bob"
-
-    def check_recovered_once() -> None:
-        status = DBOS.get_workflow_status(wfuuid)
-        assert status is not None
-        assert status.status == WorkflowStatusString.SUCCESS.value
-        # Original attempt + the single dequeue that recovered it.
-        assert status.recovery_attempts == 2
-
-    retry_until_success(check_recovered_once)
+    assert handle.get_result() == "bob"
 
 
 def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
     """Repeatedly recovering an executor that is alive and running the workflow must not re-run its body.
 
-    Recovery re-enqueues the row, but the ownership check in the execution path
-    makes the re-dequeued copy await the running one instead of executing again.
+    Recovery only re-enqueues, so each assertion has to wait for the queue to
+    actually dequeue the row: that dequeue is the point at which a missing
+    ownership check would start a second copy of the body.
     """
     start_count = 0
     blocker = threading.Event()
@@ -528,16 +542,32 @@ def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
     with SetWorkflowID(wfuuid):
         handle = DBOS.start_workflow(blocked_workflow)
 
-    def check_running() -> None:
-        assert start_count == 1
+    # Release the workflow even on failure: an assertion that escapes while it is
+    # still blocked wedges DBOS.destroy() in teardown and hangs the suite.
+    try:
 
-    retry_until_success(check_running)
+        def check_running() -> None:
+            assert start_count == 1
 
-    for _ in range(3):
-        DBOS._recover_pending_workflows([GlobalParams.executor_id])
-    assert start_count == 1
+        retry_until_success(check_running)
 
-    blocker.set()
+        # Each sweep re-enqueues the running workflow (recovering a live executor
+        # is not prevented); the dequeue that follows bumps recovery_attempts, so
+        # wait for it before asserting the body did not run a second time.
+        for expected_attempts in (2, 3):
+            DBOS._recover_pending_workflows([GlobalParams.executor_id])
+
+            def dequeued(expected: int = expected_attempts) -> None:
+                status = DBOS.get_workflow_status(wfuuid)
+                assert status is not None
+                assert status.recovery_attempts == expected
+                assert status.status == WorkflowStatusString.PENDING.value
+
+            retry_until_success(dequeued)
+            assert start_count == 1
+    finally:
+        blocker.set()
+
     assert handle.get_result() == "done"
     assert start_count == 1
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -39,7 +39,7 @@ from dbos._error import (
 )
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import _dbos_null_topic
-from dbos._utils import GlobalParams
+from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from tests.conftest import retry_until_success, set_workflow_status, using_sqlite
 
 
@@ -442,6 +442,104 @@ def test_recovery_workflow(dbos: DBOS) -> None:
     stat = workflow_handles[0].get_status()
     assert stat
     assert stat.recovery_attempts == 2  # original attempt + recovery attempt
+
+
+def test_recovery_reenqueue_is_ownership_conditional(dbos: DBOS) -> None:
+    """Recovery only re-enqueues workflows still owned by an executor it declared dead.
+
+    Once a live executor dequeues a recovered workflow, the dequeue stamps its own
+    ID on the row, so a duplicate (or delayed) recovery sweep for the dead executor
+    must not yank the running workflow back to ENQUEUED.
+    """
+
+    @DBOS.workflow()
+    def test_workflow(var: str) -> str:
+        return var
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowID(wfuuid):
+        assert test_workflow("bob") == "bob"
+
+    # Orphan the workflow: PENDING, owned by an executor that is now dead.
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.update(SystemSchema.workflow_status)
+            .values({"status": "PENDING", "executor_id": "deadexecutor"})
+            .where(SystemSchema.workflow_status.c.workflow_uuid == wfuuid)
+        )
+
+    # A sweep naming a different executor must not touch the row.
+    assert (
+        dbos._sys_db.reenqueue_for_recovery(
+            wfuuid, ["someotherexecutor"], INTERNAL_QUEUE_NAME
+        )
+        is False
+    )
+    unchanged = DBOS.get_workflow_status(wfuuid)
+    assert unchanged and unchanged.status == "PENDING"
+
+    # A sweep naming the dead executor re-enqueues it onto the internal queue.
+    assert (
+        dbos._sys_db.reenqueue_for_recovery(
+            wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+        )
+        is True
+    )
+
+    # A duplicate sweep for the dead executor is a no-op, whether the row is
+    # still ENQUEUED or has since been dequeued and stamped with the live
+    # executor's ID. Either way the workflow starts exactly once.
+    assert (
+        dbos._sys_db.reenqueue_for_recovery(
+            wfuuid, ["deadexecutor"], INTERNAL_QUEUE_NAME
+        )
+        is False
+    )
+
+    assert DBOS.retrieve_workflow(wfuuid).get_result() == "bob"
+
+    def check_recovered_once() -> None:
+        status = DBOS.get_workflow_status(wfuuid)
+        assert status is not None
+        assert status.status == WorkflowStatusString.SUCCESS.value
+        # Original attempt + the single dequeue that recovered it.
+        assert status.recovery_attempts == 2
+
+    retry_until_success(check_recovered_once)
+
+
+def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
+    """Repeatedly recovering an executor that is alive and running the workflow must not re-run its body.
+
+    Recovery re-enqueues the row, but the ownership check in the execution path
+    makes the re-dequeued copy await the running one instead of executing again.
+    """
+    start_count = 0
+    blocker = threading.Event()
+
+    @DBOS.workflow()
+    def blocked_workflow() -> str:
+        nonlocal start_count
+        start_count += 1
+        blocker.wait()
+        return "done"
+
+    wfuuid = str(uuid.uuid4())
+    with SetWorkflowID(wfuuid):
+        handle = DBOS.start_workflow(blocked_workflow)
+
+    def check_running() -> None:
+        assert start_count == 1
+
+    retry_until_success(check_running)
+
+    for _ in range(3):
+        DBOS._recover_pending_workflows([GlobalParams.executor_id])
+    assert start_count == 1
+
+    blocker.set()
+    assert handle.get_result() == "done"
+    assert start_count == 1
 
 
 def test_recovery_empty_id_dead_letters(dbos: DBOS) -> None:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -184,7 +184,12 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
     for i in range(max_recovery_attempts):
         set_workflow_status(dbos._sys_db, wfid, "PENDING")
         handles = DBOS._recover_pending_workflows()
-        handles[0].get_result()
+        # Select our workflow rather than trusting ordering: recovery returns a
+        # polling handle for every pending row, and get_result() on the wrong one
+        # polls forever, turning a failure into a suite-level timeout.
+        recovered = [h for h in handles if h.workflow_id == wfid]
+        assert len(recovered) == 1
+        recovered[0].get_result()
         assert recovery_count == i + 2
 
     # Verify an additional attempt (either through recovery or through a direct call) throws a DLQ error

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -191,10 +191,15 @@ def test_dead_letter_queue(dbos: DBOS) -> None:
     # and puts the workflow in the DLQ status.
     set_workflow_status(dbos._sys_db, wfid, "PENDING")
     DBOS._recover_pending_workflows()
-    assert (
-        handle.get_status().status
-        == WorkflowStatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED.value
-    )
+
+    # Recovery re-enqueues, so the DLQ transition happens when the queue dequeues the workflow.
+    def check_dlq() -> None:
+        assert (
+            handle.get_status().status
+            == WorkflowStatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED.value
+        )
+
+    retry_until_success(check_dlq)
     with pytest.raises(Exception) as exc_info:
         with SetWorkflowID(wfid):
             dead_letter_workflow()

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -166,7 +166,7 @@ def test_notification_errors(dbos: DBOS, skip_with_sqlite: None) -> None:
 
 def test_dead_letter_queue(dbos: DBOS) -> None:
     event = threading.Event()
-    max_recovery_attempts = 20
+    max_recovery_attempts = 3
     recovery_count = 0
 
     @DBOS.workflow(max_recovery_attempts=max_recovery_attempts)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1839,10 +1839,10 @@ async def test_simple_queue_async(dbos: DBOS) -> None:
 
 
 def test_enqueue_options_require_a_queue(dbos: DBOS) -> None:
-    # Every enqueue option is interpreted by the queue machinery alone, so setting
-    # one without a queue silently does nothing -- and persisting it is unsafe: a
-    # dedup ID becomes a constraint violation once anything assigns the row a queue
-    # name (e.g. recovery), and a pinned app version hides the row from recovery.
+    # These options are interpreted by the queue machinery alone, so setting one
+    # without a queue silently does nothing -- and persisting a dedup ID is unsafe,
+    # because it becomes a unique-constraint violation once anything assigns the
+    # row a queue name (e.g. recovery).
 
     @DBOS.workflow()
     def test_workflow(var: str) -> str:
@@ -1851,26 +1851,47 @@ def test_enqueue_options_require_a_queue(dbos: DBOS) -> None:
     options: List[dict[str, Any]] = [
         {"deduplication_id": "dedup_without_queue"},
         {"priority": 5},
-        {"app_version": "some_other_version"},
         {"queue_partition_key": "key_without_queue"},
         {"delay_seconds": 30},
     ]
     for option in options:
+        wfid = str(uuid.uuid4())
         with pytest.raises(DBOSException) as exc_info:
             with SetEnqueueOptions(**option):
-                DBOS.start_workflow(test_workflow, "bob")
+                with SetWorkflowID(wfid):
+                    DBOS.start_workflow(test_workflow, "bob")
         message = str(exc_info.value)
         assert "not being enqueued" in message
         assert next(iter(option)) in message
+        # The call must be rejected before any row is written, or it would leave
+        # exactly the orphaned PENDING row this validation exists to prevent.
+        assert DBOS.get_workflow_status(wfid) is None
 
-    # A direct invocation never carries enqueue options, so it is unaffected and
-    # must keep working -- and must not persist any of them either.
+    # app_version is excluded: without a queue it still decides which executors
+    # can recover the workflow, so pinning it is meaningful and must keep working.
+    pinned_id = str(uuid.uuid4())
+    with SetEnqueueOptions(app_version="some_other_version"):
+        with SetWorkflowID(pinned_id):
+            DBOS.start_workflow(test_workflow, "bob")
+    pinned = DBOS.get_workflow_status(pinned_id)
+    assert pinned is not None and pinned.app_version == "some_other_version"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_options_require_a_queue_async(dbos: DBOS) -> None:
+    # start_workflow_async carries the same validation on a separate code path.
+
+    @DBOS.workflow()
+    async def test_workflow(var: str) -> str:
+        return var
+
     wfid = str(uuid.uuid4())
-    with SetEnqueueOptions(deduplication_id="dedup_without_queue", priority=5):
-        with SetWorkflowID(wfid):
-            assert test_workflow("bob") == "bob"
-    status = DBOS.get_workflow_status(wfid)
-    assert status is not None and status.deduplication_id is None
+    with pytest.raises(DBOSException) as exc_info:
+        with SetEnqueueOptions(deduplication_id="dedup_without_queue"):
+            with SetWorkflowID(wfid):
+                await DBOS.start_workflow_async(test_workflow, "bob")
+    assert "not being enqueued" in str(exc_info.value)
+    assert await DBOS.get_workflow_status_async(wfid) is None
 
 
 def test_queue_deduplication(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1848,13 +1848,14 @@ def test_enqueue_options_require_a_queue(dbos: DBOS) -> None:
     def test_workflow(var: str) -> str:
         return var
 
-    for option in (
+    options: List[dict[str, Any]] = [
         {"deduplication_id": "dedup_without_queue"},
         {"priority": 5},
         {"app_version": "some_other_version"},
         {"queue_partition_key": "key_without_queue"},
         {"delay_seconds": 30},
-    ):
+    ]
+    for option in options:
         with pytest.raises(DBOSException) as exc_info:
             with SetEnqueueOptions(**option):
                 DBOS.start_workflow(test_workflow, "bob")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1838,6 +1838,40 @@ async def test_simple_queue_async(dbos: DBOS) -> None:
     assert step_counter == 1
 
 
+def test_enqueue_options_require_a_queue(dbos: DBOS) -> None:
+    # Every enqueue option is interpreted by the queue machinery alone, so setting
+    # one without a queue silently does nothing -- and persisting it is unsafe: a
+    # dedup ID becomes a constraint violation once anything assigns the row a queue
+    # name (e.g. recovery), and a pinned app version hides the row from recovery.
+
+    @DBOS.workflow()
+    def test_workflow(var: str) -> str:
+        return var
+
+    for option in (
+        {"deduplication_id": "dedup_without_queue"},
+        {"priority": 5},
+        {"app_version": "some_other_version"},
+        {"queue_partition_key": "key_without_queue"},
+        {"delay_seconds": 30},
+    ):
+        with pytest.raises(DBOSException) as exc_info:
+            with SetEnqueueOptions(**option):
+                DBOS.start_workflow(test_workflow, "bob")
+        message = str(exc_info.value)
+        assert "not being enqueued" in message
+        assert next(iter(option)) in message
+
+    # A direct invocation never carries enqueue options, so it is unaffected and
+    # must keep working -- and must not persist any of them either.
+    wfid = str(uuid.uuid4())
+    with SetEnqueueOptions(deduplication_id="dedup_without_queue", priority=5):
+        with SetWorkflowID(wfid):
+            assert test_workflow("bob") == "bob"
+    status = DBOS.get_workflow_status(wfid)
+    assert status is not None and status.deduplication_id is None
+
+
 def test_queue_deduplication(dbos: DBOS) -> None:
     queue_name = "test_dedup_queue"
     DBOS.register_queue(queue_name)


### PR DESCRIPTION
Make workflow recovery idempotent by routing it through queues. Condition this on the workflow still having a dead executor's ID to close races.

Previously, the code would automatically retry workflow registration errors, in case a workflow was not registered during recovery. This did not have good use cases (if the workflow is not registered at launch, it is unlikely to become registered later), so we are removing it.