### PR TITLE
Update workflow status with a final result only when status is PENDING

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -729,6 +729,20 @@ def _get_wf_invoke_func(
     release_active: Callable[[], None] = lambda: None,
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
+        def await_recorded_outcome() -> R:
+            # The outcome write did not land: the row was not PENDING, so this
+            # run no longer owns the workflow's outcome. It may have been
+            # cancelled, dead-lettered, completed by a concurrent execution, or
+            # handed back to the queue by a resume. Park the execution and
+            # deliver the recorded outcome instead of the one this run computed.
+            dbos.logger.warning(
+                f"Workflow {status['workflow_uuid']} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome"
+            )
+            recorded_outcome: R = dbos._sys_db.await_workflow_result(
+                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
+            )
+            return recorded_outcome
+
         if (
             status["status"] == WorkflowStatusString.ERROR.value
             or status["status"] == WorkflowStatusString.SUCCESS.value
@@ -757,12 +771,6 @@ def _get_wf_invoke_func(
             # workflow to this executor, and a stale entry would send that
             # dispatch down the non-owner path to wait forever.
             release_active()
-            dbos._sys_db.update_workflow_outcome(
-                status["workflow_uuid"],
-                WorkflowStatusString.SUCCESS.value,
-                output=serval,
-            )
-            return output
         except DBOSWorkflowConflictIDError:
             # Await the workflow result
             dbos.logger.warning(
@@ -780,12 +788,20 @@ def _get_wf_invoke_func(
                 error, status["serialization"], dbos._serializer
             )
             release_active()
-            dbos._sys_db.update_workflow_outcome(
+            if not dbos._sys_db.update_workflow_outcome(
                 status["workflow_uuid"],
                 WorkflowStatusString.ERROR.value,
                 error=error_str,
-            )
+            ):
+                return await_recorded_outcome()
             raise
+        if not dbos._sys_db.update_workflow_outcome(
+            status["workflow_uuid"],
+            WorkflowStatusString.SUCCESS.value,
+            output=serval,
+        ):
+            return await_recorded_outcome()
+        return output
 
     return persist
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -730,9 +730,16 @@ def _get_wf_invoke_func(
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
         def adopt_recorded_outcome(warning: str) -> R:
+            # This run inserted or read the workflow's row, so it is known to
+            # have existed: a missing row here means it was deleted. Fail fast
+            # with DBOSNonExistentWorkflowError (which propagates to the
+            # handle/caller) rather than polling for a row that will never
+            # reappear.
             dbos.logger.warning(warning)
             recorded_outcome: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
+                status["workflow_uuid"],
+                polling_interval=DEFAULT_POLLING_INTERVAL,
+                fail_if_missing=True,
             )
             return recorded_outcome
 
@@ -1003,9 +1010,14 @@ def _execute_workflow_wthread(
                         functools.partial(func, *args, **kwargs)
                     )
                 else:
+                    # Parked on the concurrent execution that owns the active
+                    # entry. The row is known to exist (this dispatch inserted
+                    # or read it), so a missing row means it was deleted: fail
+                    # fast rather than polling forever.
                     output: R = dbos._sys_db.await_workflow_result(
                         status["workflow_uuid"],
                         polling_interval=DEFAULT_POLLING_INTERVAL,
+                        fail_if_missing=True,
                     )
                     return output
             except Exception as e:
@@ -1066,11 +1078,16 @@ async def _execute_workflow_async(
                     return await result()
                 else:
                     # Wait on the event loop rather than pinning a to_thread worker in a blocking poll.
+                    # Parked on the concurrent execution that owns the active
+                    # entry. The row is known to exist (this dispatch inserted
+                    # or read it), so a missing row means it was deleted: fail
+                    # fast rather than polling forever.
                     return cast(
                         R,
                         await dbos._sys_db.await_workflow_result_async(
                             status["workflow_uuid"],
                             polling_interval=DEFAULT_POLLING_INTERVAL,
+                            fail_if_missing=True,
                         ),
                     )
             except Exception as e:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -729,19 +729,15 @@ def _get_wf_invoke_func(
     release_active: Callable[[], None] = lambda: None,
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
-        def await_recorded_outcome() -> R:
-            # The outcome write did not land: the row was not PENDING, so this
-            # run no longer owns the workflow's outcome. It may have been
-            # cancelled, dead-lettered, completed by a concurrent execution, or
-            # handed back to the queue by a resume. Park the execution and
-            # deliver the recorded outcome instead of the one this run computed.
-            dbos.logger.warning(
-                f"Workflow {status['workflow_uuid']} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome"
-            )
+        def adopt_recorded_outcome(warning: str) -> R:
+            dbos.logger.warning(warning)
             recorded_outcome: R = dbos._sys_db.await_workflow_result(
                 status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
             )
             return recorded_outcome
+
+        def not_recorded_warning() -> str:
+            return f"Workflow {status['workflow_uuid']} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome"
 
         if (
             status["status"] == WorkflowStatusString.ERROR.value
@@ -772,17 +768,17 @@ def _get_wf_invoke_func(
             # dispatch down the non-owner path to wait forever.
             release_active()
         except DBOSWorkflowConflictIDError:
-            # Await the workflow result
-            dbos.logger.warning(
+            # Another execution owns this workflow's step checkpoints.
+            release_active()
+            return adopt_recorded_outcome(
                 f"Aborting duplicate execution of workflow {status['workflow_uuid']}."
             )
-            r: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
-            )
-            return r
-        except DBOSWorkflowCancelledError as error:
+        except DBOSWorkflowCancelledError:
+            # The run observed its own cancellation. Park the execution.
             release_active()
-            raise DBOSAwaitedWorkflowCancelledError(status["workflow_uuid"])
+            return adopt_recorded_outcome(
+                f"Workflow {status['workflow_uuid']} was cancelled during execution. Waiting for the recorded outcome"
+            )
         except Exception as error:
             error_str = _serialize_exception_for_persistence(
                 error, status["serialization"], dbos._serializer
@@ -793,14 +789,16 @@ def _get_wf_invoke_func(
                 WorkflowStatusString.ERROR.value,
                 error=error_str,
             ):
-                return await_recorded_outcome()
+                # We couldn't update the workflow status: park the execution.
+                return adopt_recorded_outcome(not_recorded_warning())
             raise
         if not dbos._sys_db.update_workflow_outcome(
             status["workflow_uuid"],
             WorkflowStatusString.SUCCESS.value,
             output=serval,
         ):
-            return await_recorded_outcome()
+            # We couldn't update the workflow status: park the execution.
+            return adopt_recorded_outcome(not_recorded_warning())
         return output
 
     return persist

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -736,20 +736,11 @@ def _get_wf_invoke_func(
             # handle/caller) rather than polling for a row that will never
             # reappear.
             dbos.logger.warning(warning)
-            try:
-                recorded_outcome: R = dbos._sys_db.await_workflow_result(
-                    status["workflow_uuid"],
-                    polling_interval=DEFAULT_POLLING_INTERVAL,
-                    fail_if_missing=True,
-                )
-            except DBOSAwaitedWorkflowCancelledError:
-                # await_workflow_result reports a CANCELLED row from an
-                # awaiter's point of view, but this outcome is delivered
-                # through the workflow's own handle: report the workflow's own
-                # cancellation.
-                raise DBOSWorkflowCancelledError(
-                    f"Workflow {status['workflow_uuid']} is cancelled."
-                ) from None
+            recorded_outcome: R = dbos._sys_db.await_workflow_result(
+                status["workflow_uuid"],
+                polling_interval=DEFAULT_POLLING_INTERVAL,
+                fail_if_missing=True,
+            )
             return recorded_outcome
 
         def not_recorded_warning() -> str:
@@ -764,8 +755,9 @@ def _get_wf_invoke_func(
             )
             # Directly return the result if the workflow is already completed
             recorded_result: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL,
-                fail_if_missing=True # We expect the workflow to be present (success/error come from init wf status), throw if the row is not found
+                status["workflow_uuid"],
+                polling_interval=DEFAULT_POLLING_INTERVAL,
+                fail_if_missing=True,  # We expect the workflow to be present (success/error come from init wf status), throw if the row is not found
             )
             return recorded_result
         try:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -736,11 +736,20 @@ def _get_wf_invoke_func(
             # handle/caller) rather than polling for a row that will never
             # reappear.
             dbos.logger.warning(warning)
-            recorded_outcome: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"],
-                polling_interval=DEFAULT_POLLING_INTERVAL,
-                fail_if_missing=True,
-            )
+            try:
+                recorded_outcome: R = dbos._sys_db.await_workflow_result(
+                    status["workflow_uuid"],
+                    polling_interval=DEFAULT_POLLING_INTERVAL,
+                    fail_if_missing=True,
+                )
+            except DBOSAwaitedWorkflowCancelledError:
+                # await_workflow_result reports a CANCELLED row from an
+                # awaiter's point of view, but this outcome is delivered
+                # through the workflow's own handle: report the workflow's own
+                # cancellation.
+                raise DBOSWorkflowCancelledError(
+                    f"Workflow {status['workflow_uuid']} is cancelled."
+                ) from None
             return recorded_outcome
 
         def not_recorded_warning() -> str:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -764,7 +764,8 @@ def _get_wf_invoke_func(
             )
             # Directly return the result if the workflow is already completed
             recorded_result: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL
+                status["workflow_uuid"], polling_interval=DEFAULT_POLLING_INTERVAL,
+                fail_if_missing=True # We expect the workflow to be present (success/error come from init wf status), throw if the row is not found
             )
             return recorded_result
         try:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -923,9 +923,8 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.PENDING.value
                 )
             )
-            # The guarded UPDATE matched no rows. Re-read the row (only on this
-            # rare no-op path) to distinguish a row this run no longer owns from
-            # a row that is gone.
+            # The guarded UPDATE matched no rows. Re-read the row to distinguish a row
+            # this run no longer owns from a row that is gone.
             if result.rowcount == 0:
                 current_status = c.execute(
                     sa.select(SystemSchema.workflow_status.c.status).where(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -899,10 +899,9 @@ class SystemDatabase(ABC):
         execution is already running and the status is PENDING. However, both
         executions should be deterministic and idempotent.)
 
-        Returns False when the row was CANCELLED, dead-lettered, already
-        terminal, or handed to another execution (ENQUEUED/DELAYED, e.g. by a
-        concurrent resume). Raises DBOSNonExistentWorkflowError if the row does
-        not exist at all.
+        Returning False means the row was CANCELLED, dead-lettered, already
+        terminal, handed to another execution (ENQUEUED/DELAYED, e.g. by a
+        concurrent resume), or gone entirely.
         """
         with self.engine.begin() as c:
             now_ms = self._now_ms_sql()
@@ -923,18 +922,7 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.PENDING.value
                 )
             )
-            # The guarded UPDATE matched no rows. Re-read the row to distinguish a row
-            # this run no longer owns from a row that is gone.
-            if result.rowcount == 0:
-                current_status = c.execute(
-                    sa.select(SystemSchema.workflow_status.c.status).where(
-                        SystemSchema.workflow_status.c.workflow_uuid == workflow_id
-                    )
-                ).scalar_one_or_none()
-                if current_status is None:
-                    raise DBOSNonExistentWorkflowError("target", workflow_id)
-                return False
-            return True
+            return result.rowcount > 0
 
     def cancel_workflows(
         self,
@@ -1619,14 +1607,24 @@ class SystemDatabase(ABC):
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
             ).fetchone()
 
-    def check_workflow_result(self, workflow_id: str) -> Union[NoResult, Any]:
+    def check_workflow_result(
+        self, workflow_id: str, *, fail_if_missing: bool = False
+    ) -> Union[NoResult, Any]:
         """Check if a workflow has completed and return its result.
 
         Returns NoResult() if the workflow is still pending/enqueued/delayed/not found.
         Returns the deserialized output on success.
         Raises on error, cancellation, or max recovery attempts exceeded.
+
+        A missing row normally means the workflow has not been inserted yet, so
+        it reports NoResult() and the poll keeps waiting for the row to appear.
+        Callers that know the row must already exist (e.g. a run parking on an
+        outcome it just failed to write) pass fail_if_missing to get a
+        DBOSNonExistentWorkflowError instead of polling forever.
         """
         row = self._read_workflow_result_row(workflow_id)
+        if row is None and fail_if_missing:
+            raise DBOSNonExistentWorkflowError("target", workflow_id)
         if row is not None:
             status = row[0]
             if status == WorkflowStatusString.SUCCESS.value:
@@ -1644,18 +1642,32 @@ class SystemDatabase(ABC):
                 raise DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded(workflow_id)
         return NoResult()
 
-    def await_workflow_result(self, workflow_id: str, polling_interval: float) -> Any:
+    def await_workflow_result(
+        self,
+        workflow_id: str,
+        polling_interval: float,
+        *,
+        fail_if_missing: bool = False,
+    ) -> Any:
         while True:
-            result = self.check_workflow_result(workflow_id)
+            result = self.check_workflow_result(
+                workflow_id, fail_if_missing=fail_if_missing
+            )
             if not isinstance(result, NoResult):
                 return result
             time.sleep(polling_interval)
 
     async def await_workflow_result_async(
-        self, workflow_id: str, polling_interval: float
+        self,
+        workflow_id: str,
+        polling_interval: float,
+        *,
+        fail_if_missing: bool = False,
     ) -> Any:
         while True:
-            result = await asyncio.to_thread(self.check_workflow_result, workflow_id)
+            result = await asyncio.to_thread(
+                self.check_workflow_result, workflow_id, fail_if_missing=fail_if_missing
+            )
             if not isinstance(result, NoResult):
                 return result
             await asyncio.sleep(polling_interval)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -890,12 +890,22 @@ class SystemDatabase(ABC):
         *,
         output: Optional[str] = None,
         error: Optional[str] = None,
-    ) -> None:
+    ) -> bool:
+        """Record a workflow's terminal outcome, reporting whether the write landed.
+
+        The write applies only to a PENDING row: a run owns its workflow's
+        outcome exactly as long as the row says that run is what the workflow
+        is doing. (Note: this does not prevent a write when another concurrent
+        execution is already running and the status is PENDING. However, both
+        executions should be deterministic and idempotent.)
+
+        Returns False when the row was CANCELLED, dead-lettered, already
+        terminal, or handed to another execution (ENQUEUED/DELAYED, e.g. by a
+        concurrent resume). Raises DBOSNonExistentWorkflowError if the row does
+        not exist at all.
+        """
         with self.engine.begin() as c:
             now_ms = self._now_ms_sql()
-            # Record the outcome, but never overwrite the terminal CANCELLED
-            # status: a workflow can be cancelled during its final step, and if so
-            # it must not be able to subsequently complete.
             result = c.execute(
                 sa.update(SystemSchema.workflow_status)
                 .values(
@@ -910,23 +920,22 @@ class SystemDatabase(ABC):
                 .where(SystemSchema.workflow_status.c.workflow_uuid == workflow_id)
                 .where(
                     SystemSchema.workflow_status.c.status
-                    != WorkflowStatusString.CANCELLED.value
+                    == WorkflowStatusString.PENDING.value
                 )
             )
-            # update_workflow_outcome is only called to finalize a workflow. If
-            # the guarded UPDATE above matched no rows, the workflow may have
-            # been cancelled: a cancelled workflow must not complete, so re-read
-            # the status and raise so it ends as cancelled rather than succeeding
-            # or erroring. The re-read only happens on this rare no-op path, not
-            # on every completion.
+            # The guarded UPDATE matched no rows. Re-read the row (only on this
+            # rare no-op path) to distinguish a row this run no longer owns from
+            # a row that is gone.
             if result.rowcount == 0:
                 current_status = c.execute(
                     sa.select(SystemSchema.workflow_status.c.status).where(
                         SystemSchema.workflow_status.c.workflow_uuid == workflow_id
                     )
                 ).scalar_one_or_none()
-                if current_status == WorkflowStatusString.CANCELLED.value:
-                    raise DBOSAwaitedWorkflowCancelledError(workflow_id)
+                if current_status is None:
+                    raise DBOSNonExistentWorkflowError("target", workflow_id)
+                return False
+            return True
 
     def cancel_workflows(
         self,

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -12,6 +12,7 @@ from dbos._error import (
     DBOSAwaitedWorkflowCancelledError,
     DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded,
     DBOSNonExistentWorkflowError,
+    DBOSWorkflowCancelledError,
 )
 from dbos._schemas.application_database import ApplicationSchema
 from dbos._schemas.system_database import SystemSchema
@@ -219,14 +220,25 @@ def test_workflow_outcome_is_owned_by_the_pending_row(dbos: DBOS) -> None:
         assert release.wait(timeout=30)
         return "own-result"
 
-    def start_blocked_run() -> tuple[WorkflowHandle[str], threading.Event]:
+    # Stands in for a run that observes its own cancellation mid-flight: the
+    # cancellation is raised only after the test has rewritten the row.
+    @DBOS.workflow()
+    def self_cancelling_workflow(wfid: str) -> str:
+        started, release = controls[wfid]
+        started.set()
+        assert release.wait(timeout=30)
+        raise DBOSWorkflowCancelledError(f"workflow {wfid} observed cancellation")
+
+    def start_blocked_run(
+        workflow: Any = blocked_workflow,
+    ) -> tuple[WorkflowHandle[str], threading.Event]:
         """Start a run and return once it is blocked inside the workflow
         function, with its row PENDING."""
         wfid = f"outcome-ownership-{uuid.uuid4()}"
         started, release = threading.Event(), threading.Event()
         controls[wfid] = (started, release)
         with SetWorkflowID(wfid):
-            handle = DBOS.start_workflow(blocked_workflow, wfid)
+            handle = DBOS.start_workflow(workflow, wfid)
         assert started.wait(timeout=15), "the workflow never started"
         return handle, release
 
@@ -345,6 +357,28 @@ def test_workflow_outcome_is_owned_by_the_pending_row(dbos: DBOS) -> None:
     release.set()
     with pytest.raises(DBOSNonExistentWorkflowError):
         handle.get_result()
+
+    # 6. A run that observes its own cancellation adopts the recorded outcome
+    # rather than trusting its local view: here a concurrent "resume" already
+    # rewrote the row to SUCCESS, so the handle reports that outcome instead of
+    # a cancellation that is no longer the workflow's state.
+    handle, release = start_blocked_run(self_cancelling_workflow)
+    rewrite_row(
+        handle.workflow_id, "SUCCESS", output=encode_output("recorded-after-cancel")
+    )
+    release.set()
+    assert (
+        handle.get_result() == "recorded-after-cancel"
+    ), "the run must adopt the recorded outcome, not report its cancellation"
+
+    # ... and when the row is genuinely CANCELLED, the handle still reports the
+    # awaited-cancelled error, as before.
+    handle, release = start_blocked_run(self_cancelling_workflow)
+    rewrite_row(handle.workflow_id, "CANCELLED")
+    release.set()
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        handle.get_result()
+    assert read_row(handle.workflow_id)[0] == "CANCELLED"
 
 
 def test_delete_workflow(dbos: DBOS) -> None:

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -8,8 +8,18 @@ import sqlalchemy as sa
 from sqlalchemy import event as sa_event
 
 from dbos import DBOS, DBOSClient, SetEnqueueOptions, SetWorkflowID, WorkflowHandle
-from dbos._error import DBOSAwaitedWorkflowCancelledError, DBOSNonExistentWorkflowError
+from dbos._error import (
+    DBOSAwaitedWorkflowCancelledError,
+    DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded,
+    DBOSNonExistentWorkflowError,
+)
 from dbos._schemas.application_database import ApplicationSchema
+from dbos._schemas.system_database import SystemSchema
+from dbos._serialization import (
+    deserialize_value,
+    serialize_exception,
+    serialize_value_as,
+)
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from dbos._workflow_commands import garbage_collect, global_timeout
 from tests.conftest import queue_entries_are_cleaned_up
@@ -107,12 +117,12 @@ def test_active_id_released_before_outcome_write(dbos: DBOS) -> None:
 
     def parking_update_outcome(
         workflow_id: str, status: Any, *, output: Any = None, error: Any = None
-    ) -> None:
+    ) -> bool:
         if workflow_id == wfid and not parked_once.is_set():
             parked_once.set()
             parked.set()
             assert release_stale_write.wait(timeout=30)
-        original_update_outcome(workflow_id, status, output=output, error=error)
+        return original_update_outcome(workflow_id, status, output=output, error=error)
 
     dbos._sys_db.update_workflow_outcome = parking_update_outcome  # type: ignore[method-assign]
 
@@ -188,6 +198,153 @@ def test_cancel_after_final_step(dbos: DBOS) -> None:
     assert steps_completed == 1  # step_one was already recorded, not re-run
 
     assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_workflow_outcome_is_owned_by_the_pending_row(dbos: DBOS) -> None:
+    # A run may record its outcome only while its workflow_status row is still
+    # PENDING: that row is what says "this run is what the workflow is doing".
+    # Every other status means the run lost ownership (a concurrent resume
+    # re-enqueued it, a recovery raced it, it was cancelled or dead-lettered)
+    # and the recorded outcome, not the one the run computed, is the workflow's
+    # outcome.
+
+    # Each run blocks until the test has rewritten its row, then returns a
+    # result the test can tell apart from anything recorded out-of-band.
+    controls: dict[str, tuple[threading.Event, threading.Event]] = {}
+
+    @DBOS.workflow()
+    def blocked_workflow(wfid: str) -> str:
+        started, release = controls[wfid]
+        started.set()
+        assert release.wait(timeout=30)
+        return "own-result"
+
+    def start_blocked_run() -> tuple[WorkflowHandle[str], threading.Event]:
+        """Start a run and return once it is blocked inside the workflow
+        function, with its row PENDING."""
+        wfid = f"outcome-ownership-{uuid.uuid4()}"
+        started, release = threading.Event(), threading.Event()
+        controls[wfid] = (started, release)
+        with SetWorkflowID(wfid):
+            handle = DBOS.start_workflow(blocked_workflow, wfid)
+        assert started.wait(timeout=15), "the workflow never started"
+        return handle, release
+
+    def encode_output(value: str) -> str:
+        serval, _ = serialize_value_as(value, None, dbos._serializer)
+        assert serval is not None
+        return serval
+
+    def rewrite_row(
+        wfid: str,
+        status: str,
+        output: Any = None,
+        error: Any = None,
+    ) -> None:
+        """Take the row away from the blocked run, standing in for the
+        concurrent resume/recovery/cancel that would do it in production."""
+        with dbos._sys_db.engine.begin() as c:
+            c.execute(
+                sa.update(SystemSchema.workflow_status)
+                .values(status=status, output=output, error=error)
+                .where(SystemSchema.workflow_status.c.workflow_uuid == wfid)
+            )
+
+    def read_row(wfid: str) -> Any:
+        with dbos._sys_db.engine.begin() as c:
+            return c.execute(
+                sa.select(
+                    SystemSchema.workflow_status.c.status,
+                    SystemSchema.workflow_status.c.output,
+                    SystemSchema.workflow_status.c.serialization,
+                ).where(SystemSchema.workflow_status.c.workflow_uuid == wfid)
+            ).fetchone()
+
+    # 1. A recorded success supersedes the run's own result.
+    handle, release = start_blocked_run()
+    rewrite_row(
+        handle.workflow_id, "SUCCESS", output=encode_output("recorded-elsewhere")
+    )
+    release.set()
+    assert (
+        handle.get_result() == "recorded-elsewhere"
+    ), "the run must report the recorded output, not its own"
+    row = read_row(handle.workflow_id)
+    assert row[0] == "SUCCESS"
+    assert (
+        deserialize_value(row[1], row[2], dbos._serializer) == "recorded-elsewhere"
+    ), "the recorded output must not be overwritten"
+
+    # 2. A recorded error supersedes the run's own result.
+    handle, release = start_blocked_run()
+    recorded_error, _ = serialize_exception(
+        Exception("recorded failure"), None, dbos._serializer
+    )
+    rewrite_row(handle.workflow_id, "ERROR", error=recorded_error)
+    release.set()
+    with pytest.raises(Exception, match="recorded failure"):
+        handle.get_result()
+    assert read_row(handle.workflow_id)[0] == "ERROR"
+
+    # 3. A non-terminal row parks the run until an outcome is recorded.
+    # ENQUEUED with no queue name: nothing dequeues it, so the run stays parked
+    # until this test records the outcome itself.
+    handle, release = start_blocked_run()
+    parked_wfid = handle.workflow_id
+    rewrite_row(parked_wfid, "ENQUEUED")
+    release.set()
+
+    parked_outcome: dict[str, Any] = {}
+    done = threading.Event()
+
+    def get_parked_result() -> None:
+        try:
+            parked_outcome["result"] = handle.get_result()
+        except Exception as e:
+            parked_outcome["error"] = e
+        done.set()
+
+    threading.Thread(target=get_parked_result, daemon=True).start()
+
+    # The run releases its active-workflow-ID entry immediately before it tries
+    # to record its outcome. Waiting for that makes the check below assert that
+    # the run parked, rather than merely that it had not gotten around to the
+    # write yet.
+    deadline = time.time() + 30
+    while parked_wfid in dbos._active_workflows_set.activeList():
+        assert time.time() < deadline, "the run never reached its outcome write"
+        time.sleep(0.01)
+    assert not done.wait(
+        timeout=2
+    ), f"the run must wait for the owning execution, got {parked_outcome}"
+
+    rewrite_row(parked_wfid, "SUCCESS", output=encode_output("recorded-by-owner"))
+    assert done.wait(timeout=30), "the parked run did not pick up the recorded outcome"
+    assert (
+        parked_outcome.get("result") == "recorded-by-owner"
+    ), f"the run must report the recorded output, not its own: {parked_outcome}"
+
+    # 4. A dead-lettered row fails the run with the DLQ error.
+    handle, release = start_blocked_run()
+    rewrite_row(handle.workflow_id, "MAX_RECOVERY_ATTEMPTS_EXCEEDED")
+    release.set()
+    with pytest.raises(DBOSAwaitedWorkflowMaxRecoveryAttemptsExceeded):
+        handle.get_result()
+    row = read_row(handle.workflow_id)
+    assert row[0] == "MAX_RECOVERY_ATTEMPTS_EXCEEDED"
+    assert row[1] is None, "the refused outcome must not record an output"
+
+    # 5. A deleted row fails the run with the non-existent-workflow error.
+    handle, release = start_blocked_run()
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.delete(SystemSchema.workflow_status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == handle.workflow_id
+            )
+        )
+    release.set()
+    with pytest.raises(DBOSNonExistentWorkflowError):
+        handle.get_result()
 
 
 def test_delete_workflow(dbos: DBOS) -> None:

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -354,6 +354,16 @@ def test_workflow_outcome_is_owned_by_the_pending_row(dbos: DBOS) -> None:
                 SystemSchema.workflow_status.c.workflow_uuid == handle.workflow_id
             )
         )
+    # The guarded UPDATE is a single statement: on a missing row it reports
+    # not-landed rather than raising. It is the parked await, told the row must
+    # already exist, that detects the deletion and raises.
+    assert not dbos._sys_db.update_workflow_outcome(
+        handle.workflow_id, "SUCCESS", output=encode_output("never-lands")
+    )
+    with pytest.raises(DBOSNonExistentWorkflowError):
+        dbos._sys_db.await_workflow_result(
+            handle.workflow_id, polling_interval=0.01, fail_if_missing=True
+        )
     release.set()
     with pytest.raises(DBOSNonExistentWorkflowError):
         handle.get_result()


### PR DESCRIPTION
Update the workflow outcome write (`update_workflow_outcome`) to apply only while the workflow's row is still PENDING.

Recording the outcome can result either in a successful recording, the common path, or, if no rows were affected, a parking of the execution thread to adopt the final outcome, presumably handled by another execution thread.

`await_workflow_result` now raises `DBOSNonExistentWorkflowError` when a result is expected.

Because of the re-ordering of exception raising, we must now distinguish, in the error catching path, which workflow raised a cancellation error (like we already do in TS and Java). To this effect, this PR adds the workflow ID in the cancellation error.

p.s.: This does not solve the race if another execution has resumed and the workflow is PENDING -- but in this case the outcome should be deterministic and idempotent.
