### PR TITLE
Optimize Partition Query

### DIFF
--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -492,8 +492,11 @@ def queue_worker_thread(
                             local_running_count,
                         )
                     except OperationalError as e:
-                        # Lock held: another worker owns this partition, so skip it; let serialization failures propagate to the outer handler's backoff.
-                        if isinstance(e.orig, errors.LockNotAvailable):
+                        # Lock held or claim raced by another worker: skip just this partition, no queue-wide backoff.
+                        if isinstance(
+                            e.orig,
+                            (errors.LockNotAvailable, errors.SerializationFailure),
+                        ):
                             continue
                         raise
                     for id in dequeued_workflows:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3857,6 +3857,13 @@ class SystemDatabase(ABC):
         base_filter = sa.and_(
             ws.c.queue_name == queue_name,
             ws.c.status == WorkflowStatusString.ENQUEUED.value,
+            # Redundant literal IN mirroring the index's own predicate: SQLite's partial-index prover runs at prepare time, so it can't see bound params and can't derive IN membership from =.
+            ws.c.status.in_(
+                [
+                    sa.literal_column(f"'{WorkflowStatusString.ENQUEUED.value}'"),
+                    sa.literal_column(f"'{WorkflowStatusString.PENDING.value}'"),
+                ]
+            ),
         )
         partitions = (
             sa.select(sa.func.min(ws.c.queue_partition_key).label("pk"))

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3848,18 +3848,34 @@ class SystemDatabase(ABC):
         Returns:
             A list of unique partition names for the queue
         """
+        # Recursive-CTE loose index scan: neither Postgres nor SQLite can skip to the
+        # next distinct value inside a plain SELECT DISTINCT, which degenerates into a
+        # scan of every ENQUEUED row. Each iteration here is instead one index seek on
+        # idx_workflow_status_partition_dequeue, so cost scales with the number of
+        # partitions rather than the backlog depth.
+        ws = SystemSchema.workflow_status
+        base_filter = sa.and_(
+            ws.c.queue_name == queue_name,
+            ws.c.status == WorkflowStatusString.ENQUEUED.value,
+        )
+        partitions = (
+            sa.select(sa.func.min(ws.c.queue_partition_key).label("pk"))
+            .where(base_filter)
+            .where(ws.c.queue_partition_key.isnot(None))
+            .cte("partitions", recursive=True)
+        )
+        # Next key strictly after the previous one; > implies IS NOT NULL.
+        next_pk = (
+            sa.select(sa.func.min(ws.c.queue_partition_key))
+            .where(base_filter)
+            .where(ws.c.queue_partition_key > partitions.c.pk)
+            .scalar_subquery()
+        )
+        partitions = partitions.union_all(
+            sa.select(next_pk).where(partitions.c.pk.isnot(None))
+        )
+        query = sa.select(partitions.c.pk).where(partitions.c.pk.isnot(None))
         with self.engine.begin() as c:
-            query = (
-                sa.select(SystemSchema.workflow_status.c.queue_partition_key)
-                .distinct()
-                .where(SystemSchema.workflow_status.c.queue_name == queue_name)
-                .where(
-                    SystemSchema.workflow_status.c.status
-                    == WorkflowStatusString.ENQUEUED.value
-                )
-                .where(SystemSchema.workflow_status.c.queue_partition_key.isnot(None))
-            )
-
             rows = c.execute(query).fetchall()
             return [row[0] for row in rows]
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2593,6 +2593,70 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
     assert client_handle.get_result()
 
 
+def test_partition_serialization_failure_skips_key(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A serialization failure on one partition key skips only that partition:
+    the same sweep still dequeues other partitions, with no queue-wide backoff."""
+    from psycopg import errors
+    from sqlalchemy.exc import OperationalError
+
+    queue = Queue(
+        f"serialization_skip_{uuid.uuid4().hex[:8]}",
+        concurrency=1,
+        partition_queue=True,
+        polling_interval_sec=0.25,
+    )
+    # Sorts before the healthy key, so an escaping error would abort the sweep first.
+    poisoned_key = "a_poisoned"
+    healthy_key = "z_healthy"
+    poison_active = threading.Event()
+    poison_active.set()
+
+    @DBOS.workflow()
+    def wf() -> str:
+        assert DBOS.workflow_id
+        return DBOS.workflow_id
+
+    real_start = dbos._sys_db.start_queued_workflows
+
+    def poisoned_start(
+        queue_arg: Queue,
+        executor_id: str,
+        app_version: str,
+        queue_partition_key: Any = None,
+        local_running_count: int = 0,
+    ) -> List[str]:
+        if (
+            poison_active.is_set()
+            and queue_arg.name == queue.name
+            and queue_partition_key == poisoned_key
+        ):
+            raise OperationalError("dequeue", None, errors.SerializationFailure())
+        return real_start(
+            queue_arg,
+            executor_id,
+            app_version,
+            queue_partition_key,
+            local_running_count,
+        )
+
+    monkeypatch.setattr(dbos._sys_db, "start_queued_workflows", poisoned_start)
+
+    with SetEnqueueOptions(queue_partition_key=poisoned_key):
+        poisoned_handle = queue.enqueue(wf)
+    with SetEnqueueOptions(queue_partition_key=healthy_key):
+        healthy_handle = queue.enqueue(wf)
+
+    # The healthy partition drains even though the poisoned one fails every sweep.
+    assert healthy_handle.get_result()
+    assert poisoned_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
+
+    # Once the contention clears, the poisoned partition drains on a later sweep.
+    poison_active.clear()
+    assert poisoned_handle.get_result()
+
+
 @pytest.mark.asyncio
 async def test_partition_queue_worker_concurrency_async(dbos: DBOS) -> None:
     """worker_concurrency is enforced *per partition* on a partitioned queue.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -15,6 +15,12 @@ from dbos._utils import INTERNAL_QUEUE_NAME
 from .conftest import retry_until_success
 
 
+def daily_cron_far_from_now() -> str:
+    # Daily cron pinned ~12 hours away, so it can't fire mid-test at any wall-clock time.
+    t = datetime.now(timezone.utc) + timedelta(hours=12)
+    return f"{t.minute} {t.hour} * * *"
+
+
 def test_schedule_crud(dbos: DBOS) -> None:
     @DBOS.workflow()
     def my_workflow(scheduled_at: datetime, ctx: Any) -> None:
@@ -683,11 +689,11 @@ def test_dynamic_scheduler_replace_schedule(dbos: DBOS) -> None:
     def scheduled_workflow(scheduled_at: datetime, ctx: Any) -> None:
         received_contexts.append(ctx)
 
-    # Create a schedule that runs once a day — should not fire during this test
+    # A daily schedule far from now — must not fire during this test
     DBOS.create_schedule(
         schedule_name="replaceable",
         workflow_fn=scheduled_workflow,
-        schedule="0 0 * * *",
+        schedule=daily_cron_far_from_now(),
         context={"version": 1},
     )
     time.sleep(3)
@@ -735,11 +741,11 @@ def test_long_schedule_shutdown(dbos: DBOS) -> None:
         nonlocal wf_counter
         wf_counter += 1
 
-    # Create a schedule that runs once a day — should not fire during this test
+    # A daily schedule far from now — must not fire during this test
     DBOS.create_schedule(
         schedule_name="replaceable",
         workflow_fn=scheduled_workflow,
-        schedule="0 0 * * *",
+        schedule=daily_cron_far_from_now(),
     )
     time.sleep(3)
     assert wf_counter == 0
@@ -772,15 +778,17 @@ def test_backfill_schedule(dbos: DBOS) -> None:
     for h in handles:
         h.get_result()
 
+    # Filter to the window: the live schedule may also fire if the test crosses a top-of-hour
+    backfilled = [(t, c) for t, c in received if start <= t < end]
     expected = [datetime(2025, 1, 1, h, 0, 0, tzinfo=timezone.utc) for h in range(1, 4)]
-    assert sorted(t for t, _ in received) == expected
-    assert all(ctx == {"env": "backfill"} for _, ctx in received)
+    assert sorted(t for t, _ in backfilled) == expected
+    assert all(ctx == {"env": "backfill"} for _, ctx in backfilled)
 
     # Backfilling again should be idempotent (same workflow IDs)
     handles2 = DBOS.backfill_schedule("backfill-test", start, end)
     assert len(handles2) == 3
     time.sleep(1)
-    assert len(received) == 3
+    assert len([t for t, _ in received if start <= t < end]) == 3
 
     # Nonexistent schedule
     with pytest.raises(DBOSException, match="does not exist"):
@@ -812,8 +820,12 @@ def test_backfill_naive_datetime(dbos: DBOS) -> None:
     for h in handles:
         h.get_result()
 
+    # Filter to the window: the live schedule may also fire if the test crosses a top-of-hour
+    window_start = naive_start.replace(tzinfo=timezone.utc)
+    window_end = naive_end.replace(tzinfo=timezone.utc)
+    backfilled = [t for t in received if window_start <= t < window_end]
     expected = [datetime(2025, 1, 1, h, 0, 0, tzinfo=timezone.utc) for h in range(1, 4)]
-    assert sorted(received) == expected
+    assert sorted(backfilled) == expected
 
     # Mixed (aware start, naive end) should also work
     received.clear()
@@ -862,14 +874,15 @@ def test_backfill_with_timezone(dbos: DBOS) -> None:
     for h in handles_utc + handles_ny:
         h.get_result()
 
+    # Filter to the window: the live schedules may also fire if the test crosses their midnight
     # UTC schedule: midnight UTC on Jan 1 and Jan 2
-    utc_times = sorted(received_utc)
+    utc_times = sorted(t for t in received_utc if start <= t < end)
     assert len(utc_times) == 2
     assert utc_times[0].day == 1 and utc_times[0].hour == 0
     assert utc_times[1].day == 2 and utc_times[1].hour == 0
 
     # NY schedule: midnight Eastern = 05:00 UTC, so Jan 1 05:00 and Jan 2 05:00
-    ny_times = sorted(received_ny)
+    ny_times = sorted(t for t in received_ny if start <= t < end)
     assert len(ny_times) == 2
     for t in ny_times:
         # Midnight in New York
@@ -895,7 +908,7 @@ def test_trigger_schedule(dbos: DBOS) -> None:
     DBOS.create_schedule(
         schedule_name="trigger-test",
         workflow_fn=trigger_workflow,
-        schedule="0 0 * * *",  # daily, won't fire during test
+        schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
         context=[1, 2, 3],
     )
 
@@ -940,7 +953,7 @@ def test_list_workflows_by_schedule_name(dbos: DBOS) -> None:
         DBOS.create_schedule(
             schedule_name=name,
             workflow_fn=scheduled_workflow,
-            schedule="0 0 * * *",  # daily, won't fire during the test
+            schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
         )
 
     handle_a = DBOS.trigger_schedule("search-a")
@@ -978,7 +991,7 @@ def test_schedule_name_survives_export_import(dbos: DBOS) -> None:
     DBOS.create_schedule(
         schedule_name="export-test",
         workflow_fn=scheduled_workflow,
-        schedule="0 0 * * *",  # daily, won't fire during the test
+        schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
     )
     handle = DBOS.trigger_schedule("export-test")
     handle.get_result()
@@ -1248,9 +1261,11 @@ def test_client_backfill_schedule(client: DBOSClient) -> None:
     for h in handles:
         h.get_result()
 
+    # Filter to the window: the live schedule may also fire if the test crosses a top-of-hour
+    backfilled = [(t, c) for t, c in received if start <= t < end]
     expected = [datetime(2025, 6, 1, h, 0, 0, tzinfo=timezone.utc) for h in range(1, 4)]
-    assert sorted(t for t, _ in received) == expected
-    assert all(ctx == {"source": "client"} for _, ctx in received)
+    assert sorted(t for t, _ in backfilled) == expected
+    assert all(ctx == {"source": "client"} for _, ctx in backfilled)
 
     client.delete_schedule("client-backfill")
 
@@ -1265,7 +1280,7 @@ def test_client_trigger_schedule(client: DBOSClient) -> None:
     client.create_schedule(
         schedule_name="client-trigger",
         workflow_name=trigger_workflow.__qualname__,
-        schedule="0 0 * * *",
+        schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
         context="trigger-ctx",
     )
 
@@ -1833,7 +1848,7 @@ def test_scheduled_workflow_datetime_with_portable_serializer(
         DBOS.create_schedule(
             schedule_name="portable-schedule",
             workflow_fn=scheduled_workflow,
-            schedule="0 0 * * *",  # daily, won't fire during the test
+            schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
             context={"env": "test"},
         )
 
@@ -1862,7 +1877,7 @@ def test_scheduled_workflow_datetime_with_portable_serializer(
         DBOS.create_schedule(
             schedule_name="portable-class-schedule",
             workflow_fn=ScheduledClass.scheduled_wf,
-            schedule="0 0 * * *",  # daily, won't fire during the test
+            schedule=daily_cron_far_from_now(),  # daily, can't fire during the test
             context={"env": "cls"},
         )
 

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -1811,7 +1811,10 @@ def test_step_conflict_over_child_workflow_row(dbos: DBOS) -> None:
         "started_at_epoch_ms": int(time.time() * 1000),
     }
     with pytest.raises(DBOSWorkflowConflictIDError):
-        dbos._sys_db.record_operation_result(result)
+        # Explicit far-future completion time so it can't equal the child row's same-millisecond completed_at.
+        dbos._sys_db.record_operation_result(
+            result, completed_at_epoch_ms=int(time.time() * 1000) + 3_600_000
+        )
 
 
 def test_step_conflict_over_row_without_completion(dbos: DBOS) -> None:


### PR DESCRIPTION
Rewrite the `get_queue_partitions` query (which finds all active partitions in a partitioned queue) to use a recursive CTE instead of `SELECT DISTINCT`. This improves its performance when there are a small number of partitions with a large number of active entries, as Postgres by default tries to scan every active entry in each partition even though a `SELECT DISTINCT` shouldn't require it.