### PR TITLE
Lazy Client Connection Check

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -203,13 +203,15 @@ class DBOSClient:
         system_database_pool_size: Optional[int] = None,
         system_database_polling_concurrency: Optional[int] = None,
         use_listen_notify: bool = False,
+        lazy: bool = False,
     ):
         """Create a client for interacting with a DBOS application from outside it.
 
         The client talks only to the system database, so it can enqueue workflows,
         send messages, read events and streams, and manage workflows, queues, and
-        schedules without registering or running any workflow code itself. It
-        connects on construction and raises if the system database is unreachable.
+        schedules without registering or running any workflow code itself. By
+        default it connects on construction and raises if the system database is
+        unreachable; pass lazy=True to defer connecting until first use.
 
         Unlike DBOS itself, the client never runs schema migrations: the system
         database must already have been created by a DBOS application.
@@ -224,10 +226,16 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
+            lazy (bool): Whether to defer connecting to the system database until the client is first used. Defaults to False, meaning the client verifies its connection on construction. A lazy client can be constructed while the system database is unreachable (for example at import time), but then a database that never becomes reachable surfaces as operations retrying instead of as an error at construction. Call check_connection() to verify the connection explicitly. Cannot be combined with use_listen_notify, whose listener thread connects as soon as the client is created.
 
         Raises:
-            Exception: If the system database cannot be reached.
+            Exception: If the system database cannot be reached, unless lazy is True.
+            DBOSException: If both lazy and use_listen_notify are set.
         """
+        if lazy and use_listen_notify:
+            raise DBOSException(
+                "A DBOSClient cannot be both lazy and use_listen_notify: the notification listener connects to the system database immediately."
+            )
         self._serializer = serializer
         if system_database_engine:
             if "sqlite" in system_database_engine.dialect.name:
@@ -266,15 +274,24 @@ class DBOSClient:
             use_listen_notify=use_listen_notify,
             polling_concurrency=system_database_polling_concurrency,
         )
-        self._sys_db.check_connection()
         self._notification_listener_thread: Optional[threading.Thread] = None
-        if use_listen_notify:
-            # Without this thread, get_event polls the database on every wait instead.
-            self._notification_listener_thread = threading.Thread(
-                target=self._sys_db.run_notification_listener,
-                daemon=True,
-            )
-            self._notification_listener_thread.start()
+        if not lazy:
+            self._sys_db.check_connection()
+            if use_listen_notify:
+                # Without this thread, get_event polls the database on every wait instead.
+                self._notification_listener_thread = threading.Thread(
+                    target=self._sys_db.run_notification_listener,
+                    daemon=True,
+                )
+                self._notification_listener_thread.start()
+
+    def check_connection(self) -> None:
+        """Verify the client can reach the system database, raising if it cannot.
+
+        Non-lazy clients run this on construction. Lazy clients can call it to
+        check the connection at a point of their own choosing.
+        """
+        self._sys_db.check_connection()
 
     def destroy(self) -> None:
         if self._notification_listener_thread is not None:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -134,6 +134,7 @@ class DBOSClient:
         system_database_polling_concurrency: Optional[int] = None,
         use_listen_notify: bool = False,
         lazy: bool = False,
+        retry_connection_errors: bool = True,
     ):
         """Create a client for interacting with a DBOS application from outside it.
 
@@ -157,6 +158,7 @@ class DBOSClient:
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
             lazy (bool): Whether to defer connecting until the client is first used. Defaults to False, meaning the connection is checked on construction. Call check_connection() to check it explicitly. Cannot be combined with use_listen_notify, whose listener connects immediately.
+            retry_connection_errors (bool): Whether an operation that loses its database connection blocks and retries until the connection recovers. Defaults to True. Set to False to raise instead, so an unreachable database surfaces as an error rather than a wait.
 
         Raises:
             Exception: If the system database cannot be reached, unless lazy is True.
@@ -203,6 +205,7 @@ class DBOSClient:
             executor_id=None,
             use_listen_notify=use_listen_notify,
             polling_concurrency=system_database_polling_concurrency,
+            retry_connection_errors=retry_connection_errors,
         )
         self._notification_listener_thread: Optional[threading.Thread] = None
         if not lazy:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -157,7 +157,7 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
-            lazy (bool): Whether to defer connecting until the client is first used. Defaults to False, meaning the connection is checked on construction. Call check_connection() to check it explicitly. Cannot be combined with use_listen_notify, whose listener connects immediately.
+            lazy (bool): Whether to defer connecting until the client is first used. Defaults to False, meaning the connection is checked on construction. Call check_connection() or check_connection_async() to check it explicitly. Cannot be combined with use_listen_notify, whose listener connects immediately.
             retry_connection_errors (bool): Whether an operation that loses its database connection blocks and retries until the connection recovers. Defaults to True. Set to False to raise instead, so an unreachable database surfaces as an error rather than a wait.
 
         Raises:
@@ -220,7 +220,14 @@ class DBOSClient:
 
     def check_connection(self) -> None:
         """Verify the client can reach the system database, raising if it cannot."""
+        _warn_sync_db_call_in_async_context(
+            "DBOSClient.check_connection", "DBOSClient.check_connection_async"
+        )
         self._sys_db.check_connection()
+
+    async def check_connection_async(self) -> None:
+        """Verify the client can reach the system database, raising if it cannot."""
+        await asyncio.to_thread(self._sys_db.check_connection)
 
     def destroy(self) -> None:
         if self._notification_listener_thread is not None:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -209,9 +209,9 @@ class DBOSClient:
 
         The client talks only to the system database, so it can enqueue workflows,
         send messages, read events and streams, and manage workflows, queues, and
-        schedules without registering or running any workflow code itself. By
-        default it connects on construction and raises if the system database is
-        unreachable; pass lazy=True to defer connecting until first use.
+        schedules without registering or running any workflow code itself. It
+        connects on construction and raises if the system database is
+        unreachable, unless it is created with lazy=True.
 
         Unlike DBOS itself, the client never runs schema migrations: the system
         database must already have been created by a DBOS application.
@@ -226,7 +226,7 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
-            lazy (bool): Whether to defer connecting to the system database until the client is first used. Defaults to False, meaning the client verifies its connection on construction. A lazy client can be constructed while the system database is unreachable (for example at import time), but then a database that never becomes reachable surfaces as operations retrying instead of as an error at construction. Call check_connection() to verify the connection explicitly. Cannot be combined with use_listen_notify, whose listener thread connects as soon as the client is created.
+            lazy (bool): Whether to defer connecting until the client is first used. Defaults to False, meaning the connection is checked on construction. Call check_connection() to check it explicitly. Cannot be combined with use_listen_notify, whose listener connects immediately.
 
         Raises:
             Exception: If the system database cannot be reached, unless lazy is True.
@@ -234,7 +234,7 @@ class DBOSClient:
         """
         if lazy and use_listen_notify:
             raise DBOSException(
-                "A DBOSClient cannot be both lazy and use_listen_notify: the notification listener connects to the system database immediately."
+                "A DBOSClient cannot be both lazy and use_listen_notify: the notification listener connects immediately."
             )
         self._serializer = serializer
         if system_database_engine:
@@ -286,11 +286,7 @@ class DBOSClient:
                 self._notification_listener_thread.start()
 
     def check_connection(self) -> None:
-        """Verify the client can reach the system database, raising if it cannot.
-
-        Non-lazy clients run this on construction. Lazy clients can call it to
-        check the connection at a point of their own choosing.
-        """
+        """Verify the client can reach the system database, raising if it cannot."""
         self._sys_db.check_connection()
 
     def destroy(self) -> None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -483,7 +483,7 @@ def db_retry(
     retry_connection_errors=False opts out, raising connection errors instead.
 
     Args:
-        sys_db (SystemDatabase): The system database whose retry setting applies, for call sites where it is not the decorated function's first argument (closures within a method).
+        sys_db (SystemDatabase): The system database whose retry setting applies, for call sites where it is not the first argument (closures within a method).
     """
 
     def decorator(func: F) -> F:
@@ -498,12 +498,12 @@ def db_retry(
                 except Exception as e:
 
                     # Determine if this is a retriable exception
-                    sqlite_retriable = retriable_sqlite_exception(e)
-                    if not retriable_postgres_exception(e) and not sqlite_retriable:
+                    postgres_retriable = retriable_postgres_exception(e)
+                    if not postgres_retriable and not retriable_sqlite_exception(e):
                         raise
 
-                    # Retrying connection errors is optional; SQLite lock contention is not a connection error and always retries.
-                    if not sqlite_retriable and not getattr(
+                    # Connection-error retries are optional. Judge the error itself: a DBAPIError renders its parameters, so program data can read as lock contention.
+                    if postgres_retriable and not getattr(
                         db, "_retry_connection_errors", True
                     ):
                         raise

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -469,19 +469,27 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def db_retry(
-    initial_backoff: float = 1.0, max_backoff: float = 60.0
+    initial_backoff: float = 1.0,
+    max_backoff: float = 60.0,
+    *,
+    sys_db: Optional["SystemDatabase"] = None,
 ) -> Callable[[F], F]:
     """
     If a workflow encounters a database connection issue while performing an operation,
     block the workflow and retry the operation until it reconnects and succeeds.
 
     In other words, if DBOS loses its database connection, everything pauses until the connection is recovered,
-    trading off availability for correctness.
+    trading off availability for correctness. A system database created with
+    retry_connection_errors=False opts out, raising connection errors instead.
+
+    Args:
+        sys_db (SystemDatabase): The system database whose retry setting applies, for call sites where it is not the decorated function's first argument (closures within a method).
     """
 
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            db = sys_db if sys_db is not None else (args[0] if args else None)
             retries: int = 0
             backoff: float = initial_backoff
             while True:
@@ -490,9 +498,14 @@ def db_retry(
                 except Exception as e:
 
                     # Determine if this is a retriable exception
-                    if not retriable_postgres_exception(
-                        e
-                    ) and not retriable_sqlite_exception(e):
+                    sqlite_retriable = retriable_sqlite_exception(e)
+                    if not retriable_postgres_exception(e) and not sqlite_retriable:
+                        raise
+
+                    # Retrying connection errors is optional; SQLite lock contention is not a connection error and always retries.
+                    if not sqlite_retriable and not getattr(
+                        db, "_retry_connection_errors", True
+                    ):
                         raise
 
                     retries += 1
@@ -533,6 +546,7 @@ class SystemDatabase(ABC):
         notification_listener_polling_interval_sec: float = 1.0,
         notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
+        retry_connection_errors: bool = True,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
         if system_database_url.startswith("sqlite"):
@@ -549,6 +563,7 @@ class SystemDatabase(ABC):
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
                 notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
+                retry_connection_errors=retry_connection_errors,
             )
         else:
             from ._sys_db_postgres import PostgresSystemDatabase
@@ -564,6 +579,7 @@ class SystemDatabase(ABC):
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
                 notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
+                retry_connection_errors=retry_connection_errors,
             )
 
     def __init__(
@@ -579,6 +595,7 @@ class SystemDatabase(ABC):
         notification_listener_polling_interval_sec: float = 1.0,
         notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
+        retry_connection_errors: bool = True,
     ):
         import sqlalchemy.dialects.postgresql as pg
         import sqlalchemy.dialects.sqlite as sq
@@ -609,6 +626,8 @@ class SystemDatabase(ABC):
         self.dialect = sq if system_database_url.startswith("sqlite") else pg
         self.serializer = serializer
         self.use_listen_notify = use_listen_notify
+        # Whether db_retry blocks on a lost connection until it recovers, or raises.
+        self._retry_connection_errors = retry_connection_errors
 
         if system_database_url.startswith("sqlite"):
             self.schema = None
@@ -1133,7 +1152,7 @@ class SystemDatabase(ABC):
         if conn is not None:
             return _do(conn)
 
-        @db_retry()
+        @db_retry(sys_db=self)
         def _standalone() -> DebounceResult:
             with self.engine.begin() as c:
                 return _do(c)
@@ -2551,7 +2570,7 @@ class SystemDatabase(ABC):
             else int(time.time() * 1000)
         )
 
-        @db_retry()
+        @db_retry(sys_db=self)
         def record_operation_result_retry() -> None:
             with self.engine.begin() as c:
                 self._record_operation_result_txn(result, completed_at, c)
@@ -2579,7 +2598,7 @@ class SystemDatabase(ABC):
         workflow_id = ctx.workflow_id
         function_id = ctx.function_id
 
-        @db_retry()
+        @db_retry(sys_db=self)
         def record() -> None:
             # Because there's no corresponding check, we do nothing on conflict
             # and do not raise a DBOSWorkflowConflictIDError

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -499,10 +499,14 @@ def db_retry(
 
                     # Determine if this is a retriable exception
                     postgres_retriable = retriable_postgres_exception(e)
-                    if not postgres_retriable and not retriable_sqlite_exception(e):
+                    # The SQLite heuristic matches rendered error text, which can include program data, so only trust it on an actual SQLite database.
+                    sqlite_retriable = getattr(
+                        db, "_is_sqlite", True
+                    ) and retriable_sqlite_exception(e)
+                    if not postgres_retriable and not sqlite_retriable:
                         raise
 
-                    # Connection-error retries are optional. Judge the error itself: a DBAPIError renders its parameters, so program data can read as lock contention.
+                    # Connection-error retries are optional; SQLite lock contention is not a connection error and always retries.
                     if postgres_retriable and not getattr(
                         db, "_retry_connection_errors", True
                     ):
@@ -628,6 +632,8 @@ class SystemDatabase(ABC):
         self.use_listen_notify = use_listen_notify
         # Whether db_retry blocks on a lost connection until it recovers, or raises.
         self._retry_connection_errors = retry_connection_errors
+        # db_retry trusts the text-based SQLite retriability heuristic only on SQLite.
+        self._is_sqlite = system_database_url.startswith("sqlite")
 
         if system_database_url.startswith("sqlite"):
             self.schema = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -545,6 +545,8 @@ def test_client_lazy_defers_connecting() -> None:
     try:
         with pytest.raises(Exception):
             client.check_connection()
+        with pytest.raises(Exception):
+            asyncio.run(client.check_connection_async())
     finally:
         client.destroy()
 
@@ -598,8 +600,11 @@ def test_db_retry_connection_error_opt_out() -> None:
     but SQLite lock contention is not a connection error and always retries."""
 
     class FakeSystemDatabase:
-        def __init__(self, retry_connection_errors: bool) -> None:
+        def __init__(
+            self, retry_connection_errors: bool, is_sqlite: bool = True
+        ) -> None:
             self._retry_connection_errors = retry_connection_errors
+            self._is_sqlite = is_sqlite
 
     calls = 0
 
@@ -623,6 +628,12 @@ def test_db_retry_connection_error_opt_out() -> None:
     locked = OperationalError("SELECT 1", None, Exception("database is locked"))
     assert flaky(FakeSystemDatabase(False), locked) == "ok"
     assert calls == 3
+
+    # On Postgres, "database is locked" can only be rendered program data, so it is not retriable at all.
+    calls = 0
+    with pytest.raises(OperationalError):
+        flaky(FakeSystemDatabase(True, is_sqlite=False), locked)
+    assert calls == 1
 
     # A DBAPIError renders its parameters, so program data can read as lock contention.
     calls = 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ import psycopg
 import pytest
 import sqlalchemy as sa
 from opentelemetry import context as otel_context
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import Session
 
@@ -588,7 +588,7 @@ def test_client_lazy_rejects_listen_notify(config: DBOSConfig) -> None:
 
 
 def _connection_error() -> DBAPIError:
-    return sa.exc.OperationalError(
+    return OperationalError(
         "SELECT 1", None, psycopg.OperationalError("connection failed")
     )
 
@@ -620,13 +620,13 @@ def test_db_retry_connection_error_opt_out() -> None:
     assert calls == 1
 
     calls = 0
-    locked = sa.exc.OperationalError("SELECT 1", None, Exception("database is locked"))
+    locked = OperationalError("SELECT 1", None, Exception("database is locked"))
     assert flaky(FakeSystemDatabase(False), locked) == "ok"
     assert calls == 3
 
     # A DBAPIError renders its parameters, so program data can read as lock contention.
     calls = 0
-    lookalike = sa.exc.OperationalError(
+    lookalike = OperationalError(
         "INSERT INTO dbos.workflow_status (inputs) VALUES (%(inputs)s)",
         {"inputs": '{"args": ["database is locked"]}'},
         psycopg.OperationalError("connection failed"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,7 +26,7 @@ from dbos import (
     SetWorkflowID,
 )
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
-from dbos._error import DBOSNonExistentWorkflowError
+from dbos._error import DBOSException, DBOSNonExistentWorkflowError
 from dbos._schemas.system_database import SystemSchema
 from tests import client_collateral
 from tests.client_collateral import event_test, retrieve_test, send_test
@@ -527,6 +527,61 @@ async def test_client_get_event_async_prompt_delivery(
 
 def test_client_no_listener_by_default(client: DBOSClient) -> None:
     assert client._notification_listener_thread is None
+
+
+# Nothing listens here, so connecting fails immediately instead of hanging.
+_UNREACHABLE_SYSTEM_DATABASE_URL = (
+    "postgresql://postgres:dbos@127.0.0.1:59999/dbostestpy_lazy_dbos_sys"
+)
+
+
+def test_client_lazy_defers_connecting() -> None:
+    """A lazy client constructs while the system database is unreachable; an eager one raises."""
+    client = DBOSClient(system_database_url=_UNREACHABLE_SYSTEM_DATABASE_URL, lazy=True)
+    try:
+        # The connection is checked only when explicitly requested.
+        with pytest.raises(Exception):
+            client.check_connection()
+    finally:
+        client.destroy()
+
+    with pytest.raises(Exception):
+        DBOSClient(system_database_url=_UNREACHABLE_SYSTEM_DATABASE_URL)
+
+
+def test_client_lazy_connects_on_first_use(config: DBOSConfig, dbos: DBOS) -> None:
+    """A lazy client against a live database behaves exactly like an eager one."""
+    assert config["system_database_url"] is not None
+    client = DBOSClient(system_database_url=config["system_database_url"], lazy=True)
+    try:
+        client.check_connection()
+        run_client_collateral()
+
+        wfid = str(uuid.uuid4())
+        options: EnqueueOptions = {
+            "queue_name": "test_queue",
+            "workflow_name": "enqueue_test",
+            "workflow_id": wfid,
+        }
+        johnDoe: Person = {"first": "John", "last": "Doe", "age": 30}
+        handle: WorkflowHandle[str] = client.enqueue(options, 42, "test", johnDoe)
+        assert (
+            handle.get_result() == '42-test-{"first": "John", "last": "Doe", "age": 30}'
+        )
+    finally:
+        client.destroy()
+
+
+def test_client_lazy_rejects_listen_notify(config: DBOSConfig) -> None:
+    """The listener thread connects immediately, so it cannot combine with lazy."""
+    assert config["system_database_url"] is not None
+    with pytest.raises(DBOSException) as exc_info:
+        DBOSClient(
+            system_database_url=config["system_database_url"],
+            use_listen_notify=True,
+            lazy=True,
+        )
+    assert "lazy" in str(exc_info.value)
 
 
 def test_client_listen_notify_get_event(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,6 +31,7 @@ from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
 from dbos._error import DBOSException, DBOSNonExistentWorkflowError
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import db_retry
+from dbos._utils import retriable_sqlite_exception
 from tests import client_collateral
 from tests.client_collateral import event_test, retrieve_test, send_test
 from tests.conftest import TestOtelType, set_workflow_status, wait_for_client_listener
@@ -622,6 +623,18 @@ def test_db_retry_connection_error_opt_out() -> None:
     locked = sa.exc.OperationalError("SELECT 1", None, Exception("database is locked"))
     assert flaky(FakeSystemDatabase(False), locked) == "ok"
     assert calls == 3
+
+    # A DBAPIError renders its parameters, so program data can read as lock contention.
+    calls = 0
+    lookalike = sa.exc.OperationalError(
+        "INSERT INTO dbos.workflow_status (inputs) VALUES (%(inputs)s)",
+        {"inputs": '{"args": ["database is locked"]}'},
+        psycopg.OperationalError("connection failed"),
+    )
+    assert retriable_sqlite_exception(lookalike)
+    with pytest.raises(DBAPIError):
+        flaky(FakeSystemDatabase(False), lookalike)
+    assert calls == 1
 
 
 def test_client_no_retry_raises_on_unreachable_database() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,11 +5,13 @@ import os
 import runpy
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
 from typing import Any, Optional, TypedDict
 
+import psycopg
 import pytest
 import sqlalchemy as sa
 from opentelemetry import context as otel_context
@@ -28,6 +30,7 @@ from dbos import (
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
 from dbos._error import DBOSException, DBOSNonExistentWorkflowError
 from dbos._schemas.system_database import SystemSchema
+from dbos._sys_db import db_retry
 from tests import client_collateral
 from tests.client_collateral import event_test, retrieve_test, send_test
 from tests.conftest import TestOtelType, set_workflow_status, wait_for_client_listener
@@ -581,6 +584,74 @@ def test_client_lazy_rejects_listen_notify(config: DBOSConfig) -> None:
             lazy=True,
         )
     assert "lazy" in str(exc_info.value)
+
+
+def _connection_error() -> DBAPIError:
+    return sa.exc.OperationalError(
+        "SELECT 1", None, psycopg.OperationalError("connection failed")
+    )
+
+
+def test_db_retry_connection_error_opt_out() -> None:
+    """db_retry rides out connection errors by default and raises when opted out,
+    but SQLite lock contention is not a connection error and always retries."""
+
+    class FakeSystemDatabase:
+        def __init__(self, retry_connection_errors: bool) -> None:
+            self._retry_connection_errors = retry_connection_errors
+
+    calls = 0
+
+    @db_retry(initial_backoff=0.01)
+    def flaky(sys_db: Any, error: Exception) -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise error
+        return "ok"
+
+    assert flaky(FakeSystemDatabase(True), _connection_error()) == "ok"
+    assert calls == 3
+
+    calls = 0
+    with pytest.raises(DBAPIError):
+        flaky(FakeSystemDatabase(False), _connection_error())
+    assert calls == 1
+
+    calls = 0
+    locked = sa.exc.OperationalError("SELECT 1", None, Exception("database is locked"))
+    assert flaky(FakeSystemDatabase(False), locked) == "ok"
+    assert calls == 3
+
+
+def test_client_no_retry_raises_on_unreachable_database() -> None:
+    """retry_connection_errors=False surfaces an unreachable database as an error, not a wait."""
+    client = DBOSClient(
+        system_database_url=_UNREACHABLE_SYSTEM_DATABASE_URL,
+        lazy=True,
+        retry_connection_errors=False,
+    )
+    options: EnqueueOptions = {
+        "queue_name": "test_queue",
+        "workflow_name": "enqueue_test",
+    }
+    raised: list[Exception] = []
+
+    def enqueue() -> None:
+        try:
+            client.enqueue(options)
+        except Exception as e:
+            raised.append(e)
+
+    # Retrying would never return, so bound the wait instead of hanging the suite.
+    thread = threading.Thread(target=enqueue, daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+    try:
+        assert not thread.is_alive()
+        assert isinstance(raised[0], DBAPIError)
+    finally:
+        client.destroy()
 
 
 def test_client_listen_notify_get_event(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -529,7 +529,7 @@ def test_client_no_listener_by_default(client: DBOSClient) -> None:
     assert client._notification_listener_thread is None
 
 
-# Nothing listens here, so connecting fails immediately instead of hanging.
+# Nothing listens here, so connecting fails fast.
 _UNREACHABLE_SYSTEM_DATABASE_URL = (
     "postgresql://postgres:dbos@127.0.0.1:59999/dbostestpy_lazy_dbos_sys"
 )
@@ -539,7 +539,6 @@ def test_client_lazy_defers_connecting() -> None:
     """A lazy client constructs while the system database is unreachable; an eager one raises."""
     client = DBOSClient(system_database_url=_UNREACHABLE_SYSTEM_DATABASE_URL, lazy=True)
     try:
-        # The connection is checked only when explicitly requested.
         with pytest.raises(Exception):
             client.check_connection()
     finally:
@@ -550,7 +549,7 @@ def test_client_lazy_defers_connecting() -> None:
 
 
 def test_client_lazy_connects_on_first_use(config: DBOSConfig, dbos: DBOS) -> None:
-    """A lazy client against a live database behaves exactly like an eager one."""
+    """Against a live database, a lazy client behaves like an eager one."""
     assert config["system_database_url"] is not None
     client = DBOSClient(system_database_url=config["system_database_url"], lazy=True)
     try:

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1171,7 +1171,13 @@ class _RetryOnceEngine:
     def begin(self) -> Any:
         if not self.fired and threading.get_ident() == self._thread_id:
             self.fired = True
-            raise Exception("database is locked")  # retriable on pg and sqlite
+            # connection_invalidated makes this retriable on both pg and sqlite
+            raise DBAPIError(
+                "SELECT 1",
+                None,
+                Exception("simulated dropped connection"),
+                connection_invalidated=True,
+            )
         return self._real.begin()
 
     def __getattr__(self, name: str) -> Any:


### PR DESCRIPTION
The `DBOSClient` now supports a `lazy` parameter (default `False`). If `lazy=True`, the system database does not check connection at startup, but defers the check until the first request is made. A new `check_connection` method lets you check your connection anytime.

By default, the client retries connection errors. This behavior can now be configured through the `retry_connection_errors` (default `True`).