### PR TITLE
Deprecate the Admin Server

### DIFF
--- a/dbos/_admin_server.py
+++ b/dbos/_admin_server.py
@@ -44,11 +44,6 @@ class AdminServer:
     """DEPRECATED: this server will be removed in a future version of DBOS."""
 
     def __init__(self, dbos: DBOS, port: int = 3001) -> None:
-        # Don't warn in DBOS Cloud, which runs the admin server on the user's behalf.
-        if not GlobalParams.dbos_cloud:
-            dbos_logger.warning(
-                "The DBOS admin server is deprecated and will be removed in a future version of DBOS."
-            )
         self.port = port
         handler = partial(AdminRequestHandler, dbos)
         self.server = ThreadingHTTPServer(("0.0.0.0", port), handler)
@@ -57,6 +52,12 @@ class AdminServer:
 
         dbos_logger.debug("Starting DBOS admin server on port %d", self.port)
         self.server_thread.start()
+
+        # Warn only once the server is actually up, and not in DBOS Cloud, which runs it on the user's behalf.
+        if not GlobalParams.dbos_cloud:
+            dbos_logger.warning(
+                "The DBOS admin server is deprecated and will be removed in a future version of DBOS."
+            )
 
     def stop(self) -> None:
         dbos_logger.debug("Stopping DBOS admin server")

--- a/dbos/_admin_server.py
+++ b/dbos/_admin_server.py
@@ -1,3 +1,8 @@
+"""
+DEPRECATED: The DBOS admin server is deprecated and will be removed in a future version of DBOS.
+It is disabled by default; set run_admin_server=True in your DBOS config to re-enable it.
+"""
+
 from __future__ import annotations
 
 import json
@@ -36,7 +41,14 @@ _conductor_path = "/conductor"
 
 
 class AdminServer:
+    """DEPRECATED: this server will be removed in a future version of DBOS."""
+
     def __init__(self, dbos: DBOS, port: int = 3001) -> None:
+        # Don't warn in DBOS Cloud, which runs the admin server on the user's behalf.
+        if not GlobalParams.dbos_cloud:
+            dbos_logger.warning(
+                "The DBOS admin server is deprecated and will be removed in a future version of DBOS."
+            )
         self.port = port
         handler = partial(AdminRequestHandler, dbos)
         self.server = ThreadingHTTPServer(("0.0.0.0", port), handler)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -628,7 +628,6 @@ class DBOS:
                 validate_kafka_consumers(self)
                 configure_kafka_queues(self)
 
-            # Deprecated: the admin server is off by default (except in DBOS Cloud) and will be removed in a future version.
             admin_port = self._config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -628,6 +628,7 @@ class DBOS:
                 validate_kafka_consumers(self)
                 configure_kafka_queues(self)
 
+            # Deprecated: the admin server is off by default (except in DBOS Cloud) and will be removed in a future version.
             admin_port = self._config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -13,6 +13,7 @@ from dbos._serialization import Serializer
 from ._error import DBOSInitializationError
 from ._logger import dbos_logger
 from ._schemas.system_database import SystemSchema
+from ._utils import GlobalParams
 
 DBOS_CONFIG_PATH = "dbos-config.yaml"
 
@@ -34,8 +35,8 @@ class DBOSConfig(TypedDict, total=False):
         console_log_level: Optional[str]: log level specficially for console logging; must be no less severe than log_level
         otlp_traces_endpoints: List[str]: OTLP traces endpoints
         otlp_logs_endpoints: List[str]: OTLP logs endpoints
-        admin_port (int): Admin port
-        run_admin_server (bool): Whether to run the DBOS admin server
+        admin_port (int): (DEPRECATED) Port of the DBOS admin server. The admin server is deprecated and will be removed in a future version of DBOS.
+        run_admin_server (bool): (DEPRECATED) Whether to run the DBOS admin server. Defaults to False (True in DBOS Cloud). The admin server is deprecated and will be removed in a future version of DBOS.
         otlp_attributes (dict[str, str]): A set of custom attributes to apply OTLP-exported logs and traces
         application_version (str): Application version
         executor_id (str): Executor ID, used to identify the application instance in distributed environments
@@ -149,6 +150,11 @@ class ConfigFile(TypedDict, total=False):
     use_listen_notify: bool
 
 
+def _default_run_admin_server() -> bool:
+    # The admin server is deprecated and off by default, except in DBOS Cloud, which depends on it.
+    return GlobalParams.dbos_cloud
+
+
 def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
     if "name" not in config:
         raise DBOSInitializationError(f"Configuration must specify an application name")
@@ -183,7 +189,9 @@ def translate_dbos_config_to_config_file(config: DBOSConfig) -> ConfigFile:
         translated_config["dbos_system_schema"] = config.get("dbos_system_schema")
 
     # Runtime config
-    translated_config["runtimeConfig"] = {"run_admin_server": True}
+    translated_config["runtimeConfig"] = {
+        "run_admin_server": _default_run_admin_server()
+    }
     if "admin_port" in config:
         translated_config["runtimeConfig"]["admin_port"] = config["admin_port"]
     if "run_admin_server" in config:
@@ -393,10 +401,10 @@ def process_config(
     # Handle admin server config
     if not data.get("runtimeConfig"):
         data["runtimeConfig"] = {
-            "run_admin_server": True,
+            "run_admin_server": _default_run_admin_server(),
         }
     elif "run_admin_server" not in data["runtimeConfig"]:
-        data["runtimeConfig"]["run_admin_server"] = True
+        data["runtimeConfig"]["run_admin_server"] = _default_run_admin_server()
 
     # Ensure database dict exists
     data.setdefault("database", {})

--- a/dbos/_dbos_config.py
+++ b/dbos/_dbos_config.py
@@ -35,7 +35,7 @@ class DBOSConfig(TypedDict, total=False):
         console_log_level: Optional[str]: log level specficially for console logging; must be no less severe than log_level
         otlp_traces_endpoints: List[str]: OTLP traces endpoints
         otlp_logs_endpoints: List[str]: OTLP logs endpoints
-        admin_port (int): (DEPRECATED) Port of the DBOS admin server. The admin server is deprecated and will be removed in a future version of DBOS.
+        admin_port (int): (DEPRECATED) Port of the DBOS admin server. Has no effect unless run_admin_server is True. The admin server is deprecated and will be removed in a future version of DBOS.
         run_admin_server (bool): (DEPRECATED) Whether to run the DBOS admin server. Defaults to False (True in DBOS Cloud). The admin server is deprecated and will be removed in a future version of DBOS.
         otlp_attributes (dict[str, str]): A set of custom attributes to apply OTLP-exported logs and traces
         application_version (str): Application version

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -4,6 +4,7 @@ import threading
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Dict
 
 import pytest
@@ -17,6 +18,15 @@ from dbos._error import DBOSAwaitedWorkflowCancelledError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import WorkflowStatusString
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
+from tests.conftest import default_config
+
+
+@pytest.fixture()
+def config(sqlite_path: Path) -> DBOSConfig:
+    # The admin server is deprecated and off by default, so these tests must opt in.
+    config = default_config(sqlite_path)
+    config["run_admin_server"] = True
+    return config
 
 
 def test_admin_endpoints(dbos: DBOS) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ from dbos._dbos_config import (
     translate_dbos_config_to_config_file,
 )
 from dbos._error import DBOSException, DBOSInitializationError
+from dbos._utils import GlobalParams
 
 mock_filename = "dbos-config.yaml"
 original_open = __builtins__["open"]
@@ -301,7 +302,7 @@ def test_process_config_load_defaults():
     assert processed_config["database"]["db_engine_kwargs"] is not None
     assert processed_config["database"]["sys_db_engine_kwargs"] is not None
     assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
-    assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    assert processed_config["runtimeConfig"]["run_admin_server"] == False
 
 
 def test_process_config_load_default_with_None_database_url():
@@ -316,7 +317,7 @@ def test_process_config_load_default_with_None_database_url():
     assert processed_config["database"]["db_engine_kwargs"] is not None
     assert processed_config["database"]["sys_db_engine_kwargs"] is not None
     assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
-    assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    assert processed_config["runtimeConfig"]["run_admin_server"] == False
 
 
 def test_process_config_load_default_with_empty_database_url():
@@ -331,7 +332,7 @@ def test_process_config_load_default_with_empty_database_url():
     assert processed_config["database"]["db_engine_kwargs"] is not None
     assert processed_config["database"]["sys_db_engine_kwargs"] is not None
     assert processed_config["telemetry"]["logs"]["logLevel"] == "INFO"
-    assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    assert processed_config["runtimeConfig"]["run_admin_server"] == False
 
 
 def test_config_missing_name():
@@ -692,7 +693,7 @@ def test_translate_dbosconfig_minimal_input():
 
     assert translated_config["name"] == "test-app"
     assert translated_config["telemetry"]["logs"]["logLevel"] == "INFO"
-    assert translated_config["runtimeConfig"]["run_admin_server"] == True
+    assert translated_config["runtimeConfig"]["run_admin_server"] == False
     assert "admin_port" not in translated_config["runtimeConfig"]
     assert "database" not in translated_config
     assert "env" not in translated_config
@@ -751,8 +752,9 @@ def test_translate_dbosconfig_just_admin_port():
     }
     translated_config = translate_dbos_config_to_config_file(config)
 
+    # Setting a port does not enable the deprecated admin server; run_admin_server must be set explicitly.
     assert translated_config["runtimeConfig"]["admin_port"] == 8001
-    assert translated_config["runtimeConfig"]["run_admin_server"] == True
+    assert translated_config["runtimeConfig"]["run_admin_server"] == False
     assert "env" not in translated_config
     assert "database" not in translated_config
 
@@ -770,6 +772,20 @@ def test_translate_dbosconfig_just_run_admin_server():
     assert "admin_port" not in translated_config["runtimeConfig"]
     assert "env" not in translated_config
     assert "database" not in translated_config
+
+
+def test_admin_server_defaults_on_in_dbos_cloud():
+    # The deprecated admin server is off by default everywhere except DBOS Cloud, which depends on it.
+    original = GlobalParams.dbos_cloud
+    GlobalParams.dbos_cloud = True
+    try:
+        translated_config = translate_dbos_config_to_config_file({"name": "test-app"})
+        assert translated_config["runtimeConfig"]["run_admin_server"] == True
+        # overwrite_config strips run_admin_server in DBOS Cloud, so process_config must default it back on.
+        processed_config = process_config(data={"name": "test-app"})
+        assert processed_config["runtimeConfig"]["run_admin_server"] == True
+    finally:
+        GlobalParams.dbos_cloud = original
 
 
 def test_translate_empty_otlp_traces_endpoints():


### PR DESCRIPTION
The admin server is not part of the documented public interface of DBOS. This PR formally deprecates it and switches it off by default. It will be removed in a future release.