### PR TITLE
Enqueue With Options

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -22,8 +22,7 @@ from sqlalchemy.orm import Session
 
 from dbos._core import DEFAULT_POLLING_INTERVAL
 
-# EnqueueOptions is re-exported here: it is public as dbos.EnqueueOptions but is
-# shared with DBOS.enqueue_workflow_with_options, so it lives in a module both can import.
+# Re-exported: EnqueueOptions is public as dbos.EnqueueOptions but is shared with _core.
 from dbos._enqueue_options import EnqueueOptions as EnqueueOptions
 from dbos._enqueue_options import build_enqueue_status
 from dbos._logger import dbos_logger

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 from dbos._core import DEFAULT_POLLING_INTERVAL
 
 # EnqueueOptions is re-exported here: it is public as dbos.EnqueueOptions but is
-# shared with DBOS.enqueue_workflow_by_name, so it lives in a module both can import.
+# shared with DBOS.enqueue_workflow_with_options, so it lives in a module both can import.
 from dbos._enqueue_options import EnqueueOptions as EnqueueOptions
 from dbos._enqueue_options import build_enqueue_status
 from dbos._logger import dbos_logger

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import threading
 import time
 from datetime import datetime
@@ -13,7 +12,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    TypedDict,
     TypeVar,
     Union,
 )
@@ -22,14 +20,12 @@ from zoneinfo import ZoneInfo
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from dbos._context import (
-    OTEL_CARRIER_ATTRIBUTE,
-    MaxPriority,
-    MinPriority,
-    inject_trace_context,
-    validate_workflow_id,
-)
 from dbos._core import DEFAULT_POLLING_INTERVAL
+
+# EnqueueOptions is re-exported here: it is public as dbos.EnqueueOptions but is
+# shared with DBOS.enqueue_workflow_by_name, so it lives in a module both can import.
+from dbos._enqueue_options import EnqueueOptions as EnqueueOptions
+from dbos._enqueue_options import build_enqueue_status
 from dbos._logger import dbos_logger
 from dbos._queue import (
     Queue,
@@ -42,13 +38,7 @@ from dbos._sys_db import SystemDatabase
 from dbos._utils import generate_uuid
 
 if TYPE_CHECKING:
-    from opentelemetry.context import Context as OtelContext
-
     from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
-else:
-    # EnqueueOptions is public, so its annotations must stay resolvable at runtime for
-    # get_type_hints()/pydantic without importing the optional opentelemetry package.
-    OtelContext = Any
 
 from dbos._croniter import croniter  # type: ignore
 from dbos._dbos_config import get_system_database_url, is_valid_database_url
@@ -59,7 +49,6 @@ from dbos._serialization import (
     Serializer,
     WorkflowSerializationFormat,
     safe_deserialize_schedule_context,
-    serialize_args,
 )
 from dbos._sys_db import (
     ClientScheduleInput,
@@ -70,7 +59,6 @@ from dbos._sys_db import (
     WorkflowSchedule,
     WorkflowStatus,
     WorkflowStatusInternal,
-    WorkflowStatusString,
     _dbos_stream_closed_sentinel,
     _no_stream_value,
     workflow_is_active,
@@ -78,63 +66,6 @@ from dbos._sys_db import (
 from dbos._workflow_commands import fork_workflow, get_workflow
 
 R = TypeVar("R", covariant=True)  # A generic type for workflow return values
-
-
-# Required EnqueueOptions fields
-class _EnqueueOptionsRequired(TypedDict):
-    workflow_name: str
-    queue_name: str
-
-
-# Optional EnqueueOptions fields
-class EnqueueOptions(_EnqueueOptionsRequired, total=False):
-    workflow_id: str
-    app_version: str
-    workflow_timeout: float
-    delay_seconds: float
-    deduplication_id: str
-    priority: int
-    max_recovery_attempts: int
-    queue_partition_key: str
-    authenticated_user: str
-    authenticated_roles: list[str]
-    serialization_type: WorkflowSerializationFormat
-    class_name: str
-    instance_name: str
-    attributes: Dict[str, Any]
-    # Parents the enqueued workflow's span to this OpenTelemetry context, so it joins
-    # this trace when it runs. The client-side PropagateOtelContext.
-    otel_context: "OtelContext"
-
-
-def validate_enqueue_options(options: EnqueueOptions) -> None:
-    priority = options.get("priority")
-    if priority is not None and (priority < MinPriority or priority > MaxPriority):
-        raise DBOSException(
-            f"Invalid priority {priority}. Priority must be between {MinPriority}~{MaxPriority}."
-        )
-    workflow_id = options.get("workflow_id")
-    if workflow_id is not None:
-        validate_workflow_id(workflow_id)
-
-
-def _attributes_with_otel_context(
-    attributes: Optional[Dict[str, Any]], otel_context: "Optional[OtelContext]"
-) -> Optional[Dict[str, Any]]:
-    """Fold an otel_context option into the workflow's persisted attributes.
-
-    The client-side counterpart of PropagateOtelContext. Records nothing when there is
-    no valid context to propagate, and wins over a hand-written carrier in attributes.
-    Only the W3C trace context travels, not baggage.
-    """
-    if otel_context is None:
-        return attributes
-    carrier = inject_trace_context(otel_context)
-    if not carrier:
-        return attributes
-    merged = dict(attributes) if attributes else {}
-    merged[OTEL_CARRIER_ATTRIBUTE] = carrier
-    return merged
 
 
 class WorkflowHandleClientPolling(Generic[R]):
@@ -292,86 +223,7 @@ class DBOSClient:
     def _build_enqueue_status(
         self, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> tuple[str, WorkflowStatusInternal]:
-        validate_enqueue_options(options)
-        workflow_name = options["workflow_name"]
-        queue_name = options["queue_name"]
-
-        workflow_id = options.get("workflow_id")
-        if workflow_id is None:
-            workflow_id = generate_uuid()
-        workflow_timeout = options.get("workflow_timeout", None)
-        delay_seconds = options.get("delay_seconds", None)
-        delay_until_epoch_ms: Optional[int] = (
-            int((time.time() + delay_seconds) * 1000)
-            if delay_seconds is not None
-            else None
-        )
-
-        authenticated_user = options.get("authenticated_user")
-        authenticated_roles = (
-            json.dumps(options.get("authenticated_roles"))
-            if options.get("authenticated_roles")
-            else None
-        )
-
-        inputs, serialization = serialize_args(
-            args,
-            kwargs,
-            options.get("serialization_type"),
-            self._serializer,
-        )
-
-        attributes = _attributes_with_otel_context(
-            options.get("attributes"), options.get("otel_context")
-        )
-
-        status: WorkflowStatusInternal = {
-            "workflow_uuid": workflow_id,
-            "status": (
-                WorkflowStatusString.DELAYED.value
-                if delay_until_epoch_ms is not None
-                else WorkflowStatusString.ENQUEUED.value
-            ),
-            "name": workflow_name,
-            "class_name": options.get("class_name"),
-            "queue_name": queue_name,
-            "app_version": options.get("app_version"),
-            "config_name": options.get("instance_name"),
-            "authenticated_user": authenticated_user,
-            "assumed_role": None,
-            "authenticated_roles": authenticated_roles,
-            "output": None,
-            "error": None,
-            "created_at": None,
-            "updated_at": None,
-            "executor_id": None,
-            "recovery_attempts": None,
-            "app_id": None,
-            "workflow_timeout_ms": (
-                int(workflow_timeout * 1000) if workflow_timeout is not None else None
-            ),
-            "workflow_deadline_epoch_ms": None,
-            "deduplication_id": options.get("deduplication_id", None),
-            "priority": (
-                options.get("priority", 0)
-                if options.get("priority", None) is not None
-                else 0
-            ),
-            "inputs": inputs,
-            "serialization": serialization,
-            "queue_partition_key": options.get("queue_partition_key", None),
-            "forked_from": None,
-            "parent_workflow_id": None,
-            "started_at_epoch_ms": None,
-            "owner_xid": None,
-            "delay_until_epoch_ms": delay_until_epoch_ms,
-            "attributes": attributes,
-            "schedule_name": None,
-            # Set only by the debouncer via _enqueue_debounced, never from options.
-            "debounce_deadline_epoch_ms": None,
-            "is_debounced": False,
-        }
-        return workflow_id, status
+        return build_enqueue_status(options, self._serializer, args, kwargs)
 
     def _enqueue(self, options: EnqueueOptions, *args: Any, **kwargs: Any) -> str:
         workflow_id, status = self._build_enqueue_status(options, *args, **kwargs)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1596,46 +1596,53 @@ def _build_enqueue_with_options(
         status["status"] = WorkflowStatusString.DELAYED.value
     ambient_attributes = _attributes_with_otel_carrier(new_wf_ctx)
     if ambient_attributes is not None:
-        # Merge rather than replace: options win per key, but neither an ambient
-        # SetWorkflowAttributes nor a PropagateOtelContext carrier is dropped.
+        # Merge rather than replace: ambient attributes survive, but options win per
+        # key, including the otel carrier an ambient PropagateOtelContext set.
         status["attributes"] = {**ambient_attributes, **(status["attributes"] or {})}
     return status
+
+
+def _check_recorded_enqueue(
+    dbos: "DBOS", new_wf_ctx: DBOSContext, wf_name: str
+) -> Optional[str]:
+    """Return the child ID this enqueue already recorded, or None if it is new.
+
+    Raises the recorded error if the original call failed. Runs before the row is
+    built so a replay re-validates and re-serializes nothing it already checkpointed.
+    """
+    if not new_wf_ctx.has_parent():
+        return None
+    recorded_result = dbos._sys_db.check_operation_execution(
+        new_wf_ctx.parent_workflow_id,
+        new_wf_ctx.parent_workflow_fid,
+        wf_name,
+    )
+    if recorded_result and recorded_result["error"]:
+        e: Exception = deserialize_exception(
+            recorded_result["error"],
+            recorded_result["serialization"],
+            dbos._sys_db.serializer,
+        )
+        raise e
+    elif recorded_result and recorded_result["child_workflow_id"]:
+        return recorded_result["child_workflow_id"]
+    return None
 
 
 def _persist_enqueue_with_options(
     dbos: "DBOS",
     new_wf_ctx: DBOSContext,
     status: WorkflowStatusInternal,
-    max_recovery_attempts: Optional[int],
 ) -> str:
-    """Persist the enqueue, recording it as a child of the calling workflow.
-
-    Returns the enqueued workflow's ID, which on a replay is the ID recorded by
-    the original call rather than the one just built.
-    """
+    """Persist the enqueue, recording it as a child of the calling workflow."""
     wf_name = status["name"]
     workflow_id = status["workflow_uuid"]
     child_start_time = int(time.time() * 1000)
-    if new_wf_ctx.has_parent():
-        recorded_result = dbos._sys_db.check_operation_execution(
-            new_wf_ctx.parent_workflow_id,
-            new_wf_ctx.parent_workflow_fid,
-            wf_name,
-        )
-        if recorded_result and recorded_result["error"]:
-            e: Exception = deserialize_exception(
-                recorded_result["error"],
-                recorded_result["serialization"],
-                dbos._sys_db.serializer,
-            )
-            raise e
-        elif recorded_result and recorded_result["child_workflow_id"]:
-            return recorded_result["child_workflow_id"]
-
     try:
         dbos._sys_db.init_workflow(
             status,
-            max_recovery_attempts=max_recovery_attempts,
+            # Ignored like every other options-based enqueue; the executor that runs the workflow applies its own limit.
+            max_recovery_attempts=None,
             owner_xid=None,
             is_recovery_request=False,
             is_dequeued_request=False,
@@ -1678,12 +1685,15 @@ def enqueue_workflow_with_options(
 ) -> "WorkflowHandle[Any]":
     local_ctx = get_local_dbos_context()
     new_wf_ctx = DBOSContext.create_start_workflow_child(local_ctx)
+    recorded_child_id = _check_recorded_enqueue(
+        dbos, new_wf_ctx, options["workflow_name"]
+    )
+    if recorded_child_id is not None:
+        return WorkflowHandlePolling(recorded_child_id, dbos)
     status = _build_enqueue_with_options(
         dbos, local_ctx, new_wf_ctx, options, args, kwargs
     )
-    workflow_id = _persist_enqueue_with_options(
-        dbos, new_wf_ctx, status, options.get("max_recovery_attempts")
-    )
+    workflow_id = _persist_enqueue_with_options(dbos, new_wf_ctx, status)
     return WorkflowHandlePolling(workflow_id, dbos)
 
 
@@ -1695,15 +1705,16 @@ async def enqueue_workflow_with_options_async(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> "WorkflowHandleAsync[Any]":
+    recorded_child_id = await asyncio.to_thread(
+        _check_recorded_enqueue, dbos, new_wf_ctx, options["workflow_name"]
+    )
+    if recorded_child_id is not None:
+        return WorkflowHandleAsyncPolling(recorded_child_id, dbos)
     status = _build_enqueue_with_options(
         dbos, local_ctx, new_wf_ctx, options, args, kwargs
     )
     workflow_id = await asyncio.to_thread(
-        _persist_enqueue_with_options,
-        dbos,
-        new_wf_ctx,
-        status,
-        options.get("max_recovery_attempts"),
+        _persist_enqueue_with_options, dbos, new_wf_ctx, status
     )
     return WorkflowHandleAsyncPolling(workflow_id, dbos)
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1507,31 +1507,33 @@ def _build_enqueue_with_options(
     the row. Unset routes it to the latest registered version instead, which
     callers targeting another binary must account for.
     """
+    # An option set to None counts as unset, matching validate_enqueue_options and
+    # build_enqueue_status, so a dict built from config cannot defeat the fallbacks.
     resolved = copy.copy(options)
-    if "workflow_id" not in resolved and new_wf_ctx.id_assigned_for_next_workflow:
+    if resolved.get("workflow_id") is None and new_wf_ctx.id_assigned_for_next_workflow:
         resolved["workflow_id"] = new_wf_ctx.id_assigned_for_next_workflow
     if local_ctx is not None:
         if (
-            "deduplication_id" not in resolved
+            resolved.get("deduplication_id") is None
             and local_ctx.deduplication_id is not None
         ):
             resolved["deduplication_id"] = local_ctx.deduplication_id
-        if "priority" not in resolved and local_ctx.priority is not None:
+        if resolved.get("priority") is None and local_ctx.priority is not None:
             resolved["priority"] = local_ctx.priority
-        if "app_version" not in resolved and local_ctx.app_version is not None:
+        if resolved.get("app_version") is None and local_ctx.app_version is not None:
             resolved["app_version"] = local_ctx.app_version
         if (
-            "queue_partition_key" not in resolved
+            resolved.get("queue_partition_key") is None
             and local_ctx.queue_partition_key is not None
         ):
             resolved["queue_partition_key"] = local_ctx.queue_partition_key
         if (
-            "authenticated_user" not in resolved
+            resolved.get("authenticated_user") is None
             and local_ctx.authenticated_user is not None
         ):
             resolved["authenticated_user"] = local_ctx.authenticated_user
         if (
-            "authenticated_roles" not in resolved
+            resolved.get("authenticated_roles") is None
             and local_ctx.authenticated_roles is not None
         ):
             resolved["authenticated_roles"] = local_ctx.authenticated_roles
@@ -1547,20 +1549,23 @@ def _build_enqueue_with_options(
     status["parent_workflow_id"] = (
         new_wf_ctx.parent_workflow_id if new_wf_ctx.has_parent() else None
     )
-    if "workflow_timeout" not in resolved:
+    if resolved.get("workflow_timeout") is None:
         # Inherit an explicit SetWorkflowTimeout, else the parent's propagated deadline.
         status["workflow_timeout_ms"], status["workflow_deadline_epoch_ms"] = (
             _get_timeout_deadline(local_ctx, resolved["queue_name"])
         )
     if (
-        "delay_seconds" not in resolved
+        resolved.get("delay_seconds") is None
         and local_ctx is not None
         and local_ctx.delay_until_epoch_ms is not None
     ):
         status["delay_until_epoch_ms"] = local_ctx.delay_until_epoch_ms
         status["status"] = WorkflowStatusString.DELAYED.value
-    if status["attributes"] is None:
-        status["attributes"] = _attributes_with_otel_carrier(new_wf_ctx)
+    ambient_attributes = _attributes_with_otel_carrier(new_wf_ctx)
+    if ambient_attributes is not None:
+        # Merge rather than replace: options win per key, but neither an ambient
+        # SetWorkflowAttributes nor a PropagateOtelContext carrier is dropped.
+        status["attributes"] = {**ambient_attributes, **(status["attributes"] or {})}
     return status
 
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -52,6 +52,7 @@ from ._context import (
     otel_carrier_from_attributes,
     restore_otel_carrier,
 )
+from ._enqueue_options import EnqueueOptions, build_enqueue_status
 from ._error import (
     DBOSAwaitedWorkflowCancelledError,
     DBOSException,
@@ -1485,6 +1486,183 @@ async def start_workflow_async(
     # Nothing awaits this future when dequeue/recovery callers discard the handle (#796)
     task.add_done_callback(_retrieve_future_exception)
     return WorkflowHandleAsyncTask(new_child_workflow_id, task, dbos)
+
+
+def _build_enqueue_by_name(
+    dbos: "DBOS",
+    local_ctx: Optional[DBOSContext],
+    new_wf_ctx: DBOSContext,
+    options: "EnqueueOptions",
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> WorkflowStatusInternal:
+    """Build (without persisting) the ENQUEUED row for a workflow named by string.
+
+    The options are authoritative; anything they leave unset falls back to the
+    ambient DBOS context (SetWorkflowID, SetEnqueueOptions, SetWorkflowTimeout,
+    SetWorkflowAttributes, PropagateOtelContext), so this behaves like every other
+    enqueue from inside an application. The one deliberate exception is
+    app_version, which stays unset unless asked for: the target workflow belongs
+    to another executor, so stamping the caller's version would make the row
+    undequeueable by anyone.
+    """
+    resolved = copy.copy(options)
+    if "workflow_id" not in resolved and new_wf_ctx.id_assigned_for_next_workflow:
+        resolved["workflow_id"] = new_wf_ctx.id_assigned_for_next_workflow
+    if local_ctx is not None:
+        if (
+            "deduplication_id" not in resolved
+            and local_ctx.deduplication_id is not None
+        ):
+            resolved["deduplication_id"] = local_ctx.deduplication_id
+        if "priority" not in resolved and local_ctx.priority is not None:
+            resolved["priority"] = local_ctx.priority
+        if "app_version" not in resolved and local_ctx.app_version is not None:
+            resolved["app_version"] = local_ctx.app_version
+        if (
+            "queue_partition_key" not in resolved
+            and local_ctx.queue_partition_key is not None
+        ):
+            resolved["queue_partition_key"] = local_ctx.queue_partition_key
+        if (
+            "authenticated_user" not in resolved
+            and local_ctx.authenticated_user is not None
+        ):
+            resolved["authenticated_user"] = local_ctx.authenticated_user
+        if (
+            "authenticated_roles" not in resolved
+            and local_ctx.authenticated_roles is not None
+        ):
+            resolved["authenticated_roles"] = local_ctx.authenticated_roles
+    if (
+        resolved.get("queue_partition_key") is not None
+        and resolved.get("deduplication_id") is not None
+    ):
+        raise DBOSException("Deduplication is not supported for partitioned queues")
+
+    _, status = build_enqueue_status(resolved, dbos._serializer, args, kwargs)
+
+    status["app_id"] = new_wf_ctx.app_id
+    status["parent_workflow_id"] = (
+        new_wf_ctx.parent_workflow_id if new_wf_ctx.has_parent() else None
+    )
+    if "workflow_timeout" not in resolved:
+        # Inherit an explicit SetWorkflowTimeout, else the parent's propagated deadline.
+        status["workflow_timeout_ms"], status["workflow_deadline_epoch_ms"] = (
+            _get_timeout_deadline(local_ctx, resolved["queue_name"])
+        )
+    if (
+        "delay_seconds" not in resolved
+        and local_ctx is not None
+        and local_ctx.delay_until_epoch_ms is not None
+    ):
+        status["delay_until_epoch_ms"] = local_ctx.delay_until_epoch_ms
+        status["status"] = WorkflowStatusString.DELAYED.value
+    if status["attributes"] is None:
+        status["attributes"] = _attributes_with_otel_carrier(new_wf_ctx)
+    return status
+
+
+def _persist_enqueue_by_name(
+    dbos: "DBOS",
+    new_wf_ctx: DBOSContext,
+    status: WorkflowStatusInternal,
+    max_recovery_attempts: Optional[int],
+) -> str:
+    """Persist a by-name enqueue, recording it as a child of the calling workflow.
+
+    Returns the enqueued workflow's ID, which on a replay is the ID recorded by
+    the original call rather than the one just built.
+    """
+    wf_name = status["name"]
+    workflow_id = status["workflow_uuid"]
+    child_start_time = int(time.time() * 1000)
+    if new_wf_ctx.has_parent():
+        recorded_result = dbos._sys_db.check_operation_execution(
+            new_wf_ctx.parent_workflow_id,
+            new_wf_ctx.parent_workflow_fid,
+            wf_name,
+        )
+        if recorded_result and recorded_result["error"]:
+            e: Exception = deserialize_exception(
+                recorded_result["error"],
+                recorded_result["serialization"],
+                dbos._sys_db.serializer,
+            )
+            raise e
+        elif recorded_result and recorded_result["child_workflow_id"]:
+            return recorded_result["child_workflow_id"]
+
+    try:
+        dbos._sys_db.init_workflow(
+            status,
+            max_recovery_attempts=max_recovery_attempts,
+            owner_xid=None,
+            is_recovery_request=False,
+            is_dequeued_request=False,
+        )
+    except DBOSQueueDeduplicatedError as e:
+        sererr, serialization = serialize_exception(
+            e,
+            status["serialization"],
+            dbos._serializer,
+        )
+        if new_wf_ctx.has_parent():
+            result: OperationResultInternal = {
+                "workflow_uuid": new_wf_ctx.parent_workflow_id,
+                "function_id": new_wf_ctx.parent_workflow_fid,
+                "function_name": wf_name,
+                "output": None,
+                "error": sererr,
+                "serialization": serialization,
+                "started_at_epoch_ms": child_start_time,
+            }
+            dbos._sys_db.record_operation_result(result)
+        raise
+
+    if new_wf_ctx.has_parent():
+        dbos._sys_db.record_child_workflow(
+            new_wf_ctx.parent_workflow_id,
+            workflow_id,
+            new_wf_ctx.parent_workflow_fid,
+            wf_name,
+            started_at_epoch_ms=child_start_time,
+        )
+    return workflow_id
+
+
+def enqueue_workflow_by_name(
+    dbos: "DBOS",
+    options: "EnqueueOptions",
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> "WorkflowHandle[Any]":
+    local_ctx = get_local_dbos_context()
+    new_wf_ctx = DBOSContext.create_start_workflow_child(local_ctx)
+    status = _build_enqueue_by_name(dbos, local_ctx, new_wf_ctx, options, args, kwargs)
+    workflow_id = _persist_enqueue_by_name(
+        dbos, new_wf_ctx, status, options.get("max_recovery_attempts")
+    )
+    return WorkflowHandlePolling(workflow_id, dbos)
+
+
+async def enqueue_workflow_by_name_async(
+    dbos: "DBOS",
+    local_ctx: Optional[DBOSContext],
+    new_wf_ctx: DBOSContext,
+    options: "EnqueueOptions",
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> "WorkflowHandleAsync[Any]":
+    status = _build_enqueue_by_name(dbos, local_ctx, new_wf_ctx, options, args, kwargs)
+    workflow_id = await asyncio.to_thread(
+        _persist_enqueue_by_name,
+        dbos,
+        new_wf_ctx,
+        status,
+        options.get("max_recovery_attempts"),
+    )
+    return WorkflowHandleAsyncPolling(workflow_id, dbos)
 
 
 if sys.version_info < (3, 12):

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1488,7 +1488,7 @@ async def start_workflow_async(
     return WorkflowHandleAsyncTask(new_child_workflow_id, task, dbos)
 
 
-def _build_enqueue_by_name(
+def _build_enqueue_with_options(
     dbos: "DBOS",
     local_ctx: Optional[DBOSContext],
     new_wf_ctx: DBOSContext,
@@ -1563,13 +1563,13 @@ def _build_enqueue_by_name(
     return status
 
 
-def _persist_enqueue_by_name(
+def _persist_enqueue_with_options(
     dbos: "DBOS",
     new_wf_ctx: DBOSContext,
     status: WorkflowStatusInternal,
     max_recovery_attempts: Optional[int],
 ) -> str:
-    """Persist a by-name enqueue, recording it as a child of the calling workflow.
+    """Persist the enqueue, recording it as a child of the calling workflow.
 
     Returns the enqueued workflow's ID, which on a replay is the ID recorded by
     the original call rather than the one just built.
@@ -1631,7 +1631,7 @@ def _persist_enqueue_by_name(
     return workflow_id
 
 
-def enqueue_workflow_by_name(
+def enqueue_workflow_with_options(
     dbos: "DBOS",
     options: "EnqueueOptions",
     args: tuple[Any, ...],
@@ -1639,14 +1639,16 @@ def enqueue_workflow_by_name(
 ) -> "WorkflowHandle[Any]":
     local_ctx = get_local_dbos_context()
     new_wf_ctx = DBOSContext.create_start_workflow_child(local_ctx)
-    status = _build_enqueue_by_name(dbos, local_ctx, new_wf_ctx, options, args, kwargs)
-    workflow_id = _persist_enqueue_by_name(
+    status = _build_enqueue_with_options(
+        dbos, local_ctx, new_wf_ctx, options, args, kwargs
+    )
+    workflow_id = _persist_enqueue_with_options(
         dbos, new_wf_ctx, status, options.get("max_recovery_attempts")
     )
     return WorkflowHandlePolling(workflow_id, dbos)
 
 
-async def enqueue_workflow_by_name_async(
+async def enqueue_workflow_with_options_async(
     dbos: "DBOS",
     local_ctx: Optional[DBOSContext],
     new_wf_ctx: DBOSContext,
@@ -1654,9 +1656,11 @@ async def enqueue_workflow_by_name_async(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> "WorkflowHandleAsync[Any]":
-    status = _build_enqueue_by_name(dbos, local_ctx, new_wf_ctx, options, args, kwargs)
+    status = _build_enqueue_with_options(
+        dbos, local_ctx, new_wf_ctx, options, args, kwargs
+    )
     workflow_id = await asyncio.to_thread(
-        _persist_enqueue_by_name,
+        _persist_enqueue_with_options,
         dbos,
         new_wf_ctx,
         status,

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1496,15 +1496,15 @@ def _build_enqueue_with_options(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> WorkflowStatusInternal:
-    """Build (without persisting) the ENQUEUED row for a workflow named by string.
+    """Build (without persisting) the ENQUEUED row described by these options.
 
     The options are authoritative; anything they leave unset falls back to the
     ambient DBOS context (SetWorkflowID, SetEnqueueOptions, SetWorkflowTimeout,
-    SetWorkflowAttributes, PropagateOtelContext), so this behaves like every other
-    enqueue from inside an application. The one deliberate exception is
-    app_version, which stays unset unless asked for: the target workflow belongs
-    to another executor, so stamping the caller's version would make the row
-    undequeueable by anyone.
+    SetWorkflowAttributes, PropagateOtelContext), so this behaves like every
+    other enqueue from inside an application. The one deliberate exception is
+    app_version, which stays unset unless asked for: the target workflow may
+    belong to another executor, so stamping the caller's version would make the
+    row undequeueable by anyone.
     """
     resolved = copy.copy(options)
     if "workflow_id" not in resolved and new_wf_ctx.id_assigned_for_next_workflow:

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1503,8 +1503,9 @@ def _build_enqueue_with_options(
     SetWorkflowAttributes, PropagateOtelContext), so this behaves like every
     other enqueue from inside an application. The one deliberate exception is
     app_version, which stays unset unless asked for: the target workflow may
-    belong to another executor, so stamping the caller's version would make the
-    row undequeueable by anyone.
+    belong to another executor, so stamping the caller's version would strand
+    the row. Unset routes it to the latest registered version instead, which
+    callers targeting another binary must account for.
     """
     resolved = copy.copy(options)
     if "workflow_id" not in resolved and new_wf_ctx.id_assigned_for_next_workflow:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -62,8 +62,8 @@ from ._core import (
     decorate_step,
     decorate_transaction,
     decorate_workflow,
-    enqueue_workflow_by_name,
-    enqueue_workflow_by_name_async,
+    enqueue_workflow_with_options,
+    enqueue_workflow_with_options_async,
     execute_workflow_by_id,
     record_sleep,
     run_step,
@@ -1276,7 +1276,7 @@ class DBOS:
         return await queue.enqueue_async(func, *args, **kwargs)
 
     @classmethod
-    def enqueue_workflow_by_name(
+    def enqueue_workflow_with_options(
         cls, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> WorkflowHandle[Any]:
         """Enqueue a workflow by name, without a reference to its function.
@@ -1293,20 +1293,22 @@ class DBOS:
         workflow is dequeued by whichever executor is running the latest
         application version rather than being pinned to this one.
         """
-        return enqueue_workflow_by_name(_get_dbos_instance(), options, args, kwargs)
+        return enqueue_workflow_with_options(
+            _get_dbos_instance(), options, args, kwargs
+        )
 
     @classmethod
-    async def enqueue_workflow_by_name_async(
+    async def enqueue_workflow_with_options_async(
         cls, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> WorkflowHandleAsync[Any]:
-        """Async version of :meth:`enqueue_workflow_by_name`."""
+        """Async version of :meth:`enqueue_workflow_with_options`."""
         # To allow safe concurrent async operations, all context management
         # must run synchronously before the first `await`.
         ctx = get_local_dbos_context()
         parent_ctx_copy = copy.copy(ctx)
         child_ctx = DBOSContext.create_start_workflow_child(ctx)
         await cls._configure_asyncio_thread_pool()
-        return await enqueue_workflow_by_name_async(
+        return await enqueue_workflow_with_options_async(
             _get_dbos_instance(), parent_ctx_copy, child_ctx, options, args, kwargs
         )
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -62,6 +62,8 @@ from ._core import (
     decorate_step,
     decorate_transaction,
     decorate_workflow,
+    enqueue_workflow_by_name,
+    enqueue_workflow_by_name_async,
     execute_workflow_by_id,
     record_sleep,
     run_step,
@@ -73,6 +75,7 @@ from ._core import (
     write_stream,
 )
 from ._croniter import croniter  # type: ignore
+from ._enqueue_options import EnqueueOptions
 from ._queue import (
     Queue,
     QueueConflictResolution,
@@ -1271,6 +1274,41 @@ class DBOS:
         await cls._configure_asyncio_thread_pool()
         queue = Queue(queue_name, database_backed_queue=True)
         return await queue.enqueue_async(func, *args, **kwargs)
+
+    @classmethod
+    def enqueue_workflow_by_name(
+        cls, options: EnqueueOptions, *args: Any, **kwargs: Any
+    ) -> WorkflowHandle[Any]:
+        """Enqueue a workflow by name, without a reference to its function.
+
+        Takes the same options as :meth:`DBOSClient.enqueue` and builds the same
+        row, so the workflow may be implemented by another process, another
+        binary, or another language, as long as it shares this system database.
+        Called from inside a workflow, the enqueued workflow is recorded as a
+        child: it is enqueued exactly once across replays, and the returned
+        handle awaits it.
+
+        Unlike :meth:`enqueue_workflow`, nothing here is validated against the
+        local registry, and ``app_version`` is left unset unless given, so the
+        workflow is dequeued by whichever executor is running the latest
+        application version rather than being pinned to this one.
+        """
+        return enqueue_workflow_by_name(_get_dbos_instance(), options, args, kwargs)
+
+    @classmethod
+    async def enqueue_workflow_by_name_async(
+        cls, options: EnqueueOptions, *args: Any, **kwargs: Any
+    ) -> WorkflowHandleAsync[Any]:
+        """Async version of :meth:`enqueue_workflow_by_name`."""
+        # To allow safe concurrent async operations, all context management
+        # must run synchronously before the first `await`.
+        ctx = get_local_dbos_context()
+        parent_ctx_copy = copy.copy(ctx)
+        child_ctx = DBOSContext.create_start_workflow_child(ctx)
+        await cls._configure_asyncio_thread_pool()
+        return await enqueue_workflow_by_name_async(
+            _get_dbos_instance(), parent_ctx_copy, child_ctx, options, args, kwargs
+        )
 
     @classmethod
     @overload

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1279,19 +1279,16 @@ class DBOS:
     def enqueue_workflow_with_options(
         cls, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> WorkflowHandle[Any]:
-        """Enqueue a workflow by name, without a reference to its function.
+        """Enqueue a workflow by options, without a reference to its function.
 
         Takes the same options as :meth:`DBOSClient.enqueue` and builds the same
-        row, so the workflow may be implemented by another process, another
-        binary, or another language, as long as it shares this system database.
-        Called from inside a workflow, the enqueued workflow is recorded as a
-        child: it is enqueued exactly once across replays, and the returned
-        handle awaits it.
+        row, so the workflow may be implemented by another process, as long as
+        it shares this system database. Can safely be called from inside a
+        workflow, the enqueued workflow is recorded as a child.
 
-        Unlike :meth:`enqueue_workflow`, nothing here is validated against the
-        local registry, and ``app_version`` is left unset unless given, so the
-        workflow is dequeued by whichever executor is running the latest
-        application version rather than being pinned to this one.
+        Unlike :meth:`enqueue_workflow`, options are deliberately not validated
+        against the local registry, and ``app_version`` is left unset unless
+        given.
         """
         return enqueue_workflow_with_options(
             _get_dbos_instance(), options, args, kwargs
@@ -1302,8 +1299,7 @@ class DBOS:
         cls, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> WorkflowHandleAsync[Any]:
         """Async version of :meth:`enqueue_workflow_with_options`."""
-        # To allow safe concurrent async operations, all context management
-        # must run synchronously before the first `await`.
+        # All context management runs before the first await, for concurrency safety.
         ctx = get_local_dbos_context()
         parent_ctx_copy = copy.copy(ctx)
         child_ctx = DBOSContext.create_start_workflow_child(ctx)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1288,7 +1288,8 @@ class DBOS:
 
         Unlike :meth:`enqueue_workflow`, options are deliberately not validated
         against the local registry, and ``app_version`` is left unset unless
-        given.
+        given. An unset ``app_version`` is only dequeued by an executor running
+        the latest registered application version.
         """
         return enqueue_workflow_with_options(
             _get_dbos_instance(), options, args, kwargs

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -1,7 +1,7 @@
 """Options and status-row construction for enqueueing a workflow by name.
 
 Shared by DBOSClient.enqueue, which enqueues from outside an application, and
-DBOS.enqueue_workflow_by_name, which enqueues from inside one. Both build the
+DBOS.enqueue_workflow_with_options, which enqueues from inside one. Both build the
 same ENQUEUED row from the same options, so a workflow enqueued either way is
 indistinguishable to the executor that eventually runs it.
 """
@@ -93,7 +93,7 @@ def build_enqueue_status(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> tuple[str, WorkflowStatusInternal]:
-    """Build (without persisting) the ENQUEUED row for a by-name enqueue.
+    """Build (without persisting) the ENQUEUED row for a workflow named by string.
 
     Fields DBOS-internal callers own (parent linkage, app id) are left unset here
     and stamped by the caller.

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -1,9 +1,9 @@
-"""Options and status-row construction for enqueueing a workflow by name.
+"""Options and status-row construction for enqueueing a workflow from options.
 
 Shared by DBOSClient.enqueue, which enqueues from outside an application, and
-DBOS.enqueue_workflow_with_options, which enqueues from inside one. Both build the
-same ENQUEUED row from the same options, so a workflow enqueued either way is
-indistinguishable to the executor that eventually runs it.
+DBOS.enqueue_workflow_with_options, which enqueues from inside one. Both build
+the same ENQUEUED row from the same options, so a workflow enqueued either way
+is indistinguishable to the executor that eventually runs it.
 """
 
 import json
@@ -93,7 +93,7 @@ def build_enqueue_status(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> tuple[str, WorkflowStatusInternal]:
-    """Build (without persisting) the ENQUEUED row for a workflow named by string.
+    """Build (without persisting) the ENQUEUED row described by these options.
 
     Fields DBOS-internal callers own (parent linkage, app id) are left unset here
     and stamped by the caller.

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -1,0 +1,178 @@
+"""Options and status-row construction for enqueueing a workflow by name.
+
+Shared by DBOSClient.enqueue, which enqueues from outside an application, and
+DBOS.enqueue_workflow_by_name, which enqueues from inside one. Both build the
+same ENQUEUED row from the same options, so a workflow enqueued either way is
+indistinguishable to the executor that eventually runs it.
+"""
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict
+
+from dbos._context import (
+    OTEL_CARRIER_ATTRIBUTE,
+    MaxPriority,
+    MinPriority,
+    inject_trace_context,
+    validate_workflow_id,
+)
+from dbos._error import DBOSException
+from dbos._serialization import Serializer, WorkflowSerializationFormat, serialize_args
+from dbos._sys_db import WorkflowStatusInternal, WorkflowStatusString
+from dbos._utils import generate_uuid
+
+if TYPE_CHECKING:
+    from opentelemetry.context import Context as OtelContext
+else:
+    # EnqueueOptions is public, so its annotations must stay resolvable at runtime for
+    # get_type_hints()/pydantic without importing the optional opentelemetry package.
+    OtelContext = Any
+
+
+# Required EnqueueOptions fields
+class _EnqueueOptionsRequired(TypedDict):
+    workflow_name: str
+    queue_name: str
+
+
+# Optional EnqueueOptions fields
+class EnqueueOptions(_EnqueueOptionsRequired, total=False):
+    workflow_id: str
+    app_version: str
+    workflow_timeout: float
+    delay_seconds: float
+    deduplication_id: str
+    priority: int
+    max_recovery_attempts: int
+    queue_partition_key: str
+    authenticated_user: str
+    authenticated_roles: list[str]
+    serialization_type: WorkflowSerializationFormat
+    class_name: str
+    instance_name: str
+    attributes: Dict[str, Any]
+    # Parents the enqueued workflow's span to this OpenTelemetry context, so it joins
+    # this trace when it runs. The client-side PropagateOtelContext.
+    otel_context: "OtelContext"
+
+
+def validate_enqueue_options(options: EnqueueOptions) -> None:
+    priority = options.get("priority")
+    if priority is not None and (priority < MinPriority or priority > MaxPriority):
+        raise DBOSException(
+            f"Invalid priority {priority}. Priority must be between {MinPriority}~{MaxPriority}."
+        )
+    workflow_id = options.get("workflow_id")
+    if workflow_id is not None:
+        validate_workflow_id(workflow_id)
+
+
+def attributes_with_otel_context(
+    attributes: Optional[Dict[str, Any]], otel_context: "Optional[OtelContext]"
+) -> Optional[Dict[str, Any]]:
+    """Fold an otel_context option into the workflow's persisted attributes.
+
+    The client-side counterpart of PropagateOtelContext. Records nothing when there is
+    no valid context to propagate, and wins over a hand-written carrier in attributes.
+    Only the W3C trace context travels, not baggage.
+    """
+    if otel_context is None:
+        return attributes
+    carrier = inject_trace_context(otel_context)
+    if not carrier:
+        return attributes
+    merged = dict(attributes) if attributes else {}
+    merged[OTEL_CARRIER_ATTRIBUTE] = carrier
+    return merged
+
+
+def build_enqueue_status(
+    options: EnqueueOptions,
+    serializer: Serializer,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> tuple[str, WorkflowStatusInternal]:
+    """Build (without persisting) the ENQUEUED row for a by-name enqueue.
+
+    Fields DBOS-internal callers own (parent linkage, app id) are left unset here
+    and stamped by the caller.
+    """
+    validate_enqueue_options(options)
+    workflow_name = options["workflow_name"]
+    queue_name = options["queue_name"]
+
+    workflow_id = options.get("workflow_id")
+    if workflow_id is None:
+        workflow_id = generate_uuid()
+    workflow_timeout = options.get("workflow_timeout", None)
+    delay_seconds = options.get("delay_seconds", None)
+    delay_until_epoch_ms: Optional[int] = (
+        int((time.time() + delay_seconds) * 1000) if delay_seconds is not None else None
+    )
+
+    authenticated_user = options.get("authenticated_user")
+    authenticated_roles = (
+        json.dumps(options.get("authenticated_roles"))
+        if options.get("authenticated_roles")
+        else None
+    )
+
+    inputs, serialization = serialize_args(
+        args,
+        kwargs,
+        options.get("serialization_type"),
+        serializer,
+    )
+
+    attributes = attributes_with_otel_context(
+        options.get("attributes"), options.get("otel_context")
+    )
+
+    status: WorkflowStatusInternal = {
+        "workflow_uuid": workflow_id,
+        "status": (
+            WorkflowStatusString.DELAYED.value
+            if delay_until_epoch_ms is not None
+            else WorkflowStatusString.ENQUEUED.value
+        ),
+        "name": workflow_name,
+        "class_name": options.get("class_name"),
+        "queue_name": queue_name,
+        "app_version": options.get("app_version"),
+        "config_name": options.get("instance_name"),
+        "authenticated_user": authenticated_user,
+        "assumed_role": None,
+        "authenticated_roles": authenticated_roles,
+        "output": None,
+        "error": None,
+        "created_at": None,
+        "updated_at": None,
+        "executor_id": None,
+        "recovery_attempts": None,
+        "app_id": None,
+        "workflow_timeout_ms": (
+            int(workflow_timeout * 1000) if workflow_timeout is not None else None
+        ),
+        "workflow_deadline_epoch_ms": None,
+        "deduplication_id": options.get("deduplication_id", None),
+        "priority": (
+            options.get("priority", 0)
+            if options.get("priority", None) is not None
+            else 0
+        ),
+        "inputs": inputs,
+        "serialization": serialization,
+        "queue_partition_key": options.get("queue_partition_key", None),
+        "forked_from": None,
+        "parent_workflow_id": None,
+        "started_at_epoch_ms": None,
+        "owner_xid": None,
+        "delay_until_epoch_ms": delay_until_epoch_ms,
+        "attributes": attributes,
+        "schedule_name": None,
+        # Set only by the debouncer via _enqueue_debounced, never from options.
+        "debounce_deadline_epoch_ms": None,
+        "is_debounced": False,
+    }
+    return workflow_id, status

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -21,6 +21,7 @@ from dbos import (
     DBOSClient,
     DBOSConfig,
     DBOSConfiguredInstance,
+    EnqueueOptions,
     Queue,
     SetEnqueueOptions,
     SetWorkflowID,
@@ -3602,6 +3603,46 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
     )
     assert handle2.get_result() == 42
 
+    # Park a workflow to hold a deduplication ID for the collision below.
+    parked: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+        {
+            "workflow_name": "with_options_passthrough_target",
+            "queue_name": "with_options_passthrough_queue",
+            "deduplication_id": "held-key",
+            "delay_seconds": 3600,
+        },
+        21,
+    )
+
+    @DBOS.workflow()
+    def with_options_dedup_parent() -> int:
+        handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+            {
+                "workflow_name": "with_options_passthrough_target",
+                "queue_name": "with_options_passthrough_queue",
+                "deduplication_id": "held-key",
+            },
+            21,
+        )
+        return handle.get_result()
+
+    # A deduplicated enqueue inside a workflow checkpoints its error, so the
+    # replay raises the same error rather than enqueueing a second time.
+    parent_id = str(uuid.uuid4())
+    with SetWorkflowID(parent_id):
+        with pytest.raises(DBOSQueueDeduplicatedError):
+            with_options_dedup_parent()
+
+    set_workflow_status(dbos._sys_db, parent_id, "PENDING")
+    recovered = [
+        h for h in DBOS._recover_pending_workflows() if h.get_workflow_id() == parent_id
+    ]
+    assert len(recovered) == 1
+    with pytest.raises(DBOSQueueDeduplicatedError):
+        recovered[0].get_result()
+
+    DBOS.cancel_workflow(parked.get_workflow_id())
+
 
 def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
     """A name this executor cannot resolve is enqueued without complaint: the
@@ -3635,35 +3676,49 @@ def test_enqueue_with_options_child(dbos: DBOS) -> None:
 
     @DBOS.workflow()
     def with_options_parent(x: int) -> int:
-        handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
-            {
-                "workflow_name": "with_options_child",
-                "queue_name": "with_options_child_queue",
-            },
-            x,
+        # One options dict, enqueued twice: the caller's copy must not be mutated.
+        options: EnqueueOptions = {
+            "workflow_name": "with_options_child",
+            "queue_name": "with_options_child_queue",
+        }
+        first: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(options, x)
+        second: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+            options, x + 10
         )
-        return handle.get_result()
+        return first.get_result() + second.get_result()
 
     DBOS.register_queue("with_options_child_queue")
 
     wfid = str(uuid.uuid4())
-    with SetWorkflowID(wfid):
-        assert with_options_parent(1) == 2
-    assert child_counter == 1
+    with SetWorkflowTimeout(300):
+        with SetWorkflowID(wfid):
+            assert with_options_parent(1) == 14
+    assert child_counter == 2
 
-    # The child is recorded against the parent; the second step is its get_result.
+    # Each child is recorded against the parent, with an ID from the parent's
+    # function counter; the trailing steps are the two get_results.
     steps = DBOS.list_workflow_steps(wfid)
-    assert len(steps) == 2
+    assert len(steps) == 4
     assert steps[0]["function_name"] == "with_options_child"
     assert steps[0]["child_workflow_id"] == f"{wfid}-1"
+    assert steps[1]["child_workflow_id"] == f"{wfid}-2"
     assert DBOS.retrieve_workflow(f"{wfid}-1").get_status().parent_workflow_id == wfid
 
-    # On recovery the parent re-runs but returns the recorded child, not a new one.
+    # The children inherit the parent's deadline instead of running unbounded.
+    parent_deadline = (
+        DBOS.retrieve_workflow(wfid).get_status().workflow_deadline_epoch_ms
+    )
+    assert parent_deadline is not None
+    for child_id in (f"{wfid}-1", f"{wfid}-2"):
+        child_status = DBOS.retrieve_workflow(child_id).get_status()
+        assert child_status.workflow_deadline_epoch_ms == parent_deadline
+
+    # On recovery the parent re-runs but returns the recorded children, not new ones.
     set_workflow_status(dbos._sys_db, wfid, "PENDING")
     handles = DBOS._recover_pending_workflows()
     assert len(handles) == 1
-    assert handles[0].get_result() == 2
-    assert child_counter == 1
+    assert handles[0].get_result() == 14
+    assert child_counter == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3541,3 +3541,191 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
         assert not dbos._workflow_tasks
 
     retry_until_success(check_task_released, interval=0.1, max_attempts=50)
+
+
+def test_enqueue_by_name(dbos: DBOS) -> None:
+    @DBOS.workflow(name="by_name_target")
+    def by_name_target(x: int, y: int = 0) -> int:
+        return x + y
+
+    DBOS.register_queue("by_name_queue")
+
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+        {"workflow_name": "by_name_target", "queue_name": "by_name_queue"}, 5, y=3
+    )
+    assert handle.get_result() == 8
+
+    status = handle.get_status()
+    assert status.name == "by_name_target"
+    assert status.queue_name == "by_name_queue"
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_enqueue_by_name_options(dbos: DBOS) -> None:
+    @DBOS.workflow(name="by_name_options_target")
+    def by_name_options_target(x: int) -> int:
+        return x * 2
+
+    DBOS.register_queue("by_name_options_queue")
+
+    wfid = str(uuid.uuid4())
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+        {
+            "workflow_name": "by_name_options_target",
+            "queue_name": "by_name_options_queue",
+            "workflow_id": wfid,
+            "app_version": GlobalParams.app_version,
+            "deduplication_id": "dedup-key",
+            "authenticated_user": "alice",
+            "authenticated_roles": ["admin"],
+        },
+        21,
+    )
+    assert handle.get_workflow_id() == wfid
+    assert handle.get_result() == 42
+
+    status = handle.get_status()
+    assert status.app_version == GlobalParams.app_version
+    assert status.authenticated_user == "alice"
+    assert status.authenticated_roles == ["admin"]
+
+    # A second enqueue under the same deduplication ID is rejected while the
+    # first is still in flight; it is released once the first completes.
+    handle2: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+        {
+            "workflow_name": "by_name_options_target",
+            "queue_name": "by_name_options_queue",
+            "deduplication_id": "dedup-key",
+        },
+        21,
+    )
+    assert handle2.get_result() == 42
+
+
+def test_enqueue_by_name_unknown_workflow(dbos: DBOS) -> None:
+    """A name this executor cannot resolve is enqueued without complaint: the
+    point of the API is that the target is implemented elsewhere."""
+    DBOS.register_queue("by_name_unknown_queue")
+
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+        {
+            "workflow_name": "not_registered_anywhere",
+            "queue_name": "by_name_unknown_queue",
+            # Parks the row so no worker dequeues a name it cannot run.
+            "delay_seconds": 3600,
+        },
+        1,
+    )
+    status = handle.get_status()
+    assert status.status == WorkflowStatusString.DELAYED.value
+    # The target may live in another executor, so the row must not be pinned to
+    # this application's version. (Dequeueing stamps the running executor's.)
+    assert status.app_version is None
+    DBOS.cancel_workflow(handle.get_workflow_id())
+
+
+def test_enqueue_by_name_child(dbos: DBOS) -> None:
+    child_counter: int = 0
+
+    @DBOS.workflow(name="by_name_child")
+    def by_name_child(x: int) -> int:
+        nonlocal child_counter
+        child_counter += 1
+        return x + 1
+
+    @DBOS.workflow()
+    def by_name_parent(x: int) -> int:
+        handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+            {"workflow_name": "by_name_child", "queue_name": "by_name_child_queue"}, x
+        )
+        return handle.get_result()
+
+    DBOS.register_queue("by_name_child_queue")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert by_name_parent(1) == 2
+    assert child_counter == 1
+
+    # The child is recorded against the parent, with the ID derived from the
+    # parent's function counter like any other child workflow. The second step
+    # is the handle's get_result.
+    steps = DBOS.list_workflow_steps(wfid)
+    assert len(steps) == 2
+    assert steps[0]["function_name"] == "by_name_child"
+    assert steps[0]["child_workflow_id"] == f"{wfid}-1"
+    assert DBOS.retrieve_workflow(f"{wfid}-1").get_status().parent_workflow_id == wfid
+
+    # On recovery the parent re-runs its body but must not enqueue a second
+    # child: the recorded child ID is returned instead.
+    set_workflow_status(dbos._sys_db, wfid, "PENDING")
+    handles = DBOS._recover_pending_workflows()
+    assert len(handles) == 1
+    assert handles[0].get_result() == 2
+    assert child_counter == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_by_name_async(dbos: DBOS) -> None:
+    @DBOS.workflow(name="by_name_async_child")
+    async def by_name_async_child(x: int) -> int:
+        return x + 1
+
+    @DBOS.workflow()
+    async def by_name_async_parent(x: int) -> int:
+        handle: WorkflowHandleAsync[int] = await DBOS.enqueue_workflow_by_name_async(
+            {
+                "workflow_name": "by_name_async_child",
+                "queue_name": "by_name_async_queue",
+            },
+            x,
+        )
+        return await handle.get_result()
+
+    await DBOS.register_queue_async("by_name_async_queue")
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert await by_name_async_parent(1) == 2
+
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    assert steps[0]["function_name"] == "by_name_async_child"
+    assert steps[0]["child_workflow_id"] == f"{wfid}-1"
+
+
+def test_enqueue_by_name_context_options(dbos: DBOS) -> None:
+    @DBOS.workflow(name="by_name_ctx_target")
+    def by_name_ctx_target(x: int) -> int:
+        return x
+
+    DBOS.register_queue("by_name_ctx_queue")
+
+    # Ambient enqueue options apply to a by-name enqueue like any other.
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        with SetEnqueueOptions(app_version="ambient-version"):
+            handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+                {
+                    "workflow_name": "by_name_ctx_target",
+                    "queue_name": "by_name_ctx_queue",
+                },
+                1,
+            )
+    assert handle.get_workflow_id() == wfid
+    status = handle.get_status()
+    assert status.app_version == "ambient-version"
+    # No executor runs that version, so the workflow stays enqueued.
+    assert status.status == WorkflowStatusString.ENQUEUED.value
+    DBOS.cancel_workflow(wfid)
+
+    # An explicit option still wins over the ambient one.
+    with SetEnqueueOptions(app_version="ambient-version"):
+        explicit: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+            {
+                "workflow_name": "by_name_ctx_target",
+                "queue_name": "by_name_ctx_queue",
+                "app_version": GlobalParams.app_version,
+            },
+            2,
+        )
+    assert explicit.get_result() == 2

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -21,6 +21,7 @@ from dbos import (
     DBOSClient,
     DBOSConfig,
     DBOSConfiguredInstance,
+    DBOSContextSetAuth,
     EnqueueOptions,
     Queue,
     SetEnqueueOptions,
@@ -3603,16 +3604,30 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
     )
     assert handle2.get_result() == 42
 
-    # Park a workflow to hold a deduplication ID for the collision below.
+    # Park a workflow to hold a deduplication ID for the collisions below.
     parked: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
             "workflow_name": "with_options_passthrough_target",
             "queue_name": "with_options_passthrough_queue",
             "deduplication_id": "held-key",
             "delay_seconds": 3600,
+            "workflow_timeout": 300,
         },
         21,
     )
+    # An explicit timeout survives; it is not overwritten by the ambient deadline.
+    assert parked.get_status().workflow_timeout_ms == 300000
+
+    # Colliding with a held key outside a workflow raises directly.
+    with pytest.raises(DBOSQueueDeduplicatedError):
+        DBOS.enqueue_workflow_with_options(
+            {
+                "workflow_name": "with_options_passthrough_target",
+                "queue_name": "with_options_passthrough_queue",
+                "deduplication_id": "held-key",
+            },
+            21,
+        )
 
     @DBOS.workflow()
     def with_options_dedup_parent() -> int:
@@ -3626,13 +3641,20 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
         )
         return handle.get_result()
 
-    # A deduplicated enqueue inside a workflow checkpoints its error, so the
-    # replay raises the same error rather than enqueueing a second time.
     parent_id = str(uuid.uuid4())
     with SetWorkflowID(parent_id):
         with pytest.raises(DBOSQueueDeduplicatedError):
             with_options_dedup_parent()
 
+    # The failed enqueue is checkpointed against the parent: an error, no child.
+    steps = DBOS.list_workflow_steps(parent_id)
+    assert len(steps) == 1
+    assert steps[0]["error"] is not None
+    assert steps[0]["child_workflow_id"] is None
+
+    # Free the key BEFORE recovery, so a re-attempted enqueue would now succeed.
+    # Only a replay of the checkpointed error can still raise here.
+    DBOS.cancel_workflow(parked.get_workflow_id())
     set_workflow_status(dbos._sys_db, parent_id, "PENDING")
     recovered = [
         h for h in DBOS._recover_pending_workflows() if h.get_workflow_id() == parent_id
@@ -3640,8 +3662,6 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
     assert len(recovered) == 1
     with pytest.raises(DBOSQueueDeduplicatedError):
         recovered[0].get_result()
-
-    DBOS.cancel_workflow(parked.get_workflow_id())
 
 
 def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
@@ -3714,11 +3734,17 @@ def test_enqueue_with_options_child(dbos: DBOS) -> None:
         assert child_status.workflow_deadline_epoch_ms == parent_deadline
 
     # On recovery the parent re-runs but returns the recorded children, not new ones.
+    # A re-attempted enqueue would rebuild the same deterministic ID and upsert
+    # over the finished child, so watch updated_at: only a replay leaves it alone.
+    child_updated_at = DBOS.retrieve_workflow(f"{wfid}-1").get_status().updated_at
     set_workflow_status(dbos._sys_db, wfid, "PENDING")
     handles = DBOS._recover_pending_workflows()
     assert len(handles) == 1
     assert handles[0].get_result() == 14
     assert child_counter == 2
+    assert (
+        DBOS.retrieve_workflow(f"{wfid}-1").get_status().updated_at == child_updated_at
+    )
 
 
 @pytest.mark.asyncio
@@ -3775,6 +3801,51 @@ def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
     # No executor runs that version, so the workflow stays enqueued.
     assert status.status == WorkflowStatusString.ENQUEUED.value
     DBOS.cancel_workflow(wfid)
+
+    # Ambient deduplication_id, priority and delay all reach the row.
+    with SetEnqueueOptions(
+        deduplication_id="ambient-dedup", priority=5, delay_seconds=3600
+    ):
+        ambient: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+            {
+                "workflow_name": "with_options_ctx_target",
+                "queue_name": "with_options_ctx_queue",
+            },
+            3,
+        )
+    ambient_status = ambient.get_status()
+    assert ambient_status.status == WorkflowStatusString.DELAYED.value
+    assert ambient_status.deduplication_id == "ambient-dedup"
+    assert ambient_status.priority == 5
+    DBOS.cancel_workflow(ambient.get_workflow_id())
+
+    # An ambient partition key reaches the row too, where it is rejected
+    # alongside an explicit deduplication ID.
+    with pytest.raises(DBOSException):
+        with SetEnqueueOptions(queue_partition_key="tenant-1"):
+            DBOS.enqueue_workflow_with_options(
+                {
+                    "workflow_name": "with_options_ctx_target",
+                    "queue_name": "with_options_ctx_queue",
+                    "deduplication_id": "never-written",
+                },
+                4,
+            )
+
+    # Ambient authentication is inherited when the options do not set it.
+    with DBOSContextSetAuth("bob", ["auditor"]):
+        with SetEnqueueOptions(delay_seconds=3600):
+            authed: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+                {
+                    "workflow_name": "with_options_ctx_target",
+                    "queue_name": "with_options_ctx_queue",
+                },
+                5,
+            )
+    authed_status = authed.get_status()
+    assert authed_status.authenticated_user == "bob"
+    assert authed_status.authenticated_roles == ["auditor"]
+    DBOS.cancel_workflow(authed.get_workflow_id())
 
     # An explicit option still wins over the ambient one.
     with SetEnqueueOptions(app_version="ambient-version"):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3544,37 +3544,37 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
 
 
 def test_enqueue_with_options(dbos: DBOS) -> None:
-    @DBOS.workflow(name="enqueue_opts_target")
-    def enqueue_opts_target(x: int, y: int = 0) -> int:
+    @DBOS.workflow(name="with_options_target")
+    def with_options_target(x: int, y: int = 0) -> int:
         return x + y
 
-    DBOS.register_queue("enqueue_opts_queue")
+    DBOS.register_queue("with_options_queue")
 
     handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
-        {"workflow_name": "enqueue_opts_target", "queue_name": "enqueue_opts_queue"},
+        {"workflow_name": "with_options_target", "queue_name": "with_options_queue"},
         5,
         y=3,
     )
     assert handle.get_result() == 8
 
     status = handle.get_status()
-    assert status.name == "enqueue_opts_target"
-    assert status.queue_name == "enqueue_opts_queue"
+    assert status.name == "with_options_target"
+    assert status.queue_name == "with_options_queue"
     assert queue_entries_are_cleaned_up(dbos)
 
 
 def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
-    @DBOS.workflow(name="enqueue_opts_passthrough_target")
-    def enqueue_opts_passthrough_target(x: int) -> int:
+    @DBOS.workflow(name="with_options_passthrough_target")
+    def with_options_passthrough_target(x: int) -> int:
         return x * 2
 
-    DBOS.register_queue("enqueue_opts_passthrough_queue")
+    DBOS.register_queue("with_options_passthrough_queue")
 
     wfid = str(uuid.uuid4())
     handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
-            "workflow_name": "enqueue_opts_passthrough_target",
-            "queue_name": "enqueue_opts_passthrough_queue",
+            "workflow_name": "with_options_passthrough_target",
+            "queue_name": "with_options_passthrough_queue",
             "workflow_id": wfid,
             "app_version": GlobalParams.app_version,
             "deduplication_id": "dedup-key",
@@ -3591,12 +3591,11 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
     assert status.authenticated_user == "alice"
     assert status.authenticated_roles == ["admin"]
 
-    # A second enqueue under the same deduplication ID is rejected while the
-    # first is still in flight; it is released once the first completes.
+    # The deduplication ID is released once the first workflow completes.
     handle2: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
-            "workflow_name": "enqueue_opts_passthrough_target",
-            "queue_name": "enqueue_opts_passthrough_queue",
+            "workflow_name": "with_options_passthrough_target",
+            "queue_name": "with_options_passthrough_queue",
             "deduplication_id": "dedup-key",
         },
         21,
@@ -3607,12 +3606,12 @@ def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
 def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
     """A name this executor cannot resolve is enqueued without complaint: the
     point of the API is that the target is implemented elsewhere."""
-    DBOS.register_queue("enqueue_opts_unknown_queue")
+    DBOS.register_queue("with_options_unknown_queue")
 
     handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
             "workflow_name": "not_registered_anywhere",
-            "queue_name": "enqueue_opts_unknown_queue",
+            "queue_name": "with_options_unknown_queue",
             # Parks the row so no worker dequeues a name it cannot run.
             "delay_seconds": 3600,
         },
@@ -3620,8 +3619,7 @@ def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
     )
     status = handle.get_status()
     assert status.status == WorkflowStatusString.DELAYED.value
-    # The target may live in another executor, so the row must not be pinned to
-    # this application's version. (Dequeueing stamps the running executor's.)
+    # The target may live in another executor, so the row is left unpinned.
     assert status.app_version is None
     DBOS.cancel_workflow(handle.get_workflow_id())
 
@@ -3629,41 +3627,38 @@ def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
 def test_enqueue_with_options_child(dbos: DBOS) -> None:
     child_counter: int = 0
 
-    @DBOS.workflow(name="enqueue_opts_child")
-    def enqueue_opts_child(x: int) -> int:
+    @DBOS.workflow(name="with_options_child")
+    def with_options_child(x: int) -> int:
         nonlocal child_counter
         child_counter += 1
         return x + 1
 
     @DBOS.workflow()
-    def enqueue_opts_parent(x: int) -> int:
+    def with_options_parent(x: int) -> int:
         handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
             {
-                "workflow_name": "enqueue_opts_child",
-                "queue_name": "enqueue_opts_child_queue",
+                "workflow_name": "with_options_child",
+                "queue_name": "with_options_child_queue",
             },
             x,
         )
         return handle.get_result()
 
-    DBOS.register_queue("enqueue_opts_child_queue")
+    DBOS.register_queue("with_options_child_queue")
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        assert enqueue_opts_parent(1) == 2
+        assert with_options_parent(1) == 2
     assert child_counter == 1
 
-    # The child is recorded against the parent, with the ID derived from the
-    # parent's function counter like any other child workflow. The second step
-    # is the handle's get_result.
+    # The child is recorded against the parent; the second step is its get_result.
     steps = DBOS.list_workflow_steps(wfid)
     assert len(steps) == 2
-    assert steps[0]["function_name"] == "enqueue_opts_child"
+    assert steps[0]["function_name"] == "with_options_child"
     assert steps[0]["child_workflow_id"] == f"{wfid}-1"
     assert DBOS.retrieve_workflow(f"{wfid}-1").get_status().parent_workflow_id == wfid
 
-    # On recovery the parent re-runs its body but must not enqueue a second
-    # child: the recorded child ID is returned instead.
+    # On recovery the parent re-runs but returns the recorded child, not a new one.
     set_workflow_status(dbos._sys_db, wfid, "PENDING")
     handles = DBOS._recover_pending_workflows()
     assert len(handles) == 1
@@ -3673,40 +3668,40 @@ def test_enqueue_with_options_child(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_enqueue_with_options_async(dbos: DBOS) -> None:
-    @DBOS.workflow(name="enqueue_opts_async_child")
-    async def enqueue_opts_async_child(x: int) -> int:
+    @DBOS.workflow(name="with_options_async_child")
+    async def with_options_async_child(x: int) -> int:
         return x + 1
 
     @DBOS.workflow()
-    async def enqueue_opts_async_parent(x: int) -> int:
+    async def with_options_async_parent(x: int) -> int:
         handle: WorkflowHandleAsync[int] = (
             await DBOS.enqueue_workflow_with_options_async(
                 {
-                    "workflow_name": "enqueue_opts_async_child",
-                    "queue_name": "enqueue_opts_async_queue",
+                    "workflow_name": "with_options_async_child",
+                    "queue_name": "with_options_async_queue",
                 },
                 x,
             )
         )
         return await handle.get_result()
 
-    await DBOS.register_queue_async("enqueue_opts_async_queue")
+    await DBOS.register_queue_async("with_options_async_queue")
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        assert await enqueue_opts_async_parent(1) == 2
+        assert await with_options_async_parent(1) == 2
 
     steps = await DBOS.list_workflow_steps_async(wfid)
-    assert steps[0]["function_name"] == "enqueue_opts_async_child"
+    assert steps[0]["function_name"] == "with_options_async_child"
     assert steps[0]["child_workflow_id"] == f"{wfid}-1"
 
 
 def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
-    @DBOS.workflow(name="enqueue_opts_ctx_target")
-    def enqueue_opts_ctx_target(x: int) -> int:
+    @DBOS.workflow(name="with_options_ctx_target")
+    def with_options_ctx_target(x: int) -> int:
         return x
 
-    DBOS.register_queue("enqueue_opts_ctx_queue")
+    DBOS.register_queue("with_options_ctx_queue")
 
     # Ambient enqueue options apply here like they do to any other enqueue.
     wfid = str(uuid.uuid4())
@@ -3714,8 +3709,8 @@ def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
         with SetEnqueueOptions(app_version="ambient-version"):
             handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
                 {
-                    "workflow_name": "enqueue_opts_ctx_target",
-                    "queue_name": "enqueue_opts_ctx_queue",
+                    "workflow_name": "with_options_ctx_target",
+                    "queue_name": "with_options_ctx_queue",
                 },
                 1,
             )
@@ -3730,8 +3725,8 @@ def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
     with SetEnqueueOptions(app_version="ambient-version"):
         explicit: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
             {
-                "workflow_name": "enqueue_opts_ctx_target",
-                "queue_name": "enqueue_opts_ctx_queue",
+                "workflow_name": "with_options_ctx_target",
+                "queue_name": "with_options_ctx_queue",
                 "app_version": GlobalParams.app_version,
             },
             2,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,6 +25,7 @@ from dbos import (
     EnqueueOptions,
     Queue,
     SetEnqueueOptions,
+    SetWorkflowAttributes,
     SetWorkflowID,
     SetWorkflowTimeout,
     WorkflowHandle,
@@ -3802,16 +3803,18 @@ def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
     assert status.status == WorkflowStatusString.ENQUEUED.value
     DBOS.cancel_workflow(wfid)
 
-    # Ambient deduplication_id, priority and delay all reach the row.
+    # Ambient deduplication_id, priority and delay all reach the row. The
+    # explicit None must count as unset, or it would defeat the fallback.
+    ambient_opts: EnqueueOptions = {
+        "workflow_name": "with_options_ctx_target",
+        "queue_name": "with_options_ctx_queue",
+    }
+    ambient_opts["deduplication_id"] = None  # type: ignore[typeddict-item]
     with SetEnqueueOptions(
         deduplication_id="ambient-dedup", priority=5, delay_seconds=3600
     ):
         ambient: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
-            {
-                "workflow_name": "with_options_ctx_target",
-                "queue_name": "with_options_ctx_queue",
-            },
-            3,
+            ambient_opts, 3
         )
     ambient_status = ambient.get_status()
     assert ambient_status.status == WorkflowStatusString.DELAYED.value
@@ -3846,6 +3849,20 @@ def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
     assert authed_status.authenticated_user == "bob"
     assert authed_status.authenticated_roles == ["auditor"]
     DBOS.cancel_workflow(authed.get_workflow_id())
+
+    # Options attributes merge with ambient ones rather than replacing them.
+    with SetWorkflowAttributes({"ambient": "a"}):
+        with SetEnqueueOptions(delay_seconds=3600):
+            merged: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+                {
+                    "workflow_name": "with_options_ctx_target",
+                    "queue_name": "with_options_ctx_queue",
+                    "attributes": {"explicit": "b"},
+                },
+                6,
+            )
+    assert merged.get_status().attributes == {"ambient": "a", "explicit": "b"}
+    DBOS.cancel_workflow(merged.get_workflow_id())
 
     # An explicit option still wins over the ambient one.
     with SetEnqueueOptions(app_version="ambient-version"):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3543,36 +3543,38 @@ def test_enqueued_async_workflow_survives_gc(dbos: DBOS) -> None:
     retry_until_success(check_task_released, interval=0.1, max_attempts=50)
 
 
-def test_enqueue_by_name(dbos: DBOS) -> None:
-    @DBOS.workflow(name="by_name_target")
-    def by_name_target(x: int, y: int = 0) -> int:
+def test_enqueue_with_options(dbos: DBOS) -> None:
+    @DBOS.workflow(name="enqueue_opts_target")
+    def enqueue_opts_target(x: int, y: int = 0) -> int:
         return x + y
 
-    DBOS.register_queue("by_name_queue")
+    DBOS.register_queue("enqueue_opts_queue")
 
-    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
-        {"workflow_name": "by_name_target", "queue_name": "by_name_queue"}, 5, y=3
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+        {"workflow_name": "enqueue_opts_target", "queue_name": "enqueue_opts_queue"},
+        5,
+        y=3,
     )
     assert handle.get_result() == 8
 
     status = handle.get_status()
-    assert status.name == "by_name_target"
-    assert status.queue_name == "by_name_queue"
+    assert status.name == "enqueue_opts_target"
+    assert status.queue_name == "enqueue_opts_queue"
     assert queue_entries_are_cleaned_up(dbos)
 
 
-def test_enqueue_by_name_options(dbos: DBOS) -> None:
-    @DBOS.workflow(name="by_name_options_target")
-    def by_name_options_target(x: int) -> int:
+def test_enqueue_with_options_passthrough(dbos: DBOS) -> None:
+    @DBOS.workflow(name="enqueue_opts_passthrough_target")
+    def enqueue_opts_passthrough_target(x: int) -> int:
         return x * 2
 
-    DBOS.register_queue("by_name_options_queue")
+    DBOS.register_queue("enqueue_opts_passthrough_queue")
 
     wfid = str(uuid.uuid4())
-    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
-            "workflow_name": "by_name_options_target",
-            "queue_name": "by_name_options_queue",
+            "workflow_name": "enqueue_opts_passthrough_target",
+            "queue_name": "enqueue_opts_passthrough_queue",
             "workflow_id": wfid,
             "app_version": GlobalParams.app_version,
             "deduplication_id": "dedup-key",
@@ -3591,10 +3593,10 @@ def test_enqueue_by_name_options(dbos: DBOS) -> None:
 
     # A second enqueue under the same deduplication ID is rejected while the
     # first is still in flight; it is released once the first completes.
-    handle2: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+    handle2: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
-            "workflow_name": "by_name_options_target",
-            "queue_name": "by_name_options_queue",
+            "workflow_name": "enqueue_opts_passthrough_target",
+            "queue_name": "enqueue_opts_passthrough_queue",
             "deduplication_id": "dedup-key",
         },
         21,
@@ -3602,15 +3604,15 @@ def test_enqueue_by_name_options(dbos: DBOS) -> None:
     assert handle2.get_result() == 42
 
 
-def test_enqueue_by_name_unknown_workflow(dbos: DBOS) -> None:
+def test_enqueue_with_options_unknown_workflow(dbos: DBOS) -> None:
     """A name this executor cannot resolve is enqueued without complaint: the
     point of the API is that the target is implemented elsewhere."""
-    DBOS.register_queue("by_name_unknown_queue")
+    DBOS.register_queue("enqueue_opts_unknown_queue")
 
-    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+    handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
         {
             "workflow_name": "not_registered_anywhere",
-            "queue_name": "by_name_unknown_queue",
+            "queue_name": "enqueue_opts_unknown_queue",
             # Parks the row so no worker dequeues a name it cannot run.
             "delay_seconds": 3600,
         },
@@ -3624,27 +3626,31 @@ def test_enqueue_by_name_unknown_workflow(dbos: DBOS) -> None:
     DBOS.cancel_workflow(handle.get_workflow_id())
 
 
-def test_enqueue_by_name_child(dbos: DBOS) -> None:
+def test_enqueue_with_options_child(dbos: DBOS) -> None:
     child_counter: int = 0
 
-    @DBOS.workflow(name="by_name_child")
-    def by_name_child(x: int) -> int:
+    @DBOS.workflow(name="enqueue_opts_child")
+    def enqueue_opts_child(x: int) -> int:
         nonlocal child_counter
         child_counter += 1
         return x + 1
 
     @DBOS.workflow()
-    def by_name_parent(x: int) -> int:
-        handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
-            {"workflow_name": "by_name_child", "queue_name": "by_name_child_queue"}, x
+    def enqueue_opts_parent(x: int) -> int:
+        handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
+            {
+                "workflow_name": "enqueue_opts_child",
+                "queue_name": "enqueue_opts_child_queue",
+            },
+            x,
         )
         return handle.get_result()
 
-    DBOS.register_queue("by_name_child_queue")
+    DBOS.register_queue("enqueue_opts_child_queue")
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        assert by_name_parent(1) == 2
+        assert enqueue_opts_parent(1) == 2
     assert child_counter == 1
 
     # The child is recorded against the parent, with the ID derived from the
@@ -3652,7 +3658,7 @@ def test_enqueue_by_name_child(dbos: DBOS) -> None:
     # is the handle's get_result.
     steps = DBOS.list_workflow_steps(wfid)
     assert len(steps) == 2
-    assert steps[0]["function_name"] == "by_name_child"
+    assert steps[0]["function_name"] == "enqueue_opts_child"
     assert steps[0]["child_workflow_id"] == f"{wfid}-1"
     assert DBOS.retrieve_workflow(f"{wfid}-1").get_status().parent_workflow_id == wfid
 
@@ -3666,48 +3672,50 @@ def test_enqueue_by_name_child(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_enqueue_by_name_async(dbos: DBOS) -> None:
-    @DBOS.workflow(name="by_name_async_child")
-    async def by_name_async_child(x: int) -> int:
+async def test_enqueue_with_options_async(dbos: DBOS) -> None:
+    @DBOS.workflow(name="enqueue_opts_async_child")
+    async def enqueue_opts_async_child(x: int) -> int:
         return x + 1
 
     @DBOS.workflow()
-    async def by_name_async_parent(x: int) -> int:
-        handle: WorkflowHandleAsync[int] = await DBOS.enqueue_workflow_by_name_async(
-            {
-                "workflow_name": "by_name_async_child",
-                "queue_name": "by_name_async_queue",
-            },
-            x,
+    async def enqueue_opts_async_parent(x: int) -> int:
+        handle: WorkflowHandleAsync[int] = (
+            await DBOS.enqueue_workflow_with_options_async(
+                {
+                    "workflow_name": "enqueue_opts_async_child",
+                    "queue_name": "enqueue_opts_async_queue",
+                },
+                x,
+            )
         )
         return await handle.get_result()
 
-    await DBOS.register_queue_async("by_name_async_queue")
+    await DBOS.register_queue_async("enqueue_opts_async_queue")
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        assert await by_name_async_parent(1) == 2
+        assert await enqueue_opts_async_parent(1) == 2
 
     steps = await DBOS.list_workflow_steps_async(wfid)
-    assert steps[0]["function_name"] == "by_name_async_child"
+    assert steps[0]["function_name"] == "enqueue_opts_async_child"
     assert steps[0]["child_workflow_id"] == f"{wfid}-1"
 
 
-def test_enqueue_by_name_context_options(dbos: DBOS) -> None:
-    @DBOS.workflow(name="by_name_ctx_target")
-    def by_name_ctx_target(x: int) -> int:
+def test_enqueue_with_options_ambient_context(dbos: DBOS) -> None:
+    @DBOS.workflow(name="enqueue_opts_ctx_target")
+    def enqueue_opts_ctx_target(x: int) -> int:
         return x
 
-    DBOS.register_queue("by_name_ctx_queue")
+    DBOS.register_queue("enqueue_opts_ctx_queue")
 
-    # Ambient enqueue options apply to a by-name enqueue like any other.
+    # Ambient enqueue options apply here like they do to any other enqueue.
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
         with SetEnqueueOptions(app_version="ambient-version"):
-            handle: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+            handle: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
                 {
-                    "workflow_name": "by_name_ctx_target",
-                    "queue_name": "by_name_ctx_queue",
+                    "workflow_name": "enqueue_opts_ctx_target",
+                    "queue_name": "enqueue_opts_ctx_queue",
                 },
                 1,
             )
@@ -3720,10 +3728,10 @@ def test_enqueue_by_name_context_options(dbos: DBOS) -> None:
 
     # An explicit option still wins over the ambient one.
     with SetEnqueueOptions(app_version="ambient-version"):
-        explicit: WorkflowHandle[int] = DBOS.enqueue_workflow_by_name(
+        explicit: WorkflowHandle[int] = DBOS.enqueue_workflow_with_options(
             {
-                "workflow_name": "by_name_ctx_target",
-                "queue_name": "by_name_ctx_queue",
+                "workflow_name": "enqueue_opts_ctx_target",
+                "queue_name": "enqueue_opts_ctx_queue",
                 "app_version": GlobalParams.app_version,
             },
             2,


### PR DESCRIPTION
Adds the following methods providing more flexibility in enqueueing workflows from the runtime. Closes https://github.com/dbos-inc/dbos-transact-py/issues/806

```py
def enqueue_workflow_with_options(
    options: EnqueueOptions, *args: Any, **kwargs: Any
) -> WorkflowHandle[Any]:
    """Enqueue a workflow by options, without a reference to its function.

    Takes the same options as :meth:`DBOSClient.enqueue` and builds the same
    row, so the workflow may be implemented by another process, as long as
    it shares this system database. Can safely be called from inside a
    workflow, the enqueued workflow is recorded as a child.

    Unlike :meth:`enqueue_workflow`, options are deliberately not validated
    against the local registry, and ``app_version`` is left unset unless
    given.
    """

async def enqueue_workflow_with_options_async(
    options: EnqueueOptions, *args: Any, **kwargs: Any
) -> WorkflowHandleAsync[Any]:
    """Async version of :meth:`enqueue_workflow_with_options`."""
```