### PR TITLE
Application Name

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -160,7 +160,7 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
-            application_name (str): The application this client acts on behalf of. Defaults to None, meaning no application identity: the client writes unclaimed rows, which any application may run. Set it when several applications share this system database, so the client's writes are owned by that application.
+            application_name (str): The application this client acts on behalf of. Always set this when several applications share this system database, so workflows, schedules, and queues created by this client are owned by that application.
             lazy (bool): Whether to defer connecting until the client is first used. Defaults to False, meaning the connection is checked on construction. Call check_connection() or check_connection_async() to check it explicitly. Cannot be combined with use_listen_notify, whose listener connects immediately.
             retry_connection_errors (bool): Whether an operation that loses its database connection blocks and retries until the connection recovers. Defaults to True. Set to False to raise instead, so an unreachable database surfaces as an error rather than a wait.
 
@@ -486,8 +486,8 @@ class DBOSClient:
     ) -> List[Queue]:
         """List all database-backed queues registered in the system database.
 
-        :param application_name: Restrict to queues owned by these applications.
-            Unset lists every application's, as on :meth:`list_workflows`.
+        :param application_name: List only queues owned by these applications.
+            By default, only list this application's queues.
         """
         _warn_sync_db_call_in_async_context(
             "DBOSClient.list_queues", "DBOSClient.list_queues_async"
@@ -1344,8 +1344,8 @@ class DBOSClient:
             status: Filter by status (e.g. ``"ACTIVE"``) or a list of statuses
             workflow_name: Filter by workflow name or a list of names
             schedule_name_prefix: Filter by schedule name prefix or a list of prefixes
-            application_name: Restrict to schedules owned by these applications.
-                Unset lists every application's, as on list_workflows.
+            application_name: List only schedules owned by these applications.
+                By default, only list this application's schedules.
         """
         schedules = self._sys_db.list_schedules(
             status=status,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -222,7 +222,13 @@ class DBOSClient:
     def _build_enqueue_status(
         self, options: EnqueueOptions, *args: Any, **kwargs: Any
     ) -> tuple[str, WorkflowStatusInternal]:
-        return build_enqueue_status(options, self._serializer, args, kwargs)
+        workflow_id, status = build_enqueue_status(
+            options, self._serializer, args, kwargs
+        )
+        if status["application_name"] is None:
+            # Fall back to the client's own application, if it was given one.
+            status["application_name"] = self._sys_db.app_name
+        return workflow_id, status
 
     def _enqueue(self, options: EnqueueOptions, *args: Any, **kwargs: Any) -> str:
         workflow_id, status = self._build_enqueue_status(options, *args, **kwargs)
@@ -1258,8 +1264,7 @@ class DBOSClient:
                 automatic_backfill=automatic_backfill,
                 cron_timezone=cron_timezone,
                 queue_name=queue_name,
-                # Ownership is stamped by the system database on write.
-                application_name=None,
+                application_name=self._sys_db.app_name,
             )
         )
 
@@ -1411,8 +1416,7 @@ class DBOSClient:
                     automatic_backfill=entry.get("automatic_backfill", False),
                     cron_timezone=cron_timezone,
                     queue_name=entry.get("queue_name"),
-                    # Ownership is stamped by the system database on write.
-                    application_name=None,
+                    application_name=self._sys_db.app_name,
                 )
             )
         with self._sys_db.engine.begin() as c:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1573,17 +1573,15 @@ class DBOSClient:
         adopt_unclaimed_rows: bool = False,
     ) -> ApplicationRowCounts:
         """Give an application ownership of rows another name holds, rows nobody holds,
-        or both. Stop the application being renamed first, or its dequeues race this.
+        or both. Do not run while your application is running.
 
         :param old_name: The application's previous name. ``None`` moves nothing
             but the unclaimed rows, so it requires ``adopt_unclaimed_rows``.
         :param new_name: The application that ends up owning the rows.
         :param batch_size: Terminal workflows and steps are re-owned this many at
             a time. ``None`` moves them in a single transaction.
-        :param adopt_unclaimed_rows: Also take rows no application owns. They
-            belong to every application sharing this system database, so adopting
-            them takes them from any peer. Defaults to ``False``, which leaves
-            them alone.
+        :param adopt_unclaimed_rows: Also take rows no application owns
+            (``application_name=NULL``). Default to ``False``.
 
         :returns: The number of rows moved, by table.
         """

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1516,10 +1516,19 @@ class DBOSClient:
         """Return the latest application version."""
         return self._sys_db.get_latest_application_version()
 
-    def set_latest_application_version(self, version_name: str) -> None:
-        """Set a version as the latest by updating its timestamp to now."""
+    def set_latest_application_version(
+        self, version_name: str, *, application_name: Optional[str] = None
+    ) -> None:
+        """Set a version as the latest by updating its timestamp to now.
+
+        :param application_name: Which application's version to promote.
+            Defaults to this caller's; required when the version name is
+            registered by more than one application.
+        """
         new_timestamp = int(time.time() * 1000)
-        self._sys_db.update_application_version_timestamp(version_name, new_timestamp)
+        self._sys_db.update_application_version_timestamp(
+            version_name, new_timestamp, application_name=application_name
+        )
 
     async def list_application_versions_async(self) -> List[VersionInfo]:
         """Async version of :meth:`list_application_versions`."""
@@ -1529,6 +1538,12 @@ class DBOSClient:
         """Async version of :meth:`get_latest_application_version`."""
         return await asyncio.to_thread(self.get_latest_application_version)
 
-    async def set_latest_application_version_async(self, version_name: str) -> None:
+    async def set_latest_application_version_async(
+        self, version_name: str, *, application_name: Optional[str] = None
+    ) -> None:
         """Async version of :meth:`set_latest_application_version`."""
-        await asyncio.to_thread(self.set_latest_application_version, version_name)
+        await asyncio.to_thread(
+            lambda: self.set_latest_application_version(
+                version_name, application_name=application_name
+            )
+        )

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -133,6 +133,7 @@ class DBOSClient:
         system_database_pool_size: Optional[int] = None,
         system_database_polling_concurrency: Optional[int] = None,
         use_listen_notify: bool = False,
+        application_name: Optional[str] = None,
     ):
         """Create a client for interacting with a DBOS application from outside it.
 
@@ -154,6 +155,7 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
+            application_name (str): The application this client acts on behalf of. Defaults to None, meaning no application identity: the client sees every application's rows and writes unclaimed ones, which any application may run. Set it when several applications share this system database, so the client's writes are owned and its reads are scoped. Individual methods take an application_name that overrides this.
 
         Raises:
             Exception: If the system database cannot be reached.
@@ -195,6 +197,7 @@ class DBOSClient:
             executor_id=None,
             use_listen_notify=use_listen_notify,
             polling_concurrency=system_database_polling_concurrency,
+            app_name=application_name,
         )
         self._sys_db.check_connection()
         self._notification_listener_thread: Optional[threading.Thread] = None
@@ -326,6 +329,7 @@ class DBOSClient:
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "always_update",
+        application_name: Optional[str] = None,
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
@@ -357,6 +361,9 @@ class DBOSClient:
             ``"update_if_latest_version"`` is rejected because clients are not
             associated with an application version. ``"never_update"`` leaves
             the existing row unchanged.
+        :param application_name: The application that owns this queue and polls
+            it. Defaults to the client's own application. Registering a queue
+            already owned by a different application raises.
 
         :returns: A :class:`Queue` bound to this client's system database.
         """
@@ -391,6 +398,7 @@ class DBOSClient:
             partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
+            application_name=application_name,
         )
         queue = self._sys_db.get_queue(name, client_system_database=self._sys_db)
         assert queue is not None, f"Queue {name} missing from database after upsert"
@@ -409,6 +417,7 @@ class DBOSClient:
         partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "always_update",
+        application_name: Optional[str] = None,
     ) -> Queue:
         """Async version of :meth:`register_queue`."""
         return await asyncio.to_thread(
@@ -421,6 +430,7 @@ class DBOSClient:
                 partition_queue=partition_queue,
                 polling_interval_sec=polling_interval_sec,
                 on_conflict=on_conflict,
+                application_name=application_name,
             )
         )
 
@@ -845,6 +855,7 @@ class DBOSClient:
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
         schedule_name: Optional[str | list[str]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         return self._sys_db.list_workflows(
             workflow_ids=workflow_ids,
@@ -873,6 +884,7 @@ class DBOSClient:
             has_parent=has_parent,
             attributes=attributes,
             schedule_name=schedule_name,
+            application_name=application_name,
         )
 
     async def list_workflows_async(
@@ -904,6 +916,7 @@ class DBOSClient:
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
         schedule_name: Optional[str | list[str]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         return await asyncio.to_thread(
             self.list_workflows,
@@ -933,6 +946,7 @@ class DBOSClient:
             has_parent=has_parent,
             attributes=attributes,
             schedule_name=schedule_name,
+            application_name=application_name,
         )
 
     def list_queued_workflows(
@@ -961,6 +975,7 @@ class DBOSClient:
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         return self._sys_db.list_workflows(
             workflow_ids=workflow_ids,
@@ -987,6 +1002,7 @@ class DBOSClient:
             queues_only=True,
             has_parent=has_parent,
             attributes=attributes,
+            application_name=application_name,
         )
 
     async def list_queued_workflows_async(
@@ -1015,6 +1031,7 @@ class DBOSClient:
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         return await asyncio.to_thread(
             self.list_queued_workflows,
@@ -1041,6 +1058,7 @@ class DBOSClient:
             executor_id=executor_id,
             has_parent=has_parent,
             attributes=attributes,
+            application_name=application_name,
         )
 
     def list_workflow_steps(
@@ -1227,6 +1245,7 @@ class DBOSClient:
         automatic_backfill: bool = False,
         cron_timezone: Optional[str] = None,
         queue_name: Optional[str] = None,
+        application_name: Optional[str] = None,
     ) -> None:
         """
         Create a cron schedule that periodically invokes a workflow.
@@ -1240,9 +1259,10 @@ class DBOSClient:
             automatic_backfill: If ``True``, on startup the scheduler will automatically backfill missed executions since the last time the schedule fired. Defaults to ``False``.
             cron_timezone: IANA timezone name (e.g. ``"America/New_York"``) in which to evaluate the cron expression. Defaults to ``None`` (UTC).
             queue_name: Optional name of a queue to enqueue scheduled workflows to. If ``None``, uses the internal queue. Defaults to ``None``.
+            application_name: The application that owns this schedule and runs its workflows. Defaults to the client's own application. Leaving both unset creates an unclaimed schedule, which every application sharing the system database will run.
 
         Raises:
-            DBOSException: If the cron expression is invalid or a schedule with the same name already exists.
+            DBOSException: If the cron expression is invalid, a schedule with the same name already exists, or the existing schedule belongs to another application.
         """
         if not croniter.is_valid(schedule, second_at_beginning=True):
             raise DBOSException(f"Invalid cron schedule: '{schedule}'")
@@ -1264,7 +1284,11 @@ class DBOSClient:
                 automatic_backfill=automatic_backfill,
                 cron_timezone=cron_timezone,
                 queue_name=queue_name,
-                application_name=self._sys_db.app_name,
+                application_name=(
+                    application_name
+                    if application_name is not None
+                    else self._sys_db.app_name
+                ),
             )
         )
 
@@ -1322,6 +1346,7 @@ class DBOSClient:
         automatic_backfill: bool = False,
         cron_timezone: Optional[str] = None,
         queue_name: Optional[str] = None,
+        application_name: Optional[str] = None,
     ) -> None:
         """Async version of :meth:`create_schedule`."""
         await asyncio.to_thread(
@@ -1334,6 +1359,7 @@ class DBOSClient:
             automatic_backfill=automatic_backfill,
             cron_timezone=cron_timezone,
             queue_name=queue_name,
+            application_name=application_name,
         )
 
     async def list_schedules_async(
@@ -1416,7 +1442,9 @@ class DBOSClient:
                     automatic_backfill=entry.get("automatic_backfill", False),
                     cron_timezone=cron_timezone,
                     queue_name=entry.get("queue_name"),
-                    application_name=self._sys_db.app_name,
+                    application_name=entry.get(
+                        "application_name", self._sys_db.app_name
+                    ),
                 )
             )
         with self._sys_db.engine.begin() as c:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -456,16 +456,28 @@ class DBOSClient:
         """Async version of :meth:`delete_queue`."""
         await asyncio.to_thread(self.delete_queue, name)
 
-    def list_queues(self) -> List[Queue]:
-        """List all database-backed queues registered in the system database."""
+    def list_queues(
+        self, *, application_name: Optional[Union[str, List[str]]] = None
+    ) -> List[Queue]:
+        """List all database-backed queues registered in the system database.
+
+        :param application_name: Restrict to queues owned by these applications.
+            Unset lists every application's, as on :meth:`list_workflows`.
+        """
         _warn_sync_db_call_in_async_context(
             "DBOSClient.list_queues", "DBOSClient.list_queues_async"
         )
-        return self._sys_db.list_queues(client_system_database=self._sys_db)
+        return self._sys_db.list_queues(
+            application_name=application_name, client_system_database=self._sys_db
+        )
 
-    async def list_queues_async(self) -> List[Queue]:
+    async def list_queues_async(
+        self, *, application_name: Optional[Union[str, List[str]]] = None
+    ) -> List[Queue]:
         """Async version of :meth:`list_queues`."""
-        return await asyncio.to_thread(self.list_queues)
+        return await asyncio.to_thread(
+            lambda: self.list_queues(application_name=application_name)
+        )
 
     def retrieve_workflow(self, workflow_id: str) -> "WorkflowHandle[R]":
         status = get_workflow(self._sys_db, workflow_id)

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1572,23 +1572,8 @@ class DBOSClient:
         batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
         adopt_unclaimed_rows: bool = False,
     ) -> ApplicationRowCounts:
-        """Give an application ownership of rows another name holds, rows nobody
-        holds, or both.
-
-        Ownership is recorded on each row, so renaming an application in its
-        configuration strands everything written under the old name: those
-        workflows stop being dequeued, recovered, or garbage collected. Run this
-        against the system database to move them, then start the application
-        under its new name.
-
-        Omitting ``old_name`` and setting ``adopt_unclaimed_rows`` adopts without
-        renaming, which is how an application takes over a system database whose
-        rows predate ownership.
-
-        This is deliberately not available on a launched :class:`DBOS`: an
-        application cannot safely rename itself, because its own dequeues would
-        stamp the old name back onto rows the rename has already passed. Stop the
-        application first.
+        """Give an application ownership of rows another name holds, rows nobody holds,
+        or both. Stop the application being renamed first, or its dequeues race this.
 
         :param old_name: The application's previous name. ``None`` moves nothing
             but the unclaimed rows, so it requires ``adopt_unclaimed_rows``.

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1533,9 +1533,9 @@ class DBOSClient:
     ) -> None:
         """Set a version as the latest by updating its timestamp to now.
 
-        :param application_name: Which application's version to promote.
-            Defaults to this caller's; required when the version name is
-            registered by more than one application.
+        :param application_name: The application to act as. Defaults to this
+            caller's. Version names are global, so promoting one registered by
+            a different application raises.
         """
         new_timestamp = int(time.time() * 1000)
         self._sys_db.update_application_version_timestamp(

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -50,6 +50,8 @@ from dbos._serialization import (
     safe_deserialize_schedule_context,
 )
 from dbos._sys_db import (
+    DEFAULT_RENAME_BATCH_SIZE,
+    ApplicationRowCounts,
     ClientScheduleInput,
     SendMessage,
     StepInfo,
@@ -1557,5 +1559,73 @@ class DBOSClient:
         await asyncio.to_thread(
             lambda: self.set_latest_application_version(
                 version_name, application_name=application_name
+            )
+        )
+
+    # ── Application Rename API ──────────────────────────────────
+
+    def rename_application(
+        self,
+        old_name: Optional[str],
+        new_name: str,
+        *,
+        batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
+        adopt_unclaimed_rows: bool = False,
+    ) -> ApplicationRowCounts:
+        """Give an application ownership of rows another name holds, rows nobody
+        holds, or both.
+
+        Ownership is recorded on each row, so renaming an application in its
+        configuration strands everything written under the old name: those
+        workflows stop being dequeued, recovered, or garbage collected. Run this
+        against the system database to move them, then start the application
+        under its new name.
+
+        Omitting ``old_name`` and setting ``adopt_unclaimed_rows`` adopts without
+        renaming, which is how an application takes over a system database whose
+        rows predate ownership.
+
+        This is deliberately not available on a launched :class:`DBOS`: an
+        application cannot safely rename itself, because its own dequeues would
+        stamp the old name back onto rows the rename has already passed. Stop the
+        application first.
+
+        :param old_name: The application's previous name. ``None`` moves nothing
+            but the unclaimed rows, so it requires ``adopt_unclaimed_rows``.
+        :param new_name: The application that ends up owning the rows.
+        :param batch_size: Terminal workflows and steps are re-owned this many at
+            a time. ``None`` moves them in a single transaction.
+        :param adopt_unclaimed_rows: Also take rows no application owns. They
+            belong to every application sharing this system database, so adopting
+            them takes them from any peer. Defaults to ``False``, which leaves
+            them alone.
+
+        :returns: The number of rows moved, by table.
+        """
+        _warn_sync_db_call_in_async_context(
+            "DBOSClient.rename_application", "DBOSClient.rename_application_async"
+        )
+        return self._sys_db.rename_application(
+            old_name,
+            new_name,
+            batch_size=batch_size,
+            adopt_unclaimed_rows=adopt_unclaimed_rows,
+        )
+
+    async def rename_application_async(
+        self,
+        old_name: Optional[str],
+        new_name: str,
+        *,
+        batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
+        adopt_unclaimed_rows: bool = False,
+    ) -> ApplicationRowCounts:
+        """Async version of :meth:`rename_application`."""
+        return await asyncio.to_thread(
+            lambda: self._sys_db.rename_application(
+                old_name,
+                new_name,
+                batch_size=batch_size,
+                adopt_unclaimed_rows=adopt_unclaimed_rows,
             )
         )

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1258,6 +1258,8 @@ class DBOSClient:
                 automatic_backfill=automatic_backfill,
                 cron_timezone=cron_timezone,
                 queue_name=queue_name,
+                # Ownership is stamped by the system database on write.
+                application_name=None,
             )
         )
 
@@ -1409,6 +1411,8 @@ class DBOSClient:
                     automatic_backfill=entry.get("automatic_backfill", False),
                     cron_timezone=cron_timezone,
                     queue_name=entry.get("queue_name"),
+                    # Ownership is stamped by the system database on write.
+                    application_name=None,
                 )
             )
         with self._sys_db.engine.begin() as c:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1298,6 +1298,7 @@ class DBOSClient:
         status: Optional[Union[str, List[str]]] = None,
         workflow_name: Optional[Union[str, List[str]]] = None,
         schedule_name_prefix: Optional[Union[str, List[str]]] = None,
+        application_name: Optional[Union[str, List[str]]] = None,
     ) -> List[WorkflowSchedule]:
         """
         Return all registered workflow schedules, optionally filtered.
@@ -1306,11 +1307,14 @@ class DBOSClient:
             status: Filter by status (e.g. ``"ACTIVE"``) or a list of statuses
             workflow_name: Filter by workflow name or a list of names
             schedule_name_prefix: Filter by schedule name prefix or a list of prefixes
+            application_name: Restrict to schedules owned by these applications.
+                Unset lists every application's, as on list_workflows.
         """
         schedules = self._sys_db.list_schedules(
             status=status,
             workflow_name=workflow_name,
             schedule_name_prefix=schedule_name_prefix,
+            application_name=application_name,
         )
         for s in schedules:
             s["context"] = safe_deserialize_schedule_context(
@@ -1368,6 +1372,7 @@ class DBOSClient:
         status: Optional[Union[str, List[str]]] = None,
         workflow_name: Optional[Union[str, List[str]]] = None,
         schedule_name_prefix: Optional[Union[str, List[str]]] = None,
+        application_name: Optional[Union[str, List[str]]] = None,
     ) -> List[WorkflowSchedule]:
         """Async version of :meth:`list_schedules`."""
         return await asyncio.to_thread(
@@ -1375,6 +1380,7 @@ class DBOSClient:
             status=status,
             workflow_name=workflow_name,
             schedule_name_prefix=schedule_name_prefix,
+            application_name=application_name,
         )
 
     async def get_schedule_async(self, name: str) -> Optional[WorkflowSchedule]:

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -157,7 +157,7 @@ class DBOSClient:
             system_database_pool_size (int): System database pool size. Defaults to 5.
             system_database_polling_concurrency (int): Maximum number of DB-backed polling reads (from wait operations such as get_result, get_event, and read_stream) that may run concurrently against the system database pool. Defaults to half the system database pool size (minimum 1). Set to a non-positive value to disable the limiter.
             use_listen_notify (bool): Whether to run a listener thread so get_event and read_stream are woken by notifications rather than polling the database. Defaults to False. Only enable this if the system database was created with use_listen_notify=True (the DBOS default).
-            application_name (str): The application this client acts on behalf of. Defaults to None, meaning no application identity: the client sees every application's rows and writes unclaimed ones, which any application may run. Set it when several applications share this system database, so the client's writes are owned and its reads are scoped. Individual methods take an application_name that overrides this.
+            application_name (str): The application this client acts on behalf of. Defaults to None, meaning no application identity: the client writes unclaimed rows, which any application may run. Set it when several applications share this system database, so the client's writes are owned by that application.
 
         Raises:
             Exception: If the system database cannot be reached.

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -746,6 +746,9 @@ class ConductorWebsocket(threading.Thread):
                                         load_context=load_context,
                                     )
                                     for s in self.dbos._sys_db.list_schedules(
+                                        application_name=sched_body.get(
+                                            "application_name", None
+                                        ),
                                         status=sched_body.get("status", None),
                                         workflow_name=sched_body.get(
                                             "workflow_name", None
@@ -1083,11 +1086,17 @@ class ConductorWebsocket(threading.Thread):
                                 ).to_json()
                             )
                         elif msg_type == p.MessageType.LIST_QUEUES:
+                            list_queues_message = p.ListQueuesRequest.from_json(message)
+                            queues_body = list_queues_message.body
                             queues_output: list[p.QueueOutput] = []
                             try:
                                 queues_output = [
                                     p.QueueOutput.from_queue(q)
-                                    for q in self.dbos._sys_db.list_queues()
+                                    for q in self.dbos._sys_db.list_queues(
+                                        application_name=queues_body.get(
+                                            "application_name", None
+                                        )
+                                    )
                                 ]
                             except Exception:
                                 error_message = (

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -338,6 +338,7 @@ class ConductorWebsocket(threading.Thread):
                                     dequeued_before=body.get("dequeued_before", None),
                                     status=body.get("status", None),
                                     app_version=body.get("application_version", None),
+                                    application_name=body.get("application_name", None),
                                     forked_from=body.get("forked_from", None),
                                     parent_workflow_id=body.get(
                                         "parent_workflow_id", None
@@ -393,6 +394,9 @@ class ConductorWebsocket(threading.Thread):
                                     dequeued_before=q_body.get("dequeued_before", None),
                                     status=q_body.get("status", None),
                                     app_version=q_body.get("application_version", None),
+                                    application_name=q_body.get(
+                                        "application_name", None
+                                    ),
                                     forked_from=q_body.get("forked_from", None),
                                     parent_workflow_id=q_body.get(
                                         "parent_workflow_id", None
@@ -948,6 +952,9 @@ class ConductorWebsocket(threading.Thread):
                                     group_by_application_version=agg_body.get(
                                         "group_by_application_version", False
                                     ),
+                                    group_by_application_name=agg_body.get(
+                                        "group_by_application_name", False
+                                    ),
                                     select_count=select_count,
                                     select_min_created_at=select_min_created_at,
                                     select_max_queue_wait_ms=select_max_queue_wait_ms,
@@ -982,6 +989,9 @@ class ConductorWebsocket(threading.Thread):
                                     ),
                                     user=agg_body.get("user", None),
                                     schedule_name=agg_body.get("schedule_name", None),
+                                    application_name=agg_body.get(
+                                        "application_name", None
+                                    ),
                                     was_forked_from=agg_body.get(
                                         "was_forked_from", None
                                     ),
@@ -1048,6 +1058,9 @@ class ConductorWebsocket(threading.Thread):
                                     ),
                                     completed_before=step_agg_body.get(
                                         "completed_before", None
+                                    ),
+                                    application_name=step_agg_body.get(
+                                        "application_name", None
                                     ),
                                 )
                                 step_agg_output = [

--- a/dbos/_conductor/conductor.py
+++ b/dbos/_conductor/conductor.py
@@ -640,6 +640,7 @@ class ConductorWebsocket(threading.Thread):
                                     sys_metrics = self.dbos._sys_db.get_metrics(
                                         get_metrics_message.start_time,
                                         get_metrics_message.end_time,
+                                        get_metrics_message.application_name,
                                     )
                                     metrics_data = [
                                         p.MetricData(

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -198,6 +198,7 @@ class ListWorkflowsBody(TypedDict, total=False):
     has_parent: Optional[bool]
     attributes: Optional[Dict[str, Any]]
     schedule_name: Optional[Union[str, List[str]]]
+    application_name: Optional[Union[str, List[str]]]
 
 
 @dataclass
@@ -231,6 +232,7 @@ class WorkflowsOutput:
     CompletedAt: Optional[str]
     Attributes: Optional[str]
     ScheduleName: Optional[str]
+    ApplicationName: Optional[str]
 
     @classmethod
     def from_workflow_information(cls, info: WorkflowStatus) -> "WorkflowsOutput":
@@ -302,6 +304,7 @@ class WorkflowsOutput:
             CompletedAt=completed_at_str,
             Attributes=attributes_str,
             ScheduleName=info.schedule_name,
+            ApplicationName=info.application_name,
         )
 
 
@@ -377,6 +380,7 @@ class ListQueuedWorkflowsBody(TypedDict, total=False):
     has_parent: Optional[bool]
     attributes: Optional[Dict[str, Any]]
     schedule_name: Optional[Union[str, List[str]]]
+    application_name: Optional[Union[str, List[str]]]
 
 
 @dataclass
@@ -790,6 +794,7 @@ class GetWorkflowAggregatesBody(TypedDict, total=False):
     group_by_queue_name: bool
     group_by_executor_id: bool
     group_by_application_version: bool
+    group_by_application_name: bool
     select_count: bool
     select_min_created_at: bool
     select_max_queue_wait_ms: bool
@@ -812,6 +817,7 @@ class GetWorkflowAggregatesBody(TypedDict, total=False):
     parent_workflow_id: Optional[List[str]]
     user: Optional[List[str]]
     schedule_name: Optional[List[str]]
+    application_name: Optional[List[str]]
     was_forked_from: Optional[bool]
     has_parent: Optional[bool]
     attributes: Optional[Dict[str, Any]]
@@ -848,6 +854,7 @@ class GetStepAggregatesBody(TypedDict, total=False):
     workflow_id_prefix: Optional[List[str]]
     completed_after: Optional[str]
     completed_before: Optional[str]
+    application_name: Optional[List[str]]
 
 
 @dataclass

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -565,6 +565,7 @@ class ScheduleOutput:
     automatic_backfill: bool
     cron_timezone: Optional[str]
     queue_name: Optional[str]
+    application_name: Optional[str]
 
     @classmethod
     def from_schedule(
@@ -597,6 +598,7 @@ class ScheduleOutput:
             automatic_backfill=s.get("automatic_backfill", False),
             cron_timezone=s.get("cron_timezone"),
             queue_name=s.get("queue_name"),
+            application_name=s.get("application_name"),
         )
 
 
@@ -604,6 +606,7 @@ class ListSchedulesBody(TypedDict, total=False):
     status: Optional[Union[str, List[str]]]
     workflow_name: Optional[Union[str, List[str]]]
     schedule_name_prefix: Optional[Union[str, List[str]]]
+    application_name: Optional[Union[str, List[str]]]
     load_context: bool
 
 
@@ -888,6 +891,7 @@ class QueueOutput:
     priority_enabled: bool
     partition_queue: bool
     polling_interval_sec: float
+    application_name: Optional[str]
 
     @classmethod
     def from_queue(cls, q: "Queue") -> "QueueOutput":
@@ -900,12 +904,19 @@ class QueueOutput:
             priority_enabled=q._priority_enabled,
             partition_queue=q._partition_queue,
             polling_interval_sec=q._polling_interval_sec,
+            application_name=q.application_name,
         )
+
+
+class ListQueuesBody(TypedDict, total=False):
+    application_name: Optional[Union[str, List[str]]]
 
 
 @dataclass
 class ListQueuesRequest(BaseMessage):
-    pass
+    # Defaulted: this message carried no body before the application_name filter,
+    # so a Conductor that still omits it must keep working.
+    body: ListQueuesBody = field(default_factory=lambda: ListQueuesBody())
 
 
 @dataclass

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -498,6 +498,9 @@ class GetMetricsRequest(BaseMessage):
     start_time: str  # ISO 8601
     end_time: str  # ISO 8601
     metric_class: str
+    # Defaulted so a Conductor predating the field still deserializes; unset counts
+    # every co-tenant application's workflows and steps.
+    application_name: Optional[List[str]] = None
 
 
 @dataclass

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -498,8 +498,7 @@ class GetMetricsRequest(BaseMessage):
     start_time: str  # ISO 8601
     end_time: str  # ISO 8601
     metric_class: str
-    # Defaulted so a Conductor predating the field still deserializes; unset counts
-    # every co-tenant application's workflows and steps.
+    # Defaulted so a Conductor predating the field still deserializes, as unscoped.
     application_name: Optional[List[str]] = None
 
 

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -914,8 +914,7 @@ class ListQueuesBody(TypedDict, total=False):
 
 @dataclass
 class ListQueuesRequest(BaseMessage):
-    # Defaulted: this message carried no body before the application_name filter,
-    # so a Conductor that still omits it must keep working.
+    # Defaulted: a Conductor that predates the filter still sends no body.
     body: ListQueuesBody = field(default_factory=lambda: ListQueuesBody())
 
 

--- a/dbos/_context.py
+++ b/dbos/_context.py
@@ -156,6 +156,8 @@ class DBOSContext:
         self.debounce_deadline_epoch_ms: Optional[int] = None
         # Whether the next enqueued workflow is debounced (its dedup ID is a debounce key cleared on DELAYED->ENQUEUED).
         self.is_debounced: bool = False
+        # The application the next debounced enqueue acts for; None means this one.
+        self.debounce_application_name: Optional[str] = None
 
     def create_child(self, *, is_for_workflow: bool) -> DBOSContext:
         rv = DBOSContext()
@@ -200,6 +202,7 @@ class DBOSContext:
         rv.delay_until_epoch_ms = self.delay_until_epoch_ms
         rv.debounce_deadline_epoch_ms = self.debounce_deadline_epoch_ms
         rv.is_debounced = self.is_debounced
+        rv.debounce_application_name = self.debounce_application_name
         rv.workflow_attributes = self.workflow_attributes
         rv.otel_carrier = self.otel_carrier
         self.function_id += 1
@@ -838,9 +841,10 @@ class SetWorkflowDebounce:
     """Internal: mark the next enqueued workflow as debounced.
 
     Sets the deduplication ID (a debounce key), the initial delay, the absolute
-    debounce deadline, and the is_debounced flag on the context, restoring them
-    on exit. Unlike SetEnqueueOptions, it leaves priority/app_version/partition
-    untouched so a debounced workflow still inherits the caller's other options.
+    debounce deadline, the is_debounced flag, and the application the debounce
+    acts for on the context, restoring them on exit. Unlike SetEnqueueOptions,
+    it leaves priority/app_version/partition untouched so a debounced workflow
+    still inherits the caller's other options.
 
     It also clears any propagated workflow deadline: a debounce called inside a
     workflow that has a timeout would otherwise pass that workflow's absolute
@@ -856,16 +860,19 @@ class SetWorkflowDebounce:
         deduplication_id: str,
         delay_until_epoch_ms: int,
         debounce_deadline_epoch_ms: Optional[int],
+        application_name: Optional[str] = None,
     ) -> None:
         self.created_ctx = False
         self.deduplication_id = deduplication_id
         self.delay_until_epoch_ms = delay_until_epoch_ms
         self.debounce_deadline_epoch_ms = debounce_deadline_epoch_ms
+        self.application_name = application_name
         self.saved_deduplication_id: Optional[str] = None
         self.saved_delay_until_epoch_ms: Optional[int] = None
         self.saved_debounce_deadline_epoch_ms: Optional[int] = None
         self.saved_is_debounced: bool = False
         self.saved_workflow_deadline_epoch_ms: Optional[int] = None
+        self.saved_debounce_application_name: Optional[str] = None
 
     def __enter__(self) -> SetWorkflowDebounce:
         ctx = get_local_dbos_context()
@@ -878,10 +885,12 @@ class SetWorkflowDebounce:
         self.saved_debounce_deadline_epoch_ms = ctx.debounce_deadline_epoch_ms
         self.saved_is_debounced = ctx.is_debounced
         self.saved_workflow_deadline_epoch_ms = ctx.workflow_deadline_epoch_ms
+        self.saved_debounce_application_name = ctx.debounce_application_name
         ctx.deduplication_id = self.deduplication_id
         ctx.delay_until_epoch_ms = self.delay_until_epoch_ms
         ctx.debounce_deadline_epoch_ms = self.debounce_deadline_epoch_ms
         ctx.is_debounced = True
+        ctx.debounce_application_name = self.application_name
         # Don't inherit the caller workflow's deadline onto the debounced workflow.
         ctx.workflow_deadline_epoch_ms = None
         return self
@@ -898,6 +907,7 @@ class SetWorkflowDebounce:
         curr_ctx.debounce_deadline_epoch_ms = self.saved_debounce_deadline_epoch_ms
         curr_ctx.is_debounced = self.saved_is_debounced
         curr_ctx.workflow_deadline_epoch_ms = self.saved_workflow_deadline_epoch_ms
+        curr_ctx.debounce_application_name = self.saved_debounce_application_name
         if self.created_ctx:
             _clear_local_dbos_context()
         return False

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1597,7 +1597,11 @@ def _build_enqueue_with_options(
 
     _, status = build_enqueue_status(resolved, dbos._serializer, args, kwargs)
 
-    status["application_name"] = resolve_application_name(dbos, resolved["queue_name"])
+    if status["application_name"] is None:
+        # No explicit target, so stamp ownership the way a directly enqueued workflow does.
+        status["application_name"] = resolve_application_name(
+            dbos, resolved["queue_name"]
+        )
     status["app_id"] = new_wf_ctx.app_id
     status["parent_workflow_id"] = (
         new_wf_ctx.parent_workflow_id if new_wf_ctx.has_parent() else None

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -540,8 +540,7 @@ def _assemble_workflow_status(
         # schedule_name is only set by the persistent scheduler, which builds
         # the workflow status directly rather than going through this path.
         "schedule_name": None,
-        # This application owns what it starts. Enqueueing onto another application's
-        # queue requires naming it explicitly, via the application_name option.
+        # This application owns what it starts; reaching another one requires naming it.
         "application_name": GlobalParams.app_name,
     }
     # Consume the attributes from the workflow's context so that workflows

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -461,6 +461,14 @@ def _assemble_workflow_status(
         inputs["args"], inputs["kwargs"], sertype, dbos._serializer
     )
 
+    # This application owns what it starts; only a debounce acting for another names one here.
+    owner_app = (
+        enqueue_options["application_name"]
+        if enqueue_options is not None
+        and enqueue_options["application_name"] is not None
+        else GlobalParams.app_name
+    )
+
     # Initialize a workflow status object from the context
     status: WorkflowStatusInternal = {
         "workflow_uuid": wfid,
@@ -484,7 +492,10 @@ def _assemble_workflow_status(
             enqueue_options["app_version"]
             if enqueue_options is not None
             and enqueue_options["app_version"] is not None
-            else GlobalParams.app_version
+            # Left unset for another application, whose own latest version must run it.
+            else (
+                GlobalParams.app_version if owner_app == GlobalParams.app_name else None
+            )
         ),
         "executor_id": ctx.executor_id,
         "recovery_attempts": None,
@@ -540,8 +551,7 @@ def _assemble_workflow_status(
         # schedule_name is only set by the persistent scheduler, which builds
         # the workflow status directly rather than going through this path.
         "schedule_name": None,
-        # This application owns what it starts; reaching another one requires naming it.
-        "application_name": GlobalParams.app_name,
+        "application_name": owner_app,
     }
     # Consume the attributes from the workflow's context so that workflows
     # started inside this workflow do not inherit them.
@@ -688,6 +698,7 @@ def prepare_enqueued_workflow(
         delay_until_epoch_ms=None,
         debounce_deadline_epoch_ms=None,
         is_debounced=False,
+        application_name=None,
     )
     return _assemble_workflow_status(
         dbos,
@@ -1304,6 +1315,9 @@ def start_workflow(
             local_ctx.debounce_deadline_epoch_ms if local_ctx is not None else None
         ),
         is_debounced=(local_ctx.is_debounced if local_ctx is not None else False),
+        application_name=(
+            local_ctx.debounce_application_name if local_ctx is not None else None
+        ),
     )
     new_wf_ctx = DBOSContext.create_start_workflow_child(local_ctx)
     new_child_workflow_id = new_wf_ctx.id_assigned_for_next_workflow
@@ -1440,6 +1454,9 @@ async def start_workflow_async(
             local_ctx.debounce_deadline_epoch_ms if local_ctx is not None else None
         ),
         is_debounced=(local_ctx.is_debounced if local_ctx is not None else False),
+        application_name=(
+            local_ctx.debounce_application_name if local_ctx is not None else None
+        ),
     )
     new_child_workflow_id = new_wf_ctx.id_assigned_for_next_workflow
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from dbos._outcome import DeferredResult, NoResult, Outcome, Pending
-from dbos._utils import GlobalParams, retriable_postgres_exception
+from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams, retriable_postgres_exception
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
 from ._context import (
@@ -416,6 +416,24 @@ def _attributes_with_otel_carrier(ctx: DBOSContext) -> Optional[dict[str, Any]]:
     return attributes
 
 
+def resolve_application_name(dbos: "DBOS", queue_name: Optional[str]) -> Optional[str]:
+    """The application that should own a new workflow row.
+
+    None means unclaimed: the row is routed by its (globally unique) queue name to
+    whichever application serves that queue. A workflow that will run in this
+    process, or that lands on the internal queue whose name every application
+    shares, must be owned outright.
+    """
+    if queue_name is None or queue_name == INTERNAL_QUEUE_NAME:
+        return GlobalParams.app_name
+    if (
+        queue_name in dbos._registry.queue_info_map
+        or queue_name in dbos._polled_queue_names
+    ):
+        return GlobalParams.app_name
+    return None
+
+
 def _assemble_workflow_status(
     dbos: "DBOS",
     ctx: DBOSContext,
@@ -540,6 +558,7 @@ def _assemble_workflow_status(
         # schedule_name is only set by the persistent scheduler, which builds
         # the workflow status directly rather than going through this path.
         "schedule_name": None,
+        "application_name": resolve_application_name(dbos, queue),
     }
     # Consume the attributes from the workflow's context so that workflows
     # started inside this workflow do not inherit them.
@@ -1578,6 +1597,7 @@ def _build_enqueue_with_options(
 
     _, status = build_enqueue_status(resolved, dbos._serializer, args, kwargs)
 
+    status["application_name"] = resolve_application_name(dbos, resolved["queue_name"])
     status["app_id"] = new_wf_ctx.app_id
     status["parent_workflow_id"] = (
         new_wf_ctx.parent_workflow_id if new_wf_ctx.has_parent() else None

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from dbos._outcome import DeferredResult, NoResult, Outcome, Pending
-from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams, retriable_postgres_exception
+from dbos._utils import GlobalParams, retriable_postgres_exception
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
 from ._context import (
@@ -416,24 +416,6 @@ def _attributes_with_otel_carrier(ctx: DBOSContext) -> Optional[dict[str, Any]]:
     return attributes
 
 
-def resolve_application_name(dbos: "DBOS", queue_name: Optional[str]) -> Optional[str]:
-    """The application that should own a new workflow row.
-
-    None means unclaimed: the row is routed by its (globally unique) queue name to
-    whichever application serves that queue. A workflow that will run in this
-    process, or that lands on the internal queue whose name every application
-    shares, must be owned outright.
-    """
-    if queue_name is None or queue_name == INTERNAL_QUEUE_NAME:
-        return GlobalParams.app_name
-    if (
-        queue_name in dbos._registry.queue_info_map
-        or queue_name in dbos._polled_queue_names
-    ):
-        return GlobalParams.app_name
-    return None
-
-
 def _assemble_workflow_status(
     dbos: "DBOS",
     ctx: DBOSContext,
@@ -558,7 +540,9 @@ def _assemble_workflow_status(
         # schedule_name is only set by the persistent scheduler, which builds
         # the workflow status directly rather than going through this path.
         "schedule_name": None,
-        "application_name": resolve_application_name(dbos, queue),
+        # This application owns what it starts. Enqueueing onto another application's
+        # queue requires naming it explicitly, via the application_name option.
+        "application_name": GlobalParams.app_name,
     }
     # Consume the attributes from the workflow's context so that workflows
     # started inside this workflow do not inherit them.
@@ -1598,10 +1582,8 @@ def _build_enqueue_with_options(
     _, status = build_enqueue_status(resolved, dbos._serializer, args, kwargs)
 
     if status["application_name"] is None:
-        # No explicit target, so stamp ownership the way a directly enqueued workflow does.
-        status["application_name"] = resolve_application_name(
-            dbos, resolved["queue_name"]
-        )
+        # No explicit target, so this application owns it.
+        status["application_name"] = GlobalParams.app_name
     status["app_id"] = new_wf_ctx.app_id
     status["parent_workflow_id"] = (
         new_wf_ctx.parent_workflow_id if new_wf_ctx.has_parent() else None

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1044,8 +1044,8 @@ class DBOS:
         """
         List database-backed queues registered in the system database.
 
-        :param application_name: Restrict to queues owned by these applications.
-            Unset lists every application's, as on :meth:`list_workflows`.
+        :param application_name: List only queues owned by these applications.
+            By default, only list this application's queues.
         """
         check_async("list_queues")
         return _get_dbos_instance()._sys_db.list_queues(
@@ -2871,8 +2871,8 @@ class DBOS:
             status: Filter by status (e.g. ``"ACTIVE"``) or a list of statuses
             workflow_name: Filter by workflow name or a list of names
             schedule_name_prefix: Filter by schedule name prefix or a list of prefixes
-            application_name: Restrict to schedules owned by these applications.
-                Unset lists every application's, as on list_workflows.
+            application_name: List only schedules owned by these applications.
+                By default, only list this application's schedules.
         """
         dbos = _get_dbos_instance()
         ctx = snapshot_step_context(reserve_sleep_id=False)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -301,10 +301,7 @@ class DBOSRegistry:
         and because it iterates through the workflows in sorted order.
         This way, if the app's workflows are updated (which would break recovery), its version changes.
         App version can be manually set through the application_version field in DBOSConfig.
-
-        The application's name is hashed in too: version names are globally unique across
-        applications sharing a system database, so two applications built from the same
-        workflow source must not compute the same version and collide on registration.
+        The application name is hashed in too, so peers built from one source do not collide.
         """
         hasher = hashlib.md5()
         try:
@@ -1319,8 +1316,7 @@ class DBOS:
         the latest registered application version.
 
         The enqueued workflow is owned by this application unless
-        ``application_name`` names another one. Enqueueing onto an application
-        that does not share this one's name requires setting it explicitly.
+        ``application_name`` names another one.
         """
         return enqueue_workflow_with_options(
             _get_dbos_instance(), options, args, kwargs

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3190,11 +3190,20 @@ class DBOS:
         return dbos._sys_db.get_latest_application_version()
 
     @classmethod
-    def set_latest_application_version(cls, version_name: str) -> None:
-        """Set a version as the latest by updating its timestamp to now."""
+    def set_latest_application_version(
+        cls, version_name: str, *, application_name: Optional[str] = None
+    ) -> None:
+        """Set a version as the latest by updating its timestamp to now.
+
+        :param application_name: Which application's version to promote.
+            Defaults to this caller's; required when the version name is
+            registered by more than one application.
+        """
         dbos = _get_dbos_instance()
         new_timestamp = int(time.time() * 1000)
-        dbos._sys_db.update_application_version_timestamp(version_name, new_timestamp)
+        dbos._sys_db.update_application_version_timestamp(
+            version_name, new_timestamp, application_name=application_name
+        )
 
     @classmethod
     async def list_application_versions_async(cls) -> List[VersionInfo]:
@@ -3209,10 +3218,16 @@ class DBOS:
         return await asyncio.to_thread(cls.get_latest_application_version)
 
     @classmethod
-    async def set_latest_application_version_async(cls, version_name: str) -> None:
+    async def set_latest_application_version_async(
+        cls, version_name: str, *, application_name: Optional[str] = None
+    ) -> None:
         """Async version of :meth:`set_latest_application_version`."""
         await cls._configure_asyncio_thread_pool()
-        await asyncio.to_thread(cls.set_latest_application_version, version_name)
+        await asyncio.to_thread(
+            lambda: cls.set_latest_application_version(
+                version_name, application_name=application_name
+            )
+        )
 
     @classproperty
     def application_version(cls) -> str:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -3200,9 +3200,9 @@ class DBOS:
     ) -> None:
         """Set a version as the latest by updating its timestamp to now.
 
-        :param application_name: Which application's version to promote.
-            Defaults to this caller's; required when the version name is
-            registered by more than one application.
+        :param application_name: The application to act as. Defaults to this
+            caller's. Version names are global, so promoting one registered by
+            a different application raises.
         """
         dbos = _get_dbos_instance()
         new_timestamp = int(time.time() * 1000)

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -2455,6 +2455,7 @@ class DBOS:
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
         schedule_name: Optional[str | list[str]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         check_async("list_workflows")
 
@@ -2486,6 +2487,7 @@ class DBOS:
                 has_parent=has_parent,
                 attributes=attributes,
                 schedule_name=schedule_name,
+                application_name=application_name,
             )
 
         return _get_dbos_instance()._sys_db.call_function_as_step(
@@ -2522,6 +2524,7 @@ class DBOS:
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
         schedule_name: Optional[str | list[str]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         step_ctx = snapshot_step_context(reserve_sleep_id=False)
         await cls._configure_asyncio_thread_pool()
@@ -2554,6 +2557,7 @@ class DBOS:
                 has_parent=has_parent,
                 attributes=attributes,
                 schedule_name=schedule_name,
+                application_name=application_name,
             )
 
         return await asyncio.to_thread(
@@ -2590,6 +2594,7 @@ class DBOS:
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         check_async("list_queued_workflows")
 
@@ -2619,6 +2624,7 @@ class DBOS:
                 queues_only=True,
                 has_parent=has_parent,
                 attributes=attributes,
+                application_name=application_name,
             )
 
         return _get_dbos_instance()._sys_db.call_function_as_step(
@@ -2654,6 +2660,7 @@ class DBOS:
         executor_id: Optional[str | list[str]] = None,
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         step_ctx = snapshot_step_context(reserve_sleep_id=False)
         await cls._configure_asyncio_thread_pool()
@@ -2684,6 +2691,7 @@ class DBOS:
                 queues_only=True,
                 has_parent=has_parent,
                 attributes=attributes,
+                application_name=application_name,
             )
 
         return await asyncio.to_thread(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -399,6 +399,8 @@ class DBOS:
             _dbos_global_registry = None
         GlobalParams.app_version = os.environ.get("DBOS__APPVERSION", "")
         GlobalParams.executor_id = os.environ.get("DBOS__VMID", "local")
+        # Set at launch from the config, so a relaunch under another name must not inherit this one.
+        GlobalParams.app_name = None
         dbos_logger.info("DBOS successfully shut down")
 
     def __init__(

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -421,6 +421,10 @@ class DBOS:
         self._registry: DBOSRegistry = _get_or_create_dbos_registry()
         self._registry.dbos = self
         self._listening_queues: Optional[List[str]] = None
+        # Queue names this process is currently polling, republished each pass by
+        # queue_thread. Read on the enqueue path to decide whether this application
+        # owns the target queue; never mutated in place, so reads need no lock.
+        self._polled_queue_names: frozenset[str] = frozenset()
         self._admin_server_field: Optional[AdminServer] = None
         # Stop internal background threads (queue thread, timeout threads, etc.)
         self.background_thread_stop_events: List[threading.Event] = []
@@ -558,8 +562,10 @@ class DBOS:
                 GlobalParams.app_version = self._registry.compute_app_version()
             if self.conductor_key is not None:
                 GlobalParams.executor_id = generate_uuid()
+            GlobalParams.app_name = self._config["name"]
             dbos_logger.info(f"Executor ID: {GlobalParams.executor_id}")
             dbos_logger.info(f"Application version: {GlobalParams.app_version}")
+            dbos_logger.info(f"Application name: {GlobalParams.app_name}")
 
             max_executor_threads = (
                 self._config.get("runtimeConfig", {}).get("max_executor_threads")
@@ -597,6 +603,7 @@ class DBOS:
                 polling_concurrency=self._config["database"].get(
                     "sys_db_polling_concurrency"
                 ),
+                app_name=GlobalParams.app_name,
             )
             assert self._config["database"]["db_engine_kwargs"] is not None
             if self._config["database_url"]:
@@ -2806,6 +2813,8 @@ class DBOS:
             automatic_backfill=automatic_backfill,
             cron_timezone=cron_timezone,
             queue_name=queue_name,
+            # Ownership is stamped by the system database on write.
+            application_name=None,
         )
         ctx = snapshot_step_context(reserve_sleep_id=False)
         if ctx and ctx.is_workflow():
@@ -3070,6 +3079,8 @@ class DBOS:
                     automatic_backfill=entry.get("automatic_backfill", False),
                     cron_timezone=cron_timezone,
                     queue_name=entry_queue_name,
+                    # Ownership is stamped by the system database on write.
+                    application_name=None,
                 )
             )
         with dbos._sys_db.engine.begin() as c:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1028,18 +1028,29 @@ class DBOS:
         await asyncio.to_thread(cls.delete_queue, name)
 
     @classmethod
-    def list_queues(cls) -> List[Queue]:
+    def list_queues(
+        cls, *, application_name: Optional[Union[str, List[str]]] = None
+    ) -> List[Queue]:
         """
-        List all database-backed queues registered in the system database.
+        List database-backed queues registered in the system database.
+
+        :param application_name: Restrict to queues owned by these applications.
+            Unset lists every application's, as on :meth:`list_workflows`.
         """
         check_async("list_queues")
-        return _get_dbos_instance()._sys_db.list_queues()
+        return _get_dbos_instance()._sys_db.list_queues(
+            application_name=application_name
+        )
 
     @classmethod
-    async def list_queues_async(cls) -> List[Queue]:
+    async def list_queues_async(
+        cls, *, application_name: Optional[Union[str, List[str]]] = None
+    ) -> List[Queue]:
         """Async version of :meth:`list_queues`."""
         await cls._configure_asyncio_thread_pool()
-        return await asyncio.to_thread(cls.list_queues)
+        return await asyncio.to_thread(
+            lambda: cls.list_queues(application_name=application_name)
+        )
 
     # Decorators for DBOS functionality
     @classmethod
@@ -2842,6 +2853,7 @@ class DBOS:
         status: Optional[Union[str, List[str]]] = None,
         workflow_name: Optional[Union[str, List[str]]] = None,
         schedule_name_prefix: Optional[Union[str, List[str]]] = None,
+        application_name: Optional[Union[str, List[str]]] = None,
     ) -> List["WorkflowSchedule"]:
         """
         Return all registered workflow schedules, optionally filtered.
@@ -2850,6 +2862,8 @@ class DBOS:
             status: Filter by status (e.g. ``"ACTIVE"``) or a list of statuses
             workflow_name: Filter by workflow name or a list of names
             schedule_name_prefix: Filter by schedule name prefix or a list of prefixes
+            application_name: Restrict to schedules owned by these applications.
+                Unset lists every application's, as on list_workflows.
         """
         dbos = _get_dbos_instance()
         ctx = snapshot_step_context(reserve_sleep_id=False)
@@ -2863,6 +2877,7 @@ class DBOS:
                         status=status,
                         workflow_name=workflow_name,
                         schedule_name_prefix=schedule_name_prefix,
+                        application_name=application_name,
                         conn=c,
                     ),
                 )
@@ -2871,6 +2886,7 @@ class DBOS:
                 status=status,
                 workflow_name=workflow_name,
                 schedule_name_prefix=schedule_name_prefix,
+                application_name=application_name,
             )
         for s in schedules:
             s["context"] = safe_deserialize_schedule_context(
@@ -2951,6 +2967,7 @@ class DBOS:
         status: Optional[Union[str, List[str]]] = None,
         workflow_name: Optional[Union[str, List[str]]] = None,
         schedule_name_prefix: Optional[Union[str, List[str]]] = None,
+        application_name: Optional[Union[str, List[str]]] = None,
     ) -> List["WorkflowSchedule"]:
         """Async version of :meth:`list_schedules`."""
         await cls._configure_asyncio_thread_pool()
@@ -2959,6 +2976,7 @@ class DBOS:
             status=status,
             workflow_name=workflow_name,
             schedule_name_prefix=schedule_name_prefix,
+            application_name=application_name,
         )
 
     @classmethod

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -421,10 +421,6 @@ class DBOS:
         self._registry: DBOSRegistry = _get_or_create_dbos_registry()
         self._registry.dbos = self
         self._listening_queues: Optional[List[str]] = None
-        # Queue names this process is currently polling, republished each pass by
-        # queue_thread. Read on the enqueue path to decide whether this application
-        # owns the target queue; never mutated in place, so reads need no lock.
-        self._polled_queue_names: frozenset[str] = frozenset()
         self._admin_server_field: Optional[AdminServer] = None
         # Stop internal background threads (queue thread, timeout threads, etc.)
         self.background_thread_stop_events: List[threading.Event] = []
@@ -1297,6 +1293,10 @@ class DBOS:
         against the local registry, and ``app_version`` is left unset unless
         given. An unset ``app_version`` is only dequeued by an executor running
         the latest registered application version.
+
+        The enqueued workflow is owned by this application unless
+        ``application_name`` names another one. Enqueueing onto an application
+        that does not share this one's name requires setting it explicitly.
         """
         return enqueue_workflow_with_options(
             _get_dbos_instance(), options, args, kwargs

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -2813,8 +2813,7 @@ class DBOS:
             automatic_backfill=automatic_backfill,
             cron_timezone=cron_timezone,
             queue_name=queue_name,
-            # Ownership is stamped by the system database on write.
-            application_name=None,
+            application_name=GlobalParams.app_name,
         )
         ctx = snapshot_step_context(reserve_sleep_id=False)
         if ctx and ctx.is_workflow():
@@ -3079,8 +3078,7 @@ class DBOS:
                     automatic_backfill=entry.get("automatic_backfill", False),
                     cron_timezone=cron_timezone,
                     queue_name=entry_queue_name,
-                    # Ownership is stamped by the system database on write.
-                    application_name=None,
+                    application_name=GlobalParams.app_name,
                 )
             )
         with dbos._sys_db.engine.begin() as c:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -294,13 +294,17 @@ class DBOSRegistry:
         else:
             self.instance_info_map[fn] = inst
 
-    def compute_app_version(self) -> str:
+    def compute_app_version(self, app_name: str) -> str:
         """
         An application's version is computed from a hash of the source of its workflows.
         This is guaranteed to be stable given identical source code because it uses an MD5 hash
         and because it iterates through the workflows in sorted order.
         This way, if the app's workflows are updated (which would break recovery), its version changes.
         App version can be manually set through the application_version field in DBOSConfig.
+
+        The application's name is hashed in too: version names are globally unique across
+        applications sharing a system database, so two applications built from the same
+        workflow source must not compute the same version and collide on registration.
         """
         hasher = hashlib.md5()
         try:
@@ -309,11 +313,13 @@ class DBOSRegistry:
             )
         except Exception:
             dbos_logger.warning(
-                "Could not get workflow source code to compute an application version, defaulting application version to 'DEFAULT_VERSION'. Set a custom version through the 'application_version' field in DBOSConfig"
+                "Could not get workflow source code to compute an application version, defaulting application version to 'DEFAULT_VERSION-<app name>'. Set a custom version through the 'application_version' field in DBOSConfig"
             )
-            return "DEFAULT_VERSION"
+            # Suffixed, so peers sharing a system database do not all fall back onto one name.
+            return f"DEFAULT_VERSION-{app_name}"
         # Different DBOS versions should produce different app versions
         sources.append(GlobalParams.dbos_version)
+        sources.append(app_name)
         for source in sources:
             hasher.update(source.encode("utf-8"))
         return hasher.hexdigest()
@@ -556,11 +562,13 @@ class DBOS:
                 dbos_logger.warning(f"DBOS was already launched")
                 return
             self._launched = True
+            GlobalParams.app_name = self._config["name"]
             if GlobalParams.app_version == "":
-                GlobalParams.app_version = self._registry.compute_app_version()
+                GlobalParams.app_version = self._registry.compute_app_version(
+                    GlobalParams.app_name
+                )
             if self.conductor_key is not None:
                 GlobalParams.executor_id = generate_uuid()
-            GlobalParams.app_name = self._config["name"]
             dbos_logger.info(f"Executor ID: {GlobalParams.executor_id}")
             dbos_logger.info(f"Application version: {GlobalParams.app_version}")
             dbos_logger.info(f"Application name: {GlobalParams.app_name}")

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -928,6 +928,9 @@ class DBOS:
             - ``"always_update"``: always overwrite the existing row.
             - ``"never_update"``: leave the existing row unchanged.
 
+            A queue already registered by a different application raises in every
+            mode: the name is its address, so a collision is not ours to resolve.
+
         :returns: A :class:`Queue` reflecting the persisted configuration.
         """
         check_async("register_queue")

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -132,7 +132,7 @@ def _classify_bounce(
     if result["holder_workflow_name"] != workflow_name:
         return "raise"
     # A foreign holder never leaves DELAYED on the target's account, so retrying would spin.
-    holder_app = result["holder_application_name"]
+    holder_app = result.get("holder_application_name")
     if target_application_name is not None and holder_app is not None:
         if holder_app != target_application_name:
             return "raise"

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -77,12 +77,14 @@ def _reject_conflicting_options(
     has_delay: bool,
     has_priority: bool,
     has_partition_key: bool,
+    has_application_name: bool = False,
 ) -> None:
     """A debounce owns the workflow's deduplication ID (the debounce key) and its
     delay (the debounce period), so a caller must not also set them. Priority and
     partition keys are rejected because they cannot apply to a debounced enqueue
     (the default internal queue has no priority, and partitioned queues do not
-    support the deduplication a debounce requires)."""
+    support the deduplication a debounce requires). An application_name is
+    rejected because a debounce always acts as its caller's own application."""
     if has_deduplication_id:
         raise DBOSException(
             "Cannot debounce a workflow with a deduplication_id set: the debounce "
@@ -102,6 +104,12 @@ def _reject_conflicting_options(
         raise DBOSException(
             "Cannot debounce a workflow with a queue partition key set: partitioned "
             "queues do not support deduplication, which debouncing requires."
+        )
+    if has_application_name:
+        raise DBOSException(
+            "Cannot debounce a workflow with an application_name set: a debounce "
+            "always acts as the client's own application. Create the DBOSClient "
+            "with application_name set to the target application instead."
         )
 
 
@@ -384,13 +392,15 @@ class DebouncerClient:
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
-        # The workflow options must not set a deduplication_id, delay, priority, or partition key.
+        # The workflow options must not set a deduplication_id, delay, priority, partition key, or application_name.
         _reject_conflicting_options(
             has_deduplication_id=self.workflow_options.get("deduplication_id")
             is not None,
             has_delay=self.workflow_options.get("delay_seconds") is not None,
             has_priority=self.workflow_options.get("priority") is not None,
             has_partition_key=self.workflow_options.get("queue_partition_key")
+            is not None,
+            has_application_name=self.workflow_options.get("application_name")
             is not None,
         )
 

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -109,14 +109,17 @@ def _reject_conflicting_options(
 _BounceAction = Literal["return", "enqueue", "raise", "retry"]
 
 
-def _classify_bounce(result: DebounceResult, workflow_name: str) -> _BounceAction:
+def _classify_bounce(
+    result: DebounceResult, workflow_name: str, application_name: Optional[str]
+) -> _BounceAction:
     """Decide what a debounce caller should do after a bounce attempt.
 
     - "return": an existing debounced workflow was extended; return a handle to
       ``result["bounced_workflow_id"]``.
     - "enqueue": the key is unheld; enqueue a fresh debounced workflow.
-    - "raise": the key is held by a non-debounced workflow or by a different
-      workflow whose debounce key collides; surface the deduplication conflict.
+    - "raise": the key is held by a non-debounced workflow, by a different
+      workflow whose debounce key collides, or by another application; surface
+      the deduplication conflict.
     - "retry": a same-name debounced holder flipped out of DELAYED mid-bounce
       (a rare race); retry the bounce.
     """
@@ -128,6 +131,14 @@ def _classify_bounce(result: DebounceResult, workflow_name: str) -> _BounceActio
         return "raise"
     if result["holder_workflow_name"] != workflow_name:
         return "raise"
+    # A foreign holder never leaves DELAYED on our account, so retrying would spin.
+    # Mirrors the scope of the bounce itself: unclaimed rows and nameless callers match.
+    # A foreign holder never leaves DELAYED on our account, so retrying would spin.
+    # Mirrors the scope of the bounce itself: unclaimed rows and nameless callers match.
+    holder_app = result["holder_application_name"]
+    if application_name is not None and holder_app is not None:
+        if holder_app != application_name:
+            return "raise"
     return "retry"
 
 
@@ -300,7 +311,9 @@ class Debouncer(Generic[P, R]):
                     args,
                     kwargs,
                 )
-            action = _classify_bounce(result, self.options["workflow_name"])
+            action = _classify_bounce(
+                result, self.options["workflow_name"], dbos._sys_db.app_name
+            )
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
                 assert bounced_wfid is not None
@@ -406,7 +419,11 @@ class DebouncerClient:
                 inputs=inputs,
                 serialization=serialization,
             )
-            action = _classify_bounce(result, self.debouncer_options["workflow_name"])
+            action = _classify_bounce(
+                result,
+                self.debouncer_options["workflow_name"],
+                self.client._sys_db.app_name,
+            )
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
                 assert bounced_wfid is not None

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -77,14 +77,12 @@ def _reject_conflicting_options(
     has_delay: bool,
     has_priority: bool,
     has_partition_key: bool,
-    has_application_name: bool = False,
 ) -> None:
     """A debounce owns the workflow's deduplication ID (the debounce key) and its
     delay (the debounce period), so a caller must not also set them. Priority and
     partition keys are rejected because they cannot apply to a debounced enqueue
     (the default internal queue has no priority, and partitioned queues do not
-    support the deduplication a debounce requires). An application_name is
-    rejected because a debounce always acts as its caller's own application."""
+    support the deduplication a debounce requires)."""
     if has_deduplication_id:
         raise DBOSException(
             "Cannot debounce a workflow with a deduplication_id set: the debounce "
@@ -105,12 +103,6 @@ def _reject_conflicting_options(
             "Cannot debounce a workflow with a queue partition key set: partitioned "
             "queues do not support deduplication, which debouncing requires."
         )
-    if has_application_name:
-        raise DBOSException(
-            "Cannot debounce a workflow with an application_name set: a debounce "
-            "always acts as the client's own application. Create the DBOSClient "
-            "with application_name set to the target application instead."
-        )
 
 
 # The action a debounce caller should take after a bounce attempt.
@@ -118,7 +110,7 @@ _BounceAction = Literal["return", "enqueue", "raise", "retry"]
 
 
 def _classify_bounce(
-    result: DebounceResult, workflow_name: str, application_name: Optional[str]
+    result: DebounceResult, workflow_name: str, target_application_name: Optional[str]
 ) -> _BounceAction:
     """Decide what a debounce caller should do after a bounce attempt.
 
@@ -126,8 +118,8 @@ def _classify_bounce(
       ``result["bounced_workflow_id"]``.
     - "enqueue": the key is unheld; enqueue a fresh debounced workflow.
     - "raise": the key is held by a non-debounced workflow, by a different
-      workflow whose debounce key collides, or by another application; surface
-      the deduplication conflict.
+      workflow whose debounce key collides, or by an application other than the
+      target; surface the deduplication conflict.
     - "retry": a same-name debounced holder flipped out of DELAYED mid-bounce
       (a rare race); retry the bounce.
     """
@@ -139,10 +131,10 @@ def _classify_bounce(
         return "raise"
     if result["holder_workflow_name"] != workflow_name:
         return "raise"
-    # A foreign holder never leaves DELAYED on our account, so retrying would spin.
+    # A foreign holder never leaves DELAYED on the target's account, so retrying would spin.
     holder_app = result["holder_application_name"]
-    if application_name is not None and holder_app is not None:
-        if holder_app != application_name:
+    if target_application_name is not None and holder_app is not None:
+        if holder_app != target_application_name:
             return "raise"
     return "retry"
 
@@ -152,6 +144,8 @@ class DebouncerOptions(TypedDict):
     workflow_name: str
     debounce_timeout_sec: Optional[float]
     queue_name: Optional[str]
+    # The application the debounce acts for; None means the caller's own.
+    application_name: Optional[str]
 
 
 class Debouncer(Generic[P, R]):
@@ -162,12 +156,14 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        application_name: Optional[str] = None,
     ):
         self.func_name = workflow_name
         self.options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
             "queue_name": _resolve_queue_name(queue),
             "workflow_name": workflow_name,
+            "application_name": application_name,
         }
 
     @staticmethod
@@ -176,6 +172,7 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        application_name: Optional[str] = None,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -184,6 +181,7 @@ class Debouncer(Generic[P, R]):
             get_dbos_func_name(workflow),
             debounce_timeout_sec=debounce_timeout_sec,
             queue=queue,
+            application_name=application_name,
         )
 
     @staticmethod
@@ -192,6 +190,7 @@ class Debouncer(Generic[P, R]):
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        application_name: Optional[str] = None,
     ) -> "Debouncer[P, R]":
 
         if isinstance(workflow, (types.MethodType)):
@@ -200,6 +199,7 @@ class Debouncer(Generic[P, R]):
             get_dbos_func_name(workflow),
             debounce_timeout_sec=debounce_timeout_sec,
             queue=queue,
+            application_name=application_name,
         )
 
     def _bounce(
@@ -211,6 +211,8 @@ class Debouncer(Generic[P, R]):
         debounce_period_sec: float,
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
+        *,
+        application_name: Optional[str],
         conn: Optional[sa.Connection] = None,
     ) -> DebounceResult:
         # Serialize new inputs with the workflow's format so a bounce stays consistent with the initial enqueue.
@@ -227,6 +229,7 @@ class Debouncer(Generic[P, R]):
             delay_until_epoch_ms=delay_until_epoch_ms,
             inputs=inputs,
             serialization=serialization,
+            application_name=application_name,
             conn=conn,
         )
         return result
@@ -281,6 +284,12 @@ class Debouncer(Generic[P, R]):
 
         deduplication_id = f"{self.options['workflow_name']}-{debounce_key}"
         timeout_sec = self.options["debounce_timeout_sec"]
+        # One owner for the whole operation: the bounce scope, the conflict check, and the fresh enqueue must agree.
+        target_app = (
+            self.options["application_name"]
+            if self.options["application_name"] is not None
+            else dbos._sys_db.app_name
+        )
 
         while True:
             # Try to extend an existing debounced workflow for this key first (hot path, sole coalescing mechanism).
@@ -303,6 +312,7 @@ class Debouncer(Generic[P, R]):
                             debounce_period_sec,
                             args,
                             kwargs,
+                            application_name=target_app,
                             conn=c,
                         ),
                     )
@@ -315,10 +325,9 @@ class Debouncer(Generic[P, R]):
                     debounce_period_sec,
                     args,
                     kwargs,
+                    application_name=target_app,
                 )
-            action = _classify_bounce(
-                result, self.options["workflow_name"], dbos._sys_db.app_name
-            )
+            action = _classify_bounce(result, self.options["workflow_name"], target_app)
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
                 assert bounced_wfid is not None
@@ -346,6 +355,7 @@ class Debouncer(Generic[P, R]):
                     deduplication_id=deduplication_id,
                     delay_until_epoch_ms=delay_until_ms,
                     debounce_deadline_epoch_ms=deadline_ms,
+                    application_name=self.options["application_name"],
                 ):
                     return queue.enqueue(func, *args, **kwargs)
             except (DBOSQueueDeduplicatedError, PortableWorkflowError) as e:
@@ -380,27 +390,27 @@ class DebouncerClient:
         *,
         debounce_timeout_sec: Optional[float] = None,
         queue: Optional[Union[Queue, str]] = None,
+        application_name: Optional[str] = None,
     ):
         self.workflow_options = workflow_options
         self.debouncer_options: DebouncerOptions = {
             "debounce_timeout_sec": debounce_timeout_sec,
             "queue_name": _resolve_queue_name(queue),
             "workflow_name": workflow_options["workflow_name"],
+            "application_name": application_name,
         }
         self.client = client
 
     def debounce(
         self, debounce_key: str, debounce_period_sec: float, *args: Any, **kwargs: Any
     ) -> "WorkflowHandle[R]":
-        # The workflow options must not set a deduplication_id, delay, priority, partition key, or application_name.
+        # The workflow options must not set a deduplication_id, delay, priority, or partition key.
         _reject_conflicting_options(
             has_deduplication_id=self.workflow_options.get("deduplication_id")
             is not None,
             has_delay=self.workflow_options.get("delay_seconds") is not None,
             has_priority=self.workflow_options.get("priority") is not None,
             has_partition_key=self.workflow_options.get("queue_partition_key")
-            is not None,
-            has_application_name=self.workflow_options.get("application_name")
             is not None,
         )
 
@@ -410,6 +420,12 @@ class DebouncerClient:
         )
         deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
         timeout_sec = self.debouncer_options["debounce_timeout_sec"]
+        # One owner for the whole operation: the debouncer's target wins, then the workflow options', then the client's identity.
+        target_app = self.debouncer_options["application_name"]
+        if target_app is None:
+            target_app = self.workflow_options.get("application_name")
+        if target_app is None:
+            target_app = self.client._sys_db.app_name
         serialization_type = self.workflow_options.get("serialization_type")
 
         while True:
@@ -425,11 +441,12 @@ class DebouncerClient:
                 delay_until_epoch_ms=bounce_delay_ms,
                 inputs=inputs,
                 serialization=serialization,
+                application_name=target_app,
             )
             action = _classify_bounce(
                 result,
                 self.debouncer_options["workflow_name"],
-                self.client._sys_db.app_name,
+                target_app,
             )
             if action == "return":
                 bounced_wfid = result["bounced_workflow_id"]
@@ -456,6 +473,8 @@ class DebouncerClient:
                     "queue_name": queue_name,
                     "deduplication_id": deduplication_id,
                     "delay_seconds": delay_sec,
+                    # The resolved target, so the fresh holder matches the bounce scope.
+                    "application_name": target_app,
                 },
             )
             try:

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -132,9 +132,6 @@ def _classify_bounce(
     if result["holder_workflow_name"] != workflow_name:
         return "raise"
     # A foreign holder never leaves DELAYED on our account, so retrying would spin.
-    # Mirrors the scope of the bounce itself: unclaimed rows and nameless callers match.
-    # A foreign holder never leaves DELAYED on our account, so retrying would spin.
-    # Mirrors the scope of the bounce itself: unclaimed rows and nameless callers match.
     holder_app = result["holder_application_name"]
     if application_name is not None and holder_app is not None:
         if holder_app != application_name:

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -420,7 +420,7 @@ class DebouncerClient:
         )
         deduplication_id = f"{self.debouncer_options['workflow_name']}-{debounce_key}"
         timeout_sec = self.debouncer_options["debounce_timeout_sec"]
-        # One owner for the whole operation: the debouncer's target wins, then the workflow options', then the client's identity.
+        # Same one-owner rule as Debouncer.debounce; the debouncer's target wins, then the workflow options', then the client's identity.
         target_app = self.debouncer_options["application_name"]
         if target_app is None:
             target_app = self.workflow_options.get("application_name")
@@ -473,7 +473,6 @@ class DebouncerClient:
                     "queue_name": queue_name,
                     "deduplication_id": deduplication_id,
                     "delay_seconds": delay_sec,
-                    # The resolved target, so the fresh holder matches the bounce scope.
                     "application_name": target_app,
                 },
             )

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -52,7 +52,7 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     class_name: str
     instance_name: str
     attributes: Dict[str, Any]
-    # Owning application; unset lets the caller decide whether to stamp itself.
+    # Owning application. Unset defaults to the caller's name.
     application_name: Optional[str]
     # Parents the enqueued workflow's span to this OpenTelemetry context, so it joins
     # this trace when it runs. The client-side PropagateOtelContext.

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -52,6 +52,11 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     class_name: str
     instance_name: str
     attributes: Dict[str, Any]
+    # The application that owns the enqueued workflow and will run it. Unset lets the
+    # caller decide: an application stamps itself, a client writes it unclaimed.
+    # Spelled in full, unlike the adjacent app_version, to match the column and every
+    # other application_name in the API.
+    application_name: Optional[str]
     # Parents the enqueued workflow's span to this OpenTelemetry context, so it joins
     # this trace when it runs. The client-side PropagateOtelContext.
     otel_context: "OtelContext"
@@ -174,7 +179,6 @@ def build_enqueue_status(
         # Set only by the debouncer via _enqueue_debounced, never from options.
         "debounce_deadline_epoch_ms": None,
         "is_debounced": False,
-        # Left unclaimed here; callers inside an application stamp their own name.
-        "application_name": None,
+        "application_name": options.get("application_name"),
     }
     return workflow_id, status

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -174,5 +174,7 @@ def build_enqueue_status(
         # Set only by the debouncer via _enqueue_debounced, never from options.
         "debounce_deadline_epoch_ms": None,
         "is_debounced": False,
+        # Left unclaimed here; callers inside an application stamp their own name.
+        "application_name": None,
     }
     return workflow_id, status

--- a/dbos/_enqueue_options.py
+++ b/dbos/_enqueue_options.py
@@ -52,10 +52,7 @@ class EnqueueOptions(_EnqueueOptionsRequired, total=False):
     class_name: str
     instance_name: str
     attributes: Dict[str, Any]
-    # The application that owns the enqueued workflow and will run it. Unset lets the
-    # caller decide: an application stamps itself, a client writes it unclaimed.
-    # Spelled in full, unlike the adjacent app_version, to match the column and every
-    # other application_name in the API.
+    # Owning application; unset lets the caller decide whether to stamp itself.
     application_name: Optional[str]
     # Parents the enqueued workflow's span to this OpenTelemetry context, so it joins
     # this trace when it runs. The client-side PropagateOtelContext.

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -17,12 +17,6 @@ SHARED_MIGRATION_BASE = 100
 def _pad_to_shared_base(migrations: list[str]) -> list[str]:
     """Pad a language's own history out to SHARED_MIGRATION_BASE - 1. Earlier
     indices stay per-language, safe to skip only because the schemas converge."""
-    if len(migrations) >= SHARED_MIGRATION_BASE:
-        raise ValueError(
-            f"Migration history is {len(migrations)} long, which reaches the "
-            f"shared numbering base {SHARED_MIGRATION_BASE}. Shared migrations "
-            f"must be appended after it, not merged into the history."
-        )
     return migrations + [""] * (SHARED_MIGRATION_BASE - 1 - len(migrations))
 
 

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -8,7 +8,25 @@ from ._logger import dbos_logger
 # autocommit (CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction
 # block on Postgres). On CockroachDB, schema changes are inherently online,
 # so this set is ignored and the regular transactional path is used.
-_ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37, 45, 46, 47}
+_ONLINE_MIGRATIONS = {
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    29,
+    30,
+    31,
+    32,
+    34,
+    35,
+    37,
+    45,
+    46,
+    47,
+    107,
+}
 
 # From this index on, every SDK defines the same migration at the same index.
 SHARED_MIGRATION_BASE = 100
@@ -1074,16 +1092,19 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
 
 
 def get_dbos_migration_hundredsix(schema: str) -> str:
-    # Expand half of retiring version_name's global uniqueness: the ownership-scoped key that replaces it, unclaimed counting as its own owner. The constraint may not be dropped until every SDK reaching this database is past this migration.
+    # With 107, the key replacing version_name's retiring global uniqueness, unclaimed counting as its own owner. The constraint may not be dropped until every SDK reaching this database is past 107, which runs online because every unclaimed row matches its predicate.
     return f"""
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owner_version"
     ON "{schema}"."application_versions" ("application_name", "version_name")
     WHERE "application_name" IS NOT NULL;
-
-CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
-    ON "{schema}"."application_versions" ("version_name")
-    WHERE "application_name" IS NULL;
 """
+
+
+def get_dbos_migration_hundredseven(schema: str, is_cockroach: bool) -> str:
+    c = _concurrently(is_cockroach)
+    return f"""CREATE UNIQUE INDEX {c} IF NOT EXISTS "uq_application_versions_unclaimed_version"
+    ON "{schema}"."application_versions" ("version_name")
+    WHERE "application_name" IS NULL"""
 
 
 def get_dbos_migrations(
@@ -1147,6 +1168,7 @@ def get_dbos_migrations(
         get_dbos_migration_hundredfour(schema),
         get_dbos_migration_hundredfive(schema, is_cockroach),
         get_dbos_migration_hundredsix(schema),
+        get_dbos_migration_hundredseven(schema, is_cockroach),
     ]
 
 
@@ -1440,7 +1462,9 @@ sqlite_migration_hundredsix = """
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owner_version"
     ON application_versions ("application_name", "version_name")
     WHERE "application_name" IS NOT NULL;
+"""
 
+sqlite_migration_hundredseven = """
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
     ON application_versions ("version_name")
     WHERE "application_name" IS NULL;
@@ -1504,4 +1528,5 @@ sqlite_migrations = [
     # Postgres migration 105 rewrites a stored function; SQLite has none.
     "",
     sqlite_migration_hundredsix,
+    sqlite_migration_hundredseven,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -1079,6 +1079,19 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
     return migration
 
 
+def get_dbos_migration_hundredsix(schema: str) -> str:
+    # Expand half of retiring version_name's global uniqueness: the ownership-scoped key that replaces it, unclaimed counting as its own owner. The constraint may not be dropped until every SDK reaching this database is past this migration.
+    return f"""
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owner_version"
+    ON "{schema}"."application_versions" ("application_name", "version_name")
+    WHERE "application_name" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
+    ON "{schema}"."application_versions" ("version_name")
+    WHERE "application_name" IS NULL;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -1139,6 +1152,7 @@ def get_dbos_migrations(
         get_dbos_migration_hundredthree(schema),
         get_dbos_migration_hundredfour(schema),
         get_dbos_migration_hundredfive(schema, is_cockroach),
+        get_dbos_migration_hundredsix(schema),
     ]
 
 
@@ -1427,6 +1441,17 @@ sqlite_migration_hundredfour = (
     'ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL'
 )
 
+# See get_dbos_migration_hundredsix: the same key, built while the constraint still implies it.
+sqlite_migration_hundredsix = """
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owner_version"
+    ON application_versions ("application_name", "version_name")
+    WHERE "application_name" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
+    ON application_versions ("version_name")
+    WHERE "application_name" IS NULL;
+"""
+
 _sqlite_history = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1484,4 +1509,5 @@ sqlite_migrations = [
     sqlite_migration_hundredfour,
     # Postgres migration 105 rewrites a stored function; SQLite has none.
     "",
+    sqlite_migration_hundredsix,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -174,10 +174,8 @@ def run_dbos_migrations(
         if i <= last_applied:
             continue
 
-        # Renumbering left long runs of empty migrations; say nothing of them.
+        # Renumbering left long runs of empty migrations; skip them without a round trip.
         if not migration_sql.strip():
-            _bump_migration_version(engine, schema, i, last_applied)
-            last_applied = i
             continue
 
         dbos_logger.info(f"Applying DBOS system database schema migration {i}")
@@ -232,6 +230,10 @@ def run_dbos_migrations(
                     {"version": i},
                 )
             last_applied = i
+
+    # Empty migrations at the end still count as applied, so record them in one write.
+    if len(migrations) > last_applied:
+        _bump_migration_version(engine, schema, len(migrations), last_applied)
 
 
 def get_dbos_migration_one(schema: str, use_listen_notify: bool) -> str:

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -174,13 +174,13 @@ def run_dbos_migrations(
         if i <= last_applied:
             continue
 
-        dbos_logger.info(f"Applying DBOS system database schema migration {i}")
-
+        # Renumbering left long runs of empty migrations; say nothing of them.
         if not migration_sql.strip():
-            dbos_logger.info(f"Migration {i} has no statements; skipping.")
             _bump_migration_version(engine, schema, i, last_applied)
             last_applied = i
             continue
+
+        dbos_logger.info(f"Applying DBOS system database schema migration {i}")
 
         # Online migrations contain CONCURRENTLY index DDL and must run with
         # autocommit. On CockroachDB, schema changes are inherently online, so

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -933,6 +933,7 @@ ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_n
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """
 
 
@@ -1372,6 +1373,7 @@ ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL;
+ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL;
 """
 
 sqlite_migrations = [

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -942,8 +942,7 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
 
 
 def get_dbos_migration_hundred(schema: str) -> str:
-    # NULL means unclaimed: any application may read and claim the row. One table per
-    # migration, so a table blocked by a reader does not hold the others' locks with it.
+    # NULL means unclaimed: any application may read and claim the row. One table per migration, so a blocked table does not hold the others' locks.
     return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -942,17 +942,38 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
 
 
 def get_dbos_migration_hundred(schema: str) -> str:
-    # Catalog-only. NULL means unclaimed: any application may read and claim the row.
+    # NULL means unclaimed: any application may read and claim the row. One table per
+    # migration, so a table blocked by a reader does not hold the others' locks with it.
     return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+"""
+
+
+def get_dbos_migration_hundredone(schema: str) -> str:
+    return f"""
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+"""
+
+
+def get_dbos_migration_hundredtwo(schema: str) -> str:
+    return f"""
 ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+"""
+
+
+def get_dbos_migration_hundredthree(schema: str) -> str:
+    return f"""
 ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+"""
+
+
+def get_dbos_migration_hundredfour(schema: str) -> str:
+    return f"""
 ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """
 
 
-def get_dbos_migration_hundredone(schema: str, is_cockroach: bool) -> str:
+def get_dbos_migration_hundredfive(schema: str, is_cockroach: bool) -> str:
     # Callers omitting the trailing application_name enqueue an unclaimed workflow.
     migration = f"""
 DROP FUNCTION IF EXISTS "{schema}".enqueue_workflow(
@@ -1114,7 +1135,11 @@ def get_dbos_migrations(
     return [
         *_pad_to_shared_base(history),
         get_dbos_migration_hundred(schema),
-        get_dbos_migration_hundredone(schema, is_cockroach),
+        get_dbos_migration_hundredone(schema),
+        get_dbos_migration_hundredtwo(schema),
+        get_dbos_migration_hundredthree(schema),
+        get_dbos_migration_hundredfour(schema),
+        get_dbos_migration_hundredfive(schema, is_cockroach),
     ]
 
 
@@ -1383,13 +1408,25 @@ sqlite_migration_fortyseven = (
     'DROP INDEX IF EXISTS "idx_workflow_status_partition_dequeue"'
 )
 
-sqlite_migration_hundred = """
-ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
-ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
-ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
-ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL;
-ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL;
-"""
+sqlite_migration_hundred = (
+    'ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL'
+)
+
+sqlite_migration_hundredone = (
+    'ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL'
+)
+
+sqlite_migration_hundredtwo = (
+    'ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL'
+)
+
+sqlite_migration_hundredthree = (
+    'ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL'
+)
+
+sqlite_migration_hundredfour = (
+    'ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL'
+)
 
 _sqlite_history = [
     sqlite_migration_one,
@@ -1442,6 +1479,10 @@ _sqlite_history = [
 sqlite_migrations = [
     *_pad_to_shared_base(_sqlite_history),
     sqlite_migration_hundred,
-    # Postgres migration 101 rewrites a stored function; SQLite has none.
+    sqlite_migration_hundredone,
+    sqlite_migration_hundredtwo,
+    sqlite_migration_hundredthree,
+    sqlite_migration_hundredfour,
+    # Postgres migration 105 rewrites a stored function; SQLite has none.
     "",
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -948,9 +948,7 @@ ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "applicatio
 ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """
-    # A version name is content, not an address: two applications legitimately
-    # compute the same one, so identity is (application_name, version_name).
-    # Two partial indexes because a composite unique does not dedupe NULLs.
+    # Identity is (application_name, version_name); two indexes since a composite unique keeps no NULLs apart.
     if is_cockroach:
         migration += f"""
 DROP INDEX IF EXISTS "{schema}"."application_versions_version_name_key" CASCADE;
@@ -1402,9 +1400,7 @@ sqlite_migration_fortyseven = (
     'DROP INDEX IF EXISTS "idx_workflow_status_partition_dequeue"'
 )
 
-# NULL means unclaimed: any application may read and claim the row.
-# application_versions is rebuilt because SQLite declared its UNIQUE inline, which
-# leaves an undroppable autoindex; the table is bounded by deploy count.
+# Rebuilt because SQLite declared the UNIQUE inline, leaving an undroppable autoindex.
 sqlite_migration_hundred = f"""
 ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -924,6 +924,126 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
     )
 
 
+def get_dbos_migration_fortyeight(schema: str) -> str:
+    # ADD COLUMN with no default is catalog-only. NULL means the row is unclaimed:
+    # it is written by SDKs that predate this column and may be read and claimed by
+    # any application sharing the system database.
+    return f"""
+ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
+"""
+
+
+def get_dbos_migration_fortynine(schema: str, is_cockroach: bool) -> str:
+    # Adds the trailing application_name parameter. Callers that omit it enqueue an
+    # unclaimed workflow, which any application listening on the queue may run.
+    migration = f"""
+DROP FUNCTION IF EXISTS "{schema}".enqueue_workflow(
+    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INT4, TEXT, TEXT, TEXT, BIGINT
+);
+
+CREATE OR REPLACE FUNCTION "{schema}".enqueue_workflow(
+    workflow_name TEXT,
+    queue_name TEXT,
+    positional_args JSON[] DEFAULT ARRAY[]::JSON[],
+    named_args JSON DEFAULT '{{}}'::JSON,
+    class_name TEXT DEFAULT NULL,
+    config_name TEXT DEFAULT NULL,
+    workflow_id TEXT DEFAULT NULL,
+    app_version TEXT DEFAULT NULL,
+    timeout_ms BIGINT DEFAULT NULL,
+    deadline_epoch_ms BIGINT DEFAULT NULL,
+    deduplication_id TEXT DEFAULT NULL,
+    priority INT4 DEFAULT NULL,
+    queue_partition_key TEXT DEFAULT NULL,
+    authenticated_user TEXT DEFAULT NULL,
+    authenticated_roles TEXT DEFAULT NULL,
+    delay_until_epoch_ms BIGINT DEFAULT NULL,
+    application_name TEXT DEFAULT NULL
+) RETURNS TEXT AS $$
+DECLARE
+    v_workflow_id TEXT;
+    v_serialized_inputs TEXT;
+    v_owner_xid TEXT;
+    v_now BIGINT;
+    v_recovery_attempts INT4 := 0;
+    v_priority INT4;
+    v_status TEXT;
+BEGIN
+
+    -- Validate required parameters
+    IF workflow_name IS NULL OR workflow_name = '' THEN
+        RAISE EXCEPTION 'Workflow name cannot be null or empty';
+    END IF;
+    IF queue_name IS NULL OR queue_name = '' THEN
+        RAISE EXCEPTION 'Queue name cannot be null or empty';
+    END IF;
+    IF named_args IS NOT NULL AND jsonb_typeof(named_args::jsonb) != 'object' THEN
+        RAISE EXCEPTION 'Named args must be a JSON object';
+    END IF;
+    IF workflow_id IS NOT NULL AND workflow_id = '' THEN
+        RAISE EXCEPTION 'Workflow ID cannot be an empty string if provided.';
+    END IF;
+    IF delay_until_epoch_ms IS NOT NULL AND delay_until_epoch_ms < 0 THEN
+        RAISE EXCEPTION 'delay_until_epoch_ms must be >= 0';
+    END IF;
+
+    v_workflow_id := COALESCE(workflow_id, gen_random_uuid()::TEXT);
+    v_owner_xid := gen_random_uuid()::TEXT;
+    v_priority := COALESCE(priority, 0);
+    v_serialized_inputs := json_build_object(
+        'positionalArgs', positional_args,
+        'namedArgs', named_args
+    )::TEXT;
+    v_now := EXTRACT(epoch FROM now()) * 1000;
+    v_status := CASE WHEN delay_until_epoch_ms IS NULL THEN 'ENQUEUED' ELSE 'DELAYED' END;
+
+    INSERT INTO "{schema}".workflow_status (
+        workflow_uuid, status, inputs,
+        name, class_name, config_name,
+        queue_name, deduplication_id, priority, queue_partition_key,
+        application_version,
+        created_at, updated_at, recovery_attempts,
+        workflow_timeout_ms, workflow_deadline_epoch_ms,
+        parent_workflow_id, owner_xid, serialization,
+        authenticated_user, authenticated_roles,
+        delay_until_epoch_ms, application_name
+    ) VALUES (
+        v_workflow_id, v_status, v_serialized_inputs,
+        workflow_name, class_name, config_name,
+        queue_name, deduplication_id, v_priority, queue_partition_key,
+        app_version,
+        v_now, v_now, v_recovery_attempts,
+        timeout_ms, deadline_epoch_ms,
+        NULL, v_owner_xid, 'portable_json',
+        authenticated_user, authenticated_roles,
+        delay_until_epoch_ms, application_name
+    )
+    ON CONFLICT (workflow_uuid)
+    DO UPDATE SET
+        updated_at = EXCLUDED.updated_at;
+
+    RETURN v_workflow_id;
+
+EXCEPTION
+    WHEN unique_violation THEN
+        RAISE EXCEPTION 'DBOS queue duplicated'
+            USING DETAIL = format('Workflow %s with queue %s and deduplication ID %s already exists', v_workflow_id, queue_name, deduplication_id),
+                ERRCODE = 'unique_violation';
+END;
+$$ LANGUAGE plpgsql;
+"""
+    if not is_cockroach:
+        migration += f"""
+ALTER FUNCTION "{schema}".enqueue_workflow(
+    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INT4, TEXT, TEXT, TEXT, BIGINT, TEXT
+) SET search_path = pg_catalog, pg_temp;
+"""
+    return migration
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -975,6 +1095,8 @@ def get_dbos_migrations(
         get_dbos_migration_fortyfive(schema, is_cockroach),
         get_dbos_migration_fortysix(schema, is_cockroach),
         get_dbos_migration_fortyseven(schema, is_cockroach),
+        get_dbos_migration_fortyeight(schema),
+        get_dbos_migration_fortynine(schema, is_cockroach),
     ]
 
 
@@ -1243,6 +1365,15 @@ sqlite_migration_fortyseven = (
     'DROP INDEX IF EXISTS "idx_workflow_status_partition_dequeue"'
 )
 
+# NULL means the row is unclaimed: written by SDKs that predate this column, and
+# readable and claimable by any application sharing the system database.
+sqlite_migration_fortyeight = """
+ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
+ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
+ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
+ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL;
+"""
+
 sqlite_migrations = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1289,4 +1420,6 @@ sqlite_migrations = [
     sqlite_migration_fortyfive,
     sqlite_migration_fortysix,
     sqlite_migration_fortyseven,
+    sqlite_migration_fortyeight,
+    # There is no SQLite version of migration forty-nine
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -939,34 +939,15 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
     )
 
 
-def get_dbos_migration_hundred(schema: str, is_cockroach: bool) -> str:
+def get_dbos_migration_hundred(schema: str) -> str:
     # Catalog-only. NULL means unclaimed: any application may read and claim the row.
-    migration = f"""
+    return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """
-    # Identity is (application_name, version_name); two indexes since a composite unique keeps no NULLs apart.
-    if is_cockroach:
-        migration += f"""
-DROP INDEX IF EXISTS "{schema}"."application_versions_version_name_key" CASCADE;
-"""
-    else:
-        migration += f"""
-ALTER TABLE "{schema}"."application_versions"
-    DROP CONSTRAINT IF EXISTS application_versions_version_name_key;
-"""
-    migration += f"""
-CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owned_name"
-    ON "{schema}"."application_versions" ("application_name", "version_name")
-    WHERE "application_name" IS NOT NULL;
-CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_name"
-    ON "{schema}"."application_versions" ("version_name")
-    WHERE "application_name" IS NULL;
-"""
-    return migration
 
 
 def get_dbos_migration_hundredone(schema: str, is_cockroach: bool) -> str:
@@ -1130,7 +1111,7 @@ def get_dbos_migrations(
     ]
     return [
         *_pad_to_shared_base(history),
-        get_dbos_migration_hundred(schema, is_cockroach),
+        get_dbos_migration_hundred(schema),
         get_dbos_migration_hundredone(schema, is_cockroach),
     ]
 
@@ -1400,31 +1381,12 @@ sqlite_migration_fortyseven = (
     'DROP INDEX IF EXISTS "idx_workflow_status_partition_dequeue"'
 )
 
-# Rebuilt because SQLite declared the UNIQUE inline, leaving an undroppable autoindex.
-sqlite_migration_hundred = f"""
+sqlite_migration_hundred = """
 ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL;
-CREATE TABLE application_versions_rebuilt (
-    version_id TEXT NOT NULL PRIMARY KEY,
-    version_name TEXT NOT NULL,
-    version_timestamp INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
-    created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
-    application_name TEXT DEFAULT NULL
-);
-INSERT INTO application_versions_rebuilt
-    SELECT version_id, version_name, version_timestamp, created_at, application_name
-    FROM application_versions;
-DROP TABLE application_versions;
-ALTER TABLE application_versions_rebuilt RENAME TO application_versions;
-CREATE UNIQUE INDEX "uq_application_versions_owned_name"
-    ON application_versions ("application_name", "version_name")
-    WHERE "application_name" IS NOT NULL;
-CREATE UNIQUE INDEX "uq_application_versions_unclaimed_name"
-    ON application_versions ("version_name")
-    WHERE "application_name" IS NULL;
 """
 
 _sqlite_history = [

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -925,9 +925,7 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
 
 
 def get_dbos_migration_fortyeight(schema: str) -> str:
-    # ADD COLUMN with no default is catalog-only. NULL means the row is unclaimed:
-    # it is written by SDKs that predate this column and may be read and claimed by
-    # any application sharing the system database.
+    # Catalog-only. NULL means unclaimed: any application may read and claim the row.
     return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
@@ -938,8 +936,7 @@ ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application
 
 
 def get_dbos_migration_fortynine(schema: str, is_cockroach: bool) -> str:
-    # Adds the trailing application_name parameter. Callers that omit it enqueue an
-    # unclaimed workflow, which any application listening on the queue may run.
+    # Callers omitting the trailing application_name enqueue an unclaimed workflow.
     migration = f"""
 DROP FUNCTION IF EXISTS "{schema}".enqueue_workflow(
     TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INT4, TEXT, TEXT, TEXT, BIGINT
@@ -1366,8 +1363,7 @@ sqlite_migration_fortyseven = (
     'DROP INDEX IF EXISTS "idx_workflow_status_partition_dequeue"'
 )
 
-# NULL means the row is unclaimed: written by SDKs that predate this column, and
-# readable and claimable by any application sharing the system database.
+# NULL means unclaimed: any application may read and claim the row.
 sqlite_migration_fortyeight = """
 ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -10,6 +10,21 @@ from ._logger import dbos_logger
 # so this set is ignored and the regular transactional path is used.
 _ONLINE_MIGRATIONS = {22, 23, 24, 25, 26, 27, 29, 30, 31, 32, 34, 35, 37, 45, 46, 47}
 
+# From this index on, every SDK defines the same migration at the same index.
+SHARED_MIGRATION_BASE = 100
+
+
+def _pad_to_shared_base(migrations: list[str]) -> list[str]:
+    """Pad a language's own history out to SHARED_MIGRATION_BASE - 1. Earlier
+    indices stay per-language, safe to skip only because the schemas converge."""
+    if len(migrations) >= SHARED_MIGRATION_BASE:
+        raise ValueError(
+            f"Migration history is {len(migrations)} long, which reaches the "
+            f"shared numbering base {SHARED_MIGRATION_BASE}. Shared migrations "
+            f"must be appended after it, not merged into the history."
+        )
+    return migrations + [""] * (SHARED_MIGRATION_BASE - 1 - len(migrations))
+
 
 def _concurrently(is_cockroach: bool) -> str:
     """Render the CONCURRENTLY keyword for online index DDL.
@@ -924,7 +939,7 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
     )
 
 
-def get_dbos_migration_fortyeight(schema: str) -> str:
+def get_dbos_migration_hundred(schema: str) -> str:
     # Catalog-only. NULL means unclaimed: any application may read and claim the row.
     return f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
@@ -935,7 +950,7 @@ ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application
 """
 
 
-def get_dbos_migration_fortynine(schema: str, is_cockroach: bool) -> str:
+def get_dbos_migration_hundredone(schema: str, is_cockroach: bool) -> str:
     # Callers omitting the trailing application_name enqueue an unclaimed workflow.
     migration = f"""
 DROP FUNCTION IF EXISTS "{schema}".enqueue_workflow(
@@ -1045,7 +1060,7 @@ ALTER FUNCTION "{schema}".enqueue_workflow(
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
-    return [
+    history = [
         get_dbos_migration_one(schema, use_listen_notify),
         get_dbos_migration_two(schema),
         get_dbos_migration_three(schema),
@@ -1093,8 +1108,11 @@ def get_dbos_migrations(
         get_dbos_migration_fortyfive(schema, is_cockroach),
         get_dbos_migration_fortysix(schema, is_cockroach),
         get_dbos_migration_fortyseven(schema, is_cockroach),
-        get_dbos_migration_fortyeight(schema),
-        get_dbos_migration_fortynine(schema, is_cockroach),
+    ]
+    return [
+        *_pad_to_shared_base(history),
+        get_dbos_migration_hundred(schema),
+        get_dbos_migration_hundredone(schema, is_cockroach),
     ]
 
 
@@ -1364,7 +1382,7 @@ sqlite_migration_fortyseven = (
 )
 
 # NULL means unclaimed: any application may read and claim the row.
-sqlite_migration_fortyeight = """
+sqlite_migration_hundred = """
 ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
@@ -1372,7 +1390,7 @@ ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL
 ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL;
 """
 
-sqlite_migrations = [
+_sqlite_history = [
     sqlite_migration_one,
     sqlite_migration_two,
     sqlite_migration_three,
@@ -1418,6 +1436,11 @@ sqlite_migrations = [
     sqlite_migration_fortyfive,
     sqlite_migration_fortysix,
     sqlite_migration_fortyseven,
-    sqlite_migration_fortyeight,
-    # There is no SQLite version of migration forty-nine
+]
+
+sqlite_migrations = [
+    *_pad_to_shared_base(_sqlite_history),
+    sqlite_migration_hundred,
+    # Postgres migration 101 rewrites a stored function; SQLite has none.
+    "",
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -939,15 +939,36 @@ def get_dbos_migration_fortyseven(schema: str, is_cockroach: bool) -> str:
     )
 
 
-def get_dbos_migration_hundred(schema: str) -> str:
+def get_dbos_migration_hundred(schema: str, is_cockroach: bool) -> str:
     # Catalog-only. NULL means unclaimed: any application may read and claim the row.
-    return f"""
+    migration = f"""
 ALTER TABLE "{schema}"."workflow_status" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."workflow_schedules" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."application_versions" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 ALTER TABLE "{schema}"."operation_outputs" ADD COLUMN IF NOT EXISTS "application_name" TEXT DEFAULT NULL;
 """
+    # A version name is content, not an address: two applications legitimately
+    # compute the same one, so identity is (application_name, version_name).
+    # Two partial indexes because a composite unique does not dedupe NULLs.
+    if is_cockroach:
+        migration += f"""
+DROP INDEX IF EXISTS "{schema}"."application_versions_version_name_key" CASCADE;
+"""
+    else:
+        migration += f"""
+ALTER TABLE "{schema}"."application_versions"
+    DROP CONSTRAINT IF EXISTS application_versions_version_name_key;
+"""
+    migration += f"""
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_owned_name"
+    ON "{schema}"."application_versions" ("application_name", "version_name")
+    WHERE "application_name" IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_name"
+    ON "{schema}"."application_versions" ("version_name")
+    WHERE "application_name" IS NULL;
+"""
+    return migration
 
 
 def get_dbos_migration_hundredone(schema: str, is_cockroach: bool) -> str:
@@ -1111,7 +1132,7 @@ def get_dbos_migrations(
     ]
     return [
         *_pad_to_shared_base(history),
-        get_dbos_migration_hundred(schema),
+        get_dbos_migration_hundred(schema, is_cockroach),
         get_dbos_migration_hundredone(schema, is_cockroach),
     ]
 
@@ -1382,12 +1403,32 @@ sqlite_migration_fortyseven = (
 )
 
 # NULL means unclaimed: any application may read and claim the row.
-sqlite_migration_hundred = """
+# application_versions is rebuilt because SQLite declared its UNIQUE inline, which
+# leaves an undroppable autoindex; the table is bounded by deploy count.
+sqlite_migration_hundred = f"""
 ALTER TABLE workflow_status ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE workflow_schedules ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE application_versions ADD COLUMN "application_name" TEXT DEFAULT NULL;
 ALTER TABLE operation_outputs ADD COLUMN "application_name" TEXT DEFAULT NULL;
+CREATE TABLE application_versions_rebuilt (
+    version_id TEXT NOT NULL PRIMARY KEY,
+    version_name TEXT NOT NULL,
+    version_timestamp INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+    created_at INTEGER NOT NULL DEFAULT {get_sqlite_timestamp_expr()},
+    application_name TEXT DEFAULT NULL
+);
+INSERT INTO application_versions_rebuilt
+    SELECT version_id, version_name, version_timestamp, created_at, application_name
+    FROM application_versions;
+DROP TABLE application_versions;
+ALTER TABLE application_versions_rebuilt RENAME TO application_versions;
+CREATE UNIQUE INDEX "uq_application_versions_owned_name"
+    ON application_versions ("application_name", "version_name")
+    WHERE "application_name" IS NOT NULL;
+CREATE UNIQUE INDEX "uq_application_versions_unclaimed_name"
+    ON application_versions ("version_name")
+    WHERE "application_name" IS NULL;
 """
 
 _sqlite_history = [

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -77,6 +77,7 @@ class Queue:
         polling_interval_sec: float = DEFAULT_QUEUE_POLLING_INTERVAL_SEC,
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
+        application_name: Optional[str] = None,
     ) -> None:
         Queue._validate_queue(
             concurrency=concurrency,
@@ -86,6 +87,9 @@ class Queue:
         )
         self.name = name
         self.database_backed_queue = database_backed_queue
+        # Owning application, from the queues table. None for in-memory queues,
+        # which have no row, and for rows written before the column existed.
+        self.application_name = application_name
         # When set, getters/setters use this SystemDatabase instead of the
         # DBOS singleton's. This allows a DBOSClient to manipulate queues
         # without depending on a launched DBOS process.
@@ -588,7 +592,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                 if name in listening_set
             }
             try:
-                for queue in dbos._sys_db.list_queues():
+                for queue in dbos._sys_db.list_claimable_queues():
                     if queue.name in listening_set and queue.name not in current_queues:
                         current_queues[queue.name] = queue
             except Exception as e:
@@ -615,7 +619,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             # Else, check all in-memory and database-backed queues
             current_queues = dict(dbos._registry.queue_info_map)
             try:
-                for queue in dbos._sys_db.list_queues():
+                for queue in dbos._sys_db.list_claimable_queues():
                     if queue.name in dbos._registry.queue_info_map:
                         dbos.logger.warning(
                             f"Database-backed queue {queue.name} has the same "
@@ -702,7 +706,7 @@ def log_queues(dbos: "DBOS", listening_queues: Optional[list[str]]) -> None:
     """
     queues: dict[str, Queue] = dict(dbos._registry.queue_info_map)
     try:
-        for q in dbos._sys_db.list_queues():
+        for q in dbos._sys_db.list_claimable_queues():
             queues.setdefault(q.name, q)
     except Exception as e:
         dbos.logger.warning(f"Exception listing database-backed queues: {e}")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -591,7 +591,9 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
                 if name in listening_set
             }
             try:
-                for queue in dbos._sys_db.list_claimable_queues():
+                for queue in dbos._sys_db.list_queues(
+                    application_name=dbos._sys_db.app_name
+                ):
                     if queue.name in listening_set and queue.name not in current_queues:
                         current_queues[queue.name] = queue
             except Exception as e:
@@ -618,7 +620,9 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             # Else, check all in-memory and database-backed queues
             current_queues = dict(dbos._registry.queue_info_map)
             try:
-                for queue in dbos._sys_db.list_claimable_queues():
+                for queue in dbos._sys_db.list_queues(
+                    application_name=dbos._sys_db.app_name
+                ):
                     if queue.name in dbos._registry.queue_info_map:
                         dbos.logger.warning(
                             f"Database-backed queue {queue.name} has the same "
@@ -705,7 +709,7 @@ def log_queues(dbos: "DBOS", listening_queues: Optional[list[str]]) -> None:
     """
     queues: dict[str, Queue] = dict(dbos._registry.queue_info_map)
     try:
-        for q in dbos._sys_db.list_claimable_queues():
+        for q in dbos._sys_db.list_queues(application_name=dbos._sys_db.app_name):
             queues.setdefault(q.name, q)
     except Exception as e:
         dbos.logger.warning(f"Exception listing database-backed queues: {e}")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -634,10 +634,6 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             except Exception as e:
                 dbos.logger.warning(f"Exception listing database-backed queues: {e}")
 
-        # Republish the polled set so the enqueue path can tell which queues this
-        # application serves. Rebind rather than mutate, so readers never tear.
-        dbos._polled_queue_names = frozenset(current_queues)
-
         # Transition any DELAYED workflows whose delay has expired to ENQUEUED.
         try:
             dbos._sys_db.transition_delayed_workflows()

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -634,6 +634,10 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
             except Exception as e:
                 dbos.logger.warning(f"Exception listing database-backed queues: {e}")
 
+        # Republish the polled set so the enqueue path can tell which queues this
+        # application serves. Rebind rather than mutate, so readers never tear.
+        dbos._polled_queue_names = frozenset(current_queues)
+
         # Transition any DELAYED workflows whose delay has expired to ENQUEUED.
         try:
             dbos._sys_db.transition_delayed_workflows()

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -171,6 +171,7 @@ class Queue:
         self._priority_enabled = latest._priority_enabled
         self._partition_queue = latest._partition_queue
         self._polling_interval_sec = latest._polling_interval_sec
+        self.application_name = latest.application_name
 
     async def _configure_thread_pool(self) -> None:
         """Route ``asyncio.to_thread`` through DBOS's executor for DBOS-bound

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -87,8 +87,7 @@ class Queue:
         )
         self.name = name
         self.database_backed_queue = database_backed_queue
-        # Owning application, from the queues table. None for in-memory queues,
-        # which have no row, and for rows written before the column existed.
+        # Owner from the queues table; None for in-memory and pre-upgrade queues.
         self.application_name = application_name
         # When set, getters/setters use this SystemDatabase instead of the
         # DBOS singleton's. This allows a DBOSClient to manipulate queues

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -260,7 +260,9 @@ def dynamic_scheduler_loop(
 
     while not stop_event.is_set():
         try:
-            schedules = dbos._sys_db.list_claimable_schedules()
+            schedules = dbos._sys_db.list_schedules(
+                application_name=dbos._sys_db.app_name
+            )
         except Exception:
             dbos_logger.warning(
                 f"Exception polling schedules: {traceback.format_exc()}"

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -260,7 +260,7 @@ def dynamic_scheduler_loop(
 
     while not stop_event.is_set():
         try:
-            schedules = dbos._sys_db.list_schedules()
+            schedules = dbos._sys_db.list_claimable_schedules()
         except Exception:
             dbos_logger.warning(
                 f"Exception polling schedules: {traceback.format_exc()}"

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -157,6 +157,9 @@ def _enqueue_scheduled_workflow(
         "schedule_name": schedule_name,
         "debounce_deadline_epoch_ms": None,
         "is_debounced": False,
+        # Always owned: scheduled workflows default to the internal queue, whose
+        # name every application shares, so an unclaimed row could run anywhere.
+        "application_name": sys_db.app_name,
     }
     sys_db.init_workflow(
         status,

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -157,8 +157,7 @@ def _enqueue_scheduled_workflow(
         "schedule_name": schedule_name,
         "debounce_deadline_epoch_ms": None,
         "is_debounced": False,
-        # Always owned: scheduled workflows default to the internal queue, whose
-        # name every application shares, so an unclaimed row could run anywhere.
+        # Always owned: the internal queue's shared name cannot route an unclaimed row.
         "application_name": sys_db.app_name,
     }
     sys_db.init_workflow(

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -123,8 +123,7 @@ def _enqueue_scheduled_workflow(
     application_name: Optional[str] = None,
 ) -> None:
     """Enqueue a single scheduled workflow execution via init_workflow."""
-    # The schedule's owner routes its runs, whoever fires them; an unclaimed
-    # schedule falls back to the firing handle, which may itself have no identity.
+    # The schedule's owner routes its runs, whoever fires them; an unclaimed one falls back to the firing handle, which may have no identity itself.
     owner = application_name if application_name is not None else sys_db.app_name
     # Scheduled workflows are always enqueued to their owner's latest application version
     latest_application_version = sys_db.get_latest_application_version(

--- a/dbos/_scheduler.py
+++ b/dbos/_scheduler.py
@@ -35,6 +35,7 @@ class _ScheduleThread:
         tz_name = schedule.get("cron_timezone")
         self.tzinfo = ZoneInfo(tz_name) if tz_name else timezone.utc
         self.queue_name: Optional[str] = schedule.get("queue_name")
+        self.application_name: Optional[str] = schedule.get("application_name")
         # Definition snapshot; the loop restarts the thread when it changes.
         self.signature: tuple[Any, ...] = self.compute_signature(schedule)
         self._stop_event = threading.Event()
@@ -89,6 +90,7 @@ class _ScheduleThread:
                         self.context,
                         self.class_name,
                         self.queue_name,
+                        self.application_name,
                     )
                 dbos._sys_db.update_last_fired_at(
                     self.schedule_name, next_exec_time.isoformat()
@@ -118,10 +120,16 @@ def _enqueue_scheduled_workflow(
     context: Any = None,
     class_name: Optional[str] = None,
     queue_name: Optional[str] = None,
+    application_name: Optional[str] = None,
 ) -> None:
     """Enqueue a single scheduled workflow execution via init_workflow."""
-    # Scheduled workflows are always enqueued to the latest application version
-    latest_application_version = sys_db.get_latest_application_version()["version_name"]
+    # The schedule's owner routes its runs, whoever fires them; an unclaimed
+    # schedule falls back to the firing handle, which may itself have no identity.
+    owner = application_name if application_name is not None else sys_db.app_name
+    # Scheduled workflows are always enqueued to their owner's latest application version
+    latest_application_version = sys_db.get_latest_application_version(
+        application_name=owner
+    )["version_name"]
     inputs: WorkflowInputs = {"args": (scheduled_at, context), "kwargs": {}}
     status: WorkflowStatusInternal = {
         "workflow_uuid": workflow_id,
@@ -157,8 +165,8 @@ def _enqueue_scheduled_workflow(
         "schedule_name": schedule_name,
         "debounce_deadline_epoch_ms": None,
         "is_debounced": False,
-        # Always owned: the internal queue's shared name cannot route an unclaimed row.
-        "application_name": sys_db.app_name,
+        # Owned where possible: the internal queue's shared name cannot route an unclaimed row.
+        "application_name": owner,
     }
     sys_db.init_workflow(
         status,
@@ -206,6 +214,7 @@ def backfill_schedule(
                 context,
                 class_name,
                 queue_name,
+                schedule.get("application_name"),
             )
         workflow_ids.append(workflow_id)
     return workflow_ids
@@ -230,6 +239,7 @@ def trigger_schedule(sys_db: "SystemDatabase", schedule_name: str) -> str:
         context,
         class_name,
         queue_name,
+        schedule.get("application_name"),
     )
     return workflow_id
 

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -292,7 +292,9 @@ class SystemSchema:
         "application_versions",
         metadata_obj,
         Column("version_id", Text, primary_key=True),
-        Column("version_name", Text, nullable=False, unique=True),
+        # Identity is (application_name, version_name): a version is content, not an
+        # address, so two applications legitimately compute the same one.
+        Column("version_name", Text, nullable=False),
         Column(
             "version_timestamp",
             BigInteger,
@@ -303,8 +305,23 @@ class SystemSchema:
             BigInteger,
             nullable=False,
         ),
-        # Owning application. NULL means unclaimed; version_name stays globally unique.
+        # Owning application. NULL means unclaimed.
         Column("application_name", Text, nullable=True),
+        Index(
+            "uq_application_versions_owned_name",
+            "application_name",
+            "version_name",
+            unique=True,
+            postgresql_where=text("application_name IS NOT NULL"),
+            sqlite_where=text("application_name IS NOT NULL"),
+        ),
+        Index(
+            "uq_application_versions_unclaimed_name",
+            "version_name",
+            unique=True,
+            postgresql_where=text("application_name IS NULL"),
+            sqlite_where=text("application_name IS NULL"),
+        ),
     )
 
     queues = Table(

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -292,8 +292,7 @@ class SystemSchema:
         "application_versions",
         metadata_obj,
         Column("version_id", Text, primary_key=True),
-        # Identity is (application_name, version_name): a version is content, not an
-        # address, so two applications legitimately compute the same one.
+        # Identity is (application_name, version_name): a version is content, not an address.
         Column("version_name", Text, nullable=False),
         Column(
             "version_timestamp",

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -174,9 +174,7 @@ class SystemSchema:
         Column("started_at_epoch_ms", BigInteger, nullable=True),
         Column("completed_at_epoch_ms", BigInteger, nullable=True),
         Column("serialization", Text()),
-        # Denormalized from the parent workflow so step-level observability can
-        # filter by application without a semi-join back to workflow_status,
-        # whose hash build side scales with the table rather than the time window.
+        # Denormalized from the parent so step observability filters without a join.
         Column("application_name", Text, nullable=True),
         PrimaryKeyConstraint("workflow_uuid", "function_id"),
         Index(

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -303,8 +303,24 @@ class SystemSchema:
             BigInteger,
             nullable=False,
         ),
-        # Owning application. NULL means unclaimed; version_name stays globally unique.
+        # Owning application. NULL means unclaimed; version_name's global uniqueness is being retired for the indexes below, so no write may infer it as an ON CONFLICT arbiter.
         Column("application_name", Text, nullable=True),
+        # Two partial indexes, not one composite: NULL owners would otherwise be free to duplicate.
+        Index(
+            "uq_application_versions_owner_version",
+            "application_name",
+            "version_name",
+            unique=True,
+            postgresql_where=text("application_name IS NOT NULL"),
+            sqlite_where=text("application_name IS NOT NULL"),
+        ),
+        Index(
+            "uq_application_versions_unclaimed_version",
+            "version_name",
+            unique=True,
+            postgresql_where=text("application_name IS NULL"),
+            sqlite_where=text("application_name IS NULL"),
+        ),
     )
 
     queues = Table(

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -292,8 +292,7 @@ class SystemSchema:
         "application_versions",
         metadata_obj,
         Column("version_id", Text, primary_key=True),
-        # Identity is (application_name, version_name): a version is content, not an address.
-        Column("version_name", Text, nullable=False),
+        Column("version_name", Text, nullable=False, unique=True),
         Column(
             "version_timestamp",
             BigInteger,
@@ -304,23 +303,8 @@ class SystemSchema:
             BigInteger,
             nullable=False,
         ),
-        # Owning application. NULL means unclaimed.
+        # Owning application. NULL means unclaimed; version_name stays globally unique.
         Column("application_name", Text, nullable=True),
-        Index(
-            "uq_application_versions_owned_name",
-            "application_name",
-            "version_name",
-            unique=True,
-            postgresql_where=text("application_name IS NOT NULL"),
-            sqlite_where=text("application_name IS NOT NULL"),
-        ),
-        Index(
-            "uq_application_versions_unclaimed_name",
-            "version_name",
-            unique=True,
-            postgresql_where=text("application_name IS NULL"),
-            sqlite_where=text("application_name IS NULL"),
-        ),
     )
 
     queues = Table(

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -78,6 +78,8 @@ class SystemSchema:
         Column("schedule_name", Text, nullable=True),
         Column("debounce_deadline_epoch_ms", BigInteger, nullable=True),
         Column("is_debounced", Boolean, nullable=False, server_default="false"),
+        # Owning application. NULL means unclaimed: any application may read and claim the row.
+        Column("application_name", Text, nullable=True),
         Index("workflow_status_created_at_index", "created_at"),
         Index(
             "idx_workflow_status_delayed",
@@ -280,6 +282,8 @@ class SystemSchema:
         Column("automatic_backfill", Boolean, nullable=False, server_default="false"),
         Column("cron_timezone", Text, nullable=True),
         Column("queue_name", Text, nullable=True),
+        # Owning application. NULL means unclaimed; schedule_name stays globally unique.
+        Column("application_name", Text, nullable=True),
     )
 
     application_versions = Table(
@@ -297,6 +301,8 @@ class SystemSchema:
             BigInteger,
             nullable=False,
         ),
+        # Owning application. NULL means unclaimed; version_name stays globally unique.
+        Column("application_name", Text, nullable=True),
     )
 
     queues = Table(
@@ -318,4 +324,6 @@ class SystemSchema:
         Column("polling_interval_sec", Float, nullable=False, server_default="1.0"),
         Column("created_at", BigInteger, nullable=False),
         Column("updated_at", BigInteger, nullable=False),
+        # Owning application. NULL means unclaimed; name stays globally unique.
+        Column("application_name", Text, nullable=True),
     )

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -174,6 +174,10 @@ class SystemSchema:
         Column("started_at_epoch_ms", BigInteger, nullable=True),
         Column("completed_at_epoch_ms", BigInteger, nullable=True),
         Column("serialization", Text()),
+        # Denormalized from the parent workflow so step-level observability can
+        # filter by application without a semi-join back to workflow_status,
+        # whose hash build side scales with the table rather than the time window.
+        Column("application_name", Text, nullable=True),
         PrimaryKeyConstraint("workflow_uuid", "function_id"),
         Index(
             "idx_operation_outputs_completed_at_function_name",

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -785,6 +785,14 @@ class SystemDatabase(ABC):
         names = [value] if isinstance(value, str) else value
         return sa.or_(col.in_(names), col.is_(None))
 
+    def _observability_filter(
+        self, col: sa.ColumnElement[Any], value: Optional[Union[str, List[str]]]
+    ) -> sa.ColumnElement[bool]:
+        """_name_filter defaulted to this handle's own application: an unset filter
+        scopes to what this application owns, not to every application's rows. A
+        handle with no application of its own still matches every one."""
+        return self._name_filter(col, value if value is not None else self.app_name)
+
     def _resolve_row_owner(
         self,
         conn: sa.Connection,
@@ -1912,8 +1920,10 @@ class SystemDatabase(ABC):
         executor_id_list = _to_list(executor_id)
         prefix_list = _to_list(workflow_id_prefix)
         schedule_name_list = _to_list(schedule_name)
-        # An ordinary filter, not the claiming scope: unset means every application.
-        application_name_list = _to_list(application_name)
+        # Unset scopes to this application, as on every other observability query.
+        application_name_list = _to_list(
+            application_name if application_name is not None else self.app_name
+        )
 
         load_columns = [
             SystemSchema.workflow_status.c.workflow_uuid,
@@ -2423,7 +2433,7 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name)
             )
         query = query.where(
-            self._name_filter(
+            self._observability_filter(
                 SystemSchema.workflow_status.c.application_name, application_name
             )
         )
@@ -2597,7 +2607,7 @@ class SystemDatabase(ABC):
                 <= datetime.datetime.fromisoformat(completed_before).timestamp() * 1000
             )
         query = query.where(
-            self._name_filter(
+            self._observability_filter(
                 SystemSchema.operation_outputs.c.application_name, application_name
             )
         )
@@ -5202,8 +5212,8 @@ class SystemDatabase(ABC):
         Args:
             start_time: ISO 8601 formatted start time
             end_time: ISO 8601 formatted end time
-            application_name: Restrict to these owning applications. Unset counts
-                every application's workflows and steps.
+            application_name: Count only workflows and steps owned by these
+                applications. By default, only count this application's.
         """
         # Convert ISO 8601 times to epoch milliseconds
         start_epoch_ms = int(
@@ -5231,7 +5241,7 @@ class SystemDatabase(ABC):
                 .group_by(SystemSchema.workflow_status.c.name)
             )
             workflow_query = workflow_query.where(
-                self._name_filter(
+                self._observability_filter(
                     SystemSchema.workflow_status.c.application_name, application_name
                 )
             )
@@ -5263,7 +5273,7 @@ class SystemDatabase(ABC):
                 .group_by(SystemSchema.operation_outputs.c.function_name)
             )
             step_query = step_query.where(
-                self._name_filter(
+                self._observability_filter(
                     SystemSchema.operation_outputs.c.application_name, application_name
                 )
             )
@@ -5817,10 +5827,10 @@ class SystemDatabase(ABC):
         application_name: Optional[Union[str, List[str]]] = None,
         conn: Optional[sa.Connection] = None,
     ) -> List[WorkflowSchedule]:
-        """Schedules owned by these applications, plus unclaimed ones. Unset lists
-        every application's, as on list_workflows."""
+        """List only schedules owned by these applications, plus unclaimed ones.
+        By default, only list this application's schedules."""
         return self._list_schedules(
-            self._name_filter(
+            self._observability_filter(
                 SystemSchema.workflow_schedules.c.application_name, application_name
             ),
             status=status,
@@ -6105,12 +6115,12 @@ class SystemDatabase(ABC):
         application_name: Optional[Union[str, List[str]]] = None,
         client_system_database: Optional["SystemDatabase"] = None,
     ) -> List["Queue"]:
-        """Queues owned by these applications, plus unclaimed ones. Unset lists
-        every application's, as on list_workflows."""
+        """List only queues owned by these applications, plus unclaimed ones.
+        By default, only list this application's queues."""
         with self.engine.begin() as c:
             rows = c.execute(
                 sa.select(SystemSchema.queues).where(
-                    self._name_filter(
+                    self._observability_filter(
                         SystemSchema.queues.c.application_name, application_name
                     )
                 )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1332,6 +1332,11 @@ class SystemDatabase(ABC):
                 if original_workflow_id not in status_by_id:
                     raise DBOSNonExistentWorkflowError("target", original_workflow_id)
             statuses = [status_by_id[wid] for wid in original_workflow_ids]
+            # One owner per fork, shared by its status row and its copied steps.
+            fork_owners = {
+                fork_id: (status[11] if status[11] is not None else self.app_name)
+                for fork_id, status in zip(forked_workflow_ids, statuses)
+            }
             # Bulk insert all forked workflow status rows in one statement.
             c.execute(
                 sa.insert(SystemSchema.workflow_status).values(
@@ -1358,9 +1363,7 @@ class SystemDatabase(ABC):
                             forked_from=original_workflow_id,
                             attributes=status[10],
                             # Inherit the source's owner so the fork runs on the same application; claim an unclaimed one, as dequeue does.
-                            application_name=(
-                                status[11] if status[11] is not None else self.app_name
-                            ),
+                            application_name=fork_owners[forked_workflow_id],
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
                             original_workflow_ids, forked_workflow_ids, statuses
@@ -1398,6 +1401,10 @@ class SystemDatabase(ABC):
                             sa.literal(orig_id).label("orig_id"),
                             sa.literal(fork_id).label("fork_id"),
                             sa.literal(step).label("start_step"),
+                            # Cast, since an unclaimed fork makes this a bare NULL the union cannot type.
+                            sa.cast(sa.literal(fork_owners[fork_id]), sa.Text).label(
+                                "owner"
+                            ),
                         )
                         for orig_id, fork_id, step in fork_mappings
                     ]
@@ -1444,9 +1451,7 @@ class SystemDatabase(ABC):
                             oo.c.started_at_epoch_ms,
                             oo.c.completed_at_epoch_ms,
                             # Copied steps carry the owner the fork itself resolved to.
-                            sa.func.coalesce(
-                                oo.c.application_name, sa.literal(self.app_name)
-                            ),
+                            mapping_subquery.c.owner,
                         ).select_from(
                             mapping_subquery.join(
                                 oo,
@@ -4287,6 +4292,13 @@ class SystemDatabase(ABC):
                     .where(
                         SystemSchema.workflow_status.c.status
                         == WorkflowStatusString.ENQUEUED.value
+                    )
+                    # Re-check ownership alongside status, as the partitioned claim_guard does.
+                    .where(
+                        self._name_filter(
+                            SystemSchema.workflow_status.c.application_name,
+                            self.app_name,
+                        )
                     )
                     .values(
                         status=WorkflowStatusString.PENDING.value,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1983,7 +1983,13 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name_list)
             )
         query = query.where(
-            self._observability_filter(
+            # A workflow ID is a global address, so an ID-keyed read is an identity
+            # read: it takes an explicit filter but is never defaulted to this one.
+            self._name_filter(
+                SystemSchema.workflow_status.c.application_name, application_name
+            )
+            if workflow_ids
+            else self._observability_filter(
                 SystemSchema.workflow_status.c.application_name, application_name
             )
         )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1920,10 +1920,6 @@ class SystemDatabase(ABC):
         executor_id_list = _to_list(executor_id)
         prefix_list = _to_list(workflow_id_prefix)
         schedule_name_list = _to_list(schedule_name)
-        # Unset scopes to this application, as on every other observability query.
-        application_name_list = _to_list(
-            application_name if application_name is not None else self.app_name
-        )
 
         load_columns = [
             SystemSchema.workflow_status.c.workflow_uuid,
@@ -1987,8 +1983,8 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name_list)
             )
         query = query.where(
-            self._name_filter(
-                SystemSchema.workflow_status.c.application_name, application_name_list
+            self._observability_filter(
+                SystemSchema.workflow_status.c.application_name, application_name
             )
         )
         if user_list:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -359,6 +359,20 @@ class VersionInfo(TypedDict):
     application_name: Optional[str]
 
 
+# Workflows re-owned per transaction by a rename. Matches the GC default.
+DEFAULT_RENAME_BATCH_SIZE = 10_000
+
+
+class ApplicationRowCounts(TypedDict):
+    """Rows a rename moved, by table."""
+
+    queues: int
+    schedules: int
+    versions: int
+    workflows: int
+    steps: int
+
+
 class StepInfo(TypedDict):
     # The unique ID of the step in the workflow
     function_id: int
@@ -767,7 +781,9 @@ class SystemDatabase(ABC):
         raise DBOSException(
             f"{kind} '{name}' is already registered by application "
             f"'{current}' in this system database. {kind} names must be "
-            f"unique across applications sharing a system database."
+            f"unique across applications sharing a system database. "
+            f"If you renamed '{current}' to '{owner}', re-own its rows first: "
+            f"dbos rename-application --from {current} --to {owner}"
         )
 
     def _insert_workflow_status(
@@ -6170,6 +6186,159 @@ class SystemDatabase(ABC):
                 created_at=row[3],
                 application_name=row[4],
             )
+
+    # ── Application Rename ──────────────────────────────────────
+
+    # Rows a rename must move atomically: a half-owned application dequeues work whose version row it can no longer see.
+    _RENAME_ATOMIC_STATUSES = [
+        WorkflowStatusString.PENDING.value,
+        WorkflowStatusString.ENQUEUED.value,
+        WorkflowStatusString.DELAYED.value,
+    ]
+
+    @staticmethod
+    def _rename_source(
+        col: sa.ColumnElement[Any],
+        old_name: Optional[str],
+        adopt_unclaimed_rows: bool,
+    ) -> sa.ColumnElement[bool]:
+        """Rows a rename moves: an application's own, unclaimed ones, or both. Unlike
+        _name_filter, unclaimed rows are not implied -- they belong to every
+        application, so a rename takes them only when asked."""
+        clauses = []
+        if old_name is not None:
+            clauses.append(col == old_name)
+        if adopt_unclaimed_rows:
+            clauses.append(col.is_(None))
+        # Callers validate that at least one source is named.
+        return sa.or_(*clauses)
+
+    def _rename_rows_in_batches(
+        self,
+        table: sa.Table,
+        key_col: sa.ColumnElement[Any],
+        old_name: Optional[str],
+        new_name: str,
+        batch_size: Optional[int],
+        adopt_unclaimed_rows: bool,
+    ) -> int:
+        """Re-own a table's rows, batching by key so a long history does not move in one
+        transaction. Each pass shrinks its own predicate, so this terminates on its own
+        and a re-run resumes an interrupted rename."""
+        predicate = self._rename_source(
+            table.c.application_name, old_name, adopt_unclaimed_rows
+        )
+        if batch_size is None:
+            with self.engine.begin() as c:
+                return c.execute(
+                    sa.update(table).where(predicate).values(application_name=new_name)
+                ).rowcount
+        total = 0
+        while True:
+            with self.engine.begin() as c:
+                # correlate(None): otherwise SQLAlchemy correlates the subquery to the UPDATE target and drops its FROM.
+                keys = (
+                    sa.select(key_col)
+                    .select_from(table)
+                    .where(predicate)
+                    .distinct()
+                    .limit(batch_size)
+                    .correlate(None)
+                )
+                # Re-check the predicate: a key may also address rows another application owns, which this rename must not take.
+                updated = c.execute(
+                    sa.update(table)
+                    .where(key_col.in_(keys), predicate)
+                    .values(application_name=new_name)
+                ).rowcount
+            if updated == 0:
+                return total
+            total += updated
+
+    def rename_application(
+        self,
+        old_name: Optional[str],
+        new_name: str,
+        *,
+        batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
+        adopt_unclaimed_rows: bool = False,
+    ) -> ApplicationRowCounts:
+        """Give ``new_name`` ownership of rows another name holds, rows nobody holds,
+        or both. Naming ``old_name`` alone renames an application; omitting it and
+        setting ``adopt_unclaimed_rows`` only adopts, which is how an application takes
+        over a system database whose rows predate ownership.
+
+        Queue, schedule, and version names are globally unique whatever their owner, so
+        this can never collide: it is pure re-ownership, never a merge.
+
+        The control-plane rows and every in-flight workflow move in one transaction, so
+        the application is never half-owned. Terminal workflows and their steps follow in
+        batches; they scope only observability and garbage collection, so they may lag.
+
+        The application named by ``old_name`` must not be running: a dequeue racing this
+        stamps the old name back onto a row this has already passed.
+
+        ``adopt_unclaimed_rows`` takes rows no application owns. They belong to every
+        application sharing this system database, so adopting them takes them from any
+        peer; left false, unclaimed rows are not touched.
+        """
+        from ._dbos_config import _is_valid_app_name
+
+        if old_name is not None and not old_name:
+            raise DBOSException("The application's previous name cannot be empty.")
+        if old_name is None and not adopt_unclaimed_rows:
+            raise DBOSException(
+                "Nothing to re-own: name the application to rename, adopt unclaimed "
+                "rows, or both."
+            )
+        if not _is_valid_app_name(new_name):
+            raise DBOSException(
+                f"Invalid application name '{new_name}'. Application names must be "
+                "between 3 and 30 characters long and contain only lowercase letters, "
+                "numbers, dashes, and underscores."
+            )
+        if old_name == new_name:
+            raise DBOSException(
+                f"Application '{new_name}' already holds that name; nothing to rename."
+            )
+        if batch_size is not None and batch_size < 1:
+            raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
+
+        ws = SystemSchema.workflow_status
+        with self.engine.begin() as c:
+
+            def move(table: sa.Table, *extra: sa.ColumnElement[bool]) -> int:
+                return c.execute(
+                    sa.update(table)
+                    .where(
+                        self._rename_source(
+                            table.c.application_name, old_name, adopt_unclaimed_rows
+                        ),
+                        *extra,
+                    )
+                    .values(application_name=new_name)
+                ).rowcount
+
+            queues = move(SystemSchema.queues)
+            schedules = move(SystemSchema.workflow_schedules)
+            versions = move(SystemSchema.application_versions)
+            in_flight = move(ws, ws.c.status.in_(self._RENAME_ATOMIC_STATUSES))
+
+        # Phase one already moved the in-flight rows, so these predicates now match only terminal ones.
+        terminal = self._rename_rows_in_batches(
+            ws, ws.c.workflow_uuid, old_name, new_name, batch_size, adopt_unclaimed_rows
+        )
+        oo = SystemSchema.operation_outputs
+        steps = self._rename_rows_in_batches(
+            oo, oo.c.workflow_uuid, old_name, new_name, batch_size, adopt_unclaimed_rows
+        )
+        return ApplicationRowCounts(
+            queues=queues,
+            schedules=schedules,
+            versions=versions,
+            workflows=in_flight + terminal,
+            steps=steps,
+        )
 
     @db_retry()
     def call_txn_as_step(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -2143,6 +2143,7 @@ class SystemDatabase(ABC):
         group_by_queue_name: bool = False,
         group_by_executor_id: bool = False,
         group_by_application_version: bool = False,
+        group_by_application_name: bool = False,
         select_count: bool = False,
         select_min_created_at: bool = False,
         select_max_queue_wait_ms: bool = False,
@@ -2191,6 +2192,11 @@ class SystemDatabase(ABC):
                 "application_version",
                 group_by_application_version,
                 SystemSchema.workflow_status.c.application_version,
+            ),
+            (
+                "application_name",
+                group_by_application_name,
+                SystemSchema.workflow_status.c.application_name,
             ),
         ]
         group_names: List[str] = []

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -6103,7 +6103,12 @@ class SystemDatabase(ABC):
             c.execute(stmt)
             return not existed
 
-    def get_latest_application_version(self) -> VersionInfo:
+    def get_latest_application_version(
+        self, application_name: Optional[str] = None
+    ) -> VersionInfo:
+        """Latest version registered by an application. Defaults to this handle's, so
+        a caller acting for another one — firing its schedule — must name it."""
+        owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
             row = c.execute(
                 sa.select(
@@ -6116,7 +6121,7 @@ class SystemDatabase(ABC):
                 .where(
                     self._name_filter(
                         SystemSchema.application_versions.c.application_name,
-                        self.app_name,
+                        owner,
                     )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -778,12 +778,19 @@ class SystemDatabase(ABC):
         current: Optional[str] = existing[0]
         if owner is None or current == owner:
             return current
+        # A version name is computed or pinned, never chosen like a queue's, so say so.
+        take_a_new_name = (
+            f"set a distinct application_version for '{owner}'"
+            if kind == "Application version"
+            else f"give '{owner}' a different {kind.lower()} name"
+        )
         raise DBOSException(
             f"{kind} '{name}' is already registered by application "
             f"'{current}' in this system database. {kind} names must be "
-            f"unique across applications sharing a system database. "
-            f"If you renamed '{current}' to '{owner}', re-own its rows first: "
-            f"dbos rename-application --from {current} --to {owner}"
+            f"unique across applications sharing a system database. Either "
+            f"{take_a_new_name}, or, if '{current}' was renamed to '{owner}', "
+            f"re-own its rows first with "
+            f"dbos rename-application"
         )
 
     def _insert_workflow_status(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -742,7 +742,7 @@ class SystemDatabase(ABC):
         names = [value] if isinstance(value, str) else value
         return sa.or_(col.in_(names), col.is_(None))
 
-    def _check_row_owner(
+    def _resolve_row_owner(
         self,
         conn: sa.Connection,
         table: sa.Table,
@@ -750,17 +750,21 @@ class SystemDatabase(ABC):
         name: str,
         owner: Optional[str],
         kind: str,
-    ) -> None:
-        """Reject writing over a row owned by a different application: names are
-        globally unique, so a collision is a conflict, not a last-writer-wins race."""
+    ) -> Optional[str]:
+        """Owner to persist when writing a row that may already exist. A writer with
+        no identity of its own acts on any row and leaves that row's owner intact; a
+        named one collides only with a different name, as names are globally unique."""
         existing = conn.execute(
             sa.select(table.c.application_name).where(name_col == name)
         ).fetchone()
-        if existing is None or existing[0] is None or existing[0] == owner:
-            return
+        if existing is None or existing[0] is None:
+            return owner
+        current: Optional[str] = existing[0]
+        if owner is None or current == owner:
+            return current
         raise DBOSException(
             f"{kind} '{name}' is already registered by application "
-            f"'{existing[0]}' in this system database. {kind} names must be "
+            f"'{current}' in this system database. {kind} names must be "
             f"unique across applications sharing a system database."
         )
 
@@ -5620,7 +5624,7 @@ class SystemDatabase(ABC):
         self, schedule: WorkflowSchedule, conn: Optional[sa.Connection] = None
     ) -> None:
         def _do(c: sa.Connection) -> None:
-            self._check_row_owner(
+            owner = self._resolve_row_owner(
                 c,
                 SystemSchema.workflow_schedules,
                 SystemSchema.workflow_schedules.c.schedule_name,
@@ -5642,7 +5646,7 @@ class SystemDatabase(ABC):
                         automatic_backfill=schedule.get("automatic_backfill", False),
                         cron_timezone=schedule.get("cron_timezone"),
                         queue_name=schedule.get("queue_name"),
-                        application_name=schedule.get("application_name"),
+                        application_name=owner,
                     )
                 )
             except sa.exc.IntegrityError:
@@ -5661,7 +5665,7 @@ class SystemDatabase(ABC):
     ) -> None:
         # Idempotent upsert by schedule_name; preserves schedule_id, status, and last_fired_at on conflict. The scheduler loop detects the changed definition and restarts the thread.
         def _do(c: sa.Connection) -> None:
-            self._check_row_owner(
+            owner = self._resolve_row_owner(
                 c,
                 SystemSchema.workflow_schedules,
                 SystemSchema.workflow_schedules.c.schedule_name,
@@ -5683,7 +5687,7 @@ class SystemDatabase(ABC):
                     automatic_backfill=schedule.get("automatic_backfill", False),
                     cron_timezone=schedule.get("cron_timezone"),
                     queue_name=schedule.get("queue_name"),
-                    application_name=schedule.get("application_name"),
+                    application_name=owner,
                 )
                 .on_conflict_do_update(
                     index_elements=["schedule_name"],
@@ -5695,7 +5699,7 @@ class SystemDatabase(ABC):
                         "automatic_backfill": schedule.get("automatic_backfill", False),
                         "cron_timezone": schedule.get("cron_timezone"),
                         "queue_name": schedule.get("queue_name"),
-                        "application_name": schedule.get("application_name"),
+                        "application_name": owner,
                     },
                 )
             )
@@ -6083,14 +6087,6 @@ class SystemDatabase(ABC):
             "application_name": owner,
         }
         with self.engine.begin() as c:
-            self._check_row_owner(
-                c,
-                SystemSchema.queues,
-                SystemSchema.queues.c.name,
-                name,
-                owner,
-                "Queue",
-            )
             existed = (
                 c.execute(
                     sa.select(SystemSchema.queues.c.name).where(
@@ -6098,6 +6094,16 @@ class SystemDatabase(ABC):
                     )
                 ).fetchone()
                 is not None
+            )
+            # A name collision is a conflict in every mode: the name is the queue's
+            # address, and declining to update it does not make it ours to enqueue to.
+            values["application_name"] = self._resolve_row_owner(
+                c,
+                SystemSchema.queues,
+                SystemSchema.queues.c.name,
+                name,
+                owner,
+                "Queue",
             )
             stmt = self.dialect.insert(SystemSchema.queues).values(**values)
             if update_existing:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -749,23 +749,6 @@ class SystemDatabase(ABC):
             return sa.true()
         return sa.or_(col == self.app_name, col.is_(None))
 
-    @staticmethod
-    def _owning_workflow_exists(
-        application_name: List[str],
-    ) -> sa.ColumnElement[bool]:
-        """Semi-join from operation_outputs to its workflow's owning application.
-
-        operation_outputs carries no owner of its own, so filtering steps by
-        application has to go through the parent row.
-        """
-        return sa.exists().where(
-            sa.and_(
-                SystemSchema.workflow_status.c.workflow_uuid
-                == SystemSchema.operation_outputs.c.workflow_uuid,
-                SystemSchema.workflow_status.c.application_name.in_(application_name),
-            )
-        )
-
     def _check_row_owner(
         self,
         conn: sa.Connection,
@@ -1390,6 +1373,7 @@ class SystemDatabase(ABC):
                             "child_workflow_id",
                             "started_at_epoch_ms",
                             "completed_at_epoch_ms",
+                            "application_name",
                         ],
                         sa.select(
                             mapping_subquery.c.fork_id.label("workflow_uuid"),
@@ -1401,6 +1385,9 @@ class SystemDatabase(ABC):
                             child_wf_expr,
                             oo.c.started_at_epoch_ms,
                             oo.c.completed_at_epoch_ms,
+                            # The fork inherits the source workflow's owner, so its
+                            # copied steps must inherit the same one.
+                            oo.c.application_name,
                         ).select_from(
                             mapping_subquery.join(
                                 oo,
@@ -2539,9 +2526,9 @@ class SystemDatabase(ABC):
                 <= datetime.datetime.fromisoformat(completed_before).timestamp() * 1000
             )
         if application_name:
-            # operation_outputs has no owner column; reach it through the parent
-            # workflow. Built only when filtering, so the default path is unchanged.
-            query = query.where(self._owning_workflow_exists(application_name))
+            query = query.where(
+                SystemSchema.operation_outputs.c.application_name.in_(application_name)
+            )
 
         query = query.group_by(*group_columns)
 
@@ -2620,6 +2607,9 @@ class SystemDatabase(ABC):
                     output=output,
                     error=error,
                     serialization=result["serialization"],
+                    # Mirrors the parent workflow's owner: only the application
+                    # running a workflow records its steps.
+                    application_name=self.app_name,
                 )
                 .on_conflict_do_update(
                     index_elements=[
@@ -2705,6 +2695,7 @@ class SystemDatabase(ABC):
                     started_at_epoch_ms=started_at_epoch_ms,
                     completed_at_epoch_ms=int(time.time() * 1000),
                     serialization=serialization,
+                    application_name=self.app_name,
                 )
                 .on_conflict_do_nothing()
             )
@@ -2737,6 +2728,7 @@ class SystemDatabase(ABC):
             child_workflow_id=childUUID,
             started_at_epoch_ms=started_at_epoch_ms,
             completed_at_epoch_ms=int(time.time() * 1000),
+            application_name=self.app_name,
         )
         try:
             with self.engine.begin() as c:
@@ -5184,7 +5176,9 @@ class SystemDatabase(ABC):
             )
             if application_name:
                 step_query = step_query.where(
-                    self._owning_workflow_exists(application_name)
+                    SystemSchema.operation_outputs.c.application_name.in_(
+                        application_name
+                    )
                 )
 
             step_results = c.execute(step_query).fetchall()
@@ -5413,6 +5407,7 @@ class SystemDatabase(ABC):
                         SystemSchema.operation_outputs.c.started_at_epoch_ms,
                         SystemSchema.operation_outputs.c.completed_at_epoch_ms,
                         SystemSchema.operation_outputs.c.serialization,
+                        SystemSchema.operation_outputs.c.application_name,
                     ).where(SystemSchema.operation_outputs.c.workflow_uuid == wf_id)
                 ).fetchall()
 
@@ -5427,6 +5422,7 @@ class SystemDatabase(ABC):
                         "started_at_epoch_ms": row[6],
                         "completed_at_epoch_ms": row[7],
                         "serialization": row[8],
+                        "application_name": row[9],
                     }
                     for row in output_rows
                 ]
@@ -5581,6 +5577,7 @@ class SystemDatabase(ABC):
                             started_at_epoch_ms=output["started_at_epoch_ms"],
                             completed_at_epoch_ms=output["completed_at_epoch_ms"],
                             serialization=output["serialization"],
+                            application_name=output.get("application_name"),
                         )
                     )
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1151,7 +1151,7 @@ class SystemDatabase(ABC):
         workflow_name ensures a debounce-key collision between different workflows
         (e.g. "a"+"b-c" vs "a-b"+"c") never overwrites another workflow's inputs.
         The bounce acts for ``application_name``: it extends only that
-        application's holders plus unclaimed ones, which it claims for it.
+        application's holders plus unclaimed ones, claiming those for it.
         If nothing matched, returns the current holder (or that the key is unheld)
         so the caller can decide whether to start fresh or surface a conflict.
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1153,8 +1153,7 @@ class SystemDatabase(ABC):
                 .where(wsc.deduplication_id == deduplication_id)
                 .where(wsc.status == WorkflowStatusString.DELAYED.value)
                 .where(wsc.is_debounced == True)
-                # Never extend another application's workflow: its poller would run
-                # its own code against our inputs. Falls through to the holder below.
+                # Never extend another application's workflow; falls through to the holder below.
                 .where(self._name_filter(wsc.application_name, self.app_name))
                 .values(
                     delay_until_epoch_ms=capped_delay,
@@ -1172,8 +1171,7 @@ class SystemDatabase(ABC):
                     "holder_workflow_name": None,
                     "holder_application_name": None,
                 }
-            # No match: the key is unheld, or held by a non-debounced, name-colliding,
-            # or foreign-application workflow. Unscoped, so the holder is reportable.
+            # Unscoped, so a holder that blocked the update above is reportable.
             holder = c.execute(
                 sa.select(
                     wsc.workflow_uuid, wsc.is_debounced, wsc.name, wsc.application_name
@@ -5920,8 +5918,7 @@ class SystemDatabase(ABC):
                     )
                 ).fetchone()
                 if mine is None:
-                    # Claim a pre-upgrade row so a pinned version does not stay
-                    # unclaimed; skipped if this application already has its own.
+                    # Claim a pre-upgrade row, unless this application already has its own.
                     c.execute(
                         sa.update(av)
                         .where(
@@ -6106,8 +6103,7 @@ class SystemDatabase(ABC):
                 ).fetchone()
                 is not None
             )
-            # A name collision is a conflict in every mode: the name is the queue's
-            # address, and declining to update it does not make it ours to enqueue to.
+            # A name collision is a conflict in every mode: the name is the queue's address.
             values["application_name"] = self._resolve_row_owner(
                 c,
                 SystemSchema.queues,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -6223,8 +6223,15 @@ class SystemDatabase(ABC):
         adopt_unclaimed_rows: bool,
     ) -> int:
         """Re-own a table's rows, batching by key so a long history does not move in one
-        transaction. Each pass shrinks its own predicate, so this terminates on its own
-        and a re-run resumes an interrupted rename."""
+        transaction. A re-run resumes an interrupted rename, since moved rows stop
+        matching.
+
+        Each batch is a half-open key range, advancing a watermark, so both the probe
+        and the update are index range scans. Selecting the batch with LIMIT instead
+        costs O(batches^2): the rows already moved no longer match, but the scan still
+        pages them in to skip them, and an IN list of keys plans as a whole-table hash
+        join. Both only look cheap while the table fits in cache.
+        """
         predicate = self._rename_source(
             table.c.application_name, old_name, adopt_unclaimed_rows
         )
@@ -6234,26 +6241,32 @@ class SystemDatabase(ABC):
                     sa.update(table).where(predicate).values(application_name=new_name)
                 ).rowcount
         total = 0
+        watermark: Optional[Any] = None
         while True:
+            scope = (
+                predicate
+                if watermark is None
+                else sa.and_(predicate, key_col > watermark)
+            )
             with self.engine.begin() as c:
-                # correlate(None): otherwise SQLAlchemy correlates the subquery to the UPDATE target and drops its FROM.
-                keys = (
+                # The batch_size-th matching key bounds this range; distinct, so a key's rows are never split across batches.
+                upper = c.execute(
                     sa.select(key_col)
-                    .select_from(table)
-                    .where(predicate)
+                    .where(scope)
                     .distinct()
-                    .limit(batch_size)
-                    .correlate(None)
-                )
-                # Re-check the predicate: a key may also address rows another application owns, which this rename must not take.
-                updated = c.execute(
+                    .order_by(key_col)
+                    .limit(1)
+                    .offset(batch_size - 1)
+                ).scalar()
+                total += c.execute(
                     sa.update(table)
-                    .where(key_col.in_(keys), predicate)
+                    .where(scope if upper is None else sa.and_(scope, key_col <= upper))
                     .values(application_name=new_name)
                 ).rowcount
-            if updated == 0:
+            # Fewer than a full batch remained, so that update took the rest.
+            if upper is None:
                 return total
-            total += updated
+            watermark = upper
 
     def rename_application(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -345,6 +345,8 @@ class ClientScheduleInput(TypedDict, total=False):
     automatic_backfill: bool
     cron_timezone: Optional[str]
     queue_name: Optional[str]
+    # Owning application; unset falls back to the client's own.
+    application_name: Optional[str]
 
 
 class VersionInfo(TypedDict):
@@ -730,6 +732,86 @@ class SystemDatabase(ABC):
                 return sa.func.unixepoch("subsec") * 1000
             return sa.func.strftime("%s", "now") * 1000
         return sa.func.extract("epoch", sa.func.now()) * 1000
+
+    def _app_scope(self, col: sa.ColumnElement[Any]) -> sa.ColumnElement[bool]:
+        """Rows this application may act on: its own, plus unclaimed ones.
+
+        Unclaimed (NULL) rows are written by SDKs predating the column and by
+        callers with no application identity, so every application must be able to
+        claim them — otherwise upgrading would strand in-flight work.
+
+        This is the claiming scope: dequeue, recovery, the enumeration the
+        background loops run on, and the bulk delete/cancel operations. It is
+        deliberately not what the observability filters use, which match an owner
+        exactly and default to matching nothing at all.
+        """
+        if self.app_name is None:
+            return sa.true()
+        return sa.or_(col == self.app_name, col.is_(None))
+
+    @staticmethod
+    def _owning_workflow_exists(
+        application_name: List[str],
+    ) -> sa.ColumnElement[bool]:
+        """Semi-join from operation_outputs to its workflow's owning application.
+
+        operation_outputs carries no owner of its own, so filtering steps by
+        application has to go through the parent row.
+        """
+        return sa.exists().where(
+            sa.and_(
+                SystemSchema.workflow_status.c.workflow_uuid
+                == SystemSchema.operation_outputs.c.workflow_uuid,
+                SystemSchema.workflow_status.c.application_name.in_(application_name),
+            )
+        )
+
+    def _adopt_unnamed_row(
+        self,
+        conn: sa.Connection,
+        table: sa.Table,
+        name_col: sa.ColumnElement[Any],
+        name: str,
+        owner: Optional[str],
+    ) -> None:
+        """Claim a pre-upgrade row for a name the caller declares.
+
+        Scoped to one name so an application only ever claims rows it registers
+        itself, which keeps two applications on one system database from taking
+        each other's queues or schedules.
+        """
+        if owner is None:
+            return
+        conn.execute(
+            sa.update(table)
+            .where(name_col == name, table.c.application_name.is_(None))
+            .values(application_name=owner)
+        )
+
+    def _check_row_owner(
+        self,
+        conn: sa.Connection,
+        table: sa.Table,
+        name_col: sa.ColumnElement[Any],
+        name: str,
+        owner: Optional[str],
+        kind: str,
+    ) -> None:
+        """Reject writing over a row owned by a different application.
+
+        Names stay globally unique across applications, so a collision is a real
+        conflict rather than something to silently resolve by last-writer-wins.
+        """
+        existing = conn.execute(
+            sa.select(table.c.application_name).where(name_col == name)
+        ).fetchone()
+        if existing is None or existing[0] is None or existing[0] == owner:
+            return
+        raise DBOSException(
+            f"{kind} '{name}' is already registered by application "
+            f"'{existing[0]}' in this system database. {kind} names must be "
+            f"unique across applications sharing a system database."
+        )
 
     def _insert_workflow_status(
         self,
@@ -1778,6 +1860,7 @@ class SystemDatabase(ABC):
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
         schedule_name: Optional[str | list[str]] = None,
+        application_name: Optional[str | list[str]] = None,
     ) -> List[WorkflowStatus]:
         """
         Retrieve a list of workflows based on the search criteria.
@@ -1800,6 +1883,8 @@ class SystemDatabase(ABC):
         executor_id_list = _to_list(executor_id)
         prefix_list = _to_list(workflow_id_prefix)
         schedule_name_list = _to_list(schedule_name)
+        # An ordinary filter, not the claiming scope: unset means every application.
+        application_name_list = _to_list(application_name)
 
         load_columns = [
             SystemSchema.workflow_status.c.workflow_uuid,
@@ -1861,6 +1946,12 @@ class SystemDatabase(ABC):
         if schedule_name_list:
             query = query.where(
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name_list)
+            )
+        if application_name_list:
+            query = query.where(
+                SystemSchema.workflow_status.c.application_name.in_(
+                    application_name_list
+                )
             )
         if user_list:
             query = query.where(
@@ -2034,6 +2125,9 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.PENDING.value,
                     SystemSchema.workflow_status.c.executor_id == executor_id,
                     SystemSchema.workflow_status.c.application_version == app_version,
+                    # executor_id defaults to the literal "local", so it collides
+                    # across applications on a shared host; this disambiguates.
+                    self._app_scope(SystemSchema.workflow_status.c.application_name),
                 )
             ).fetchall()
 
@@ -2125,6 +2219,7 @@ class SystemDatabase(ABC):
         parent_workflow_id: Optional[List[str]] = None,
         user: Optional[List[str]] = None,
         schedule_name: Optional[List[str]] = None,
+        application_name: Optional[List[str]] = None,
         was_forked_from: Optional[bool] = None,
         has_parent: Optional[bool] = None,
         attributes: Optional[Dict[str, Any]] = None,
@@ -2292,6 +2387,10 @@ class SystemDatabase(ABC):
             query = query.where(
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name)
             )
+        if application_name:
+            query = query.where(
+                SystemSchema.workflow_status.c.application_name.in_(application_name)
+            )
         if was_forked_from is not None:
             query = query.where(
                 SystemSchema.workflow_status.c.was_forked_from == was_forked_from
@@ -2361,6 +2460,7 @@ class SystemDatabase(ABC):
         workflow_id_prefix: Optional[List[str]] = None,
         completed_after: Optional[str] = None,
         completed_before: Optional[str] = None,
+        application_name: Optional[List[str]] = None,
     ) -> List[StepAggregateRow]:
         if time_bucket_size_ms is not None and time_bucket_size_ms <= 0:
             raise ValueError("time_bucket_size_ms must be > 0")
@@ -2460,6 +2560,10 @@ class SystemDatabase(ABC):
                 SystemSchema.operation_outputs.c.completed_at_epoch_ms
                 <= datetime.datetime.fromisoformat(completed_before).timestamp() * 1000
             )
+        if application_name:
+            # operation_outputs has no owner column; reach it through the parent
+            # workflow. Built only when filtering, so the default path is unchanged.
+            query = query.where(self._owning_workflow_exists(application_name))
 
         query = query.group_by(*group_columns)
 
@@ -3912,6 +4016,8 @@ class SystemDatabase(ABC):
                     sa.literal_column(f"'{WorkflowStatusString.PENDING.value}'"),
                 ]
             ),
+            # Only partitions this application can actually dequeue from.
+            self._app_scope(ws.c.application_name),
         )
         partitions = (
             sa.select(sa.func.min(ws.c.queue_partition_key).label("pk"))
@@ -4002,6 +4108,11 @@ class SystemDatabase(ABC):
                         SystemSchema.workflow_status.c.started_at_epoch_ms
                         > start_time_ms - limiter_period_ms
                     )
+                    # Count only what this application would dequeue, so the rate
+                    # limit matches the set the select below draws from.
+                    .where(
+                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                    )
                 )
                 if queue_partition_key is not None:
                     query = query.where(
@@ -4029,6 +4140,9 @@ class SystemDatabase(ABC):
                         SystemSchema.workflow_status.c.status
                         == WorkflowStatusString.PENDING.value
                     )
+                    .where(
+                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                    )
                 )
                 if queue_partition_key is not None:
                     global_pending_query = global_pending_query.where(
@@ -4045,6 +4159,15 @@ class SystemDatabase(ABC):
 
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
+                # This application's latest version, not the newest on the
+                # database. Unclaimed rows count: one that is newer means an
+                # older-SDK peer deployed after this worker, which really does
+                # demote it.
+                .where(
+                    self._app_scope(
+                        SystemSchema.application_versions.c.application_name
+                    )
+                )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
                 .limit(1)
             ).scalar()
@@ -4073,6 +4196,7 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.ENQUEUED.value
                 )
                 .where(version_predicate)
+                .where(self._app_scope(SystemSchema.workflow_status.c.application_name))
                 # Unless global concurrency is set, use skip_locked to only select
                 # rows that can be locked. If global concurrency is set, use no_wait
                 # to ensure all processes have a consistent view of the table.
@@ -4119,6 +4243,9 @@ class SystemDatabase(ABC):
                         status=WorkflowStatusString.PENDING.value,
                         application_version=app_version,
                         executor_id=executor_id,
+                        # Claim the row: unclaimed workflows are adopted by whoever
+                        # runs them, so the unclaimed partition drains over time.
+                        application_name=self.app_name,
                         started_at_epoch_ms=start_time_ms,
                         rate_limited=queue._limiter is not None,
                         # If a timeout is set, set the deadline on dequeue
@@ -4166,6 +4293,15 @@ class SystemDatabase(ABC):
         with self.engine.begin() as c:
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
+                # This application's latest version, not the newest on the
+                # database. Unclaimed rows count: one that is newer means an
+                # older-SDK peer deployed after this worker, which really does
+                # demote it.
+                .where(
+                    self._app_scope(
+                        SystemSchema.application_versions.c.application_name
+                    )
+                )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
                 .limit(1)
             ).scalar()
@@ -4187,6 +4323,7 @@ class SystemDatabase(ABC):
                 ws.c.queue_name == queue.name,
                 ws.c.status == WorkflowStatusString.ENQUEUED.value,
                 status_prover,
+                self._app_scope(ws.c.application_name),
             )
             # Walk distinct partition keys with a recursive-CTE loose index scan (one seek per key, mirroring get_queue_partitions) so sweep cost scales with partition count, not backlog depth.
             partitions = (
@@ -4217,7 +4354,10 @@ class SystemDatabase(ABC):
                 )
                 .limit(1)
             )
-            # Admit a partition's head only while nothing in that partition runs anywhere, on any app version.
+            # Admit a partition's head only while nothing in that partition runs
+            # anywhere, on any app version, for any application. Deliberately
+            # unscoped: this is a mutual-exclusion probe, so a row owned by someone
+            # else still has to block admission.
             pending_probe = (
                 sa.select(sa.literal(1))
                 .where(ws.c.queue_name == queue.name)
@@ -4265,6 +4405,7 @@ class SystemDatabase(ABC):
                 ws.c.queue_name == queue.name,
                 ws.c.queue_partition_key.isnot(None),
                 version_predicate,
+                self._app_scope(ws.c.application_name),
             )
             # Lock the fixed candidate set -- never a LIMIT query, whose SKIP LOCKED could slide past a locked head and admit out of order. On SQLite this is an unlocked re-read; the RETURNING flip below is the guard.
             locked_rows = c.execute(
@@ -4287,6 +4428,8 @@ class SystemDatabase(ABC):
                     status=WorkflowStatusString.PENDING.value,
                     application_version=app_version,
                     executor_id=executor_id,
+                    # Claim the row, as the unpartitioned dequeue does.
+                    application_name=self.app_name,
                     started_at_epoch_ms=start_time_ms,
                     rate_limited=False,
                     # If a timeout is set, set the deadline on dequeue
@@ -4879,6 +5022,9 @@ class SystemDatabase(ABC):
                 # Get the created_at timestamp of the rows_threshold newest row
                 result = c.execute(
                     sa.select(SystemSchema.workflow_status.c.created_at)
+                    .where(
+                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                    )
                     .order_by(SystemSchema.workflow_status.c.created_at.desc())
                     .limit(1)
                     .offset(rows_threshold - 1)
@@ -4906,6 +5052,10 @@ class SystemDatabase(ABC):
                     WorkflowStatusString.DELAYED.value,
                 ]
             ),
+            # Collect this application's rows and unclaimed ones. Unclaimed rows are
+            # included deliberately: excluding them would leak every pre-upgrade row
+            # forever, since no application would ever be entitled to collect them.
+            self._app_scope(SystemSchema.workflow_status.c.application_name),
         )
 
         if batch_size is None:
@@ -4948,7 +5098,8 @@ class SystemDatabase(ABC):
             pending_enqueued_result = c.execute(
                 sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
                     SystemSchema.workflow_status.c.created_at
-                    < cutoff_epoch_timestamp_ms
+                    < cutoff_epoch_timestamp_ms,
+                    self._app_scope(SystemSchema.workflow_status.c.application_name),
                 )
             ).fetchall()
 
@@ -4957,13 +5108,43 @@ class SystemDatabase(ABC):
                 row[0] for row in pending_enqueued_result
             ]
 
-    def get_metrics(self, start_time: str, end_time: str) -> List[MetricData]:
+    def list_timed_out_workflow_ids(self, cutoff_epoch_timestamp_ms: int) -> List[str]:
+        """IDs of this application's in-flight workflows created before the cutoff.
+
+        Uses the claiming scope rather than an exact owner match, so an upgrading
+        application still times out its own pre-upgrade (unclaimed) workflows.
+        """
+        with self.engine.begin() as c:
+            rows = c.execute(
+                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                    SystemSchema.workflow_status.c.status.in_(
+                        [
+                            WorkflowStatusString.PENDING.value,
+                            WorkflowStatusString.ENQUEUED.value,
+                            WorkflowStatusString.DELAYED.value,
+                        ]
+                    ),
+                    SystemSchema.workflow_status.c.created_at
+                    <= cutoff_epoch_timestamp_ms,
+                    self._app_scope(SystemSchema.workflow_status.c.application_name),
+                )
+            ).fetchall()
+            return [row[0] for row in rows]
+
+    def get_metrics(
+        self,
+        start_time: str,
+        end_time: str,
+        application_name: Optional[List[str]] = None,
+    ) -> List[MetricData]:
         """
         Retrieve the number of workflows and steps that ran in a time range.
 
         Args:
             start_time: ISO 8601 formatted start time
             end_time: ISO 8601 formatted end time
+            application_name: Restrict to these owning applications. Unset counts
+                every application's workflows and steps.
         """
         # Convert ISO 8601 times to epoch milliseconds
         start_epoch_ms = int(
@@ -4990,6 +5171,12 @@ class SystemDatabase(ABC):
                 )
                 .group_by(SystemSchema.workflow_status.c.name)
             )
+            if application_name:
+                workflow_query = workflow_query.where(
+                    SystemSchema.workflow_status.c.application_name.in_(
+                        application_name
+                    )
+                )
 
             workflow_results = c.execute(workflow_query).fetchall()
             for row in workflow_results:
@@ -5017,6 +5204,10 @@ class SystemDatabase(ABC):
                 )
                 .group_by(SystemSchema.operation_outputs.c.function_name)
             )
+            if application_name:
+                step_query = step_query.where(
+                    self._owning_workflow_exists(application_name)
+                )
 
             step_results = c.execute(step_query).fetchall()
             for row in step_results:
@@ -5457,6 +5648,14 @@ class SystemDatabase(ABC):
         self, schedule: WorkflowSchedule, conn: Optional[sa.Connection] = None
     ) -> None:
         def _do(c: sa.Connection) -> None:
+            self._check_row_owner(
+                c,
+                SystemSchema.workflow_schedules,
+                SystemSchema.workflow_schedules.c.schedule_name,
+                schedule["schedule_name"],
+                schedule.get("application_name"),
+                "Schedule",
+            )
             try:
                 c.execute(
                     sa.insert(SystemSchema.workflow_schedules).values(
@@ -5490,6 +5689,21 @@ class SystemDatabase(ABC):
     ) -> None:
         # Idempotent upsert by schedule_name; preserves schedule_id, status, and last_fired_at on conflict. The scheduler loop detects the changed definition and restarts the thread.
         def _do(c: sa.Connection) -> None:
+            self._check_row_owner(
+                c,
+                SystemSchema.workflow_schedules,
+                SystemSchema.workflow_schedules.c.schedule_name,
+                schedule["schedule_name"],
+                schedule.get("application_name"),
+                "Schedule",
+            )
+            self._adopt_unnamed_row(
+                c,
+                SystemSchema.workflow_schedules,
+                SystemSchema.workflow_schedules.c.schedule_name,
+                schedule["schedule_name"],
+                schedule.get("application_name"),
+            )
             c.execute(
                 self.dialect.insert(SystemSchema.workflow_schedules)
                 .values(
@@ -5549,6 +5763,9 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_schedules.c.cron_timezone,
                 SystemSchema.workflow_schedules.c.queue_name,
                 SystemSchema.workflow_schedules.c.application_name,
+            ).where(
+                # Scoped so the scheduler only runs this application's own crons.
+                self._app_scope(SystemSchema.workflow_schedules.c.application_name)
             )
             if status is not None:
                 vals = [status] if isinstance(status, str) else status
@@ -5688,22 +5905,54 @@ class SystemDatabase(ABC):
 
     # ── Application Version CRUD ────────────────────────────────
 
-    def create_application_version(self, version_name: str) -> None:
+    def create_application_version(
+        self, version_name: str, application_name: Optional[str] = None
+    ) -> None:
+        owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
+            self._check_row_owner(
+                c,
+                SystemSchema.application_versions,
+                SystemSchema.application_versions.c.version_name,
+                version_name,
+                owner,
+                "Application version",
+            )
+            self._adopt_unnamed_row(
+                c,
+                SystemSchema.application_versions,
+                SystemSchema.application_versions.c.version_name,
+                version_name,
+                owner,
+            )
             c.execute(
                 self.dialect.insert(SystemSchema.application_versions)
                 .values(
                     version_id=generate_uuid(),
                     version_name=version_name,
-                    application_name=self.app_name,
+                    application_name=owner,
                 )
                 .on_conflict_do_nothing(index_elements=["version_name"])
             )
 
     def update_application_version_timestamp(
-        self, version_name: str, new_timestamp: int
+        self,
+        version_name: str,
+        new_timestamp: int,
+        application_name: Optional[str] = None,
     ) -> None:
+        owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
+            # Naming a version explicitly is an operator action, so claim it: this
+            # is what makes rolling back to a pre-upgrade version visible to the
+            # owner-only read in get_latest_application_version.
+            self._adopt_unnamed_row(
+                c,
+                SystemSchema.application_versions,
+                SystemSchema.application_versions.c.version_name,
+                version_name,
+                owner,
+            )
             c.execute(
                 sa.update(SystemSchema.application_versions)
                 .where(SystemSchema.application_versions.c.version_name == version_name)
@@ -5719,7 +5968,13 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.version_timestamp,
                     SystemSchema.application_versions.c.created_at,
                     SystemSchema.application_versions.c.application_name,
-                ).order_by(SystemSchema.application_versions.c.version_timestamp.desc())
+                )
+                .where(
+                    self._app_scope(
+                        SystemSchema.application_versions.c.application_name
+                    )
+                )
+                .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
             ).fetchall()
             return [
                 VersionInfo(
@@ -5754,7 +6009,13 @@ class SystemDatabase(ABC):
         client_system_database: Optional["SystemDatabase"] = None,
     ) -> List["Queue"]:
         with self.engine.begin() as c:
-            rows = c.execute(sa.select(SystemSchema.queues)).fetchall()
+            rows = c.execute(
+                # Scoped so the queue thread never spawns workers for another
+                # application's database-backed queues.
+                sa.select(SystemSchema.queues).where(
+                    self._app_scope(SystemSchema.queues.c.application_name)
+                )
+            ).fetchall()
             return [
                 queue_from_db_row(row, client_system_database=client_system_database)
                 for row in rows
@@ -5792,10 +6053,12 @@ class SystemDatabase(ABC):
         partition_queue: bool,
         polling_interval_sec: float,
         update_existing: bool,
+        application_name: Optional[str] = None,
     ) -> bool:
         """Upsert a queue row. Returns True iff a new row was inserted (i.e.
         the queue did not previously exist). False if the row already existed,
         regardless of whether it was updated."""
+        owner = application_name if application_name is not None else self.app_name
         values = {
             "name": name,
             "concurrency": concurrency,
@@ -5806,9 +6069,20 @@ class SystemDatabase(ABC):
             "partition_queue": partition_queue,
             "polling_interval_sec": polling_interval_sec,
             "updated_at": int(time.time() * 1000),
-            "application_name": self.app_name,
+            "application_name": owner,
         }
         with self.engine.begin() as c:
+            self._check_row_owner(
+                c,
+                SystemSchema.queues,
+                SystemSchema.queues.c.name,
+                name,
+                owner,
+                "Queue",
+            )
+            self._adopt_unnamed_row(
+                c, SystemSchema.queues, SystemSchema.queues.c.name, name, owner
+            )
             existed = (
                 c.execute(
                     sa.select(SystemSchema.queues.c.name).where(
@@ -5838,6 +6112,11 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.version_timestamp,
                     SystemSchema.application_versions.c.created_at,
                     SystemSchema.application_versions.c.application_name,
+                )
+                .where(
+                    self._app_scope(
+                        SystemSchema.application_versions.c.application_name
+                    )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
                 .limit(1)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -6203,8 +6203,8 @@ class SystemDatabase(ABC):
         adopt_unclaimed_rows: bool,
     ) -> sa.ColumnElement[bool]:
         """Rows a rename moves: an application's own, unclaimed ones, or both. Unlike
-        _name_filter, unclaimed rows are not implied -- they belong to every
-        application, so a rename takes them only when asked."""
+        _name_filter, unclaimed rows are not implied; a rename takes them only when asked.
+        """
         clauses = []
         if old_name is not None:
             clauses.append(col == old_name)
@@ -6222,16 +6222,8 @@ class SystemDatabase(ABC):
         batch_size: Optional[int],
         adopt_unclaimed_rows: bool,
     ) -> int:
-        """Re-own a table's rows, batching by key so a long history does not move in one
-        transaction. A re-run resumes an interrupted rename, since moved rows stop
-        matching.
-
-        Each batch is a half-open key range, advancing a watermark, so both the probe
-        and the update are index range scans. Selecting the batch with LIMIT instead
-        costs O(batches^2): the rows already moved no longer match, but the scan still
-        pages them in to skip them, and an IN list of keys plans as a whole-table hash
-        join. Both only look cheap while the table fits in cache.
-        """
+        """Re-own a table's rows in half-open key ranges, so a long history neither moves
+        in one transaction nor rescans what it already moved; a re-run resumes."""
         predicate = self._rename_source(
             table.c.application_name, old_name, adopt_unclaimed_rows
         )
@@ -6241,6 +6233,7 @@ class SystemDatabase(ABC):
                     sa.update(table).where(predicate).values(application_name=new_name)
                 ).rowcount
         total = 0
+        # Ranges, not LIMIT: a LIMIT repages every row already moved, and an IN list of keys plans as a whole-table hash join.
         watermark: Optional[Any] = None
         while True:
             scope = (
@@ -6276,24 +6269,8 @@ class SystemDatabase(ABC):
         batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
         adopt_unclaimed_rows: bool = False,
     ) -> ApplicationRowCounts:
-        """Give ``new_name`` ownership of rows another name holds, rows nobody holds,
-        or both. Naming ``old_name`` alone renames an application; omitting it and
-        setting ``adopt_unclaimed_rows`` only adopts, which is how an application takes
-        over a system database whose rows predate ownership.
-
-        Queue, schedule, and version names are globally unique whatever their owner, so
-        this can never collide: it is pure re-ownership, never a merge.
-
-        The control-plane rows and every in-flight workflow move in one transaction, so
-        the application is never half-owned. Terminal workflows and their steps follow in
-        batches; they scope only observability and garbage collection, so they may lag.
-
-        The application named by ``old_name`` must not be running: a dequeue racing this
-        stamps the old name back onto a row this has already passed.
-
-        ``adopt_unclaimed_rows`` takes rows no application owns. They belong to every
-        application sharing this system database, so adopting them takes them from any
-        peer; left false, unclaimed rows are not touched.
+        """Give ``new_name`` ownership of the rows ``old_name`` holds, of unclaimed rows,
+        or of both. The renamed application must be stopped, or its dequeues race this.
         """
         from ._dbos_config import _is_valid_app_name
 
@@ -6318,6 +6295,7 @@ class SystemDatabase(ABC):
             raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
 
         ws = SystemSchema.workflow_status
+        # Never a merge: queue, schedule, and version names are globally unique whatever their owner, so this cannot collide.
         with self.engine.begin() as c:
 
             def move(table: sa.Table, *extra: sa.ColumnElement[bool]) -> int:
@@ -6337,7 +6315,7 @@ class SystemDatabase(ABC):
             versions = move(SystemSchema.application_versions)
             in_flight = move(ws, ws.c.status.in_(self._RENAME_ATOMIC_STATUSES))
 
-        # Phase one already moved the in-flight rows, so these predicates now match only terminal ones.
+        # Only terminal rows are left to match, and they scope observability and GC alone, so they may lag behind the commit above.
         terminal = self._rename_rows_in_batches(
             ws, ws.c.workflow_uuid, old_name, new_name, batch_size, adopt_unclaimed_rows
         )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1176,6 +1176,11 @@ class SystemDatabase(ABC):
                     inputs=inputs,
                     serialization=serialization,
                     updated_at=self._now_ms_sql(),
+                    # Claim it, as dequeue does: an unclaimed holder left unclaimed would let
+                    # every peer coalesce onto one workflow, last inputs winning.
+                    application_name=sa.func.coalesce(
+                        wsc.application_name, sa.literal(self.app_name)
+                    ),
                 )
                 .returning(wsc.workflow_uuid)
             ).fetchone()

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -731,21 +731,16 @@ class SystemDatabase(ABC):
             return sa.func.strftime("%s", "now") * 1000
         return sa.func.extract("epoch", sa.func.now()) * 1000
 
-    def _app_scope(self, col: sa.ColumnElement[Any]) -> sa.ColumnElement[bool]:
-        """Rows this application may act on: its own, plus unclaimed ones. The
-        claiming scope, as against the observability filters' exact owner match."""
-        if self.app_name is None:
-            return sa.true()
-        return sa.or_(col == self.app_name, col.is_(None))
-
     @staticmethod
     def _name_filter(
         col: sa.ColumnElement[Any], value: Optional[Union[str, List[str]]]
     ) -> sa.ColumnElement[bool]:
-        """An ordinary exact-match filter; unset matches every application."""
-        if value is None:
+        """Rows owned by these applications plus unclaimed ones, which belong to
+        every application. Unset, or empty, matches every application."""
+        if not value:
             return sa.true()
-        return col.in_([value] if isinstance(value, str) else value)
+        names = [value] if isinstance(value, str) else value
+        return sa.or_(col.in_(names), col.is_(None))
 
     def _check_row_owner(
         self,
@@ -1904,12 +1899,11 @@ class SystemDatabase(ABC):
             query = query.where(
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name_list)
             )
-        if application_name_list:
-            query = query.where(
-                SystemSchema.workflow_status.c.application_name.in_(
-                    application_name_list
-                )
+        query = query.where(
+            self._name_filter(
+                SystemSchema.workflow_status.c.application_name, application_name_list
             )
+        )
         if user_list:
             query = query.where(
                 SystemSchema.workflow_status.c.authenticated_user.in_(user_list)
@@ -2083,7 +2077,9 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.executor_id == executor_id,
                     SystemSchema.workflow_status.c.application_version == app_version,
                     # executor_id defaults to "local", so it collides across applications.
-                    self._app_scope(SystemSchema.workflow_status.c.application_name),
+                    self._name_filter(
+                        SystemSchema.workflow_status.c.application_name, self.app_name
+                    ),
                 )
             ).fetchall()
 
@@ -2349,10 +2345,11 @@ class SystemDatabase(ABC):
             query = query.where(
                 SystemSchema.workflow_status.c.schedule_name.in_(schedule_name)
             )
-        if application_name:
-            query = query.where(
-                SystemSchema.workflow_status.c.application_name.in_(application_name)
+        query = query.where(
+            self._name_filter(
+                SystemSchema.workflow_status.c.application_name, application_name
             )
+        )
         if was_forked_from is not None:
             query = query.where(
                 SystemSchema.workflow_status.c.was_forked_from == was_forked_from
@@ -2522,10 +2519,11 @@ class SystemDatabase(ABC):
                 SystemSchema.operation_outputs.c.completed_at_epoch_ms
                 <= datetime.datetime.fromisoformat(completed_before).timestamp() * 1000
             )
-        if application_name:
-            query = query.where(
-                SystemSchema.operation_outputs.c.application_name.in_(application_name)
+        query = query.where(
+            self._name_filter(
+                SystemSchema.operation_outputs.c.application_name, application_name
             )
+        )
 
         query = query.group_by(*group_columns)
 
@@ -3983,7 +3981,7 @@ class SystemDatabase(ABC):
                 ]
             ),
             # Only partitions this application can actually dequeue from.
-            self._app_scope(ws.c.application_name),
+            self._name_filter(ws.c.application_name, self.app_name),
         )
         partitions = (
             sa.select(sa.func.min(ws.c.queue_partition_key).label("pk"))
@@ -4076,7 +4074,10 @@ class SystemDatabase(ABC):
                     )
                     # Count only what this application would dequeue, matching the select below.
                     .where(
-                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                        self._name_filter(
+                            SystemSchema.workflow_status.c.application_name,
+                            self.app_name,
+                        )
                     )
                 )
                 if queue_partition_key is not None:
@@ -4106,7 +4107,10 @@ class SystemDatabase(ABC):
                         == WorkflowStatusString.PENDING.value
                     )
                     .where(
-                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                        self._name_filter(
+                            SystemSchema.workflow_status.c.application_name,
+                            self.app_name,
+                        )
                     )
                 )
                 if queue_partition_key is not None:
@@ -4126,8 +4130,9 @@ class SystemDatabase(ABC):
                 sa.select(SystemSchema.application_versions.c.version_name)
                 # This application's latest; a newer unclaimed row is a peer's deploy.
                 .where(
-                    self._app_scope(
-                        SystemSchema.application_versions.c.application_name
+                    self._name_filter(
+                        SystemSchema.application_versions.c.application_name,
+                        self.app_name,
                     )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
@@ -4158,7 +4163,11 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.ENQUEUED.value
                 )
                 .where(version_predicate)
-                .where(self._app_scope(SystemSchema.workflow_status.c.application_name))
+                .where(
+                    self._name_filter(
+                        SystemSchema.workflow_status.c.application_name, self.app_name
+                    )
+                )
                 # Unless global concurrency is set, use skip_locked to only select
                 # rows that can be locked. If global concurrency is set, use no_wait
                 # to ensure all processes have a consistent view of the table.
@@ -4256,8 +4265,9 @@ class SystemDatabase(ABC):
                 sa.select(SystemSchema.application_versions.c.version_name)
                 # This application's latest; a newer unclaimed row is a peer's deploy.
                 .where(
-                    self._app_scope(
-                        SystemSchema.application_versions.c.application_name
+                    self._name_filter(
+                        SystemSchema.application_versions.c.application_name,
+                        self.app_name,
                     )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
@@ -4281,7 +4291,7 @@ class SystemDatabase(ABC):
                 ws.c.queue_name == queue.name,
                 ws.c.status == WorkflowStatusString.ENQUEUED.value,
                 status_prover,
-                self._app_scope(ws.c.application_name),
+                self._name_filter(ws.c.application_name, self.app_name),
             )
             # Walk distinct partition keys with a recursive-CTE loose index scan (one seek per key, mirroring get_queue_partitions) so sweep cost scales with partition count, not backlog depth.
             partitions = (
@@ -4360,7 +4370,7 @@ class SystemDatabase(ABC):
                 ws.c.queue_name == queue.name,
                 ws.c.queue_partition_key.isnot(None),
                 version_predicate,
-                self._app_scope(ws.c.application_name),
+                self._name_filter(ws.c.application_name, self.app_name),
             )
             # Lock the fixed candidate set -- never a LIMIT query, whose SKIP LOCKED could slide past a locked head and admit out of order. On SQLite this is an unlocked re-read; the RETURNING flip below is the guard.
             locked_rows = c.execute(
@@ -4978,7 +4988,10 @@ class SystemDatabase(ABC):
                 result = c.execute(
                     sa.select(SystemSchema.workflow_status.c.created_at)
                     .where(
-                        self._app_scope(SystemSchema.workflow_status.c.application_name)
+                        self._name_filter(
+                            SystemSchema.workflow_status.c.application_name,
+                            self.app_name,
+                        )
                     )
                     .order_by(SystemSchema.workflow_status.c.created_at.desc())
                     .limit(1)
@@ -5008,7 +5021,9 @@ class SystemDatabase(ABC):
                 ]
             ),
             # Unclaimed rows included: excluding them would leak pre-upgrade rows forever.
-            self._app_scope(SystemSchema.workflow_status.c.application_name),
+            self._name_filter(
+                SystemSchema.workflow_status.c.application_name, self.app_name
+            ),
         )
 
         if batch_size is None:
@@ -5052,7 +5067,9 @@ class SystemDatabase(ABC):
                 sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
                     SystemSchema.workflow_status.c.created_at
                     < cutoff_epoch_timestamp_ms,
-                    self._app_scope(SystemSchema.workflow_status.c.application_name),
+                    self._name_filter(
+                        SystemSchema.workflow_status.c.application_name, self.app_name
+                    ),
                 )
             ).fetchall()
 
@@ -5076,7 +5093,9 @@ class SystemDatabase(ABC):
                     ),
                     SystemSchema.workflow_status.c.created_at
                     <= cutoff_epoch_timestamp_ms,
-                    self._app_scope(SystemSchema.workflow_status.c.application_name),
+                    self._name_filter(
+                        SystemSchema.workflow_status.c.application_name, self.app_name
+                    ),
                 )
             ).fetchall()
             return [row[0] for row in rows]
@@ -5121,12 +5140,11 @@ class SystemDatabase(ABC):
                 )
                 .group_by(SystemSchema.workflow_status.c.name)
             )
-            if application_name:
-                workflow_query = workflow_query.where(
-                    SystemSchema.workflow_status.c.application_name.in_(
-                        application_name
-                    )
+            workflow_query = workflow_query.where(
+                self._name_filter(
+                    SystemSchema.workflow_status.c.application_name, application_name
                 )
+            )
 
             workflow_results = c.execute(workflow_query).fetchall()
             for row in workflow_results:
@@ -5154,12 +5172,11 @@ class SystemDatabase(ABC):
                 )
                 .group_by(SystemSchema.operation_outputs.c.function_name)
             )
-            if application_name:
-                step_query = step_query.where(
-                    SystemSchema.operation_outputs.c.application_name.in_(
-                        application_name
-                    )
+            step_query = step_query.where(
+                self._name_filter(
+                    SystemSchema.operation_outputs.c.application_name, application_name
                 )
+            )
 
             step_results = c.execute(step_query).fetchall()
             for row in step_results:
@@ -5698,8 +5715,8 @@ class SystemDatabase(ABC):
         application_name: Optional[Union[str, List[str]]] = None,
         conn: Optional[sa.Connection] = None,
     ) -> List[WorkflowSchedule]:
-        """Schedules matching these filters, across every application unless
-        application_name narrows it — the same semantics as list_workflows."""
+        """Schedules owned by these applications, plus unclaimed ones. Unset lists
+        every application's, as on list_workflows."""
         return self._list_schedules(
             self._name_filter(
                 SystemSchema.workflow_schedules.c.application_name, application_name
@@ -5707,16 +5724,6 @@ class SystemDatabase(ABC):
             status=status,
             workflow_name=workflow_name,
             schedule_name_prefix=schedule_name_prefix,
-            conn=conn,
-        )
-
-    def list_claimable_schedules(
-        self, *, conn: Optional[sa.Connection] = None
-    ) -> List[WorkflowSchedule]:
-        """Schedules this application runs: its own plus unclaimed. What the
-        scheduler loop polls, so it never starts another application's crons."""
-        return self._list_schedules(
-            self._app_scope(SystemSchema.workflow_schedules.c.application_name),
             conn=conn,
         )
 
@@ -5934,8 +5941,9 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.application_name,
                 )
                 .where(
-                    self._app_scope(
-                        SystemSchema.application_versions.c.application_name
+                    self._name_filter(
+                        SystemSchema.application_versions.c.application_name,
+                        self.app_name,
                     )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
@@ -5973,30 +5981,16 @@ class SystemDatabase(ABC):
         application_name: Optional[Union[str, List[str]]] = None,
         client_system_database: Optional["SystemDatabase"] = None,
     ) -> List["Queue"]:
-        """Queues across every application unless application_name narrows it —
-        the same semantics as list_workflows."""
-        return self._list_queues(
-            self._name_filter(SystemSchema.queues.c.application_name, application_name),
-            client_system_database,
-        )
-
-    def list_claimable_queues(
-        self, *, client_system_database: Optional["SystemDatabase"] = None
-    ) -> List["Queue"]:
-        """Queues this application polls: its own plus unclaimed. What the queue
-        thread reads, so it never spawns workers for another application."""
-        return self._list_queues(
-            self._app_scope(SystemSchema.queues.c.application_name),
-            client_system_database,
-        )
-
-    def _list_queues(
-        self,
-        scope: sa.ColumnElement[bool],
-        client_system_database: Optional["SystemDatabase"],
-    ) -> List["Queue"]:
+        """Queues owned by these applications, plus unclaimed ones. Unset lists
+        every application's, as on list_workflows."""
         with self.engine.begin() as c:
-            rows = c.execute(sa.select(SystemSchema.queues).where(scope)).fetchall()
+            rows = c.execute(
+                sa.select(SystemSchema.queues).where(
+                    self._name_filter(
+                        SystemSchema.queues.c.application_name, application_name
+                    )
+                )
+            ).fetchall()
             return [
                 queue_from_db_row(row, client_system_database=client_system_database)
                 for row in rows
@@ -6092,8 +6086,9 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.application_name,
                 )
                 .where(
-                    self._app_scope(
-                        SystemSchema.application_versions.c.application_name
+                    self._name_filter(
+                        SystemSchema.application_versions.c.application_name,
+                        self.app_name,
                     )
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -281,6 +281,8 @@ class DebounceResult(TypedDict):
     holder_is_debounced: bool
     # The holder's workflow name; a mismatch with the caller's means a debounce-key collision between workflows.
     holder_workflow_name: Optional[str]
+    # The holder's owning application; a mismatch means the collision is across applications.
+    holder_application_name: Optional[str]
 
 
 class RecordedResult(TypedDict):
@@ -1151,6 +1153,9 @@ class SystemDatabase(ABC):
                 .where(wsc.deduplication_id == deduplication_id)
                 .where(wsc.status == WorkflowStatusString.DELAYED.value)
                 .where(wsc.is_debounced == True)
+                # Never extend another application's workflow: its poller would run
+                # its own code against our inputs. Falls through to the holder below.
+                .where(self._name_filter(wsc.application_name, self.app_name))
                 .values(
                     delay_until_epoch_ms=capped_delay,
                     inputs=inputs,
@@ -1165,10 +1170,14 @@ class SystemDatabase(ABC):
                     "holder_workflow_id": None,
                     "holder_is_debounced": False,
                     "holder_workflow_name": None,
+                    "holder_application_name": None,
                 }
-            # No match: the key is unheld, or held by a non-debounced or name-colliding workflow.
+            # No match: the key is unheld, or held by a non-debounced, name-colliding,
+            # or foreign-application workflow. Unscoped, so the holder is reportable.
             holder = c.execute(
-                sa.select(wsc.workflow_uuid, wsc.is_debounced, wsc.name)
+                sa.select(
+                    wsc.workflow_uuid, wsc.is_debounced, wsc.name, wsc.application_name
+                )
                 .where(wsc.queue_name == queue_name)
                 .where(wsc.deduplication_id == deduplication_id)
             ).fetchone()
@@ -1178,12 +1187,14 @@ class SystemDatabase(ABC):
                     "holder_workflow_id": None,
                     "holder_is_debounced": False,
                     "holder_workflow_name": None,
+                    "holder_application_name": None,
                 }
             return {
                 "bounced_workflow_id": None,
                 "holder_workflow_id": holder[0],
                 "holder_is_debounced": bool(holder[1]),
                 "holder_workflow_name": holder[2],
+                "holder_application_name": holder[3],
             }
 
         if conn is not None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4063,6 +4063,12 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.DELAYED.value
                 )
                 .where(SystemSchema.workflow_status.c.delay_until_epoch_ms <= now_ms)
+                # Only what this application would dequeue: a peer's debounce key is not ours to clear.
+                .where(
+                    self._name_filter(
+                        SystemSchema.workflow_status.c.application_name, self.app_name
+                    )
+                )
                 .values(
                     status=WorkflowStatusString.ENQUEUED.value,
                     deduplication_id=sa.case(
@@ -6254,10 +6260,10 @@ class SystemDatabase(ABC):
                     .limit(1)
                     .offset(batch_size - 1)
                 ).scalar()
+                # The final batch drops the watermark, so rows that appeared below it still move.
+                batch = predicate if upper is None else sa.and_(scope, key_col <= upper)
                 total += c.execute(
-                    sa.update(table)
-                    .where(scope if upper is None else sa.and_(scope, key_col <= upper))
-                    .values(application_name=new_name)
+                    sa.update(table).where(batch).values(application_name=new_name)
                 ).rowcount
             # Fewer than a full batch remained, so that update took the rest.
             if upper is None:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -6203,8 +6203,7 @@ class SystemDatabase(ABC):
         adopt_unclaimed_rows: bool,
     ) -> sa.ColumnElement[bool]:
         """Rows a rename moves: an application's own, unclaimed ones, or both. Unlike
-        _name_filter, unclaimed rows are not implied; a rename takes them only when asked.
-        """
+        _name_filter, unclaimed rows are not implied; they move only when asked."""
         clauses = []
         if old_name is not None:
             clauses.append(col == old_name)
@@ -6222,8 +6221,8 @@ class SystemDatabase(ABC):
         batch_size: Optional[int],
         adopt_unclaimed_rows: bool,
     ) -> int:
-        """Re-own a table's rows in half-open key ranges, so a long history neither moves
-        in one transaction nor rescans what it already moved; a re-run resumes."""
+        """Re-own a table's rows in half-open key ranges, so a long history neither
+        moves in one transaction nor rescans what it already moved; a re-run resumes."""
         predicate = self._rename_source(
             table.c.application_name, old_name, adopt_unclaimed_rows
         )
@@ -6269,9 +6268,8 @@ class SystemDatabase(ABC):
         batch_size: Optional[int] = DEFAULT_RENAME_BATCH_SIZE,
         adopt_unclaimed_rows: bool = False,
     ) -> ApplicationRowCounts:
-        """Give ``new_name`` ownership of the rows ``old_name`` holds, of unclaimed rows,
-        or of both. The renamed application must be stopped, or its dequeues race this.
-        """
+        """Give ``new_name`` ownership of rows ``old_name`` holds, of unclaimed rows, or
+        of both. The renamed application must be stopped, or its dequeues race this."""
         from ._dbos_config import _is_valid_app_name
 
         if old_name is not None and not old_name:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5895,38 +5895,74 @@ class SystemDatabase(ABC):
         """Register this version, claiming the row if nobody owns it yet, so a pinned
         application_version does not stay unclaimed for the life of the deployment."""
         owner = application_name if application_name is not None else self.app_name
+        av = SystemSchema.application_versions
         with self.engine.begin() as c:
-            self._check_row_owner(
-                c,
-                SystemSchema.application_versions,
-                SystemSchema.application_versions.c.version_name,
-                version_name,
-                owner,
-                "Application version",
+            if owner is not None:
+                mine = c.execute(
+                    sa.select(av.c.version_id).where(
+                        av.c.version_name == version_name,
+                        av.c.application_name == owner,
+                    )
+                ).fetchone()
+                if mine is None:
+                    # Claim a pre-upgrade row so a pinned version does not stay
+                    # unclaimed; skipped if this application already has its own.
+                    c.execute(
+                        sa.update(av)
+                        .where(
+                            av.c.version_name == version_name,
+                            av.c.application_name.is_(None),
+                        )
+                        .values(application_name=owner)
+                    )
+            stmt = self.dialect.insert(av).values(
+                version_id=generate_uuid(),
+                version_name=version_name,
+                application_name=owner,
             )
-            c.execute(
-                self.dialect.insert(SystemSchema.application_versions).values(
-                    version_id=generate_uuid(),
-                    version_name=version_name,
-                    application_name=owner,
-                )
-                # Sets only the owner, so redeploying a version is still not a promotion.
-                .on_conflict_do_update(
+            # The conflict target must name the partial index matching this owner.
+            if owner is None:
+                stmt = stmt.on_conflict_do_nothing(
                     index_elements=["version_name"],
-                    set_={"application_name": owner},
-                    where=SystemSchema.application_versions.c.application_name.is_(
-                        None
-                    ),
+                    index_where=av.c.application_name.is_(None),
                 )
-            )
+            else:
+                stmt = stmt.on_conflict_do_nothing(
+                    index_elements=["application_name", "version_name"],
+                    index_where=av.c.application_name.isnot(None),
+                )
+            c.execute(stmt)
 
     def update_application_version_timestamp(
-        self, version_name: str, new_timestamp: int
+        self,
+        version_name: str,
+        new_timestamp: int,
+        application_name: Optional[str] = None,
     ) -> None:
+        """Promote a version to latest. Raises when the caller's scope spans more
+        than one application, rather than retiming someone else's deploy."""
+        owner = application_name if application_name is not None else self.app_name
+        av = SystemSchema.application_versions
+        scope = self._name_filter(av.c.application_name, owner)
         with self.engine.begin() as c:
+            owners = [
+                r[0]
+                for r in c.execute(
+                    sa.select(av.c.application_name)
+                    .where(av.c.version_name == version_name)
+                    .where(scope)
+                )
+            ]
+            if len(owners) > 1:
+                raise DBOSException(
+                    f"Application version '{version_name}' is registered by more than "
+                    f"one application ({sorted(str(o) for o in owners)}). Pass "
+                    f"application_name to say which one to promote."
+                )
             c.execute(
-                sa.update(SystemSchema.application_versions)
-                .where(SystemSchema.application_versions.c.version_name == version_name)
+                sa.update(av)
+                .where(av.c.version_name == version_name)
+                .where(scope)
                 .values(version_timestamp=new_timestamp)
             )
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -331,7 +331,8 @@ class WorkflowSchedule(TypedDict):
     automatic_backfill: bool
     cron_timezone: Optional[str]  # IANA timezone name, stored as string in DB
     queue_name: Optional[str]
-    # Owning application; None if unclaimed.
+    # The application that owns this schedule and runs its workflows. None leaves it
+    # unclaimed. Writers may set it to provision a schedule for another application.
     application_name: Optional[str]
 
 
@@ -5470,8 +5471,7 @@ class SystemDatabase(ABC):
                         automatic_backfill=schedule.get("automatic_backfill", False),
                         cron_timezone=schedule.get("cron_timezone"),
                         queue_name=schedule.get("queue_name"),
-                        # Ownership belongs to the writer, not the payload.
-                        application_name=self.app_name,
+                        application_name=schedule.get("application_name"),
                     )
                 )
             except sa.exc.IntegrityError:
@@ -5504,8 +5504,7 @@ class SystemDatabase(ABC):
                     automatic_backfill=schedule.get("automatic_backfill", False),
                     cron_timezone=schedule.get("cron_timezone"),
                     queue_name=schedule.get("queue_name"),
-                    # Ownership belongs to the writer, not the payload.
-                    application_name=self.app_name,
+                    application_name=schedule.get("application_name"),
                 )
                 .on_conflict_do_update(
                     index_elements=["schedule_name"],
@@ -5517,7 +5516,7 @@ class SystemDatabase(ABC):
                         "automatic_backfill": schedule.get("automatic_backfill", False),
                         "cron_timezone": schedule.get("cron_timezone"),
                         "queue_name": schedule.get("queue_name"),
-                        "application_name": self.app_name,
+                        "application_name": schedule.get("application_name"),
                     },
                 )
             )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5958,20 +5958,25 @@ class SystemDatabase(ABC):
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
-            c.execute(
-                self.dialect.insert(av).values(
-                    version_id=generate_uuid(),
-                    version_name=version_name,
-                    application_name=owner,
+            # Claim a pre-upgrade row in place, so the version is not recreated or retimed.
+            claimed = c.execute(
+                sa.update(av)
+                .where(av.c.version_name == version_name)
+                .where(av.c.application_name.is_(None))
+                .values(application_name=owner)
+            ).rowcount
+            if not claimed:
+                # Targetless DO NOTHING: names no arbiter, so it survives version_name's uniqueness being dropped while still absorbing a concurrent registrar.
+                c.execute(
+                    self.dialect.insert(av)
+                    .values(
+                        version_id=generate_uuid(),
+                        version_name=version_name,
+                        application_name=owner,
+                    )
+                    .on_conflict_do_nothing()
                 )
-                # Claims a pre-upgrade row without recreating or retiming it; guarded so a registration landing first is not overwritten.
-                .on_conflict_do_update(
-                    index_elements=["version_name"],
-                    set_={"application_name": owner},
-                    where=av.c.application_name.is_(None),
-                )
-            )
-            # Read back, since the guard above is silent about why it declined to claim.
+            # Read back, since the writes above are silent about why they declined to claim.
             self._resolve_row_owner(
                 c, av, av.c.version_name, version_name, owner, "Application version"
             )
@@ -5996,9 +6001,14 @@ class SystemDatabase(ABC):
                 owner,
                 "Application version",
             )
+            # Scoped to the row this writer resolved to: once version_name is no longer globally unique, a bare name match would retime every peer's version.
+            scope: sa.ColumnElement[bool] = av.c.application_name.is_(None)
+            if resolved is not None:
+                scope = sa.or_(av.c.application_name == resolved, scope)
             c.execute(
                 sa.update(av)
                 .where(av.c.version_name == version_name)
+                .where(scope)
                 .values(version_timestamp=new_timestamp, application_name=resolved)
             )
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -766,28 +766,6 @@ class SystemDatabase(ABC):
             )
         )
 
-    def _adopt_unnamed_row(
-        self,
-        conn: sa.Connection,
-        table: sa.Table,
-        name_col: sa.ColumnElement[Any],
-        name: str,
-        owner: Optional[str],
-    ) -> None:
-        """Claim a pre-upgrade row for a name the caller declares.
-
-        Scoped to one name so an application only ever claims rows it registers
-        itself, which keeps two applications on one system database from taking
-        each other's queues or schedules.
-        """
-        if owner is None:
-            return
-        conn.execute(
-            sa.update(table)
-            .where(name_col == name, table.c.application_name.is_(None))
-            .values(application_name=owner)
-        )
-
     def _check_row_owner(
         self,
         conn: sa.Connection,
@@ -5697,13 +5675,6 @@ class SystemDatabase(ABC):
                 schedule.get("application_name"),
                 "Schedule",
             )
-            self._adopt_unnamed_row(
-                c,
-                SystemSchema.workflow_schedules,
-                SystemSchema.workflow_schedules.c.schedule_name,
-                schedule["schedule_name"],
-                schedule.get("application_name"),
-            )
             c.execute(
                 self.dialect.insert(SystemSchema.workflow_schedules)
                 .values(
@@ -5918,13 +5889,6 @@ class SystemDatabase(ABC):
                 owner,
                 "Application version",
             )
-            self._adopt_unnamed_row(
-                c,
-                SystemSchema.application_versions,
-                SystemSchema.application_versions.c.version_name,
-                version_name,
-                owner,
-            )
             c.execute(
                 self.dialect.insert(SystemSchema.application_versions)
                 .values(
@@ -5936,23 +5900,9 @@ class SystemDatabase(ABC):
             )
 
     def update_application_version_timestamp(
-        self,
-        version_name: str,
-        new_timestamp: int,
-        application_name: Optional[str] = None,
+        self, version_name: str, new_timestamp: int
     ) -> None:
-        owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
-            # Naming a version explicitly is an operator action, so claim it: this
-            # is what makes rolling back to a pre-upgrade version visible to the
-            # owner-only read in get_latest_application_version.
-            self._adopt_unnamed_row(
-                c,
-                SystemSchema.application_versions,
-                SystemSchema.application_versions.c.version_name,
-                version_name,
-                owner,
-            )
             c.execute(
                 sa.update(SystemSchema.application_versions)
                 .where(SystemSchema.application_versions.c.version_name == version_name)
@@ -6079,9 +6029,6 @@ class SystemDatabase(ABC):
                 name,
                 owner,
                 "Queue",
-            )
-            self._adopt_unnamed_row(
-                c, SystemSchema.queues, SystemSchema.queues.c.name, name, owner
             )
             existed = (
                 c.execute(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4141,7 +4141,7 @@ class SystemDatabase(ABC):
 
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
-                # This application's latest; a newer unclaimed row is a peer's deploy.
+                # Own plus unclaimed: a named peer's deploy must not demote this one.
                 .where(
                     self._name_filter(
                         SystemSchema.application_versions.c.application_name,
@@ -4276,7 +4276,7 @@ class SystemDatabase(ABC):
         with self.engine.begin() as c:
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
-                # This application's latest; a newer unclaimed row is a peer's deploy.
+                # Own plus unclaimed: a named peer's deploy must not demote this one.
                 .where(
                     self._name_filter(
                         SystemSchema.application_versions.c.application_name,
@@ -5906,44 +5906,31 @@ class SystemDatabase(ABC):
         self, version_name: str, application_name: Optional[str] = None
     ) -> None:
         """Register this version, claiming the row if nobody owns it yet, so a pinned
-        application_version does not stay unclaimed for the life of the deployment."""
+        application_version does not stay unclaimed for the life of the deployment.
+        Silent when another application already registered the name: launch must not
+        fail over a version string two applications happen to share."""
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
-            if owner is not None:
-                mine = c.execute(
-                    sa.select(av.c.version_id).where(
-                        av.c.version_name == version_name,
-                        av.c.application_name == owner,
-                    )
-                ).fetchone()
-                if mine is None:
-                    # Claim a pre-upgrade row, unless this application already has its own.
-                    c.execute(
-                        sa.update(av)
-                        .where(
-                            av.c.version_name == version_name,
-                            av.c.application_name.is_(None),
-                        )
-                        .values(application_name=owner)
-                    )
-            stmt = self.dialect.insert(av).values(
-                version_id=generate_uuid(),
-                version_name=version_name,
-                application_name=owner,
+            c.execute(
+                self.dialect.insert(av)
+                .values(
+                    version_id=generate_uuid(),
+                    version_name=version_name,
+                    application_name=owner,
+                )
+                .on_conflict_do_nothing(index_elements=["version_name"])
             )
-            # The conflict target must name the partial index matching this owner.
-            if owner is None:
-                stmt = stmt.on_conflict_do_nothing(
-                    index_elements=["version_name"],
-                    index_where=av.c.application_name.is_(None),
+            if owner is not None:
+                # One row per name, so claim a pre-upgrade one and leave a peer's alone.
+                c.execute(
+                    sa.update(av)
+                    .where(
+                        av.c.version_name == version_name,
+                        av.c.application_name.is_(None),
+                    )
+                    .values(application_name=owner)
                 )
-            else:
-                stmt = stmt.on_conflict_do_nothing(
-                    index_elements=["application_name", "version_name"],
-                    index_where=av.c.application_name.isnot(None),
-                )
-            c.execute(stmt)
 
     def update_application_version_timestamp(
         self,
@@ -5951,31 +5938,24 @@ class SystemDatabase(ABC):
         new_timestamp: int,
         application_name: Optional[str] = None,
     ) -> None:
-        """Promote a version to latest. Raises when the caller's scope spans more
-        than one application, rather than retiming someone else's deploy."""
+        """Promote a version to latest. Names are global addresses, so promoting a peer's
+        is a collision, not a retiming. Promotion claims an unclaimed row, which would
+        otherwise stay every application's latest."""
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
-        scope = self._name_filter(av.c.application_name, owner)
         with self.engine.begin() as c:
-            owners = [
-                r[0]
-                for r in c.execute(
-                    sa.select(av.c.application_name)
-                    .where(av.c.version_name == version_name)
-                    .where(scope)
-                )
-            ]
-            if len(owners) > 1:
-                raise DBOSException(
-                    f"Application version '{version_name}' is registered by more than "
-                    f"one application ({sorted(str(o) for o in owners)}). Pass "
-                    f"application_name to say which one to promote."
-                )
+            resolved = self._resolve_row_owner(
+                c,
+                av,
+                av.c.version_name,
+                version_name,
+                owner,
+                "Application version",
+            )
             c.execute(
                 sa.update(av)
                 .where(av.c.version_name == version_name)
-                .where(scope)
-                .values(version_timestamp=new_timestamp)
+                .values(version_timestamp=new_timestamp, application_name=resolved)
             )
 
     def list_application_versions(self) -> List[VersionInfo]:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -767,9 +767,8 @@ class SystemDatabase(ABC):
         owner: Optional[str],
         kind: str,
     ) -> Optional[str]:
-        """Owner to persist when writing a row that may already exist. A writer with
-        no identity of its own acts on any row and leaves that row's owner intact; a
-        named one collides only with a different name, as names are globally unique."""
+        """Owner to persist when writing a row that may already exist. A nameless writer
+        leaves the owner intact; a named one collides only with a different name."""
         existing = conn.execute(
             sa.select(table.c.application_name).where(name_col == name)
         ).fetchone()
@@ -1182,8 +1181,7 @@ class SystemDatabase(ABC):
                     inputs=inputs,
                     serialization=serialization,
                     updated_at=self._now_ms_sql(),
-                    # Claim it, as dequeue does: an unclaimed holder left unclaimed would let
-                    # every peer coalesce onto one workflow, last inputs winning.
+                    # Claim it, as dequeue does: left unclaimed, every peer coalesces onto the one workflow and the last inputs win.
                     application_name=sa.func.coalesce(
                         wsc.application_name, sa.literal(self.app_name)
                     ),
@@ -1329,8 +1327,7 @@ class SystemDatabase(ABC):
                             assumed_role=status[7],
                             forked_from=original_workflow_id,
                             attributes=status[10],
-                            # Inherit the source's owner so the fork runs on the same
-                            # application; claim an unclaimed one, as dequeue does.
+                            # Inherit the source's owner so the fork runs on the same application; claim an unclaimed one, as dequeue does.
                             application_name=(
                                 status[11] if status[11] is not None else self.app_name
                             ),
@@ -5740,8 +5737,7 @@ class SystemDatabase(ABC):
                         "automatic_backfill": schedule.get("automatic_backfill", False),
                         "cron_timezone": schedule.get("cron_timezone"),
                         "queue_name": schedule.get("queue_name"),
-                        # Claim only an unclaimed row, so a registration that lands
-                        # between the check above and this write keeps the name it took.
+                        # Claim only an unclaimed row, so a registration landing between the check above and this write keeps the name it took.
                         "application_name": sa.func.coalesce(
                             SystemSchema.workflow_schedules.c.application_name, owner
                         ),
@@ -5950,10 +5946,9 @@ class SystemDatabase(ABC):
     def create_application_version(
         self, version_name: str, application_name: Optional[str] = None
     ) -> None:
-        """Register this version, claiming the row if nobody owns it yet, so a pinned
-        application_version does not stay unclaimed for the life of the deployment.
-        Names are global addresses, so a peer's is a collision rather than a share:
-        raising here is what keeps an application from launching without a version."""
+        """Register this version, claiming the row if nobody owns it yet so a pinned version
+        does not stay unclaimed. A peer's name is a collision, which is why this raises.
+        """
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
@@ -5963,8 +5958,7 @@ class SystemDatabase(ABC):
                     version_name=version_name,
                     application_name=owner,
                 )
-                # Claims a pre-upgrade row without recreating or retiming it. Guarded so
-                # a registration that lands first cannot be overwritten by a later one.
+                # Claims a pre-upgrade row without recreating or retiming it; guarded so a registration landing first is not overwritten.
                 .on_conflict_do_update(
                     index_elements=["version_name"],
                     set_={"application_name": owner},
@@ -5982,9 +5976,9 @@ class SystemDatabase(ABC):
         new_timestamp: int,
         application_name: Optional[str] = None,
     ) -> None:
-        """Promote a version to latest. Names are global addresses, so promoting a peer's
-        is a collision, not a retiming. Promotion claims an unclaimed row, which would
-        otherwise stay every application's latest."""
+        """Promote a version to latest. Promoting a peer's is a collision, not a retiming;
+        promotion claims an unclaimed row, which would otherwise be every peer's latest.
+        """
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
@@ -6141,8 +6135,7 @@ class SystemDatabase(ABC):
                 update_set: Dict[str, Any] = {
                     k: v for k, v in values.items() if k != "name"
                 }
-                # Claim only an unclaimed row, so a registration that lands between the
-                # check above and this write keeps the name it just took.
+                # Claim only an unclaimed row, so a registration landing between the check above and this write keeps the name it just took.
                 update_set["application_name"] = sa.func.coalesce(
                     SystemSchema.queues.c.application_name, values["application_name"]
                 )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1302,8 +1302,11 @@ class SystemDatabase(ABC):
                             assumed_role=status[7],
                             forked_from=original_workflow_id,
                             attributes=status[10],
-                            # Inherit the source's owner so the fork runs on the same application.
-                            application_name=status[11],
+                            # Inherit the source's owner so the fork runs on the same
+                            # application; claim an unclaimed one, as dequeue does.
+                            application_name=(
+                                status[11] if status[11] is not None else self.app_name
+                            ),
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
                             original_workflow_ids, forked_workflow_ids, statuses
@@ -1386,8 +1389,10 @@ class SystemDatabase(ABC):
                             child_wf_expr,
                             oo.c.started_at_epoch_ms,
                             oo.c.completed_at_epoch_ms,
-                            # Copied steps inherit the owner the forked workflow inherited.
-                            oo.c.application_name,
+                            # Copied steps carry the owner the fork itself resolved to.
+                            sa.func.coalesce(
+                                oo.c.application_name, sa.literal(self.app_name)
+                            ),
                         ).select_from(
                             mapping_subquery.join(
                                 oo,
@@ -5708,9 +5713,22 @@ class SystemDatabase(ABC):
                         "automatic_backfill": schedule.get("automatic_backfill", False),
                         "cron_timezone": schedule.get("cron_timezone"),
                         "queue_name": schedule.get("queue_name"),
-                        "application_name": owner,
+                        # Claim only an unclaimed row, so a registration that lands
+                        # between the check above and this write keeps the name it took.
+                        "application_name": sa.func.coalesce(
+                            SystemSchema.workflow_schedules.c.application_name, owner
+                        ),
                     },
                 )
+            )
+            # Read back, since the guard above is silent about why it declined to claim.
+            self._resolve_row_owner(
+                c,
+                SystemSchema.workflow_schedules,
+                SystemSchema.workflow_schedules.c.schedule_name,
+                schedule["schedule_name"],
+                schedule.get("application_name"),
+                "Schedule",
             )
 
         if conn is not None:
@@ -6093,7 +6111,14 @@ class SystemDatabase(ABC):
             )
             stmt = self.dialect.insert(SystemSchema.queues).values(**values)
             if update_existing:
-                update_set = {k: v for k, v in values.items() if k != "name"}
+                update_set: Dict[str, Any] = {
+                    k: v for k, v in values.items() if k != "name"
+                }
+                # Claim only an unclaimed row, so a registration that lands between the
+                # check above and this write keeps the name it just took.
+                update_set["application_name"] = sa.func.coalesce(
+                    SystemSchema.queues.c.application_name, values["application_name"]
+                )
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["name"],
                     set_=update_set,
@@ -6101,6 +6126,15 @@ class SystemDatabase(ABC):
             else:
                 stmt = stmt.on_conflict_do_nothing(index_elements=["name"])
             c.execute(stmt)
+            # Read back, since the guard above is silent about why it declined to claim.
+            self._resolve_row_owner(
+                c,
+                SystemSchema.queues,
+                SystemSchema.queues.c.name,
+                name,
+                owner,
+                "Queue",
+            )
             return not existed
 
     def get_latest_application_version(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -270,6 +270,8 @@ class EnqueueOptionsInternal(TypedDict):
     debounce_deadline_epoch_ms: Optional[int]
     # True if this workflow's dedup ID is a debounce key to clear on the DELAYED->ENQUEUED transition.
     is_debounced: bool
+    # The application the workflow is enqueued for; None means the enqueuer's own.
+    application_name: Optional[str]
 
 
 class DebounceResult(TypedDict):
@@ -1139,6 +1141,7 @@ class SystemDatabase(ABC):
         delay_until_epoch_ms: int,
         inputs: str,
         serialization: Optional[str],
+        application_name: Optional[str],
         conn: Optional[sa.Connection] = None,
     ) -> DebounceResult:
         """Extend an existing debounced DELAYED workflow's delay and update its inputs.
@@ -1147,6 +1150,8 @@ class SystemDatabase(ABC):
         workflow's debounce_deadline_epoch_ms, if one is set. Matching on
         workflow_name ensures a debounce-key collision between different workflows
         (e.g. "a"+"b-c" vs "a-b"+"c") never overwrites another workflow's inputs.
+        The bounce acts for ``application_name``: it extends only that
+        application's holders plus unclaimed ones, which it claims for it.
         If nothing matched, returns the current holder (or that the key is unheld)
         so the caller can decide whether to start fresh or surface a conflict.
 
@@ -1174,16 +1179,16 @@ class SystemDatabase(ABC):
                 .where(wsc.deduplication_id == deduplication_id)
                 .where(wsc.status == WorkflowStatusString.DELAYED.value)
                 .where(wsc.is_debounced == True)
-                # Never extend another application's workflow; falls through to the holder below.
-                .where(self._name_filter(wsc.application_name, self.app_name))
+                # Never extend a workflow the target application doesn't own; falls through to the holder below.
+                .where(self._name_filter(wsc.application_name, application_name))
                 .values(
                     delay_until_epoch_ms=capped_delay,
                     inputs=inputs,
                     serialization=serialization,
                     updated_at=self._now_ms_sql(),
-                    # Claim it, as dequeue does: left unclaimed, every peer coalesces onto the one workflow and the last inputs win.
+                    # Claim it for the target, as its dequeue would: left unclaimed, every peer coalesces onto the one workflow and the last inputs win.
                     application_name=sa.func.coalesce(
-                        wsc.application_name, sa.literal(self.app_name)
+                        wsc.application_name, sa.literal(application_name)
                     ),
                 )
                 .returning(wsc.workflow_uuid)

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -96,6 +96,7 @@ def queue_from_db_row(
         priority_enabled=bool(m["priority_enabled"]),
         partition_queue=bool(m["partition_queue"]),
         polling_interval_sec=m["polling_interval_sec"],
+        application_name=m["application_name"],
         database_backed_queue=True,
         client_system_database=client_system_database,
     )
@@ -736,6 +737,15 @@ class SystemDatabase(ABC):
         if self.app_name is None:
             return sa.true()
         return sa.or_(col == self.app_name, col.is_(None))
+
+    @staticmethod
+    def _name_filter(
+        col: sa.ColumnElement[Any], value: Optional[Union[str, List[str]]]
+    ) -> sa.ColumnElement[bool]:
+        """An ordinary exact-match filter; unset matches every application."""
+        if value is None:
+            return sa.true()
+        return col.in_([value] if isinstance(value, str) else value)
 
     def _check_row_owner(
         self,
@@ -5685,6 +5695,38 @@ class SystemDatabase(ABC):
         status: Optional[Union[str, List[str]]] = None,
         workflow_name: Optional[Union[str, List[str]]] = None,
         schedule_name_prefix: Optional[Union[str, List[str]]] = None,
+        application_name: Optional[Union[str, List[str]]] = None,
+        conn: Optional[sa.Connection] = None,
+    ) -> List[WorkflowSchedule]:
+        """Schedules matching these filters, across every application unless
+        application_name narrows it — the same semantics as list_workflows."""
+        return self._list_schedules(
+            self._name_filter(
+                SystemSchema.workflow_schedules.c.application_name, application_name
+            ),
+            status=status,
+            workflow_name=workflow_name,
+            schedule_name_prefix=schedule_name_prefix,
+            conn=conn,
+        )
+
+    def list_claimable_schedules(
+        self, *, conn: Optional[sa.Connection] = None
+    ) -> List[WorkflowSchedule]:
+        """Schedules this application runs: its own plus unclaimed. What the
+        scheduler loop polls, so it never starts another application's crons."""
+        return self._list_schedules(
+            self._app_scope(SystemSchema.workflow_schedules.c.application_name),
+            conn=conn,
+        )
+
+    def _list_schedules(
+        self,
+        scope: sa.ColumnElement[bool],
+        *,
+        status: Optional[Union[str, List[str]]] = None,
+        workflow_name: Optional[Union[str, List[str]]] = None,
+        schedule_name_prefix: Optional[Union[str, List[str]]] = None,
         conn: Optional[sa.Connection] = None,
     ) -> List[WorkflowSchedule]:
         def _do(c: sa.Connection) -> List[WorkflowSchedule]:
@@ -5701,10 +5743,7 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_schedules.c.cron_timezone,
                 SystemSchema.workflow_schedules.c.queue_name,
                 SystemSchema.workflow_schedules.c.application_name,
-            ).where(
-                # Scoped so the scheduler only runs this application's own crons.
-                self._app_scope(SystemSchema.workflow_schedules.c.application_name)
-            )
+            ).where(scope)
             if status is not None:
                 vals = [status] if isinstance(status, str) else status
                 query = query.where(SystemSchema.workflow_schedules.c.status.in_(vals))
@@ -5931,15 +5970,33 @@ class SystemDatabase(ABC):
     def list_queues(
         self,
         *,
+        application_name: Optional[Union[str, List[str]]] = None,
         client_system_database: Optional["SystemDatabase"] = None,
     ) -> List["Queue"]:
+        """Queues across every application unless application_name narrows it —
+        the same semantics as list_workflows."""
+        return self._list_queues(
+            self._name_filter(SystemSchema.queues.c.application_name, application_name),
+            client_system_database,
+        )
+
+    def list_claimable_queues(
+        self, *, client_system_database: Optional["SystemDatabase"] = None
+    ) -> List["Queue"]:
+        """Queues this application polls: its own plus unclaimed. What the queue
+        thread reads, so it never spawns workers for another application."""
+        return self._list_queues(
+            self._app_scope(SystemSchema.queues.c.application_name),
+            client_system_database,
+        )
+
+    def _list_queues(
+        self,
+        scope: sa.ColumnElement[bool],
+        client_system_database: Optional["SystemDatabase"],
+    ) -> List["Queue"]:
         with self.engine.begin() as c:
-            rows = c.execute(
-                # Scoped so the queue thread ignores other applications' queues.
-                sa.select(SystemSchema.queues).where(
-                    self._app_scope(SystemSchema.queues.c.application_name)
-                )
-            ).fetchall()
+            rows = c.execute(sa.select(SystemSchema.queues).where(scope)).fetchall()
             return [
                 queue_from_db_row(row, client_system_database=client_system_database)
                 for row in rows

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5912,20 +5912,23 @@ class SystemDatabase(ABC):
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
-            resolved = self._resolve_row_owner(
-                c, av, av.c.version_name, version_name, owner, "Application version"
-            )
             c.execute(
                 self.dialect.insert(av).values(
                     version_id=generate_uuid(),
                     version_name=version_name,
-                    application_name=resolved,
+                    application_name=owner,
                 )
-                # Claims a pre-upgrade row without recreating or retiming it.
+                # Claims a pre-upgrade row without recreating or retiming it. Guarded so
+                # a registration that lands first cannot be overwritten by a later one.
                 .on_conflict_do_update(
                     index_elements=["version_name"],
-                    set_={"application_name": resolved},
+                    set_={"application_name": owner},
+                    where=av.c.application_name.is_(None),
                 )
+            )
+            # Read back, since the guard above is silent about why it declined to claim.
+            self._resolve_row_owner(
+                c, av, av.c.version_name, version_name, owner, "Application version"
             )
 
     def update_application_version_timestamp(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -193,8 +193,7 @@ class WorkflowStatus:
     attributes: Optional[Dict[str, Any]]
     # If this workflow was enqueued by a named schedule, that schedule's name
     schedule_name: Optional[str]
-    # The application that owns this workflow. None if unclaimed, in which case any
-    # application listening on its queue may run it.
+    # Owning application; None if unclaimed, in which case any application may run it.
     application_name: Optional[str]
 
     # INTERNAL FIELDS
@@ -331,8 +330,7 @@ class WorkflowSchedule(TypedDict):
     automatic_backfill: bool
     cron_timezone: Optional[str]  # IANA timezone name, stored as string in DB
     queue_name: Optional[str]
-    # The application that owns this schedule and runs its workflows. None leaves it
-    # unclaimed. Writers may set it to provision a schedule for another application.
+    # Owning application; None leaves it unclaimed. Writers may name another.
     application_name: Optional[str]
 
 
@@ -656,8 +654,7 @@ class SystemDatabase(ABC):
         self.workflow_events_map = ThreadSafeEventDict()
         self.streams_map = ThreadSafeEventDict()
         self.executor_id = executor_id
-        # The application this database handle acts on behalf of. None means no
-        # application identity: rows are written unclaimed.
+        # The application this handle acts for; None writes unclaimed rows.
         self.app_name = app_name
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
@@ -734,17 +731,8 @@ class SystemDatabase(ABC):
         return sa.func.extract("epoch", sa.func.now()) * 1000
 
     def _app_scope(self, col: sa.ColumnElement[Any]) -> sa.ColumnElement[bool]:
-        """Rows this application may act on: its own, plus unclaimed ones.
-
-        Unclaimed (NULL) rows are written by SDKs predating the column and by
-        callers with no application identity, so every application must be able to
-        claim them — otherwise upgrading would strand in-flight work.
-
-        This is the claiming scope: dequeue, recovery, the enumeration the
-        background loops run on, and the bulk delete/cancel operations. It is
-        deliberately not what the observability filters use, which match an owner
-        exactly and default to matching nothing at all.
-        """
+        """Rows this application may act on: its own, plus unclaimed ones. The
+        claiming scope, as against the observability filters' exact owner match."""
         if self.app_name is None:
             return sa.true()
         return sa.or_(col == self.app_name, col.is_(None))
@@ -758,11 +746,8 @@ class SystemDatabase(ABC):
         owner: Optional[str],
         kind: str,
     ) -> None:
-        """Reject writing over a row owned by a different application.
-
-        Names stay globally unique across applications, so a collision is a real
-        conflict rather than something to silently resolve by last-writer-wins.
-        """
+        """Reject writing over a row owned by a different application: names are
+        globally unique, so a collision is a conflict, not a last-writer-wins race."""
         existing = conn.execute(
             sa.select(table.c.application_name).where(name_col == name)
         ).fetchone()
@@ -842,8 +827,7 @@ class SystemDatabase(ABC):
                 schedule_name=status["schedule_name"],
                 debounce_deadline_epoch_ms=status["debounce_deadline_epoch_ms"],
                 is_debounced=status["is_debounced"],
-                # Deliberately absent from update_values: a re-enqueue must never
-                # re-own a row another application already claimed.
+                # Absent from update_values: a re-enqueue must not re-own a claimed row.
                 application_name=status["application_name"],
             )
             .on_conflict_do_update(
@@ -1300,8 +1284,7 @@ class SystemDatabase(ABC):
                             assumed_role=status[7],
                             forked_from=original_workflow_id,
                             attributes=status[10],
-                            # Inherit the source's owner so the fork runs on the
-                            # application that owns the original workflow.
+                            # Inherit the source's owner so the fork runs on the same application.
                             application_name=status[11],
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
@@ -1385,8 +1368,7 @@ class SystemDatabase(ABC):
                             child_wf_expr,
                             oo.c.started_at_epoch_ms,
                             oo.c.completed_at_epoch_ms,
-                            # The fork inherits the source workflow's owner, so its
-                            # copied steps must inherit the same one.
+                            # Copied steps inherit the owner the forked workflow inherited.
                             oo.c.application_name,
                         ).select_from(
                             mapping_subquery.join(
@@ -2090,8 +2072,7 @@ class SystemDatabase(ABC):
                     == WorkflowStatusString.PENDING.value,
                     SystemSchema.workflow_status.c.executor_id == executor_id,
                     SystemSchema.workflow_status.c.application_version == app_version,
-                    # executor_id defaults to the literal "local", so it collides
-                    # across applications on a shared host; this disambiguates.
+                    # executor_id defaults to "local", so it collides across applications.
                     self._app_scope(SystemSchema.workflow_status.c.application_name),
                 )
             ).fetchall()
@@ -2607,8 +2588,7 @@ class SystemDatabase(ABC):
                     output=output,
                     error=error,
                     serialization=result["serialization"],
-                    # Mirrors the parent workflow's owner: only the application
-                    # running a workflow records its steps.
+                    # Mirrors the parent: only the running application records its steps.
                     application_name=self.app_name,
                 )
                 .on_conflict_do_update(
@@ -4078,8 +4058,7 @@ class SystemDatabase(ABC):
                         SystemSchema.workflow_status.c.started_at_epoch_ms
                         > start_time_ms - limiter_period_ms
                     )
-                    # Count only what this application would dequeue, so the rate
-                    # limit matches the set the select below draws from.
+                    # Count only what this application would dequeue, matching the select below.
                     .where(
                         self._app_scope(SystemSchema.workflow_status.c.application_name)
                     )
@@ -4129,10 +4108,7 @@ class SystemDatabase(ABC):
 
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
-                # This application's latest version, not the newest on the
-                # database. Unclaimed rows count: one that is newer means an
-                # older-SDK peer deployed after this worker, which really does
-                # demote it.
+                # This application's latest; a newer unclaimed row is a peer's deploy.
                 .where(
                     self._app_scope(
                         SystemSchema.application_versions.c.application_name
@@ -4213,8 +4189,7 @@ class SystemDatabase(ABC):
                         status=WorkflowStatusString.PENDING.value,
                         application_version=app_version,
                         executor_id=executor_id,
-                        # Claim the row: unclaimed workflows are adopted by whoever
-                        # runs them, so the unclaimed partition drains over time.
+                        # Claim it, so the unclaimed partition drains as workflows run.
                         application_name=self.app_name,
                         started_at_epoch_ms=start_time_ms,
                         rate_limited=queue._limiter is not None,
@@ -4263,10 +4238,7 @@ class SystemDatabase(ABC):
         with self.engine.begin() as c:
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
-                # This application's latest version, not the newest on the
-                # database. Unclaimed rows count: one that is newer means an
-                # older-SDK peer deployed after this worker, which really does
-                # demote it.
+                # This application's latest; a newer unclaimed row is a peer's deploy.
                 .where(
                     self._app_scope(
                         SystemSchema.application_versions.c.application_name
@@ -4324,10 +4296,7 @@ class SystemDatabase(ABC):
                 )
                 .limit(1)
             )
-            # Admit a partition's head only while nothing in that partition runs
-            # anywhere, on any app version, for any application. Deliberately
-            # unscoped: this is a mutual-exclusion probe, so a row owned by someone
-            # else still has to block admission.
+            # Unscoped by design: a mutual-exclusion probe must block on any owner's row.
             pending_probe = (
                 sa.select(sa.literal(1))
                 .where(ws.c.queue_name == queue.name)
@@ -5022,9 +4991,7 @@ class SystemDatabase(ABC):
                     WorkflowStatusString.DELAYED.value,
                 ]
             ),
-            # Collect this application's rows and unclaimed ones. Unclaimed rows are
-            # included deliberately: excluding them would leak every pre-upgrade row
-            # forever, since no application would ever be entitled to collect them.
+            # Unclaimed rows included: excluding them would leak pre-upgrade rows forever.
             self._app_scope(SystemSchema.workflow_status.c.application_name),
         )
 
@@ -5080,10 +5047,7 @@ class SystemDatabase(ABC):
 
     def list_timed_out_workflow_ids(self, cutoff_epoch_timestamp_ms: int) -> List[str]:
         """IDs of this application's in-flight workflows created before the cutoff.
-
-        Uses the claiming scope rather than an exact owner match, so an upgrading
-        application still times out its own pre-upgrade (unclaimed) workflows.
-        """
+        Claiming-scoped, so an upgrade still times out its own unclaimed workflows."""
         with self.engine.begin() as c:
             rows = c.execute(
                 sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
@@ -5876,15 +5840,8 @@ class SystemDatabase(ABC):
     def create_application_version(
         self, version_name: str, application_name: Optional[str] = None
     ) -> None:
-        """Register this version, claiming the row if nobody owns it yet.
-
-        An unowned row is one written before this column existed. Claiming it on
-        registration means a version string that never changes — a pinned
-        application_version rather than a computed source hash — still ends up
-        owned, instead of staying unclaimed for the life of the deployment.
-        Rows owned by another application are rejected above, and a row this
-        application already owns is left alone.
-        """
+        """Register this version, claiming the row if nobody owns it yet, so a pinned
+        application_version does not stay unclaimed for the life of the deployment."""
         owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
             self._check_row_owner(
@@ -5901,9 +5858,7 @@ class SystemDatabase(ABC):
                     version_name=version_name,
                     application_name=owner,
                 )
-                # Conditional upsert rather than a preceding UPDATE: one atomic
-                # statement, and it leaves version_timestamp untouched so a
-                # redeploy of the same version still is not a promotion.
+                # Sets only the owner, so redeploying a version is still not a promotion.
                 .on_conflict_do_update(
                     index_elements=["version_name"],
                     set_={"application_name": owner},
@@ -5974,8 +5929,7 @@ class SystemDatabase(ABC):
     ) -> List["Queue"]:
         with self.engine.begin() as c:
             rows = c.execute(
-                # Scoped so the queue thread never spawns workers for another
-                # application's database-backed queues.
+                # Scoped so the queue thread ignores other applications' queues.
                 sa.select(SystemSchema.queues).where(
                     self._app_scope(SystemSchema.queues.c.application_name)
                 )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5879,6 +5879,15 @@ class SystemDatabase(ABC):
     def create_application_version(
         self, version_name: str, application_name: Optional[str] = None
     ) -> None:
+        """Register this version, claiming the row if nobody owns it yet.
+
+        An unowned row is one written before this column existed. Claiming it on
+        registration means a version string that never changes — a pinned
+        application_version rather than a computed source hash — still ends up
+        owned, instead of staying unclaimed for the life of the deployment.
+        Rows owned by another application are rejected above, and a row this
+        application already owns is left alone.
+        """
         owner = application_name if application_name is not None else self.app_name
         with self.engine.begin() as c:
             self._check_row_owner(
@@ -5890,13 +5899,21 @@ class SystemDatabase(ABC):
                 "Application version",
             )
             c.execute(
-                self.dialect.insert(SystemSchema.application_versions)
-                .values(
+                self.dialect.insert(SystemSchema.application_versions).values(
                     version_id=generate_uuid(),
                     version_name=version_name,
                     application_name=owner,
                 )
-                .on_conflict_do_nothing(index_elements=["version_name"])
+                # Conditional upsert rather than a preceding UPDATE: one atomic
+                # statement, and it leaves version_timestamp untouched so a
+                # redeploy of the same version still is not a promotion.
+                .on_conflict_do_update(
+                    index_elements=["version_name"],
+                    set_={"application_name": owner},
+                    where=SystemSchema.application_versions.c.application_name.is_(
+                        None
+                    ),
+                )
             )
 
     def update_application_version_timestamp(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5907,30 +5907,26 @@ class SystemDatabase(ABC):
     ) -> None:
         """Register this version, claiming the row if nobody owns it yet, so a pinned
         application_version does not stay unclaimed for the life of the deployment.
-        Silent when another application already registered the name: launch must not
-        fail over a version string two applications happen to share."""
+        Names are global addresses, so a peer's is a collision rather than a share:
+        raising here is what keeps an application from launching without a version."""
         owner = application_name if application_name is not None else self.app_name
         av = SystemSchema.application_versions
         with self.engine.begin() as c:
+            resolved = self._resolve_row_owner(
+                c, av, av.c.version_name, version_name, owner, "Application version"
+            )
             c.execute(
-                self.dialect.insert(av)
-                .values(
+                self.dialect.insert(av).values(
                     version_id=generate_uuid(),
                     version_name=version_name,
-                    application_name=owner,
+                    application_name=resolved,
                 )
-                .on_conflict_do_nothing(index_elements=["version_name"])
+                # Claims a pre-upgrade row without recreating or retiming it.
+                .on_conflict_do_update(
+                    index_elements=["version_name"],
+                    set_={"application_name": resolved},
+                )
             )
-            if owner is not None:
-                # One row per name, so claim a pre-upgrade one and leave a peer's alone.
-                c.execute(
-                    sa.update(av)
-                    .where(
-                        av.c.version_name == version_name,
-                        av.c.application_name.is_(None),
-                    )
-                    .values(application_name=owner)
-                )
 
     def update_application_version_timestamp(
         self,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -778,7 +778,7 @@ class SystemDatabase(ABC):
         current: Optional[str] = existing[0]
         if owner is None or current == owner:
             return current
-        # A version name is computed or pinned, never chosen like a queue's, so say so.
+        # A version name is computed or pinned, so "pick another" is config advice, not a rename.
         take_a_new_name = (
             f"set a distinct application_version for '{owner}'"
             if kind == "Application version"
@@ -787,10 +787,9 @@ class SystemDatabase(ABC):
         raise DBOSException(
             f"{kind} '{name}' is already registered by application "
             f"'{current}' in this system database. {kind} names must be "
-            f"unique across applications sharing a system database. Either "
+            "unique across applications sharing a system database. Either "
             f"{take_a_new_name}, or, if '{current}' was renamed to '{owner}', "
-            f"re-own its rows first with "
-            f"dbos rename-application"
+            "re-own its rows first with dbos rename-application"
         )
 
     def _insert_workflow_status(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -193,6 +193,9 @@ class WorkflowStatus:
     attributes: Optional[Dict[str, Any]]
     # If this workflow was enqueued by a named schedule, that schedule's name
     schedule_name: Optional[str]
+    # The application that owns this workflow. None if unclaimed, in which case any
+    # application listening on its queue may run it.
+    application_name: Optional[str]
 
     # INTERNAL FIELDS
 
@@ -238,6 +241,8 @@ class WorkflowStatusInternal(TypedDict):
     debounce_deadline_epoch_ms: Optional[int]
     # True if this workflow's dedup ID is a debounce key to clear on the DELAYED->ENQUEUED transition.
     is_debounced: bool
+    # Owning application; None writes an unclaimed row.
+    application_name: Optional[str]
 
 
 class MetricData(TypedDict):
@@ -326,6 +331,8 @@ class WorkflowSchedule(TypedDict):
     automatic_backfill: bool
     cron_timezone: Optional[str]  # IANA timezone name, stored as string in DB
     queue_name: Optional[str]
+    # Owning application; None if unclaimed.
+    application_name: Optional[str]
 
 
 class ClientScheduleInput(TypedDict, total=False):
@@ -344,6 +351,8 @@ class VersionInfo(TypedDict):
     version_name: str
     version_timestamp: int
     created_at: int
+    # Owning application; None if unclaimed.
+    application_name: Optional[str]
 
 
 class StepInfo(TypedDict):
@@ -533,6 +542,7 @@ class SystemDatabase(ABC):
         notification_listener_polling_interval_sec: float = 1.0,
         notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
+        app_name: Optional[str] = None,
     ) -> "SystemDatabase":
         """Factory method to create the appropriate SystemDatabase implementation based on URL."""
         if system_database_url.startswith("sqlite"):
@@ -549,6 +559,7 @@ class SystemDatabase(ABC):
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
                 notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
+                app_name=app_name,
             )
         else:
             from ._sys_db_postgres import PostgresSystemDatabase
@@ -564,6 +575,7 @@ class SystemDatabase(ABC):
                 notification_listener_polling_interval_sec=notification_listener_polling_interval_sec,
                 notification_coalesce_sec=notification_coalesce_sec,
                 polling_concurrency=polling_concurrency,
+                app_name=app_name,
             )
 
     def __init__(
@@ -579,6 +591,7 @@ class SystemDatabase(ABC):
         notification_listener_polling_interval_sec: float = 1.0,
         notification_coalesce_sec: float = DEFAULT_NOTIFICATION_COALESCE_SEC,
         polling_concurrency: Optional[int] = None,
+        app_name: Optional[str] = None,
     ):
         import sqlalchemy.dialects.postgresql as pg
         import sqlalchemy.dialects.sqlite as sq
@@ -640,6 +653,9 @@ class SystemDatabase(ABC):
         self.workflow_events_map = ThreadSafeEventDict()
         self.streams_map = ThreadSafeEventDict()
         self.executor_id = executor_id
+        # The application this database handle acts on behalf of. None means no
+        # application identity: rows are written unclaimed.
+        self.app_name = app_name
         self._notification_listener_polling_interval_sec = (
             notification_listener_polling_interval_sec
         )
@@ -782,6 +798,9 @@ class SystemDatabase(ABC):
                 schedule_name=status["schedule_name"],
                 debounce_deadline_epoch_ms=status["debounce_deadline_epoch_ms"],
                 is_debounced=status["is_debounced"],
+                # Deliberately absent from update_values: a re-enqueue must never
+                # re-own a row another application already claimed.
+                application_name=status["application_name"],
             )
             .on_conflict_do_update(
                 index_elements=["workflow_uuid"],
@@ -1199,6 +1218,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.inputs,
                     SystemSchema.workflow_status.c.serialization,
                     SystemSchema.workflow_status.c.attributes,
+                    SystemSchema.workflow_status.c.application_name,
                 ).where(
                     SystemSchema.workflow_status.c.workflow_uuid.in_(
                         original_workflow_ids
@@ -1236,6 +1256,9 @@ class SystemDatabase(ABC):
                             assumed_role=status[7],
                             forked_from=original_workflow_id,
                             attributes=status[10],
+                            # Inherit the source's owner so the fork runs on the
+                            # application that owns the original workflow.
+                            application_name=status[11],
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
                             original_workflow_ids, forked_workflow_ids, statuses
@@ -1553,6 +1576,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_status.c.schedule_name,
                     SystemSchema.workflow_status.c.debounce_deadline_epoch_ms,
                     SystemSchema.workflow_status.c.is_debounced,
+                    SystemSchema.workflow_status.c.application_name,
                 ).where(SystemSchema.workflow_status.c.workflow_uuid == workflow_uuid)
             ).fetchone()
             if row is None:
@@ -1591,6 +1615,7 @@ class SystemDatabase(ABC):
                 "schedule_name": row[26],
                 "debounce_deadline_epoch_ms": row[27],
                 "is_debounced": bool(row[28]),
+                "application_name": row[29],
             }
             return status
 
@@ -1804,6 +1829,7 @@ class SystemDatabase(ABC):
             SystemSchema.workflow_status.c.completed_at,
             SystemSchema.workflow_status.c.attributes,
             SystemSchema.workflow_status.c.schedule_name,
+            SystemSchema.workflow_status.c.application_name,
         ]
         if load_input:
             load_columns.append(SystemSchema.workflow_status.c.inputs)
@@ -1966,8 +1992,9 @@ class SystemDatabase(ABC):
             info.completed_at = row[25]
             info.attributes = row[26]
             info.schedule_name = row[27]
+            info.application_name = row[28]
 
-            idx = 28
+            idx = 29
             raw_input = row[idx] if load_input else None
             if load_input:
                 idx += 1
@@ -4563,12 +4590,13 @@ class SystemDatabase(ABC):
                     "delay_until_epoch_ms": status["delay_until_epoch_ms"],
                     "attributes": status["attributes"],
                     "schedule_name": status["schedule_name"],
+                    "application_name": status["application_name"],
                     "created_at": created_ats[i],
                     "updated_at": created_ats[i],
                 }
             )
         inserted: Set[str] = set()
-        # Chunk to stay well under bind-parameter limits (~29 params per row).
+        # Chunk to stay well under bind-parameter limits (~30 params per row).
         chunk_size = 500
         with self.engine.begin() as conn:
             for start in range(0, len(rows), chunk_size):
@@ -5153,6 +5181,7 @@ class SystemDatabase(ABC):
                         SystemSchema.workflow_status.c.schedule_name,
                         SystemSchema.workflow_status.c.debounce_deadline_epoch_ms,
                         SystemSchema.workflow_status.c.is_debounced,
+                        SystemSchema.workflow_status.c.application_name,
                         # owner_xid is intentionally omitted: it is a transient
                         # transaction-ownership token, not logical workflow state
                         # (get_workflow_status also returns None for it), and a
@@ -5199,6 +5228,7 @@ class SystemDatabase(ABC):
                     "schedule_name": status_row[32],
                     "debounce_deadline_epoch_ms": status_row[33],
                     "is_debounced": status_row[34],
+                    "application_name": status_row[35],
                 }
 
                 # Export operation_outputs
@@ -5364,6 +5394,7 @@ class SystemDatabase(ABC):
                             "debounce_deadline_epoch_ms"
                         ),
                         is_debounced=status.get("is_debounced", False),
+                        application_name=status.get("application_name"),
                     )
                 )
 
@@ -5439,6 +5470,8 @@ class SystemDatabase(ABC):
                         automatic_backfill=schedule.get("automatic_backfill", False),
                         cron_timezone=schedule.get("cron_timezone"),
                         queue_name=schedule.get("queue_name"),
+                        # Ownership belongs to the writer, not the payload.
+                        application_name=self.app_name,
                     )
                 )
             except sa.exc.IntegrityError:
@@ -5471,6 +5504,8 @@ class SystemDatabase(ABC):
                     automatic_backfill=schedule.get("automatic_backfill", False),
                     cron_timezone=schedule.get("cron_timezone"),
                     queue_name=schedule.get("queue_name"),
+                    # Ownership belongs to the writer, not the payload.
+                    application_name=self.app_name,
                 )
                 .on_conflict_do_update(
                     index_elements=["schedule_name"],
@@ -5482,6 +5517,7 @@ class SystemDatabase(ABC):
                         "automatic_backfill": schedule.get("automatic_backfill", False),
                         "cron_timezone": schedule.get("cron_timezone"),
                         "queue_name": schedule.get("queue_name"),
+                        "application_name": self.app_name,
                     },
                 )
             )
@@ -5513,6 +5549,7 @@ class SystemDatabase(ABC):
                 SystemSchema.workflow_schedules.c.automatic_backfill,
                 SystemSchema.workflow_schedules.c.cron_timezone,
                 SystemSchema.workflow_schedules.c.queue_name,
+                SystemSchema.workflow_schedules.c.application_name,
             )
             if status is not None:
                 vals = [status] if isinstance(status, str) else status
@@ -5554,6 +5591,7 @@ class SystemDatabase(ABC):
                     automatic_backfill=bool(row[8]),
                     cron_timezone=row[9],
                     queue_name=row[10],
+                    application_name=row[11],
                 )
                 for row in rows
             ]
@@ -5580,6 +5618,7 @@ class SystemDatabase(ABC):
                     SystemSchema.workflow_schedules.c.automatic_backfill,
                     SystemSchema.workflow_schedules.c.cron_timezone,
                     SystemSchema.workflow_schedules.c.queue_name,
+                    SystemSchema.workflow_schedules.c.application_name,
                 ).where(SystemSchema.workflow_schedules.c.schedule_name == name)
             ).fetchone()
             if row is None:
@@ -5596,6 +5635,7 @@ class SystemDatabase(ABC):
                 automatic_backfill=bool(row[8]),
                 cron_timezone=row[9],
                 queue_name=row[10],
+                application_name=row[11],
             )
 
         if conn is not None:
@@ -5656,6 +5696,7 @@ class SystemDatabase(ABC):
                 .values(
                     version_id=generate_uuid(),
                     version_name=version_name,
+                    application_name=self.app_name,
                 )
                 .on_conflict_do_nothing(index_elements=["version_name"])
             )
@@ -5678,6 +5719,7 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.version_name,
                     SystemSchema.application_versions.c.version_timestamp,
                     SystemSchema.application_versions.c.created_at,
+                    SystemSchema.application_versions.c.application_name,
                 ).order_by(SystemSchema.application_versions.c.version_timestamp.desc())
             ).fetchall()
             return [
@@ -5686,6 +5728,7 @@ class SystemDatabase(ABC):
                     version_name=row[1],
                     version_timestamp=row[2],
                     created_at=row[3],
+                    application_name=row[4],
                 )
                 for row in rows
             ]
@@ -5764,6 +5807,7 @@ class SystemDatabase(ABC):
             "partition_queue": partition_queue,
             "polling_interval_sec": polling_interval_sec,
             "updated_at": int(time.time() * 1000),
+            "application_name": self.app_name,
         }
         with self.engine.begin() as c:
             existed = (
@@ -5794,6 +5838,7 @@ class SystemDatabase(ABC):
                     SystemSchema.application_versions.c.version_name,
                     SystemSchema.application_versions.c.version_timestamp,
                     SystemSchema.application_versions.c.created_at,
+                    SystemSchema.application_versions.c.application_name,
                 )
                 .order_by(SystemSchema.application_versions.c.version_timestamp.desc())
                 .limit(1)
@@ -5805,6 +5850,7 @@ class SystemDatabase(ABC):
                 version_name=row[1],
                 version_timestamp=row[2],
                 created_at=row[3],
+                application_name=row[4],
             )
 
     @db_retry()

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -78,6 +78,20 @@ class SQLiteSystemDatabase(SystemDatabase):
                 ).fetchone()
                 last_applied = version_result[0] if version_result else 0
 
+            def record_version(version: int) -> None:
+                if last_applied == 0:
+                    conn.execute(
+                        sa.text(
+                            "INSERT INTO dbos_migrations (version) VALUES (:version)"
+                        ),
+                        {"version": version},
+                    )
+                else:
+                    conn.execute(
+                        sa.text("UPDATE dbos_migrations SET version = :version"),
+                        {"version": version},
+                    )
+
             # Apply migrations starting from the next version
             for i, migration_sql in enumerate(sqlite_migrations, 1):
                 if i <= last_applied:
@@ -87,28 +101,22 @@ class SQLiteSystemDatabase(SystemDatabase):
                 statements = [
                     stmt.strip() for stmt in migration_sql.split(";") if stmt.strip()
                 ]
-                # Renumbering left long runs of empty migrations; say nothing of them.
-                if statements:
-                    dbos_logger.info(
-                        f"Applying DBOS SQLite system database schema migration {i}"
-                    )
+                # Renumbering left long runs of empty migrations; skip them entirely.
+                if not statements:
+                    continue
+
+                dbos_logger.info(
+                    f"Applying DBOS SQLite system database schema migration {i}"
+                )
                 for statement in statements:
                     conn.execute(sa.text(statement))
 
-                # Update the single row with the new version
-                if last_applied == 0:
-                    conn.execute(
-                        sa.text(
-                            "INSERT INTO dbos_migrations (version) VALUES (:version)"
-                        ),
-                        {"version": i},
-                    )
-                else:
-                    conn.execute(
-                        sa.text("UPDATE dbos_migrations SET version = :version"),
-                        {"version": i},
-                    )
+                record_version(i)
                 last_applied = i
+
+            # Empty migrations at the end still count as applied; record them in one write.
+            if len(sqlite_migrations) > last_applied:
+                record_version(len(sqlite_migrations))
 
     def _cleanup_connections(self) -> None:
         # SQLite doesn't require special connection cleanup

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -83,15 +83,15 @@ class SQLiteSystemDatabase(SystemDatabase):
                 if i <= last_applied:
                     continue
 
-                # Execute the migration
-                dbos_logger.info(
-                    f"Applying DBOS SQLite system database schema migration {i}"
-                )
-
                 # SQLite only allows one statement at a time, so split by semicolon
                 statements = [
                     stmt.strip() for stmt in migration_sql.split(";") if stmt.strip()
                 ]
+                # Renumbering left long runs of empty migrations; say nothing of them.
+                if statements:
+                    dbos_logger.info(
+                        f"Applying DBOS SQLite system database schema migration {i}"
+                    )
                 for statement in statements:
                     conn.execute(sa.text(statement))
 

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -124,6 +124,9 @@ class PollingLimiter:
 class GlobalParams:
     app_version: str = os.environ.get("DBOS__APPVERSION", "")
     executor_id: str = os.environ.get("DBOS__VMID", "local")
+    # Set at launch from the configured application name. None outside an application
+    # (e.g. DBOSClient), which writes unclaimed rows any application may run.
+    app_name: Optional[str] = None
     dbos_cloud: bool = os.environ.get("DBOS__CLOUD") == "true"
     try:
         # Only works on Python >= 3.8

--- a/dbos/_utils.py
+++ b/dbos/_utils.py
@@ -124,8 +124,7 @@ class PollingLimiter:
 class GlobalParams:
     app_version: str = os.environ.get("DBOS__APPVERSION", "")
     executor_id: str = os.environ.get("DBOS__VMID", "local")
-    # Set at launch from the configured application name. None outside an application
-    # (e.g. DBOSClient), which writes unclaimed rows any application may run.
+    # Set at launch from the configured application name; None outside an application.
     app_name: Optional[str] = None
     dbos_cloud: bool = os.environ.get("DBOS__CLOUD") == "true"
     try:

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -99,13 +99,10 @@ def garbage_collect(
 
 
 def global_timeout(dbos: "DBOS", cutoff_epoch_timestamp_ms: int) -> None:
-    cutoff_iso = datetime.fromtimestamp(cutoff_epoch_timestamp_ms / 1000).isoformat()
-    for workflow in dbos.list_workflows(
-        status=[
-            WorkflowStatusString.PENDING.value,
-            WorkflowStatusString.ENQUEUED.value,
-            WorkflowStatusString.DELAYED.value,
-        ],
-        end_time=cutoff_iso,
+    # Scoped to this application's workflows plus unclaimed ones, not routed through
+    # list_workflows: that filter matches an owner exactly and so cannot express the
+    # unclaimed half, which is what pre-upgrade in-flight rows look like.
+    for workflow_id in dbos._sys_db.list_timed_out_workflow_ids(
+        cutoff_epoch_timestamp_ms
     ):
-        dbos.cancel_workflow(workflow.workflow_id)
+        dbos.cancel_workflow(workflow_id)

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -98,7 +98,7 @@ def garbage_collect(
 
 
 def global_timeout(dbos: "DBOS", cutoff_epoch_timestamp_ms: int) -> None:
-    # Own plus unclaimed rows, which list_workflows' exact-match filter cannot express.
+    # IDs only, so a bulk timeout does not deserialize every row's inputs and outputs.
     for workflow_id in dbos._sys_db.list_timed_out_workflow_ids(
         cutoff_epoch_timestamp_ms
     ):

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from dbos._context import get_local_dbos_context
 from dbos._utils import generate_uuid
 
-from ._sys_db import SystemDatabase, WorkflowStatus, WorkflowStatusString
+from ._sys_db import SystemDatabase, WorkflowStatus
 
 if TYPE_CHECKING:
     from ._dbos import DBOS

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -99,9 +99,7 @@ def garbage_collect(
 
 
 def global_timeout(dbos: "DBOS", cutoff_epoch_timestamp_ms: int) -> None:
-    # Scoped to this application's workflows plus unclaimed ones, not routed through
-    # list_workflows: that filter matches an owner exactly and so cannot express the
-    # unclaimed half, which is what pre-upgrade in-flight rows look like.
+    # Own plus unclaimed rows, which list_workflows' exact-match filter cannot express.
     for workflow_id in dbos._sys_db.list_timed_out_workflow_ids(
         cutoff_epoch_timestamp_ms
     ):

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -441,6 +441,7 @@ def reset(
 )
 @click.option(
     "--schema",
+    default="dbos",
     help='Schema name for DBOS system tables. Defaults to "dbos".',
 )
 def rename_application(
@@ -454,7 +455,7 @@ def rename_application(
 ) -> None:
     sources = []
     if old_name:
-        sources.append(f"'{old_name}''s rows")
+        sources.append(f"'{old_name}'s rows")
     if adopt_unclaimed_rows:
         sources.append("rows no application owns")
     if not sources:

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -441,6 +441,11 @@ def reset(
 )
 @click.option("--name", "-n", help="Retrieve workflows with this name")
 @click.option(
+    "--application-name",
+    "-a",
+    help="Retrieve workflows owned by this application",
+)
+@click.option(
     "--sort-desc",
     "-d",
     is_flag=True,
@@ -462,6 +467,7 @@ def list_workflows(
     status: Optional[str],
     application_version: Optional[str],
     name: Optional[str],
+    application_name: Optional[str],
     sort_desc: bool,
     offset: Optional[int],
     schema: Optional[str],
@@ -485,6 +491,7 @@ def list_workflows(
         status=status,
         app_version=application_version,
         name=name,
+        application_name=application_name,
     )
     print(json.dumps([w.__dict__ for w in workflows], cls=DefaultEncoder))
 
@@ -718,6 +725,11 @@ def fork(
 @click.option("--queue-name", "-q", help="Retrieve functions on this queue")
 @click.option("--name", "-n", help="Retrieve functions on this queue")
 @click.option(
+    "--application-name",
+    "-a",
+    help="Retrieve functions owned by this application",
+)
+@click.option(
     "--sort-desc",
     "-d",
     is_flag=True,
@@ -738,6 +750,7 @@ def list_queue(
     status: Optional[str],
     queue_name: Optional[str],
     name: Optional[str],
+    application_name: Optional[str],
     sort_desc: bool,
     offset: Optional[int],
     schema: Optional[str],
@@ -760,6 +773,7 @@ def list_queue(
         queue_name=queue_name,
         status=status,
         name=name,
+        application_name=application_name,
     )
     print(json.dumps([w.__dict__ for w in workflows], cls=DefaultEncoder))
 

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -29,7 +29,7 @@ from .._dbos_config import (
 )
 from .._docker_pg_helper import start_docker_pg, stop_docker_pg
 from .._logger import dbos_logger, init_logger
-from .._sys_db import SystemDatabase
+from .._sys_db import DEFAULT_RENAME_BATCH_SIZE, SystemDatabase
 from .._utils import GlobalParams
 from ..cli._github_init import create_template_from_github
 from ._template_init import copy_template, get_project_name, get_templates_directory
@@ -405,6 +405,91 @@ def reset(
     except Exception as e:
         click.echo(f"Error resetting system database: {str(e)}")
         return
+
+
+@app.command(
+    name="rename-application",
+    help="Re-own a system database's rows after an application is renamed",
+)
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.option(
+    "--sys-db-url", "-s", "system_database_url", help="Your DBOS system database URL"
+)
+@click.option(
+    "--from",
+    "-f",
+    "old_name",
+    help="The application's previous name. Omit to only adopt unclaimed rows.",
+)
+@click.option(
+    "--to",
+    "-t",
+    "new_name",
+    required=True,
+    help="The application that ends up owning the rows",
+)
+@click.option(
+    "--adopt-unclaimed-rows",
+    is_flag=True,
+    help="Also take rows no application owns, which every peer sharing this system database would otherwise share",
+)
+@click.option(
+    "--batch-size",
+    type=int,
+    default=DEFAULT_RENAME_BATCH_SIZE,
+    help="Terminal workflows and steps re-owned per transaction",
+)
+@click.option(
+    "--schema",
+    help='Schema name for DBOS system tables. Defaults to "dbos".',
+)
+def rename_application(
+    yes: bool,
+    system_database_url: Optional[str],
+    old_name: Optional[str],
+    new_name: str,
+    adopt_unclaimed_rows: bool,
+    batch_size: int,
+    schema: Optional[str],
+) -> None:
+    sources = []
+    if old_name:
+        sources.append(f"'{old_name}''s rows")
+    if adopt_unclaimed_rows:
+        sources.append("rows no application owns")
+    if not sources:
+        raise click.UsageError(
+            "Nothing to re-own: pass --from, --adopt-unclaimed-rows, or both."
+        )
+    if not yes:
+        confirm = click.confirm(
+            f"This command re-owns {' and '.join(sources)} in your DBOS system "
+            f"database as '{new_name}'. Stop the application being renamed first, or "
+            "its own dequeues may stamp the old name back. Are you sure you want to "
+            "proceed?"
+        )
+        if not confirm:
+            click.echo("Operation cancelled.")
+            raise click.exceptions.Exit()
+    system_database_url, _ = _get_db_url(
+        system_database_url=system_database_url, application_database_url=None
+    )
+    client = DBOSClient(
+        system_database_url=system_database_url, dbos_system_schema=schema
+    )
+    try:
+        moved = client.rename_application(
+            old_name,
+            new_name,
+            batch_size=batch_size,
+            adopt_unclaimed_rows=adopt_unclaimed_rows,
+        )
+        print(json.dumps(moved, indent=2))
+    except click.exceptions.Exit:
+        raise
+    except Exception as e:
+        click.echo(f"Error renaming application: {str(e)}", err=True)
+        raise click.exceptions.Exit(code=1)
 
 
 @workflow.command(name="list", help="List workflows for your application")

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -431,13 +431,13 @@ def reset(
 @click.option(
     "--adopt-unclaimed-rows",
     is_flag=True,
-    help="Also take rows no application owns, which every peer sharing this system database would otherwise share",
+    help="Also take rows no application owns (application_name=NULL)",
 )
 @click.option(
     "--batch-size",
     type=int,
     default=DEFAULT_RENAME_BATCH_SIZE,
-    help="Terminal workflows and steps re-owned per transaction",
+    help="Workflows and steps re-owned per transaction",
 )
 @click.option(
     "--schema",
@@ -464,9 +464,8 @@ def rename_application(
     if not yes:
         confirm = click.confirm(
             f"This command re-owns {' and '.join(sources)} in your DBOS system "
-            f"database as '{new_name}'. Stop the application being renamed first, or "
-            "its own dequeues may stamp the old name back. Are you sure you want to "
-            "proceed?"
+            f"database as '{new_name}'. Stop the application being renamed before "
+            "running this. Are you sure you want to proceed?"
         )
         if not confirm:
             click.echo("Operation cancelled.")

--- a/dbos/cli/migration.py
+++ b/dbos/cli/migration.py
@@ -186,6 +186,19 @@ def print_dbos_migrations(
         )
 
     version_row_exists = start > 1
+    last_emitted = start - 1
+
+    def _emit_version(version: int) -> None:
+        nonlocal version_row_exists, last_emitted
+        if version_row_exists:
+            _emit_sql(f'UPDATE "{schema}".dbos_migrations SET version = {version}')
+        else:
+            _emit_sql(
+                f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({version})'
+            )
+            version_row_exists = True
+        last_emitted = version
+
     for i in range(start, latest_version + 1):
         migration_sql = migrations[i - 1]
         if i == 10:
@@ -195,13 +208,16 @@ def print_dbos_migrations(
         elif migration_sql.strip():
             click.echo(f"-- Migration {i}")
             _emit_sql(migration_sql)
+        else:
+            # Renumbering left long runs of empty migrations; nothing to emit.
+            continue
         # Per-migration version bookkeeping, mirroring the runner: an
         # interrupted apply can be resumed from the next migration number.
-        if version_row_exists:
-            _emit_sql(f'UPDATE "{schema}".dbos_migrations SET version = {i}')
-        else:
-            _emit_sql(f'INSERT INTO "{schema}".dbos_migrations (version) VALUES ({i})')
-            version_row_exists = True
+        _emit_version(i)
+
+    # Empty migrations at the end still count as applied.
+    if latest_version > last_emitted:
+        _emit_version(latest_version)
 
 
 def print_dbos_user_role_sql(*, schema: str = "dbos", role_name: str) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -264,6 +264,22 @@ def test_reads_surface_owner_and_ids_stay_global(dbos: DBOS) -> None:
     foreign = dbos._sys_db.get_workflow_status("foreign-visible")
     assert foreign is not None and foreign["application_name"] == OTHER_APP
 
+    # Every public identity read reaches a peer's row too: these go through
+    # list_workflows, whose unset filter otherwise scopes to this application.
+    by_id = DBOS.list_workflows(workflow_ids=["foreign-visible"])
+    assert [w.workflow_id for w in by_id] == ["foreign-visible"]
+    assert by_id[0].application_name == OTHER_APP
+    assert DBOS.get_workflow_status("foreign-visible") is not None
+    assert (
+        DBOS.retrieve_workflow("foreign-visible").get_status().application_name
+        == OTHER_APP
+    )
+    # An explicit filter still narrows, even for an ID-keyed read.
+    assert (
+        DBOS.list_workflows(workflow_ids=["foreign-visible"], application_name=APP_NAME)
+        == []
+    )
+
 
 def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     @DBOS.workflow()

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -281,9 +281,11 @@ def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
-def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
-    """All four surfaces follow the one rule: unset lists every application, and
-    naming one lists its rows plus unclaimed ones."""
+def test_observability_filters_include_unclaimed_rows(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    """All four surfaces follow the one rule: unset lists this application's rows
+    plus unclaimed ones, and naming one lists its rows plus unclaimed ones."""
 
     @DBOS.step()
     def a_step() -> int:
@@ -304,13 +306,19 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
         dbos, "unclaimed-listed", status="SUCCESS", application_name=None
     )
 
+    # Unset is this application's scope, so naming it changes nothing.
     unfiltered = {w.workflow_id for w in DBOS.list_workflows()}
-    assert {handle.workflow_id, "foreign-listed", "unclaimed-listed"} <= unfiltered
+    assert {handle.workflow_id, "unclaimed-listed"} <= unfiltered
+    assert "foreign-listed" not in unfiltered
     mine = {w.workflow_id for w in DBOS.list_workflows(application_name=APP_NAME)}
     assert {handle.workflow_id, "unclaimed-listed"} <= mine
     assert "foreign-listed" not in mine
     theirs = {w.workflow_id for w in DBOS.list_workflows(application_name=OTHER_APP)}
     assert theirs == {"foreign-listed", "unclaimed-listed"}
+    # A client with no application of its own has no scope to default to.
+    assert {handle.workflow_id, "foreign-listed", "unclaimed-listed"} <= {
+        w.workflow_id for w in client.list_workflows()
+    }
 
     aggregates = dbos._sys_db.get_workflow_aggregates(
         group_by_name=True, select_count=True, application_name=[OTHER_APP]
@@ -319,13 +327,22 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
 
     # Grouping partitions where the filter deliberately overlaps.
     grouped = dbos._sys_db.get_workflow_aggregates(
-        group_by_application_name=True, select_count=True
+        group_by_application_name=True,
+        select_count=True,
+        application_name=[APP_NAME, OTHER_APP],
     )
     assert {r["group"]["application_name"] for r in grouped} == {
         APP_NAME,
         OTHER_APP,
         None,
     }
+    # Unset would have dropped the peer's group entirely.
+    assert {
+        r["group"]["application_name"]
+        for r in dbos._sys_db.get_workflow_aggregates(
+            group_by_application_name=True, select_count=True
+        )
+    } == {APP_NAME, None}
 
     steps = dbos._sys_db.get_step_aggregates(
         group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
@@ -483,13 +500,9 @@ def test_unclaimed_rows_belong_to_every_application(
                 )
             )
 
-    # Unset lists every application.
-    assert {"mine", "theirs", "unclaimed"} <= {
-        s["schedule_name"] for s in DBOS.list_schedules()
-    }
-    assert {"mine-queue", "theirs-queue", "unclaimed-queue"} <= {
-        q.name for q in DBOS.list_queues()
-    }
+    # Unset is this application's scope: its own rows plus unclaimed, never a peer's.
+    assert {s["schedule_name"] for s in DBOS.list_schedules()} == {"mine", "unclaimed"}
+    assert {q.name for q in DBOS.list_queues()} == {"mine-queue", "unclaimed-queue"}
 
     # Naming an application adds the unclaimed rows, as the loops themselves do.
     assert {

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -303,6 +303,12 @@ def test_observability_filters_are_exact_and_optional(dbos: DBOS) -> None:
     )
     assert [r["group"]["name"] for r in aggregates] == ["foreign_workflow"]
 
+    # Grouping by owner is what lets a console break down a shared database.
+    grouped = dbos._sys_db.get_workflow_aggregates(
+        group_by_application_name=True, select_count=True
+    )
+    assert {r["group"]["application_name"] for r in grouped} == {APP_NAME, OTHER_APP}
+
     steps = dbos._sys_db.get_step_aggregates(
         group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
     )
@@ -642,3 +648,32 @@ def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
         )
     with pytest.raises(DBOSException, match="already registered by application"):
         dbos._sys_db.create_application_version("conflict-version")
+
+
+def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:
+    """Click binds options to parameters by name, which mypy cannot check, so the
+    two list commands need one real invocation."""
+    from click.testing import CliRunner
+
+    from dbos.cli.cli import app
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 14
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 14
+    insert_foreign_workflow(dbos, "cli-foreign", status="SUCCESS")
+
+    runner = CliRunner()
+    for command in (["workflow", "list"], ["workflow", "queue", "list"]):
+        result = runner.invoke(
+            app, command + ["-s", config["system_database_url"], "-a", OTHER_APP]
+        )
+        assert result.exit_code == 0, result.output
+        assert handle.workflow_id not in result.output
+    listed = runner.invoke(
+        app,
+        ["workflow", "list", "-s", config["system_database_url"], "-a", OTHER_APP],
+    )
+    assert "cli-foreign" in listed.output

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -675,3 +675,76 @@ def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:
         ["workflow", "list", "-s", config["system_database_url"], "-a", OTHER_APP],
     )
     assert "cli-foreign" in listed.output
+
+
+# ── Two applications, one system database ─────────────────────────────────────
+
+
+def test_two_applications_share_one_system_database(dbos: DBOS, config: Any) -> None:
+    """The only test with genuine second and third applications. DBOS is a process
+    singleton, so each peer is its own SystemDatabase against the same database."""
+    from dbos._serialization import DefaultSerializer
+    from dbos._sys_db import SystemDatabase
+
+    url = config["system_database_url"]
+    names = ("app-a", "app-b")
+    peers = {
+        name: SystemDatabase.create(
+            system_database_url=url,
+            engine_kwargs={},
+            engine=None,
+            schema=dbos._sys_db.schema,
+            serializer=DefaultSerializer(),
+            executor_id=f"exec-{name}",
+            use_listen_notify=False,
+            app_name=name,
+        )
+        for name in names
+    }
+    clients = {
+        name: DBOSClient(system_database_url=url, application_name=name)
+        for name in names
+    }
+    try:
+        enqueued = {}
+        for name in names:
+            peers[name].upsert_queue(
+                name=f"{name}-queue",
+                concurrency=None,
+                worker_concurrency=None,
+                rate_limit_max=None,
+                rate_limit_period_sec=None,
+                priority_enabled=False,
+                partition_queue=False,
+                polling_interval_sec=1.0,
+                update_existing=True,
+            )
+            # A client that names its application owns what it writes, with no
+            # per-call option. Everything lands on the internal queue, the one
+            # name every application shares, so only ownership can route it.
+            handle: WorkflowHandle[int] = clients[name].enqueue(
+                {"workflow_name": "wf", "queue_name": INTERNAL_QUEUE_NAME}
+            )
+            enqueued[name] = handle.workflow_id
+            assert application_name_of(dbos, handle.workflow_id) == name
+
+        # Each application dequeues its own work and only its own — the positive
+        # half, which rows written by a single application cannot demonstrate.
+        internal = Queue(INTERNAL_QUEUE_NAME, database_backed_queue=True)
+        for name in names:
+            dequeued = peers[name].start_queued_workflows(
+                internal, f"exec-{name}", f"version-{name}", None, 0
+            )
+            assert dequeued == [enqueued[name]], name
+
+        # Registration made each queue owned, so neither application enumerates
+        # the other's.
+        for name in names:
+            visible = {q.name for q in peers[name].list_queues(application_name=name)}
+            assert f"{name}-queue" in visible
+            assert not {f"{other}-queue" for other in names if other != name} & visible
+    finally:
+        for c in clients.values():
+            c.destroy()
+        for p in peers.values():
+            p.destroy()

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -91,7 +91,12 @@ def insert_foreign_workflow(
 
 
 def insert_foreign_step(
-    dbos: DBOS, workflow_id: str, *, function_name: str, completed_at: int = 1
+    dbos: DBOS,
+    workflow_id: str,
+    *,
+    function_name: str,
+    completed_at: int = 1,
+    application_name: Optional[str] = OTHER_APP,
 ) -> None:
     with dbos._sys_db.engine.begin() as c:
         c.execute(
@@ -101,7 +106,7 @@ def insert_foreign_step(
                 function_name=function_name,
                 completed_at_epoch_ms=completed_at,
                 started_at_epoch_ms=completed_at,
-                application_name=OTHER_APP,
+                application_name=application_name,
             )
         )
 
@@ -849,3 +854,265 @@ def test_two_applications_share_one_system_database(dbos: DBOS, config: Any) -> 
             c.destroy()
         for p in peers.values():
             p.destroy()
+
+
+# ── Renaming an application ───────────────────────────────────────────────────
+
+
+RENAMED_APP = "renamed-app"
+
+
+def insert_foreign_control_plane(dbos: DBOS, suffix: str = "") -> None:
+    """A queue, a schedule, and a version, all held by OTHER_APP."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id=f"rename-queue-id{suffix}",
+                name=f"rename-queue{suffix}",
+                created_at=1,
+                updated_at=1,
+                application_name=OTHER_APP,
+            )
+        )
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id=f"rename-schedule-id{suffix}",
+                schedule_name=f"rename-schedule{suffix}",
+                workflow_name="foreign_workflow",
+                schedule=daily_cron_far_from_now(),
+                status="ACTIVE",
+                context="null",
+                application_name=OTHER_APP,
+            )
+        )
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id=f"rename-version-id{suffix}",
+                version_name=f"rename-version{suffix}",
+                version_timestamp=7,
+                created_at=7,
+                application_name=OTHER_APP,
+            )
+        )
+
+
+def owners_of_everything(dbos: DBOS) -> dict[str, set[Any]]:
+    """Every owner recorded in each of the five owned tables."""
+    tables = {
+        "queues": SystemSchema.queues,
+        "schedules": SystemSchema.workflow_schedules,
+        "versions": SystemSchema.application_versions,
+        "workflows": SystemSchema.workflow_status,
+        "steps": SystemSchema.operation_outputs,
+    }
+    with dbos._sys_db.engine.begin() as c:
+        return {
+            label: {r[0] for r in c.execute(sa.select(table.c.application_name))}
+            for label, table in tables.items()
+        }
+
+
+def test_rename_moves_every_owned_table(dbos: DBOS) -> None:
+    """Ownership lives on the rows, so renaming an application is a re-own of all
+    five tables. Counts are reported per table so an operator can check the move."""
+    insert_foreign_workflow(dbos, "rename-terminal", status="SUCCESS")
+    insert_foreign_workflow(dbos, "rename-inflight", status="ENQUEUED")
+    insert_foreign_step(dbos, "rename-terminal", function_name="step")
+    insert_foreign_control_plane(dbos)
+
+    assert dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP) == {
+        "queues": 1,
+        "schedules": 1,
+        "versions": 1,
+        # Both the ENQUEUED row, moved atomically, and the terminal one, moved in batches.
+        "workflows": 2,
+        "steps": 1,
+    }
+
+    # Nothing is left behind in any table.
+    for label, owners in owners_of_everything(dbos).items():
+        assert OTHER_APP not in owners, label
+        assert RENAMED_APP in owners, label
+
+
+def test_rename_spares_peers_and_unclaimed_rows(dbos: DBOS) -> None:
+    """Only the named application moves. Unclaimed rows belong to everyone, so a
+    rename must not quietly adopt them."""
+
+    @DBOS.workflow()
+    def mine() -> int:
+        return 5
+
+    insert_foreign_workflow(dbos, "rename-mine", status="SUCCESS")
+    insert_foreign_workflow(
+        dbos, "rename-unclaimed", status="SUCCESS", application_name=None
+    )
+    handle: WorkflowHandle[int] = DBOS.start_workflow(mine)
+    assert handle.get_result() == 5
+
+    dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP)
+
+    assert application_name_of(dbos, "rename-mine") == RENAMED_APP
+    assert application_name_of(dbos, "rename-unclaimed") is None
+    # The live application is untouched, so it still dequeues and recovers its own work.
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+def test_rename_batches_terminal_rows_and_resumes(dbos: DBOS) -> None:
+    """Terminal workflows and steps move in batches, so a long history does not run
+    in one transaction. The predicate shrinks as it goes, so a re-run resumes."""
+    for i in range(5):
+        insert_foreign_workflow(dbos, f"rename-batched-{i}", status="SUCCESS")
+        insert_foreign_step(dbos, f"rename-batched-{i}", function_name="step")
+
+    moved = dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP, batch_size=1)
+    assert moved["workflows"] == 5
+    assert moved["steps"] == 5
+
+    # Idempotent: a second pass finds nothing, which is what makes an interrupted one resumable.
+    again = dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP, batch_size=1)
+    assert again["workflows"] == 0 and again["steps"] == 0
+    for i in range(5):
+        assert application_name_of(dbos, f"rename-batched-{i}") == RENAMED_APP
+
+
+def test_rename_rejects_names_an_application_could_not_use(dbos: DBOS) -> None:
+    """A rename to a name the config validator rejects would strand the rows again,
+    since no application could ever launch under it."""
+    with pytest.raises(DBOSException, match="Invalid application name"):
+        dbos._sys_db.rename_application(OTHER_APP, "No Spaces Allowed")
+    with pytest.raises(DBOSException, match="Invalid application name"):
+        dbos._sys_db.rename_application(OTHER_APP, "ab")
+    with pytest.raises(DBOSException, match="already holds that name"):
+        dbos._sys_db.rename_application(OTHER_APP, OTHER_APP)
+    with pytest.raises(DBOSException, match="cannot be empty"):
+        dbos._sys_db.rename_application("", RENAMED_APP)
+    # Neither source named: a no-op that is almost certainly a mistake.
+    with pytest.raises(DBOSException, match="Nothing to re-own"):
+        dbos._sys_db.rename_application(None, RENAMED_APP)
+    with pytest.raises(ValueError, match="batch_size"):
+        dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP, batch_size=0)
+
+
+def test_unclaimed_rows_are_adopted_only_when_asked(dbos: DBOS) -> None:
+    """Unclaimed rows belong to every application, so a rename leaves them alone
+    unless it is told to take them from the peers that share them."""
+    insert_foreign_workflow(dbos, "adopt-me", status="SUCCESS", application_name=None)
+    insert_foreign_workflow(dbos, "rename-me", status="SUCCESS")
+
+    moved = dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP)
+    assert moved["workflows"] == 1
+    assert application_name_of(dbos, "rename-me") == RENAMED_APP
+    assert application_name_of(dbos, "adopt-me") is None
+
+    adopted = dbos._sys_db.rename_application(
+        RENAMED_APP, "adopting-app", adopt_unclaimed_rows=True
+    )
+    assert adopted["workflows"] == 2
+    assert application_name_of(dbos, "adopt-me") == "adopting-app"
+    assert application_name_of(dbos, "rename-me") == "adopting-app"
+
+
+def test_unclaimed_rows_can_be_adopted_without_a_rename(dbos: DBOS) -> None:
+    """Taking over a system database whose rows predate ownership is an adoption with
+    no old name to move, so the previous name is optional."""
+    insert_foreign_workflow(dbos, "legacy-wf", status="SUCCESS", application_name=None)
+    insert_foreign_step(dbos, "legacy-wf", function_name="step", application_name=None)
+    insert_foreign_workflow(dbos, "peer-wf", status="SUCCESS")
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="legacy-queue-id",
+                name="legacy-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=None,
+            )
+        )
+
+    moved = dbos._sys_db.rename_application(
+        None, RENAMED_APP, adopt_unclaimed_rows=True
+    )
+    assert moved["workflows"] == 1 and moved["steps"] == 1 and moved["queues"] == 1
+    assert application_name_of(dbos, "legacy-wf") == RENAMED_APP
+    assert step_owners(dbos, "legacy-wf") == {RENAMED_APP}
+    # A peer's own rows are never in scope for an adoption.
+    assert application_name_of(dbos, "peer-wf") == OTHER_APP
+
+
+def test_registration_conflict_points_at_the_rename_command(dbos: DBOS) -> None:
+    """The wrong order -- starting under the new name before re-owning -- fails at
+    registration. That error is where an operator learns the remedy exists."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="conflict-version-id",
+                version_name="conflict-version",
+                version_timestamp=7,
+                created_at=7,
+                application_name=OTHER_APP,
+            )
+        )
+    with pytest.raises(DBOSException) as excinfo:
+        dbos._sys_db.create_application_version(
+            "conflict-version", application_name=RENAMED_APP
+        )
+    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in str(
+        excinfo.value
+    )
+
+
+def test_cli_renames_application(dbos: DBOS, config: Any) -> None:
+    """Click binds options to parameters by name, which mypy cannot check, so the
+    command needs one real invocation."""
+    from click.testing import CliRunner
+
+    from dbos.cli.cli import app
+
+    insert_foreign_workflow(dbos, "cli-rename-me", status="SUCCESS")
+    insert_foreign_workflow(
+        dbos, "cli-adopt-me", status="SUCCESS", application_name=None
+    )
+    insert_foreign_control_plane(dbos)
+    url = config["system_database_url"]
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["rename-application", "-s", url, "-f", OTHER_APP, "-t", RENAMED_APP, "-y"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["workflows"] == 1
+    assert application_name_of(dbos, "cli-rename-me") == RENAMED_APP
+    assert application_name_of(dbos, "cli-adopt-me") is None
+
+    adopted = runner.invoke(
+        app,
+        [
+            "rename-application",
+            "-s",
+            url,
+            "-f",
+            RENAMED_APP,
+            "-t",
+            "adopting-app",
+            "--adopt-unclaimed-rows",
+            "-y",
+        ],
+    )
+    assert adopted.exit_code == 0, adopted.output
+    assert application_name_of(dbos, "cli-adopt-me") == "adopting-app"
+
+    # A name no application could launch under is refused, with a non-zero exit.
+    bad = runner.invoke(
+        app, ["rename-application", "-s", url, "-f", "adopting-app", "-t", "ab", "-y"]
+    )
+    assert bad.exit_code == 1
+    assert "Invalid application name" in bad.output
+
+    # Neither source named is CLI misuse, caught before anything connects.
+    neither = runner.invoke(
+        app, ["rename-application", "-s", url, "-t", "some-app", "-y"]
+    )
+    assert neither.exit_code == 2
+    assert "Nothing to re-own" in neither.output

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -638,9 +638,12 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
 # ── Pre-upgrade rows and conflicts ────────────────────────────────────────────
 
 
-def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
+def test_conflicting_names_across_applications_raise(
+    dbos: DBOS, client: DBOSClient
+) -> None:
     """Queue and schedule names stay globally unique — they are addresses — so a
-    collision is a conflict rather than a silent overwrite."""
+    collision is a conflict rather than a silent overwrite. A writer with no
+    identity of its own is exempt: it administers any row without taking it."""
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -675,6 +678,61 @@ def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
             workflow_fn=scheduled,
             schedule=daily_cron_far_from_now(),
         )
+
+    def conflict_queue() -> Any:
+        with dbos._sys_db.engine.begin() as c:
+            return c.execute(
+                sa.select(
+                    SystemSchema.queues.c.application_name,
+                    SystemSchema.queues.c.concurrency,
+                ).where(SystemSchema.queues.c.name == "conflict-queue")
+            ).one()
+
+    def upsert(sys_db: Any, concurrency: Optional[int], update_existing: bool) -> bool:
+        return bool(
+            sys_db.upsert_queue(
+                name="conflict-queue",
+                concurrency=concurrency,
+                worker_concurrency=None,
+                rate_limit_max=None,
+                rate_limit_period_sec=None,
+                priority_enabled=False,
+                partition_queue=False,
+                polling_interval_sec=1.0,
+                update_existing=update_existing,
+            )
+        )
+
+    # Declining to update is still a collision: silently leaving the row alone would
+    # strand every workflow enqueued here, since only its owner polls it.
+    with pytest.raises(DBOSException, match="already registered by application"):
+        upsert(dbos._sys_db, 3, update_existing=False)
+    assert conflict_queue() == (OTHER_APP, None)
+
+    # A nameless writer updates the row without stripping the owner off it.
+    assert not upsert(client._sys_db, 7, update_existing=True)
+    assert conflict_queue() == (OTHER_APP, 7)
+
+    # Same through the schedule upsert's update clause, the other way to strip one.
+    new_cron = daily_cron_far_from_now()
+    client.apply_schedules(
+        [
+            {
+                "schedule_name": "conflict-schedule",
+                "workflow_name": "scheduled",
+                "schedule": new_cron,
+            }
+        ]
+    )
+    with dbos._sys_db.engine.begin() as c:
+        assert c.execute(
+            sa.select(
+                SystemSchema.workflow_schedules.c.application_name,
+                SystemSchema.workflow_schedules.c.schedule,
+            ).where(
+                SystemSchema.workflow_schedules.c.schedule_name == "conflict-schedule"
+            )
+        ).one() == (OTHER_APP, new_cron)
 
 
 def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -130,6 +130,14 @@ def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
         assert application_name_of(dbos, workflow_id) == APP_NAME, workflow_id
 
 
+def test_destroy_clears_the_application_identity(dbos: DBOS) -> None:
+    """Identity is set at launch, so a relaunch under another name must not
+    inherit this one from the process."""
+    assert GlobalParams.app_name == APP_NAME
+    DBOS.destroy()
+    assert GlobalParams.app_name is None
+
+
 def test_explicit_application_name_wins(dbos: DBOS, client: DBOSClient) -> None:
     """Naming a target is the only way to enqueue across applications, from either
     the runtime or a client."""
@@ -434,7 +442,9 @@ def test_bulk_operations_spare_another_application(dbos: DBOS) -> None:
     assert not workflow_exists(dbos, handle.workflow_id)
 
 
-def test_unclaimed_rows_belong_to_every_application(dbos: DBOS) -> None:
+def test_unclaimed_rows_belong_to_every_application(
+    dbos: DBOS, client: DBOSClient
+) -> None:
     """One rule everywhere: naming an application lists its rows plus unclaimed
     ones. Re-registering an unclaimed row claims it through the ordinary upsert."""
 
@@ -496,6 +506,17 @@ def test_unclaimed_rows_belong_to_every_application(dbos: DBOS) -> None:
     assert {q.name for q in theirs} == {"theirs-queue", "unclaimed-queue"}
     # The listing is attributable: a Queue carries its owner.
     assert {q.application_name for q in theirs} == {OTHER_APP, None}
+    # The client runs the same query, so it takes the same filter.
+    assert {q.name for q in client.list_queues(application_name=OTHER_APP)} == {
+        "theirs-queue",
+        "unclaimed-queue",
+    }
+
+    # A read-through handle picks up ownership along with the rest of the row.
+    handle = Queue("theirs-queue", database_backed_queue=True)
+    assert handle.application_name is None
+    assert handle.concurrency is None
+    assert handle.application_name == OTHER_APP
 
     # Name-addressed lookups stay global: a globally unique name is an identity.
     assert dbos._sys_db.get_queue("theirs-queue") is not None

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -548,9 +548,9 @@ def test_latest_version_is_scoped(dbos: DBOS) -> None:
     )
 
 
-def test_create_application_version_claims_only_unclaimed_rows(dbos: DBOS) -> None:
-    """Claiming keeps a pinned application_version — whose string never changes,
-    so no fresh owned row is ever minted — from staying unclaimed forever."""
+def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
+    """A version is content, not an address, so two applications legitimately
+    compute the same one and each gets its own row."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -594,13 +594,37 @@ def test_create_application_version_claims_only_unclaimed_rows(dbos: DBOS) -> No
     # Already owned, so re-registering is a no-op.
     assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
+    # The same version name under another application is a second row, not a
+    # conflict — this is what lets both applications launch.
+    dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
+    with dbos._sys_db.engine.begin() as c:
+        owners = {
+            r[0]
+            for r in c.execute(
+                sa.select(SystemSchema.application_versions.c.application_name).where(
+                    SystemSchema.application_versions.c.version_name == "1.0.0"
+                )
+            )
+        }
+    assert owners == {APP_NAME, OTHER_APP}
+
+    # This application promotes its own row unambiguously.
+    dbos._sys_db.update_application_version_timestamp("1.0.0", FUTURE_MS)
+    assert dbos._sys_db.get_latest_application_version()["version_name"] == "1.0.0"
+
+    # A nameless client spans both rows, so promoting raises rather than
+    # retiming someone else's deploy. Naming one resolves it.
+    with pytest.raises(DBOSException, match="registered by more than one application"):
+        client.set_latest_application_version("1.0.0")
+    client.set_latest_application_version("1.0.0", application_name=OTHER_APP)
+
 
 # ── Pre-upgrade rows and conflicts ────────────────────────────────────────────
 
 
 def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
-    """Names stay globally unique, so a collision is a conflict rather than a
-    silent overwrite of another application's configuration."""
+    """Queue and schedule names stay globally unique — they are addresses — so a
+    collision is a conflict rather than a silent overwrite."""
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -627,15 +651,6 @@ def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-        c.execute(
-            sa.insert(SystemSchema.application_versions).values(
-                version_id="conflict-version-id",
-                version_name="conflict-version",
-                version_timestamp=1,
-                created_at=1,
-                application_name=OTHER_APP,
-            )
-        )
     with pytest.raises(DBOSException, match="already registered by application"):
         DBOS.register_queue("conflict-queue")
     with pytest.raises(DBOSException, match="already registered by application"):
@@ -644,8 +659,6 @@ def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
             workflow_fn=scheduled,
             schedule=daily_cron_far_from_now(),
         )
-    with pytest.raises(DBOSException, match="already registered by application"):
-        dbos._sys_db.create_application_version("conflict-version")
 
 
 def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -270,9 +270,9 @@ def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
-def test_observability_filters_are_exact_and_optional(dbos: DBOS) -> None:
-    """The four observability surfaces take an ordinary exact-match predicate,
-    unset meaning every application, unlike the claiming scope."""
+def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
+    """All four surfaces follow the one rule: unset lists every application, and
+    naming one lists its rows plus unclaimed ones."""
 
     @DBOS.step()
     def a_step() -> int:
@@ -289,24 +289,32 @@ def test_observability_filters_are_exact_and_optional(dbos: DBOS) -> None:
     insert_foreign_step(
         dbos, "foreign-listed", function_name="their_step", completed_at=now_ms
     )
+    insert_foreign_workflow(
+        dbos, "unclaimed-listed", status="SUCCESS", application_name=None
+    )
 
     unfiltered = {w.workflow_id for w in DBOS.list_workflows()}
-    assert {handle.workflow_id, "foreign-listed"} <= unfiltered
+    assert {handle.workflow_id, "foreign-listed", "unclaimed-listed"} <= unfiltered
     mine = {w.workflow_id for w in DBOS.list_workflows(application_name=APP_NAME)}
-    assert handle.workflow_id in mine and "foreign-listed" not in mine
+    assert {handle.workflow_id, "unclaimed-listed"} <= mine
+    assert "foreign-listed" not in mine
     theirs = {w.workflow_id for w in DBOS.list_workflows(application_name=OTHER_APP)}
-    assert theirs == {"foreign-listed"}
+    assert theirs == {"foreign-listed", "unclaimed-listed"}
 
     aggregates = dbos._sys_db.get_workflow_aggregates(
         group_by_name=True, select_count=True, application_name=[OTHER_APP]
     )
     assert [r["group"]["name"] for r in aggregates] == ["foreign_workflow"]
 
-    # Grouping by owner is what lets a console break down a shared database.
+    # Grouping partitions where the filter deliberately overlaps.
     grouped = dbos._sys_db.get_workflow_aggregates(
         group_by_application_name=True, select_count=True
     )
-    assert {r["group"]["application_name"] for r in grouped} == {APP_NAME, OTHER_APP}
+    assert {r["group"]["application_name"] for r in grouped} == {
+        APP_NAME,
+        OTHER_APP,
+        None,
+    }
 
     steps = dbos._sys_db.get_step_aggregates(
         group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
@@ -410,9 +418,9 @@ def test_bulk_operations_spare_another_application(dbos: DBOS) -> None:
     assert not workflow_exists(dbos, handle.workflow_id)
 
 
-def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
+def test_unclaimed_rows_belong_to_every_application(dbos: DBOS) -> None:
     """One rule everywhere: naming an application lists its rows plus unclaimed
-    ones, which belong to every application. Unset lists every application's."""
+    ones. Re-registering an unclaimed row claims it through the ordinary upsert."""
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -423,47 +431,34 @@ def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
     )
     DBOS.register_queue("mine-queue")
     with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.workflow_schedules).values(
-                schedule_id="foreign-schedule-id",
-                schedule_name="theirs",
-                workflow_name="foreign_workflow",
-                schedule="* * * * *",
-                status="ACTIVE",
-                context="null",
-                application_name=OTHER_APP,
+        for schedule_id, name, owner in (
+            ("foreign-schedule-id", "theirs", OTHER_APP),
+            ("legacy-schedule-id", "unclaimed", None),
+        ):
+            c.execute(
+                sa.insert(SystemSchema.workflow_schedules).values(
+                    schedule_id=schedule_id,
+                    schedule_name=name,
+                    workflow_name="scheduled",
+                    schedule=daily_cron_far_from_now(),
+                    status="ACTIVE",
+                    context="null",
+                    application_name=owner,
+                )
             )
-        )
-        c.execute(
-            sa.insert(SystemSchema.queues).values(
-                queue_id="foreign-queue-id",
-                name="theirs-queue",
-                created_at=1,
-                updated_at=1,
-                application_name=OTHER_APP,
+        for queue_id, name, owner in (
+            ("foreign-queue-id", "theirs-queue", OTHER_APP),
+            ("legacy-queue-id", "unclaimed-queue", None),
+        ):
+            c.execute(
+                sa.insert(SystemSchema.queues).values(
+                    queue_id=queue_id,
+                    name=name,
+                    created_at=1,
+                    updated_at=1,
+                    application_name=owner,
+                )
             )
-        )
-        # Pre-upgrade rows, owned by nobody.
-        c.execute(
-            sa.insert(SystemSchema.workflow_schedules).values(
-                schedule_id="unclaimed-schedule-id",
-                schedule_name="unclaimed",
-                workflow_name="scheduled",
-                schedule=daily_cron_far_from_now(),
-                status="ACTIVE",
-                context="null",
-                application_name=None,
-            )
-        )
-        c.execute(
-            sa.insert(SystemSchema.queues).values(
-                queue_id="unclaimed-queue-id",
-                name="unclaimed-queue",
-                created_at=1,
-                updated_at=1,
-                application_name=None,
-            )
-        )
 
     # Unset lists every application.
     assert {"mine", "theirs", "unclaimed"} <= {
@@ -473,15 +468,14 @@ def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
         q.name for q in DBOS.list_queues()
     }
 
-    # Naming an application adds the unclaimed rows to its own, and this is
-    # exactly what the queue thread and scheduler loop poll.
-    mine_schedules = {
+    # Naming an application adds the unclaimed rows, as the loops themselves do.
+    assert {
         s["schedule_name"] for s in DBOS.list_schedules(application_name=APP_NAME)
+    } == {"mine", "unclaimed"}
+    assert {q.name for q in DBOS.list_queues(application_name=APP_NAME)} == {
+        "mine-queue",
+        "unclaimed-queue",
     }
-    mine_queues = {q.name for q in DBOS.list_queues(application_name=APP_NAME)}
-    assert mine_schedules == {"mine", "unclaimed"}
-    assert mine_queues == {"mine-queue", "unclaimed-queue"}
-
     theirs = DBOS.list_queues(application_name=OTHER_APP)
     assert {q.name for q in theirs} == {"theirs-queue", "unclaimed-queue"}
     # The listing is attributable: a Queue carries its owner.
@@ -489,6 +483,32 @@ def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
 
     # Name-addressed lookups stay global: a globally unique name is an identity.
     assert dbos._sys_db.get_queue("theirs-queue") is not None
+
+    # Re-registering an unclaimed row claims it, without recreating it.
+    DBOS.register_queue("unclaimed-queue")
+    DBOS.apply_schedules(
+        [
+            {
+                "schedule_name": "unclaimed",
+                "workflow_fn": scheduled,
+                "schedule": daily_cron_far_from_now(),
+            }
+        ]
+    )
+    with dbos._sys_db.engine.begin() as c:
+        queue_owner = c.execute(
+            sa.select(SystemSchema.queues.c.application_name).where(
+                SystemSchema.queues.c.name == "unclaimed-queue"
+            )
+        ).scalar()
+        schedule_row = c.execute(
+            sa.select(
+                SystemSchema.workflow_schedules.c.application_name,
+                SystemSchema.workflow_schedules.c.schedule_id,
+            ).where(SystemSchema.workflow_schedules.c.schedule_name == "unclaimed")
+        ).fetchone()
+    assert queue_owner == APP_NAME
+    assert schedule_row == (APP_NAME, "legacy-schedule-id")
 
 
 # ── Application versions ──────────────────────────────────────────────────────
@@ -576,70 +596,6 @@ def test_create_application_version_claims_only_unclaimed_rows(dbos: DBOS) -> No
 
 
 # ── Pre-upgrade rows and conflicts ────────────────────────────────────────────
-
-
-def test_unclaimed_metadata_is_visible_then_claimed_on_registration(
-    dbos: DBOS,
-) -> None:
-    """Nothing needs claiming in advance — the claiming scope already includes
-    unclaimed rows — but re-registering claims them through the ordinary upsert."""
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.queues).values(
-                queue_id="legacy-queue-id",
-                name="legacy-queue",
-                created_at=1,
-                updated_at=1,
-                application_name=None,
-            )
-        )
-        c.execute(
-            sa.insert(SystemSchema.workflow_schedules).values(
-                schedule_id="legacy-schedule-id",
-                schedule_name="legacy-schedule",
-                workflow_name="scheduled",
-                schedule=daily_cron_far_from_now(),
-                status="ACTIVE",
-                context="null",
-                application_name=None,
-            )
-        )
-    assert "legacy-queue" in {q.name for q in dbos._sys_db.list_queues()}
-    assert "legacy-schedule" in {
-        s["schedule_name"] for s in dbos._sys_db.list_schedules()
-    }
-
-    @DBOS.workflow()
-    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
-        pass
-
-    DBOS.register_queue("legacy-queue")
-    DBOS.apply_schedules(
-        [
-            {
-                "schedule_name": "legacy-schedule",
-                "workflow_fn": scheduled,
-                "schedule": daily_cron_far_from_now(),
-            }
-        ]
-    )
-    with dbos._sys_db.engine.begin() as c:
-        queue_owner = c.execute(
-            sa.select(SystemSchema.queues.c.application_name).where(
-                SystemSchema.queues.c.name == "legacy-queue"
-            )
-        ).scalar()
-        schedule_row = c.execute(
-            sa.select(
-                SystemSchema.workflow_schedules.c.application_name,
-                SystemSchema.workflow_schedules.c.schedule_id,
-            ).where(
-                SystemSchema.workflow_schedules.c.schedule_name == "legacy-schedule"
-            )
-        ).fetchone()
-    assert queue_owner == APP_NAME
-    # Claiming must preserve identity, not recreate the row.
-    assert schedule_row == (APP_NAME, "legacy-schedule-id")
 
 
 def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -56,9 +56,9 @@ def test_enqueued_workflow_on_served_queue_is_owned(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
-def test_enqueue_to_unserved_queue_is_unclaimed(dbos: DBOS) -> None:
-    """A queue this application does not serve belongs to some other application,
-    so the row is left unclaimed and routed by its globally unique queue name."""
+def test_enqueue_to_unserved_queue_is_still_owned(dbos: DBOS) -> None:
+    """The target queue's name never affects ownership: this application owns what
+    it enqueues, and reaching another application requires naming it."""
 
     @DBOS.workflow()
     def wf() -> int:
@@ -67,7 +67,7 @@ def test_enqueue_to_unserved_queue_is_unclaimed(dbos: DBOS) -> None:
     handle = DBOS.enqueue_workflow_with_options(
         {"workflow_name": wf.__qualname__, "queue_name": "some-other-apps-queue"}
     )
-    assert application_name_of(dbos, handle.workflow_id) is None
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
 def test_enqueue_with_options_to_served_queue_is_owned(dbos: DBOS) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -825,3 +825,126 @@ def test_aggregates_filter_by_application(dbos: DBOS) -> None:
         group_by_name=True, select_count=True, application_name=[OTHER_APP]
     )
     assert [r["group"]["name"] for r in rows] == ["foreign_workflow"]
+
+
+# ── Steps carry the owner too ─────────────────────────────────────────────────
+
+
+def step_owners(dbos: DBOS, workflow_id: str) -> list[Any]:
+    with dbos._sys_db.engine.begin() as c:
+        return [
+            r[0]
+            for r in c.execute(
+                sa.select(SystemSchema.operation_outputs.c.application_name).where(
+                    SystemSchema.operation_outputs.c.workflow_uuid == workflow_id
+                )
+            )
+        ]
+
+
+def insert_foreign_step(
+    dbos: DBOS,
+    workflow_id: str,
+    *,
+    function_name: str,
+    application_name: Optional[str] = OTHER_APP,
+    completed_at: int = 1,
+) -> None:
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.operation_outputs).values(
+                workflow_uuid=workflow_id,
+                function_id=1,
+                function_name=function_name,
+                completed_at_epoch_ms=completed_at,
+                started_at_epoch_ms=completed_at,
+                application_name=application_name,
+            )
+        )
+
+
+def test_steps_carry_the_owner(dbos: DBOS) -> None:
+    """operation_outputs mirrors its parent workflow's owner, which is what lets
+    step observability filter without joining back to workflow_status."""
+
+    @DBOS.step()
+    def a_step() -> int:
+        return 1
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return a_step()
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 1
+    owners = step_owners(dbos, handle.workflow_id)
+    assert owners and set(owners) == {APP_NAME}
+
+
+def test_forked_steps_inherit_the_owner(dbos: DBOS) -> None:
+    @DBOS.step()
+    def a_step() -> int:
+        return 2
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return a_step()
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 2
+
+    forked = DBOS.fork_workflow(handle.workflow_id, 2)
+    assert forked.get_result() == 2
+    assert set(step_owners(dbos, forked.workflow_id)) == {APP_NAME}
+
+
+def test_step_aggregates_filter_by_application(dbos: DBOS) -> None:
+    @DBOS.step()
+    def a_step() -> int:
+        return 3
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return a_step()
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 3
+    insert_foreign_workflow(dbos, "foreign-stepped", status="SUCCESS")
+    insert_foreign_step(dbos, "foreign-stepped", function_name="their_step")
+
+    theirs = dbos._sys_db.get_step_aggregates(
+        group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
+    )
+    assert [r["group"]["function_name"] for r in theirs] == ["their_step"]
+
+    mine = {
+        r["group"]["function_name"]
+        for r in dbos._sys_db.get_step_aggregates(
+            group_by_function_name=True, select_count=True, application_name=[APP_NAME]
+        )
+    }
+    assert "their_step" not in mine
+    assert mine  # this application's own steps are still counted
+
+
+def test_metrics_filter_by_application(dbos: DBOS) -> None:
+    from datetime import datetime as _dt
+
+    insert_foreign_workflow(dbos, "foreign-metric", status="SUCCESS")
+    insert_foreign_step(
+        dbos,
+        "foreign-metric",
+        function_name="their_metric_step",
+        completed_at=int(_dt.now(timezone.utc).timestamp() * 1000),
+    )
+    start = _dt.fromtimestamp(0, timezone.utc).isoformat()
+    end = (_dt.now(timezone.utc) + timedelta(hours=1)).isoformat()
+
+    theirs = dbos._sys_db.get_metrics(start, end, application_name=[OTHER_APP])
+    step_names = {m["metric_name"] for m in theirs if m["metric_type"] == "step_count"}
+    assert step_names == {"their_metric_step"}
+
+    mine = dbos._sys_db.get_metrics(start, end, application_name=[APP_NAME])
+    assert "their_metric_step" not in {
+        m["metric_name"] for m in mine if m["metric_type"] == "step_count"
+    }

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -84,6 +84,44 @@ def test_enqueue_with_options_to_served_queue_is_owned(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
+def test_enqueue_options_application_name_wins(dbos: DBOS) -> None:
+    """An explicit target beats the runtime's automatic stamping, so an application
+    can enqueue on behalf of another one."""
+    Queue("override-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 14
+
+    handle = DBOS.enqueue_workflow_with_options(
+        {
+            "workflow_name": wf.__qualname__,
+            "queue_name": "override-queue",
+            "application_name": "other-app",
+        }
+    )
+    assert application_name_of(dbos, handle.workflow_id) == "other-app"
+
+
+def test_client_enqueue_options_application_name_wins(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    Queue("client-override-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 15
+
+    handle: WorkflowHandle[int] = client.enqueue(
+        {
+            "workflow_name": wf.__qualname__,
+            "queue_name": "client-override-queue",
+            "application_name": "other-app",
+        }
+    )
+    assert application_name_of(dbos, handle.workflow_id) == "other-app"
+
+
 def test_internal_queue_workflow_is_owned(dbos: DBOS) -> None:
     """The internal queue's name is shared by every application, so a row on it
     can only be routed by ownership."""

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -116,9 +116,8 @@ def insert_foreign_step(
 
 
 def test_runtime_stamps_everything_it_writes(dbos: DBOS) -> None:
-    """Workflows, whatever queue they target, and the metadata rows that route
-    them. Ownership never consults the queue, which for the internal one is
-    shared and so cannot route anything."""
+    """Workflows, whatever queue they target, and the metadata rows that route them.
+    Ownership never consults the queue, which for the internal one is shared."""
     served = Queue("served-queue")
 
     @DBOS.workflow()
@@ -360,9 +359,8 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
 
 
 def test_claiming_skips_another_applications_workflows(dbos: DBOS) -> None:
-    """Dequeue and recovery, the two ways a row gets picked up. Both collide
-    across applications by default — the internal queue's name is shared and
-    executor_id is the literal "local" — so only ownership separates them."""
+    """Dequeue and recovery, the two ways a row gets picked up. Both collide across
+    applications by default, so only ownership separates them."""
     queue = Queue("shared-name-queue")
 
     @DBOS.workflow()
@@ -552,8 +550,19 @@ def test_unclaimed_rows_belong_to_every_application(
 
 def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
     """Version names stay global addresses, so a row records which application
-    registered it. Another application's deploy must not demote this one, but an
-    unclaimed newer row is an older SDK's and does."""
+    registered it, and two peers must never compute the same one."""
+    registry = dbos._registry
+    assert registry.compute_app_version("app-a") != registry.compute_app_version(
+        "app-b"
+    )
+    assert registry.compute_app_version("app-a") == registry.compute_app_version(
+        "app-a"
+    )
+    # A builtin has no retrievable source, so the fallback runs; it is per-application too.
+    with patch.object(registry, "workflow_info_map", {"wf": len}):
+        assert registry.compute_app_version("app-a") == "DEFAULT_VERSION-app-a"
+        assert registry.compute_app_version("app-b") == "DEFAULT_VERSION-app-b"
+
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -628,8 +637,13 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
     assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
     # A name another application holds is a collision, so the caller's launch fails.
-    with pytest.raises(DBOSException, match="already registered by application"):
+    with pytest.raises(
+        DBOSException, match="already registered by application"
+    ) as info:
         dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
+    # A version is computed or pinned, so the remedy is config, not a different name.
+    assert f"set a distinct application_version for '{OTHER_APP}'" in str(info.value)
+    assert "dbos rename-application" in str(info.value)
 
     # Promoting a name another application owns is a collision, not a retiming.
     with pytest.raises(DBOSException, match="already registered by application"):
@@ -666,9 +680,8 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
 def test_conflicting_names_across_applications_raise(
     dbos: DBOS, client: DBOSClient
 ) -> None:
-    """Queue and schedule names stay globally unique — they are addresses — so a
-    collision is a conflict rather than a silent overwrite. A writer with no
-    identity of its own is exempt: it administers any row without taking it."""
+    """Queue and schedule names stay globally unique, so a collision is a conflict, not
+    a silent overwrite. A nameless writer administers any row without taking it."""
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -695,8 +708,12 @@ def test_conflicting_names_across_applications_raise(
                 application_name=OTHER_APP,
             )
         )
-    with pytest.raises(DBOSException, match="already registered by application"):
+    with pytest.raises(
+        DBOSException, match="already registered by application"
+    ) as info:
         DBOS.register_queue("conflict-queue")
+    # A queue name is the caller's to choose, unlike a version's.
+    assert f"give '{APP_NAME}' a different queue name" in str(info.value)
     with pytest.raises(DBOSException, match="already registered by application"):
         DBOS.create_schedule(
             schedule_name="conflict-schedule",
@@ -759,9 +776,9 @@ def test_conflicting_names_across_applications_raise(
         ).one() == (OTHER_APP, new_cron)
 
 
-def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:
-    """Click binds options to parameters by name, which mypy cannot check, so the
-    two list commands need one real invocation."""
+def test_cli_binds_its_application_options(dbos: DBOS, config: Any) -> None:
+    """Click binds options to parameters by name, which mypy cannot check, so every
+    command taking an application needs one real invocation."""
     from click.testing import CliRunner
 
     from dbos.cli.cli import app
@@ -773,19 +790,56 @@ def test_cli_filters_by_application(dbos: DBOS, config: Any) -> None:
     handle = DBOS.start_workflow(wf)
     assert handle.get_result() == 14
     insert_foreign_workflow(dbos, "cli-foreign", status="SUCCESS")
-
+    insert_foreign_workflow(
+        dbos, "cli-unclaimed", status="SUCCESS", application_name=None
+    )
+    url = config["system_database_url"]
     runner = CliRunner()
+
+    # Both list commands filter by owner; only the workflow list surfaces the row itself.
     for command in (["workflow", "list"], ["workflow", "queue", "list"]):
-        result = runner.invoke(
-            app, command + ["-s", config["system_database_url"], "-a", OTHER_APP]
-        )
+        result = runner.invoke(app, command + ["-s", url, "-a", OTHER_APP])
         assert result.exit_code == 0, result.output
         assert handle.workflow_id not in result.output
-    listed = runner.invoke(
-        app,
-        ["workflow", "list", "-s", config["system_database_url"], "-a", OTHER_APP],
+    assert (
+        "cli-foreign"
+        in runner.invoke(app, ["workflow", "list", "-s", url, "-a", OTHER_APP]).output
     )
-    assert "cli-foreign" in listed.output
+
+    renamed = runner.invoke(
+        app, ["rename-application", "-s", url, "-f", OTHER_APP, "-t", RENAMED_APP, "-y"]
+    )
+    assert renamed.exit_code == 0, renamed.output
+    assert json.loads(renamed.output)["workflows"] == 1
+    assert application_name_of(dbos, "cli-foreign") == RENAMED_APP
+    assert application_name_of(dbos, "cli-unclaimed") is None
+
+    adopted = runner.invoke(
+        app,
+        [
+            "rename-application",
+            "-s",
+            url,
+            "-f",
+            RENAMED_APP,
+            "-t",
+            "adopting-app",
+            "--adopt-unclaimed-rows",
+            "-y",
+        ],
+    )
+    assert adopted.exit_code == 0, adopted.output
+    assert application_name_of(dbos, "cli-unclaimed") == "adopting-app"
+
+    # A name no application could launch under is refused; naming no source is misuse.
+    bad = runner.invoke(
+        app, ["rename-application", "-s", url, "-f", "adopting-app", "-t", "ab", "-y"]
+    )
+    assert bad.exit_code == 1 and "Invalid application name" in bad.output
+    neither = runner.invoke(
+        app, ["rename-application", "-s", url, "-t", "some-app", "-y"]
+    )
+    assert neither.exit_code == 2 and "Nothing to re-own" in neither.output
 
 
 # ── Two applications, one system database ─────────────────────────────────────
@@ -936,29 +990,6 @@ def test_rename_moves_every_owned_table(dbos: DBOS) -> None:
         assert RENAMED_APP in owners, label
 
 
-def test_rename_spares_peers_and_unclaimed_rows(dbos: DBOS) -> None:
-    """Only the named application moves. Unclaimed rows belong to everyone, so a
-    rename must not quietly adopt them."""
-
-    @DBOS.workflow()
-    def mine() -> int:
-        return 5
-
-    insert_foreign_workflow(dbos, "rename-mine", status="SUCCESS")
-    insert_foreign_workflow(
-        dbos, "rename-unclaimed", status="SUCCESS", application_name=None
-    )
-    handle: WorkflowHandle[int] = DBOS.start_workflow(mine)
-    assert handle.get_result() == 5
-
-    dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP)
-
-    assert application_name_of(dbos, "rename-mine") == RENAMED_APP
-    assert application_name_of(dbos, "rename-unclaimed") is None
-    # The live application is untouched, so it still dequeues and recovers its own work.
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
-
-
 def test_rename_batches_terminal_rows_and_resumes(dbos: DBOS) -> None:
     """Terminal workflows and steps move in batches, so a long history does not run
     in one transaction. The predicate shrinks as it goes, so a re-run resumes."""
@@ -995,173 +1026,47 @@ def test_rename_rejects_names_an_application_could_not_use(dbos: DBOS) -> None:
         dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP, batch_size=0)
 
 
-def test_unclaimed_rows_are_adopted_only_when_asked(dbos: DBOS) -> None:
-    """Unclaimed rows belong to every application, so a rename leaves them alone
-    unless it is told to take them from the peers that share them."""
-    insert_foreign_workflow(dbos, "adopt-me", status="SUCCESS", application_name=None)
-    insert_foreign_workflow(dbos, "rename-me", status="SUCCESS")
+def test_rename_moves_only_the_sources_it_is_given(dbos: DBOS) -> None:
+    """Scope is the whole contract: a named application's rows, the unclaimed ones, or
+    both. Never a peer nobody named, and never the live application's own."""
 
+    @DBOS.workflow()
+    def mine() -> int:
+        return 5
+
+    insert_foreign_workflow(dbos, "peer-wf", status="SUCCESS")
+    insert_foreign_workflow(
+        dbos, "unclaimed-wf", status="SUCCESS", application_name=None
+    )
+    insert_foreign_step(
+        dbos, "unclaimed-wf", function_name="step", application_name=None
+    )
+    handle: WorkflowHandle[int] = DBOS.start_workflow(mine)
+    assert handle.get_result() == 5
+
+    # A plain rename takes the named application's rows and stops there.
     moved = dbos._sys_db.rename_application(OTHER_APP, RENAMED_APP)
     assert moved["workflows"] == 1
-    assert application_name_of(dbos, "rename-me") == RENAMED_APP
-    assert application_name_of(dbos, "adopt-me") is None
+    assert application_name_of(dbos, "peer-wf") == RENAMED_APP
+    assert application_name_of(dbos, "unclaimed-wf") is None
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
+    # No old name: an adoption, which is how an application takes over a legacy database.
     adopted = dbos._sys_db.rename_application(
-        RENAMED_APP, "adopting-app", adopt_unclaimed_rows=True
+        None, "adopting-app", adopt_unclaimed_rows=True
     )
-    assert adopted["workflows"] == 2
-    assert application_name_of(dbos, "adopt-me") == "adopting-app"
-    assert application_name_of(dbos, "rename-me") == "adopting-app"
+    assert adopted["workflows"] == 1 and adopted["steps"] == 1
+    assert application_name_of(dbos, "unclaimed-wf") == "adopting-app"
+    assert step_owners(dbos, "unclaimed-wf") == {"adopting-app"}
+    assert application_name_of(dbos, "peer-wf") == RENAMED_APP
 
-
-def test_unclaimed_rows_can_be_adopted_without_a_rename(dbos: DBOS) -> None:
-    """Taking over a system database whose rows predate ownership is an adoption with
-    no old name to move, so the previous name is optional."""
-    insert_foreign_workflow(dbos, "legacy-wf", status="SUCCESS", application_name=None)
-    insert_foreign_step(dbos, "legacy-wf", function_name="step", application_name=None)
-    insert_foreign_workflow(dbos, "peer-wf", status="SUCCESS")
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.queues).values(
-                queue_id="legacy-queue-id",
-                name="legacy-queue",
-                created_at=1,
-                updated_at=1,
-                application_name=None,
-            )
-        )
-
-    moved = dbos._sys_db.rename_application(
-        None, RENAMED_APP, adopt_unclaimed_rows=True
-    )
-    assert moved["workflows"] == 1 and moved["steps"] == 1 and moved["queues"] == 1
-    assert application_name_of(dbos, "legacy-wf") == RENAMED_APP
-    assert step_owners(dbos, "legacy-wf") == {RENAMED_APP}
-    # A peer's own rows are never in scope for an adoption.
-    assert application_name_of(dbos, "peer-wf") == OTHER_APP
-
-
-def test_version_is_per_application(dbos: DBOS) -> None:
-    """Version names are global addresses, so two applications built from one workflow
-    source must not compute the same version and collide when they both register."""
-    registry = dbos._registry
-    assert registry.compute_app_version("app-a") != registry.compute_app_version(
-        "app-b"
-    )
-    assert registry.compute_app_version("app-a") == registry.compute_app_version(
-        "app-a"
-    )
-    # The unreadable-source fallback is per-application too, not one shared sentinel.
-    # A builtin has no retrievable source, which is what sends compute_app_version there.
-    with patch.object(registry, "workflow_info_map", {"wf": len}):
-        assert registry.compute_app_version("app-a") == "DEFAULT_VERSION-app-a"
-        assert registry.compute_app_version("app-b") == "DEFAULT_VERSION-app-b"
-
-
-def test_registration_conflict_names_both_remedies(dbos: DBOS) -> None:
-    """A name collision has two causes, and the error cannot tell them apart: two
-    applications that chose one name, or one renamed before re-owning its rows."""
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.application_versions).values(
-                version_id="conflict-version-id",
-                version_name="conflict-version",
-                version_timestamp=7,
-                created_at=7,
-                application_name=OTHER_APP,
-            )
-        )
-    with pytest.raises(DBOSException) as excinfo:
-        dbos._sys_db.create_application_version(
-            "conflict-version", application_name=RENAMED_APP
-        )
-    message = str(excinfo.value)
-    assert "dbos rename-application" in message
-    # A version is computed or pinned, so telling the caller to rename it would misdirect.
-    assert f"set a distinct application_version for '{RENAMED_APP}'" in message
-
-    dbos._sys_db.upsert_queue(
-        name="conflict-queue",
-        concurrency=None,
-        worker_concurrency=None,
-        rate_limit_max=None,
-        rate_limit_period_sec=None,
-        priority_enabled=False,
-        partition_queue=False,
-        polling_interval_sec=1.0,
-        update_existing=True,
-        application_name=OTHER_APP,
-    )
-    with pytest.raises(DBOSException) as excinfo:
-        dbos._sys_db.upsert_queue(
-            name="conflict-queue",
-            concurrency=None,
-            worker_concurrency=None,
-            rate_limit_max=None,
-            rate_limit_period_sec=None,
-            priority_enabled=False,
-            partition_queue=False,
-            polling_interval_sec=1.0,
-            update_existing=True,
-            application_name=RENAMED_APP,
-        )
-    message = str(excinfo.value)
-    assert "dbos rename-application" in message
-    # A queue name is the caller's to choose, unlike a version's.
-    assert f"give '{RENAMED_APP}' a different queue name" in message
-
-
-def test_cli_renames_application(dbos: DBOS, config: Any) -> None:
-    """Click binds options to parameters by name, which mypy cannot check, so the
-    command needs one real invocation."""
-    from click.testing import CliRunner
-
-    from dbos.cli.cli import app
-
-    insert_foreign_workflow(dbos, "cli-rename-me", status="SUCCESS")
+    # Both sources at once.
     insert_foreign_workflow(
-        dbos, "cli-adopt-me", status="SUCCESS", application_name=None
+        dbos, "unclaimed-two", status="SUCCESS", application_name=None
     )
-    insert_foreign_control_plane(dbos)
-    url = config["system_database_url"]
-    runner = CliRunner()
-
-    result = runner.invoke(
-        app,
-        ["rename-application", "-s", url, "-f", OTHER_APP, "-t", RENAMED_APP, "-y"],
+    both = dbos._sys_db.rename_application(
+        RENAMED_APP, "final-app", adopt_unclaimed_rows=True
     )
-    assert result.exit_code == 0, result.output
-    assert json.loads(result.output)["workflows"] == 1
-    assert application_name_of(dbos, "cli-rename-me") == RENAMED_APP
-    assert application_name_of(dbos, "cli-adopt-me") is None
-
-    adopted = runner.invoke(
-        app,
-        [
-            "rename-application",
-            "-s",
-            url,
-            "-f",
-            RENAMED_APP,
-            "-t",
-            "adopting-app",
-            "--adopt-unclaimed-rows",
-            "-y",
-        ],
-    )
-    assert adopted.exit_code == 0, adopted.output
-    assert application_name_of(dbos, "cli-adopt-me") == "adopting-app"
-
-    # A name no application could launch under is refused, with a non-zero exit.
-    bad = runner.invoke(
-        app, ["rename-application", "-s", url, "-f", "adopting-app", "-t", "ab", "-y"]
-    )
-    assert bad.exit_code == 1
-    assert "Invalid application name" in bad.output
-
-    # Neither source named is CLI misuse, caught before anything connects.
-    neither = runner.invoke(
-        app, ["rename-application", "-s", url, "-t", "some-app", "-y"]
-    )
-    assert neither.exit_code == 2
-    assert "Nothing to re-own" in neither.output
+    assert both["workflows"] == 2
+    assert application_name_of(dbos, "peer-wf") == "final-app"
+    assert application_name_of(dbos, "unclaimed-two") == "final-app"

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -411,8 +411,8 @@ def test_bulk_operations_spare_another_application(dbos: DBOS) -> None:
 
 
 def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
-    """The claiming variants are what the queue thread and scheduler poll, so they
-    take own plus unclaimed. The public listings are ordinary filters instead."""
+    """One rule everywhere: naming an application lists its rows plus unclaimed
+    ones, which belong to every application. Unset lists every application's."""
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -443,23 +443,49 @@ def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    claimable_schedules = {
-        s["schedule_name"] for s in dbos._sys_db.list_claimable_schedules()
-    }
-    claimable_queues = {q.name for q in dbos._sys_db.list_claimable_queues()}
-    assert "mine" in claimable_schedules and "theirs" not in claimable_schedules
-    assert "mine-queue" in claimable_queues and "theirs-queue" not in claimable_queues
+        # Pre-upgrade rows, owned by nobody.
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id="unclaimed-schedule-id",
+                schedule_name="unclaimed",
+                workflow_name="scheduled",
+                schedule=daily_cron_far_from_now(),
+                status="ACTIVE",
+                context="null",
+                application_name=None,
+            )
+        )
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="unclaimed-queue-id",
+                name="unclaimed-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=None,
+            )
+        )
 
-    # Unset lists every application, and the filter matches an owner exactly.
-    assert {"mine", "theirs"} <= {s["schedule_name"] for s in DBOS.list_schedules()}
-    assert {"mine-queue", "theirs-queue"} <= {q.name for q in DBOS.list_queues()}
-    assert [
-        s["schedule_name"] for s in DBOS.list_schedules(application_name=OTHER_APP)
-    ] == ["theirs"]
+    # Unset lists every application.
+    assert {"mine", "theirs", "unclaimed"} <= {
+        s["schedule_name"] for s in DBOS.list_schedules()
+    }
+    assert {"mine-queue", "theirs-queue", "unclaimed-queue"} <= {
+        q.name for q in DBOS.list_queues()
+    }
+
+    # Naming an application adds the unclaimed rows to its own, and this is
+    # exactly what the queue thread and scheduler loop poll.
+    mine_schedules = {
+        s["schedule_name"] for s in DBOS.list_schedules(application_name=APP_NAME)
+    }
+    mine_queues = {q.name for q in DBOS.list_queues(application_name=APP_NAME)}
+    assert mine_schedules == {"mine", "unclaimed"}
+    assert mine_queues == {"mine-queue", "unclaimed-queue"}
+
     theirs = DBOS.list_queues(application_name=OTHER_APP)
-    assert [q.name for q in theirs] == ["theirs-queue"]
+    assert {q.name for q in theirs} == {"theirs-queue", "unclaimed-queue"}
     # The listing is attributable: a Queue carries its owner.
-    assert theirs[0].application_name == OTHER_APP
+    assert {q.application_name for q in theirs} == {OTHER_APP, None}
 
     # Name-addressed lookups stay global: a globally unique name is an identity.
     assert dbos._sys_db.get_queue("theirs-queue") is not None

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1058,9 +1058,9 @@ def test_version_is_per_application(dbos: DBOS) -> None:
         assert registry.compute_app_version("app-b") == "DEFAULT_VERSION-app-b"
 
 
-def test_registration_conflict_points_at_the_rename_command(dbos: DBOS) -> None:
-    """The wrong order -- starting under the new name before re-owning -- fails at
-    registration. That error is where an operator learns the remedy exists."""
+def test_registration_conflict_names_both_remedies(dbos: DBOS) -> None:
+    """A name collision has two causes, and the error cannot tell them apart: two
+    applications that chose one name, or one renamed before re-owning its rows."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -1075,9 +1075,40 @@ def test_registration_conflict_points_at_the_rename_command(dbos: DBOS) -> None:
         dbos._sys_db.create_application_version(
             "conflict-version", application_name=RENAMED_APP
         )
-    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in str(
-        excinfo.value
+    message = str(excinfo.value)
+    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in message
+    # A version is computed or pinned, so telling the caller to rename it would misdirect.
+    assert f"set a distinct application_version for '{RENAMED_APP}'" in message
+
+    dbos._sys_db.upsert_queue(
+        name="conflict-queue",
+        concurrency=None,
+        worker_concurrency=None,
+        rate_limit_max=None,
+        rate_limit_period_sec=None,
+        priority_enabled=False,
+        partition_queue=False,
+        polling_interval_sec=1.0,
+        update_existing=True,
+        application_name=OTHER_APP,
     )
+    with pytest.raises(DBOSException) as excinfo:
+        dbos._sys_db.upsert_queue(
+            name="conflict-queue",
+            concurrency=None,
+            worker_concurrency=None,
+            rate_limit_max=None,
+            rate_limit_period_sec=None,
+            priority_enabled=False,
+            partition_queue=False,
+            polling_interval_sec=1.0,
+            update_existing=True,
+            application_name=RENAMED_APP,
+        )
+    message = str(excinfo.value)
+    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in message
+    # A queue name is the caller's to choose, unlike a version's.
+    assert f"give '{RENAMED_APP}' a different queue name" in message
 
 
 def test_cli_renames_application(dbos: DBOS, config: Any) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,11 +1,5 @@
-"""Ownership of system database rows, and the isolation it buys.
-
-Two scoping rules are exercised here and are deliberately different. Claiming —
-dequeue, recovery, enumeration, and the bulk delete/cancel — matches this
-application's rows plus unclaimed ones, so upgrading never strands in-flight
-work. The observability filters match an owner exactly and default to matching
-every application.
-"""
+"""Row ownership and the isolation it buys. Claiming (dequeue, recovery,
+enumeration, bulk delete) takes own plus unclaimed; filters match an owner exactly."""
 
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -22,8 +16,7 @@ from .conftest import retry_until_success
 
 APP_NAME = "test-app"  # matches conftest.default_config
 OTHER_APP = "other-app"
-# Comfortably after any row DBOS writes during the test; epoch ms is ~1.7e12, so a
-# literal like 2**40 would silently be in the past.
+# After any row written during the test; epoch ms is ~1.7e12, so 2**40 is the past.
 FUTURE_MS = int(datetime.now(timezone.utc).timestamp() * 1000) + 10**9
 
 
@@ -280,11 +273,8 @@ def test_export_import_round_trips_owner(dbos: DBOS) -> None:
 
 
 # ── Isolation between applications ────────────────────────────────────────────
-#
-# The dbos fixture's application is "test-app". These tests write rows owned by a
-# second application directly, then assert "test-app" neither runs nor destroys
-# them. Writing the foreign rows rather than launching a second DBOS keeps this to
-# one process, which the shared test databases require.
+# Foreign rows are written directly rather than by launching a second DBOS, which
+# keeps these to one process as the shared test databases require.
 
 
 def insert_foreign_workflow(
@@ -399,9 +389,8 @@ def test_recovery_skips_another_applications_workflow(dbos: DBOS) -> None:
 
 
 def test_garbage_collect_spares_another_application(dbos: DBOS) -> None:
-    """GC collects this application's rows and unclaimed ones — excluding
-    unclaimed would leak every pre-upgrade row forever — but never another
-    application's."""
+    """GC collects own and unclaimed rows, never another application's. Unclaimed
+    are included because excluding them would leak pre-upgrade rows forever."""
 
     @DBOS.workflow()
     def wf() -> int:
@@ -515,9 +504,8 @@ def test_another_applications_version_does_not_demote(dbos: DBOS) -> None:
 
 
 def test_unclaimed_newer_version_does_demote(dbos: DBOS) -> None:
-    """An unclaimed version row that is newer means an older-SDK peer deployed
-    after this worker, so it really is stale. Excluding these would break rolling
-    upgrades, where the peer's rows carry no owner."""
+    """A newer unclaimed version means an older-SDK peer deployed after this worker,
+    so it really is stale. Excluding these would break rolling upgrades."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -552,10 +540,8 @@ def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
 
 
 def test_create_application_version_claims_unclaimed_row(dbos: DBOS) -> None:
-    """Registering a version claims a pre-upgrade row. Without this, a pinned
-    application_version — one whose string never changes — would stay unclaimed
-    for the life of the deployment, since a computed hash is what normally mints
-    a fresh owned row."""
+    """Registering a version claims a pre-upgrade row, so a pinned
+    application_version does not stay unclaimed for the life of the deployment."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1076,7 +1076,7 @@ def test_registration_conflict_names_both_remedies(dbos: DBOS) -> None:
             "conflict-version", application_name=RENAMED_APP
         )
     message = str(excinfo.value)
-    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in message
+    assert "dbos rename-application" in message
     # A version is computed or pinned, so telling the caller to rename it would misdirect.
     assert f"set a distinct application_version for '{RENAMED_APP}'" in message
 
@@ -1106,7 +1106,7 @@ def test_registration_conflict_names_both_remedies(dbos: DBOS) -> None:
             application_name=RENAMED_APP,
         )
     message = str(excinfo.value)
-    assert f"dbos rename-application --from {OTHER_APP} --to {RENAMED_APP}" in message
+    assert "dbos rename-application" in message
     # A queue name is the caller's to choose, unlike a version's.
     assert f"give '{RENAMED_APP}' a different queue name" in message
 

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -411,7 +411,10 @@ def test_bulk_operations_spare_another_application(dbos: DBOS) -> None:
     assert not workflow_exists(dbos, handle.workflow_id)
 
 
-def test_enumeration_skips_another_applications_rows(dbos: DBOS) -> None:
+def test_enumeration_scopes_the_loops_but_not_the_listings(dbos: DBOS) -> None:
+    """The claiming variants are what the queue thread and scheduler poll, so they
+    take own plus unclaimed. The public listings are ordinary filters instead."""
+
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
         pass
@@ -441,10 +444,24 @@ def test_enumeration_skips_another_applications_rows(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    schedules = {s["schedule_name"] for s in dbos._sys_db.list_schedules()}
-    queues = {q.name for q in dbos._sys_db.list_queues()}
-    assert "mine" in schedules and "theirs" not in schedules
-    assert "mine-queue" in queues and "theirs-queue" not in queues
+    claimable_schedules = {
+        s["schedule_name"] for s in dbos._sys_db.list_claimable_schedules()
+    }
+    claimable_queues = {q.name for q in dbos._sys_db.list_claimable_queues()}
+    assert "mine" in claimable_schedules and "theirs" not in claimable_schedules
+    assert "mine-queue" in claimable_queues and "theirs-queue" not in claimable_queues
+
+    # Unset lists every application, and the filter matches an owner exactly.
+    assert {"mine", "theirs"} <= {s["schedule_name"] for s in DBOS.list_schedules()}
+    assert {"mine-queue", "theirs-queue"} <= {q.name for q in DBOS.list_queues()}
+    assert [
+        s["schedule_name"] for s in DBOS.list_schedules(application_name=OTHER_APP)
+    ] == ["theirs"]
+    theirs = DBOS.list_queues(application_name=OTHER_APP)
+    assert [q.name for q in theirs] == ["theirs-queue"]
+    # The listing is attributable: a Queue carries its owner.
+    assert theirs[0].application_name == OTHER_APP
+
     # Name-addressed lookups stay global: a globally unique name is an identity.
     assert dbos._sys_db.get_queue("theirs-queue") is not None
 

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -109,14 +109,19 @@ def insert_foreign_step(
 # ── Stamping ──────────────────────────────────────────────────────────────────
 
 
-def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
-    """Ownership never depends on the target queue: one code path stamps
-    everything this application starts or enqueues."""
+def test_runtime_stamps_everything_it_writes(dbos: DBOS) -> None:
+    """Workflows, whatever queue they target, and the metadata rows that route
+    them. Ownership never consults the queue, which for the internal one is
+    shared and so cannot route anything."""
     served = Queue("served-queue")
 
     @DBOS.workflow()
     def wf() -> int:
         return 5
+
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
 
     workflow_ids = [DBOS.start_workflow(wf).workflow_id, served.enqueue(wf).workflow_id]
     # An earlier design consulted the queue here, leaving the unknown one unclaimed.
@@ -126,8 +131,30 @@ def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
                 {"workflow_name": wf.__qualname__, "queue_name": queue_name}
             ).workflow_id
         )
+
+    DBOS.register_queue("registered-queue")
+    DBOS.create_schedule(
+        schedule_name="owned-schedule",
+        workflow_fn=scheduled,
+        schedule=daily_cron_far_from_now(),
+    )
+    # trigger_schedule enqueues through the same path the cron loop uses.
+    workflow_ids.append(DBOS.trigger_schedule("owned-schedule").workflow_id)
     for workflow_id in workflow_ids:
         assert application_name_of(dbos, workflow_id) == APP_NAME, workflow_id
+
+    with dbos._sys_db.engine.begin() as c:
+        queue_owner = c.execute(
+            sa.select(SystemSchema.queues.c.application_name).where(
+                SystemSchema.queues.c.name == "registered-queue"
+            )
+        ).scalar()
+    schedule = dbos._sys_db.get_schedule("owned-schedule")
+    assert queue_owner == APP_NAME
+    assert schedule is not None and schedule["application_name"] == APP_NAME
+    assert [
+        v["application_name"] for v in dbos._sys_db.list_application_versions()
+    ] == [APP_NAME]
 
 
 def test_destroy_clears_the_application_identity(dbos: DBOS) -> None:
@@ -182,37 +209,6 @@ def test_client_without_identity_writes_unclaimed_rows(
     )
     assert polled.get_result() == 7
     assert application_name_of(dbos, polled.workflow_id) == APP_NAME
-
-
-def test_metadata_rows_are_owned(dbos: DBOS) -> None:
-    """Queue, schedule, and version rows, plus the workflows a schedule fires —
-    those land on the internal queue, whose shared name cannot route them."""
-
-    @DBOS.workflow()
-    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
-        pass
-
-    DBOS.register_queue("registered-queue")
-    DBOS.create_schedule(
-        schedule_name="owned-schedule",
-        workflow_fn=scheduled,
-        schedule=daily_cron_far_from_now(),
-    )
-    with dbos._sys_db.engine.begin() as c:
-        queue_owner = c.execute(
-            sa.select(SystemSchema.queues.c.application_name).where(
-                SystemSchema.queues.c.name == "registered-queue"
-            )
-        ).scalar()
-    schedule = dbos._sys_db.get_schedule("owned-schedule")
-    versions = dbos._sys_db.list_application_versions()
-    assert queue_owner == APP_NAME
-    assert schedule is not None and schedule["application_name"] == APP_NAME
-    assert [v["application_name"] for v in versions] == [APP_NAME]
-
-    # trigger_schedule enqueues through the same path the cron loop uses.
-    fired = DBOS.trigger_schedule("owned-schedule")
-    assert application_name_of(dbos, fired.workflow_id) == APP_NAME
 
 
 def test_steps_carry_owner_and_forks_inherit_it(dbos: DBOS) -> None:
@@ -340,8 +336,7 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
         "their_step"
     }
 
-    # The Conductor's metrics fan-out is per-application, so its request has to carry
-    # the predicate; one sent by a Conductor predating the field is still unscoped.
+    # The Conductor's metrics fan-out is per-application, so its request must carry the predicate.
     fields = {
         "type": "get_metrics",
         "request_id": "r",
@@ -358,9 +353,10 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
 # ── Isolation between applications ────────────────────────────────────────────
 
 
-def test_dequeue_skips_another_applications_workflow(dbos: DBOS) -> None:
-    """The internal queue is the load-bearing case: its name is shared, so only
-    ownership can keep one application off another's workflows."""
+def test_claiming_skips_another_applications_workflows(dbos: DBOS) -> None:
+    """Dequeue and recovery, the two ways a row gets picked up. Both collide
+    across applications by default — the internal queue's name is shared and
+    executor_id is the literal "local" — so only ownership separates them."""
     queue = Queue("shared-name-queue")
 
     @DBOS.workflow()
@@ -384,10 +380,7 @@ def test_dequeue_skips_another_applications_workflow(dbos: DBOS) -> None:
     assert status_of(dbos, "foreign-named") == "ENQUEUED"
     assert status_of(dbos, "foreign-internal") == "ENQUEUED"
 
-
-def test_recovery_skips_another_applications_workflow(dbos: DBOS) -> None:
-    """executor_id defaults to the literal "local", so it collides across
-    applications; ownership is what disambiguates recovery."""
+    # Recovery matches on executor and version, which another application shares.
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.workflow_status).values(
@@ -551,9 +544,10 @@ def test_unclaimed_rows_belong_to_every_application(
 # ── Application versions ──────────────────────────────────────────────────────
 
 
-def test_latest_version_is_scoped(dbos: DBOS) -> None:
-    """Another application's deploy must not demote this one, but an unclaimed
-    newer row is an older-SDK peer's deploy and really does."""
+def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
+    """A version is content, not an address, so two applications legitimately
+    compute the same one and each gets its own row. Another application's deploy
+    must not demote this one, but an unclaimed newer row is an older SDK's and does."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -584,10 +578,6 @@ def test_latest_version_is_scoped(dbos: DBOS) -> None:
         == "unclaimed-version"
     )
 
-
-def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
-    """A version is content, not an address, so two applications legitimately
-    compute the same one and each gets its own row."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -631,8 +621,7 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
     # Already owned, so re-registering is a no-op.
     assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
-    # The same version name under another application is a second row, not a
-    # conflict — this is what lets both applications launch.
+    # The same name under another application is a second row, which is what lets both launch.
     dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
     with dbos._sys_db.engine.begin() as c:
         owners = {
@@ -645,12 +634,11 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
         }
     assert owners == {APP_NAME, OTHER_APP}
 
-    # This application promotes its own row unambiguously.
-    dbos._sys_db.update_application_version_timestamp("1.0.0", FUTURE_MS)
+    # This application promotes its own row unambiguously, past the unclaimed one.
+    dbos._sys_db.update_application_version_timestamp("1.0.0", FUTURE_MS + 1)
     assert dbos._sys_db.get_latest_application_version()["version_name"] == "1.0.0"
 
-    # A nameless client spans both rows, so promoting raises rather than
-    # retiming someone else's deploy. Naming one resolves it.
+    # A nameless client spans both rows, so promoting raises; naming one resolves it.
     with pytest.raises(DBOSException, match="registered by more than one application"):
         client.set_latest_application_version("1.0.0")
     client.set_latest_application_version("1.0.0", application_name=OTHER_APP)
@@ -724,8 +712,7 @@ def test_conflicting_names_across_applications_raise(
             )
         )
 
-    # Declining to update is still a collision: silently leaving the row alone would
-    # strand every workflow enqueued here, since only its owner polls it.
+    # Declining to update is still a collision: only the owner ever polls the queue.
     with pytest.raises(DBOSException, match="already registered by application"):
         upsert(dbos._sys_db, 3, update_existing=False)
     assert conflict_queue() == (OTHER_APP, None)
@@ -827,17 +814,14 @@ def test_two_applications_share_one_system_database(dbos: DBOS, config: Any) -> 
                 polling_interval_sec=1.0,
                 update_existing=True,
             )
-            # A client that names its application owns what it writes, with no
-            # per-call option. Everything lands on the internal queue, the one
-            # name every application shares, so only ownership can route it.
+            # All on the internal queue, the one name every application shares, so only ownership routes it.
             handle: WorkflowHandle[int] = clients[name].enqueue(
                 {"workflow_name": "wf", "queue_name": INTERNAL_QUEUE_NAME}
             )
             enqueued[name] = handle.workflow_id
             assert application_name_of(dbos, handle.workflow_id) == name
 
-        # Each application dequeues its own work and only its own — the positive
-        # half, which rows written by a single application cannot demonstrate.
+        # Each application dequeues its own work and only its own.
         internal = Queue(INTERNAL_QUEUE_NAME, database_backed_queue=True)
         for name in names:
             dequeued = peers[name].start_queued_workflows(
@@ -845,8 +829,7 @@ def test_two_applications_share_one_system_database(dbos: DBOS, config: Any) -> 
             )
             assert dequeued == [enqueued[name]], name
 
-        # Registration made each queue owned, so neither application enumerates
-        # the other's.
+        # Registration made each queue owned, so neither application enumerates the other's.
         for name in names:
             visible = {q.name for q in peers[name].list_queues(application_name=name)}
             assert f"{name}-queue" in visible

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -532,9 +532,9 @@ def test_unclaimed_newer_version_does_demote(dbos: DBOS) -> None:
     assert latest["version_name"] == "unclaimed-version"
 
 
-def test_set_latest_version_adopts_a_legacy_row(dbos: DBOS) -> None:
-    """Naming a version explicitly is an operator action, so it claims the row —
-    which is what makes rolling back to a pre-upgrade version possible at all."""
+def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
+    """Rolling back to a pre-upgrade version needs no claiming step: unclaimed
+    rows are already inside the claiming scope."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -548,7 +548,7 @@ def test_set_latest_version_adopts_a_legacy_row(dbos: DBOS) -> None:
     dbos._sys_db.update_application_version_timestamp("legacy-version", FUTURE_MS)
     latest = dbos._sys_db.get_latest_application_version()
     assert latest["version_name"] == "legacy-version"
-    assert latest["application_name"] == APP_NAME
+    assert latest["application_name"] is None
 
 
 # ── Cross-application operations that must keep working ───────────────────────
@@ -582,12 +582,12 @@ def test_enqueue_for_another_application(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == OTHER_APP
 
 
-# ── Adoption ──────────────────────────────────────────────────────────────────
+# ── Claiming pre-upgrade rows ─────────────────────────────────────────────────
 
 
-def test_registration_adopts_unclaimed_rows(dbos: DBOS) -> None:
-    """Adoption is per-name, so an application only ever claims rows for names it
-    declares itself."""
+def test_re_registering_claims_unclaimed_rows(dbos: DBOS) -> None:
+    """Registration has no separate adoption step: the upsert writes the owner
+    itself, so re-registering a pre-upgrade row claims it."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.queues).values(
@@ -642,8 +642,38 @@ def test_registration_adopts_unclaimed_rows(dbos: DBOS) -> None:
     assert queue_owner == APP_NAME
     assert schedule_row is not None
     assert schedule_row[0] == APP_NAME
-    # Adoption must preserve identity, not recreate the row.
+    # Claiming must preserve identity, not recreate the row.
     assert schedule_row[1] == "legacy-schedule-id"
+
+
+def test_unclaimed_rows_stay_visible_without_being_claimed(dbos: DBOS) -> None:
+    """Nothing needs claiming in advance: the claiming scope already includes
+    unclaimed rows, so a pre-upgrade queue and schedule are used as they are."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="unclaimed-queue-id",
+                name="unclaimed-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=None,
+            )
+        )
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id="unclaimed-schedule-id",
+                schedule_name="unclaimed-schedule",
+                workflow_name="scheduled",
+                schedule=daily_cron_far_from_now(),
+                status="ACTIVE",
+                context="null",
+                application_name=None,
+            )
+        )
+    assert "unclaimed-queue" in {q.name for q in dbos._sys_db.list_queues()}
+    assert "unclaimed-schedule" in {
+        s["schedule_name"] for s in dbos._sys_db.list_schedules()
+    }
 
 
 # ── Ownership conflicts ───────────────────────────────────────────────────────

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -124,7 +124,7 @@ def test_runtime_stamps_everything_it_writes(dbos: DBOS) -> None:
         pass
 
     workflow_ids = [DBOS.start_workflow(wf).workflow_id, served.enqueue(wf).workflow_id]
-    # An earlier design consulted the queue here, leaving the unknown one unclaimed.
+    # A known queue and an unknown one: ownership is stamped the same either way.
     for queue_name in ("served-queue", "never-served-queue"):
         workflow_ids.append(
             DBOS.enqueue_workflow_with_options(
@@ -545,9 +545,9 @@ def test_unclaimed_rows_belong_to_every_application(
 
 
 def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
-    """A version is content, not an address, so two applications legitimately
-    compute the same one and each gets its own row. Another application's deploy
-    must not demote this one, but an unclaimed newer row is an older SDK's and does."""
+    """Version names stay global addresses, so a row records which application
+    registered it. Another application's deploy must not demote this one, but an
+    unclaimed newer row is an older SDK's and does."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -621,7 +621,7 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
     # Already owned, so re-registering is a no-op.
     assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
-    # The same name under another application is a second row, which is what lets both launch.
+    # A taken name is a silent no-op: launch must not fail over a shared version string.
     dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
     with dbos._sys_db.engine.begin() as c:
         owners = {
@@ -632,16 +632,35 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
                 )
             )
         }
-    assert owners == {APP_NAME, OTHER_APP}
+    assert owners == {APP_NAME}
 
-    # This application promotes its own row unambiguously, past the unclaimed one.
+    # Promoting a name another application owns is a collision, not a retiming.
+    with pytest.raises(DBOSException, match="already registered by application"):
+        dbos._sys_db.update_application_version_timestamp(
+            "1.0.0", FUTURE_MS + 1, application_name=OTHER_APP
+        )
+
+    # This application owns the row, so it promotes it, past the unclaimed one.
     dbos._sys_db.update_application_version_timestamp("1.0.0", FUTURE_MS + 1)
     assert dbos._sys_db.get_latest_application_version()["version_name"] == "1.0.0"
 
-    # A nameless client spans both rows, so promoting raises; naming one resolves it.
-    with pytest.raises(DBOSException, match="registered by more than one application"):
-        client.set_latest_application_version("1.0.0")
-    client.set_latest_application_version("1.0.0", application_name=OTHER_APP)
+    def owner_of(version_name: str) -> Any:
+        with dbos._sys_db.engine.begin() as c:
+            return c.execute(
+                sa.select(SystemSchema.application_versions.c.application_name).where(
+                    SystemSchema.application_versions.c.version_name == version_name
+                )
+            ).scalar()
+
+    # A nameless client administers any row without taking it.
+    client.set_latest_application_version("1.0.0")
+    assert owner_of("1.0.0") == APP_NAME
+
+    # Promotion claims an unclaimed row, which would otherwise be every peer's latest.
+    dbos._sys_db.update_application_version_timestamp(
+        "unclaimed-version", FUTURE_MS + 2
+    )
+    assert owner_of("unclaimed-version") == APP_NAME
 
 
 # ── Pre-upgrade rows and conflicts ────────────────────────────────────────────

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,0 +1,218 @@
+"""Tests that every row DBOS writes carries its owning application's name.
+
+Nothing reads application_name yet, so these assert only that ownership is
+stamped correctly: rows that will run in this process are owned outright, and
+rows routed by a globally unique queue name are left unclaimed.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import sqlalchemy as sa
+
+from dbos import DBOS, DBOSClient, Queue, WorkflowHandle
+from dbos._schemas.system_database import SystemSchema
+from dbos._utils import INTERNAL_QUEUE_NAME
+
+from .conftest import retry_until_success
+
+APP_NAME = "test-app"  # matches conftest.default_config
+
+
+def daily_cron_far_from_now() -> str:
+    # Daily cron pinned ~12 hours away, so it can't fire mid-test at any wall-clock time.
+    t = datetime.now(timezone.utc) + timedelta(hours=12)
+    return f"{t.minute} {t.hour} * * *"
+
+
+def application_name_of(dbos: DBOS, workflow_id: str) -> Any:
+    with dbos._sys_db.engine.begin() as c:
+        return c.execute(
+            sa.select(SystemSchema.workflow_status.c.application_name).where(
+                SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+            )
+        ).scalar()
+
+
+def test_started_workflow_is_owned(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 5
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 5
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+def test_enqueued_workflow_on_served_queue_is_owned(dbos: DBOS) -> None:
+    queue = Queue("owned-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 6
+
+    handle = queue.enqueue(wf)
+    assert handle.get_result() == 6
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+def test_enqueue_to_unserved_queue_is_unclaimed(dbos: DBOS) -> None:
+    """A queue this application does not serve belongs to some other application,
+    so the row is left unclaimed and routed by its globally unique queue name."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 7
+
+    handle = DBOS.enqueue_workflow_with_options(
+        {"workflow_name": wf.__qualname__, "queue_name": "some-other-apps-queue"}
+    )
+    assert application_name_of(dbos, handle.workflow_id) is None
+
+
+def test_enqueue_with_options_to_served_queue_is_owned(dbos: DBOS) -> None:
+    Queue("options-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 8
+
+    handle = DBOS.enqueue_workflow_with_options(
+        {"workflow_name": wf.__qualname__, "queue_name": "options-queue"}
+    )
+    assert handle.get_result() == 8
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+def test_internal_queue_workflow_is_owned(dbos: DBOS) -> None:
+    """The internal queue's name is shared by every application, so a row on it
+    can only be routed by ownership."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 9
+
+    handle = DBOS.enqueue_workflow_with_options(
+        {"workflow_name": wf.__qualname__, "queue_name": INTERNAL_QUEUE_NAME}
+    )
+    assert handle.get_result() == 9
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+def test_scheduled_workflow_is_owned(dbos: DBOS) -> None:
+    fired: list[str] = []
+
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        workflow_id = DBOS.workflow_id
+        assert workflow_id is not None
+        fired.append(workflow_id)
+
+    DBOS.create_schedule(
+        schedule_name="owned-schedule",
+        workflow_fn=scheduled,
+        schedule="* * * * * *",
+    )
+
+    # Indexing raises until the schedule fires, which is what retry_until_success waits on.
+    workflow_id = retry_until_success(lambda: fired[0])
+    assert application_name_of(dbos, workflow_id) == APP_NAME
+
+
+def test_client_enqueue_is_unclaimed(dbos: DBOS, client: DBOSClient) -> None:
+    """A client has no application identity, so it writes unclaimed rows that the
+    application serving the queue picks up."""
+    Queue("client-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 10
+
+    handle: WorkflowHandle[int] = client.enqueue(
+        {"workflow_name": wf.__qualname__, "queue_name": "client-queue"}
+    )
+    assert handle.get_result() == 10
+    # Nothing filters by owner yet, so the unclaimed row still runs here.
+    assert application_name_of(dbos, handle.workflow_id) is None
+
+
+def test_fork_inherits_owner(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 11
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 11
+
+    forked = DBOS.fork_workflow(handle.workflow_id, 1)
+    assert forked.get_result() == 11
+    assert application_name_of(dbos, forked.workflow_id) == APP_NAME
+
+
+def test_queue_row_is_owned(dbos: DBOS) -> None:
+    DBOS.register_queue("registered-queue")
+    with dbos._sys_db.engine.begin() as c:
+        owner = c.execute(
+            sa.select(SystemSchema.queues.c.application_name).where(
+                SystemSchema.queues.c.name == "registered-queue"
+            )
+        ).scalar()
+    assert owner == APP_NAME
+
+
+def test_schedule_row_is_owned(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
+
+    DBOS.create_schedule(
+        schedule_name="owned-schedule-row",
+        workflow_fn=scheduled,
+        schedule=daily_cron_far_from_now(),
+    )
+    schedule = dbos._sys_db.get_schedule("owned-schedule-row")
+    assert schedule is not None
+    assert schedule["application_name"] == APP_NAME
+
+
+def test_application_version_row_is_owned(dbos: DBOS) -> None:
+    versions = dbos._sys_db.list_application_versions()
+    assert len(versions) == 1
+    assert versions[0]["application_name"] == APP_NAME
+    assert dbos._sys_db.get_latest_application_version()["application_name"] == APP_NAME
+
+
+def test_status_reads_surface_owner(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 12
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 12
+
+    internal = dbos._sys_db.get_workflow_status(handle.workflow_id)
+    assert internal is not None
+    assert internal["application_name"] == APP_NAME
+
+    listed = DBOS.list_workflows(workflow_ids=[handle.workflow_id])
+    assert len(listed) == 1
+    assert listed[0].application_name == APP_NAME
+    # The trailing input/output columns must still line up after the new column.
+    assert listed[0].output == 12
+    assert listed[0].input is not None
+
+
+def test_export_import_round_trips_owner(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 13
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 13
+
+    exported = dbos._sys_db.export_workflow(handle.workflow_id, export_children=False)
+    assert exported[0]["workflow_status"]["application_name"] == APP_NAME
+
+    dbos._sys_db.delete_workflows([handle.workflow_id])
+    dbos._sys_db.import_workflow(exported)
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -551,6 +551,61 @@ def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
     assert latest["application_name"] is None
 
 
+def test_create_application_version_claims_unclaimed_row(dbos: DBOS) -> None:
+    """Registering a version claims a pre-upgrade row. Without this, a pinned
+    application_version — one whose string never changes — would stay unclaimed
+    for the life of the deployment, since a computed hash is what normally mints
+    a fresh owned row."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="pinned-version-id",
+                version_name="1.0.0",
+                version_timestamp=7,
+                created_at=7,
+                application_name=None,
+            )
+        )
+    dbos._sys_db.create_application_version("1.0.0")
+    with dbos._sys_db.engine.begin() as c:
+        row = c.execute(
+            sa.select(
+                SystemSchema.application_versions.c.application_name,
+                SystemSchema.application_versions.c.version_id,
+                SystemSchema.application_versions.c.version_timestamp,
+            ).where(SystemSchema.application_versions.c.version_name == "1.0.0")
+        ).fetchone()
+    assert row is not None
+    assert row[0] == APP_NAME
+    # Claiming must not recreate the row or promote it to latest.
+    assert row[1] == "pinned-version-id"
+    assert row[2] == 7
+
+
+def test_create_application_version_leaves_owned_rows_alone(dbos: DBOS) -> None:
+    """Re-registering an already-owned version is still a no-op, so a redeploy of
+    an unchanged version does not become a promotion."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="owned-version-id",
+                version_name="2.0.0",
+                version_timestamp=7,
+                created_at=7,
+                application_name=APP_NAME,
+            )
+        )
+    dbos._sys_db.create_application_version("2.0.0")
+    with dbos._sys_db.engine.begin() as c:
+        row = c.execute(
+            sa.select(
+                SystemSchema.application_versions.c.version_id,
+                SystemSchema.application_versions.c.version_timestamp,
+            ).where(SystemSchema.application_versions.c.version_name == "2.0.0")
+        ).fetchone()
+    assert row == ("owned-version-id", 7)
+
+
 # ── Cross-application operations that must keep working ───────────────────────
 
 

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from dbos import DBOS, DBOSClient, Queue, WorkflowHandle
 from dbos._error import DBOSException
 from dbos._schemas.system_database import SystemSchema
-from dbos._utils import INTERNAL_QUEUE_NAME
+from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
 from .conftest import retry_until_success
 
@@ -26,119 +26,165 @@ def daily_cron_far_from_now() -> str:
     return f"{t.minute} {t.hour} * * *"
 
 
-def application_name_of(dbos: DBOS, workflow_id: str) -> Any:
+def _column_of(dbos: DBOS, column: Any, workflow_id: str) -> Any:
     with dbos._sys_db.engine.begin() as c:
         return c.execute(
-            sa.select(SystemSchema.workflow_status.c.application_name).where(
+            sa.select(column).where(
                 SystemSchema.workflow_status.c.workflow_uuid == workflow_id
             )
         ).scalar()
 
 
-def test_started_workflow_is_owned(dbos: DBOS) -> None:
+def application_name_of(dbos: DBOS, workflow_id: str) -> Any:
+    return _column_of(
+        dbos, SystemSchema.workflow_status.c.application_name, workflow_id
+    )
+
+
+def status_of(dbos: DBOS, workflow_id: str) -> Any:
+    return _column_of(dbos, SystemSchema.workflow_status.c.status, workflow_id)
+
+
+def workflow_exists(dbos: DBOS, workflow_id: str) -> bool:
+    return (
+        _column_of(dbos, SystemSchema.workflow_status.c.workflow_uuid, workflow_id)
+        is not None
+    )
+
+
+def step_owners(dbos: DBOS, workflow_id: str) -> set[Any]:
+    with dbos._sys_db.engine.begin() as c:
+        return {
+            r[0]
+            for r in c.execute(
+                sa.select(SystemSchema.operation_outputs.c.application_name).where(
+                    SystemSchema.operation_outputs.c.workflow_uuid == workflow_id
+                )
+            )
+        }
+
+
+def insert_foreign_workflow(
+    dbos: DBOS,
+    workflow_id: str,
+    *,
+    status: str,
+    queue_name: Optional[str] = None,
+    application_name: Optional[str] = OTHER_APP,
+) -> None:
+    """A row owned by a second application, written directly rather than by
+    launching another DBOS, which keeps these tests to one process."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.workflow_status).values(
+                workflow_uuid=workflow_id,
+                status=status,
+                name="foreign_workflow",
+                queue_name=queue_name,
+                created_at=1,
+                updated_at=1,
+                priority=0,
+                application_name=application_name,
+                inputs='{"args": [], "kwargs": {}}',
+            )
+        )
+
+
+def insert_foreign_step(
+    dbos: DBOS, workflow_id: str, *, function_name: str, completed_at: int = 1
+) -> None:
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.operation_outputs).values(
+                workflow_uuid=workflow_id,
+                function_id=1,
+                function_name=function_name,
+                completed_at_epoch_ms=completed_at,
+                started_at_epoch_ms=completed_at,
+                application_name=OTHER_APP,
+            )
+        )
+
+
+# ── Stamping ──────────────────────────────────────────────────────────────────
+
+
+def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
+    """Ownership never depends on the target queue: one code path stamps
+    everything this application starts or enqueues."""
+    served = Queue("served-queue")
+
     @DBOS.workflow()
     def wf() -> int:
         return 5
 
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 5
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+    workflow_ids = [
+        DBOS.start_workflow(wf).workflow_id,
+        served.enqueue(wf).workflow_id,
+    ]
+    # A queue this application serves, one it has never heard of, and the internal
+    # queue whose name every application shares.
+    for queue_name in ("served-queue", "never-served-queue", INTERNAL_QUEUE_NAME):
+        workflow_ids.append(
+            DBOS.enqueue_workflow_with_options(
+                {"workflow_name": wf.__qualname__, "queue_name": queue_name}
+            ).workflow_id
+        )
+    for workflow_id in workflow_ids:
+        assert application_name_of(dbos, workflow_id) == APP_NAME, workflow_id
 
 
-def test_enqueued_workflow_on_served_queue_is_owned(dbos: DBOS) -> None:
-    queue = Queue("owned-queue")
+def test_explicit_application_name_wins(dbos: DBOS, client: DBOSClient) -> None:
+    """Naming a target is the only way to enqueue across applications, from either
+    the runtime or a client."""
+    Queue("override-queue")
 
     @DBOS.workflow()
     def wf() -> int:
         return 6
 
-    handle = queue.enqueue(wf)
-    assert handle.get_result() == 6
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+    def options() -> Any:
+        return {
+            "workflow_name": wf.__qualname__,
+            "queue_name": "override-queue",
+            "application_name": OTHER_APP,
+        }
+
+    from_runtime = DBOS.enqueue_workflow_with_options(options())
+    from_client: WorkflowHandle[int] = client.enqueue(options())
+    assert application_name_of(dbos, from_runtime.workflow_id) == OTHER_APP
+    assert application_name_of(dbos, from_client.workflow_id) == OTHER_APP
+    # Owned by another application, so this one leaves them enqueued.
+    assert status_of(dbos, from_runtime.workflow_id) == "ENQUEUED"
 
 
-def test_enqueue_to_unserved_queue_is_still_owned(dbos: DBOS) -> None:
-    """The target queue's name never affects ownership: this application owns what
-    it enqueues, and reaching another application requires naming it."""
+def test_client_without_identity_writes_unclaimed_rows(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    """A nameless client writes unclaimed rows, which whichever application runs
+    them then claims, so the unclaimed partition drains on its own."""
+    Queue("adopt-queue")
 
     @DBOS.workflow()
     def wf() -> int:
         return 7
 
-    handle = DBOS.enqueue_workflow_with_options(
-        {"workflow_name": wf.__qualname__, "queue_name": "some-other-apps-queue"}
+    # A queue nobody polls, so the row stays exactly as written.
+    unpolled: WorkflowHandle[int] = client.enqueue(
+        {"workflow_name": wf.__qualname__, "queue_name": "unpolled-queue"}
     )
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+    assert application_name_of(dbos, unpolled.workflow_id) is None
 
-
-def test_enqueue_with_options_to_served_queue_is_owned(dbos: DBOS) -> None:
-    Queue("options-queue")
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 8
-
-    handle = DBOS.enqueue_workflow_with_options(
-        {"workflow_name": wf.__qualname__, "queue_name": "options-queue"}
+    polled: WorkflowHandle[int] = client.enqueue(
+        {"workflow_name": wf.__qualname__, "queue_name": "adopt-queue"}
     )
-    assert handle.get_result() == 8
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
-
-
-def test_enqueue_options_application_name_wins(dbos: DBOS) -> None:
-    """An explicit target beats the runtime's automatic stamping, so an application
-    can enqueue on behalf of another one."""
-    Queue("override-queue")
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 14
-
-    handle = DBOS.enqueue_workflow_with_options(
-        {
-            "workflow_name": wf.__qualname__,
-            "queue_name": "override-queue",
-            "application_name": "other-app",
-        }
-    )
-    assert application_name_of(dbos, handle.workflow_id) == "other-app"
-
-
-def test_client_enqueue_options_application_name_wins(
-    dbos: DBOS, client: DBOSClient
-) -> None:
-    Queue("client-override-queue")
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 15
-
-    handle: WorkflowHandle[int] = client.enqueue(
-        {
-            "workflow_name": wf.__qualname__,
-            "queue_name": "client-override-queue",
-            "application_name": "other-app",
-        }
-    )
-    assert application_name_of(dbos, handle.workflow_id) == "other-app"
-
-
-def test_internal_queue_workflow_is_owned(dbos: DBOS) -> None:
-    """The internal queue's name is shared by every application, so a row on it
-    can only be routed by ownership."""
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 9
-
-    handle = DBOS.enqueue_workflow_with_options(
-        {"workflow_name": wf.__qualname__, "queue_name": INTERNAL_QUEUE_NAME}
-    )
-    assert handle.get_result() == 9
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+    assert polled.get_result() == 7
+    assert application_name_of(dbos, polled.workflow_id) == APP_NAME
 
 
 def test_scheduled_workflow_is_owned(dbos: DBOS) -> None:
+    """Scheduled workflows default to the internal queue, whose shared name cannot
+    route an unclaimed row."""
     fired: list[str] = []
 
     @DBOS.workflow()
@@ -152,117 +198,91 @@ def test_scheduled_workflow_is_owned(dbos: DBOS) -> None:
         workflow_fn=scheduled,
         schedule="* * * * * *",
     )
-
     # Indexing raises until the schedule fires, which is what retry_until_success waits on.
     workflow_id = retry_until_success(lambda: fired[0])
     assert application_name_of(dbos, workflow_id) == APP_NAME
 
 
-def test_client_enqueue_is_unclaimed(dbos: DBOS, client: DBOSClient) -> None:
-    """A client with no application identity writes unclaimed rows."""
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 10
-
-    # A queue no application polls, so the row stays exactly as written.
-    handle: WorkflowHandle[int] = client.enqueue(
-        {"workflow_name": wf.__qualname__, "queue_name": "unpolled-client-queue"}
-    )
-    assert application_name_of(dbos, handle.workflow_id) is None
-
-
-def test_unclaimed_workflow_is_adopted_on_dequeue(
-    dbos: DBOS, client: DBOSClient
-) -> None:
-    """Unclaimed rows are claimed by whichever application runs them, so the
-    unclaimed partition drains instead of needing a bulk backfill."""
-    Queue("client-queue")
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 10
-
-    handle: WorkflowHandle[int] = client.enqueue(
-        {"workflow_name": wf.__qualname__, "queue_name": "client-queue"}
-    )
-    assert handle.get_result() == 10
-    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
-
-
-def test_fork_inherits_owner(dbos: DBOS) -> None:
-    @DBOS.workflow()
-    def wf() -> int:
-        return 11
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 11
-
-    forked = DBOS.fork_workflow(handle.workflow_id, 1)
-    assert forked.get_result() == 11
-    assert application_name_of(dbos, forked.workflow_id) == APP_NAME
-
-
-def test_queue_row_is_owned(dbos: DBOS) -> None:
-    DBOS.register_queue("registered-queue")
-    with dbos._sys_db.engine.begin() as c:
-        owner = c.execute(
-            sa.select(SystemSchema.queues.c.application_name).where(
-                SystemSchema.queues.c.name == "registered-queue"
-            )
-        ).scalar()
-    assert owner == APP_NAME
-
-
-def test_schedule_row_is_owned(dbos: DBOS) -> None:
+def test_metadata_rows_are_owned(dbos: DBOS) -> None:
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
         pass
 
+    DBOS.register_queue("registered-queue")
     DBOS.create_schedule(
         schedule_name="owned-schedule-row",
         workflow_fn=scheduled,
         schedule=daily_cron_far_from_now(),
     )
+    with dbos._sys_db.engine.begin() as c:
+        queue_owner = c.execute(
+            sa.select(SystemSchema.queues.c.application_name).where(
+                SystemSchema.queues.c.name == "registered-queue"
+            )
+        ).scalar()
     schedule = dbos._sys_db.get_schedule("owned-schedule-row")
-    assert schedule is not None
-    assert schedule["application_name"] == APP_NAME
-
-
-def test_application_version_row_is_owned(dbos: DBOS) -> None:
     versions = dbos._sys_db.list_application_versions()
-    assert len(versions) == 1
-    assert versions[0]["application_name"] == APP_NAME
-    assert dbos._sys_db.get_latest_application_version()["application_name"] == APP_NAME
+    assert queue_owner == APP_NAME
+    assert schedule is not None and schedule["application_name"] == APP_NAME
+    assert [v["application_name"] for v in versions] == [APP_NAME]
 
 
-def test_status_reads_surface_owner(dbos: DBOS) -> None:
+def test_steps_carry_owner_and_forks_inherit_it(dbos: DBOS) -> None:
+    @DBOS.step()
+    def a_step() -> int:
+        return 8
+
     @DBOS.workflow()
     def wf() -> int:
-        return 12
+        return a_step()
 
     handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 12
+    assert handle.get_result() == 8
+    assert step_owners(dbos, handle.workflow_id) == {APP_NAME}
+
+    # Forking past the step copies its row, which must carry the owner too.
+    forked = DBOS.fork_workflow(handle.workflow_id, 2)
+    assert forked.get_result() == 8
+    assert application_name_of(dbos, forked.workflow_id) == APP_NAME
+    assert step_owners(dbos, forked.workflow_id) == {APP_NAME}
+
+
+# ── Reads ─────────────────────────────────────────────────────────────────────
+
+
+def test_reads_surface_owner_and_ids_stay_global(dbos: DBOS) -> None:
+    """Workflow IDs are unique, so identity reads are never scoped —
+    cross-application get_result and status depend on it."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 9
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 9
 
     internal = dbos._sys_db.get_workflow_status(handle.workflow_id)
-    assert internal is not None
-    assert internal["application_name"] == APP_NAME
+    assert internal is not None and internal["application_name"] == APP_NAME
 
     listed = DBOS.list_workflows(workflow_ids=[handle.workflow_id])
     assert len(listed) == 1
     assert listed[0].application_name == APP_NAME
     # The trailing input/output columns must still line up after the new column.
-    assert listed[0].output == 12
+    assert listed[0].output == 9
     assert listed[0].input is not None
+
+    insert_foreign_workflow(dbos, "foreign-visible", status="SUCCESS")
+    foreign = dbos._sys_db.get_workflow_status("foreign-visible")
+    assert foreign is not None and foreign["application_name"] == OTHER_APP
 
 
 def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     @DBOS.workflow()
     def wf() -> int:
-        return 13
+        return 10
 
     handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 13
+    assert handle.get_result() == 10
 
     exported = dbos._sys_db.export_workflow(handle.workflow_id, export_children=False)
     assert exported[0]["workflow_status"]["application_name"] == APP_NAME
@@ -272,101 +292,86 @@ def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
+def test_observability_filters_are_exact_and_optional(dbos: DBOS) -> None:
+    """The four observability surfaces take an ordinary exact-match predicate,
+    unset meaning every application, unlike the claiming scope."""
+
+    @DBOS.step()
+    def a_step() -> int:
+        return 11
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return a_step()
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 11
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    insert_foreign_workflow(dbos, "foreign-listed", status="SUCCESS")
+    insert_foreign_step(
+        dbos, "foreign-listed", function_name="their_step", completed_at=now_ms
+    )
+
+    unfiltered = {w.workflow_id for w in DBOS.list_workflows()}
+    assert {handle.workflow_id, "foreign-listed"} <= unfiltered
+    mine = {w.workflow_id for w in DBOS.list_workflows(application_name=APP_NAME)}
+    assert handle.workflow_id in mine and "foreign-listed" not in mine
+    theirs = {w.workflow_id for w in DBOS.list_workflows(application_name=OTHER_APP)}
+    assert theirs == {"foreign-listed"}
+
+    aggregates = dbos._sys_db.get_workflow_aggregates(
+        group_by_name=True, select_count=True, application_name=[OTHER_APP]
+    )
+    assert [r["group"]["name"] for r in aggregates] == ["foreign_workflow"]
+
+    steps = dbos._sys_db.get_step_aggregates(
+        group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
+    )
+    assert [r["group"]["function_name"] for r in steps] == ["their_step"]
+
+    window_start = datetime.fromtimestamp(0, timezone.utc).isoformat()
+    window_end = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    metrics = dbos._sys_db.get_metrics(
+        window_start, window_end, application_name=[OTHER_APP]
+    )
+    assert {m["metric_name"] for m in metrics if m["metric_type"] == "step_count"} == {
+        "their_step"
+    }
+
+
 # ── Isolation between applications ────────────────────────────────────────────
-# Foreign rows are written directly rather than by launching a second DBOS, which
-# keeps these to one process as the shared test databases require.
-
-
-def insert_foreign_workflow(
-    dbos: DBOS,
-    workflow_id: str,
-    *,
-    status: str,
-    queue_name: Optional[str] = None,
-    application_name: Optional[str] = OTHER_APP,
-    created_at: int = 1,
-) -> None:
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.workflow_status).values(
-                workflow_uuid=workflow_id,
-                status=status,
-                name="foreign_workflow",
-                queue_name=queue_name,
-                created_at=created_at,
-                updated_at=created_at,
-                priority=0,
-                application_name=application_name,
-                inputs='{"args": [], "kwargs": {}}',
-            )
-        )
-
-
-def workflow_exists(dbos: DBOS, workflow_id: str) -> bool:
-    with dbos._sys_db.engine.begin() as c:
-        return (
-            c.execute(
-                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
-                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
-                )
-            ).fetchone()
-            is not None
-        )
 
 
 def test_dequeue_skips_another_applications_workflow(dbos: DBOS) -> None:
+    """The internal queue is the load-bearing case: its name is shared, so only
+    ownership can keep one application off another's workflows."""
     queue = Queue("shared-name-queue")
 
     @DBOS.workflow()
     def wf() -> int:
-        return 20
+        return 12
 
     insert_foreign_workflow(
-        dbos, "foreign-enqueued", status="ENQUEUED", queue_name=queue.name
+        dbos, "foreign-named", status="ENQUEUED", queue_name=queue.name
     )
-    # Something this application does own, on the same queue, must still run.
-    handle = queue.enqueue(wf)
-    assert handle.get_result() == 20
-
-    with dbos._sys_db.engine.begin() as c:
-        status = c.execute(
-            sa.select(SystemSchema.workflow_status.c.status).where(
-                SystemSchema.workflow_status.c.workflow_uuid == "foreign-enqueued"
-            )
-        ).scalar()
-    assert status == "ENQUEUED"
-
-
-def test_internal_queue_is_scoped(dbos: DBOS) -> None:
-    """The internal queue's name is shared by every application, so ownership is
-    the only thing that can keep one application off another's workflows."""
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 21
-
     insert_foreign_workflow(
         dbos, "foreign-internal", status="ENQUEUED", queue_name=INTERNAL_QUEUE_NAME
     )
-    handle = DBOS.enqueue_workflow_with_options(
-        {"workflow_name": wf.__qualname__, "queue_name": INTERNAL_QUEUE_NAME}
+    # This application's own work on both queues still runs.
+    assert queue.enqueue(wf).get_result() == 12
+    assert (
+        DBOS.enqueue_workflow_with_options(
+            {"workflow_name": wf.__qualname__, "queue_name": INTERNAL_QUEUE_NAME}
+        ).get_result()
+        == 12
     )
-    assert handle.get_result() == 21
-
-    with dbos._sys_db.engine.begin() as c:
-        status = c.execute(
-            sa.select(SystemSchema.workflow_status.c.status).where(
-                SystemSchema.workflow_status.c.workflow_uuid == "foreign-internal"
-            )
-        ).scalar()
-    assert status == "ENQUEUED"
+    assert status_of(dbos, "foreign-named") == "ENQUEUED"
+    assert status_of(dbos, "foreign-internal") == "ENQUEUED"
 
 
 def test_recovery_skips_another_applications_workflow(dbos: DBOS) -> None:
     """executor_id defaults to the literal "local", so it collides across
     applications; ownership is what disambiguates recovery."""
-    from dbos._utils import GlobalParams
-
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.workflow_status).values(
@@ -388,66 +393,48 @@ def test_recovery_skips_another_applications_workflow(dbos: DBOS) -> None:
     assert "foreign-pending" not in [p.workflow_id for p in pending]
 
 
-def test_garbage_collect_spares_another_application(dbos: DBOS) -> None:
-    """GC collects own and unclaimed rows, never another application's. Unclaimed
-    are included because excluding them would leak pre-upgrade rows forever."""
+def test_bulk_operations_spare_another_application(dbos: DBOS) -> None:
+    """Both take own plus unclaimed rows. Unclaimed are included deliberately:
+    excluding them would leak every pre-upgrade row forever."""
+    from dbos._workflow_commands import global_timeout
 
     @DBOS.workflow()
     def wf() -> int:
-        return 22
+        return 13
 
     handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 22
-
+    assert handle.get_result() == 13
+    insert_foreign_workflow(dbos, "foreign-inflight", status="ENQUEUED")
+    insert_foreign_workflow(
+        dbos, "unclaimed-inflight", status="ENQUEUED", application_name=None
+    )
     insert_foreign_workflow(dbos, "foreign-old", status="SUCCESS")
     insert_foreign_workflow(
         dbos, "unclaimed-old", status="SUCCESS", application_name=None
     )
+    cutoff = int(datetime.now(timezone.utc).timestamp() * 1000) + 1000
+
+    global_timeout(dbos, cutoff)
+    assert status_of(dbos, "foreign-inflight") == "ENQUEUED"
+    assert status_of(dbos, "unclaimed-inflight") == "CANCELLED"
 
     dbos._sys_db.garbage_collect(
-        cutoff_epoch_timestamp_ms=int(datetime.now(timezone.utc).timestamp() * 1000)
-        + 1000,
-        rows_threshold=None,
-        batch_size=None,
+        cutoff_epoch_timestamp_ms=cutoff, rows_threshold=None, batch_size=None
     )
-
     assert workflow_exists(dbos, "foreign-old")
     assert not workflow_exists(dbos, "unclaimed-old")
     assert not workflow_exists(dbos, handle.workflow_id)
 
 
-def test_global_timeout_spares_another_application(dbos: DBOS) -> None:
-    from dbos._workflow_commands import global_timeout
-
-    insert_foreign_workflow(dbos, "foreign-inflight", status="ENQUEUED")
-    insert_foreign_workflow(
-        dbos, "unclaimed-inflight", status="ENQUEUED", application_name=None
-    )
-
-    global_timeout(dbos, int(datetime.now(timezone.utc).timestamp() * 1000) + 1000)
-
-    def status_of(workflow_id: str) -> Any:
-        with dbos._sys_db.engine.begin() as c:
-            return c.execute(
-                sa.select(SystemSchema.workflow_status.c.status).where(
-                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
-                )
-            ).scalar()
-
-    assert status_of("foreign-inflight") == "ENQUEUED"
-    assert status_of("unclaimed-inflight") == "CANCELLED"
-
-
-def test_scheduler_skips_another_applications_schedule(dbos: DBOS) -> None:
+def test_enumeration_skips_another_applications_rows(dbos: DBOS) -> None:
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
         pass
 
     DBOS.create_schedule(
-        schedule_name="mine",
-        workflow_fn=scheduled,
-        schedule=daily_cron_far_from_now(),
+        schedule_name="mine", workflow_fn=scheduled, schedule=daily_cron_far_from_now()
     )
+    DBOS.register_queue("mine-queue")
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.workflow_schedules).values(
@@ -460,14 +447,6 @@ def test_scheduler_skips_another_applications_schedule(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    names = {s["schedule_name"] for s in dbos._sys_db.list_schedules()}
-    assert "mine" in names
-    assert "theirs" not in names
-
-
-def test_queue_thread_skips_another_applications_queue(dbos: DBOS) -> None:
-    DBOS.register_queue("mine-queue")
-    with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.queues).values(
                 queue_id="foreign-queue-id",
@@ -477,16 +456,20 @@ def test_queue_thread_skips_another_applications_queue(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    names = {q.name for q in dbos._sys_db.list_queues()}
-    assert "mine-queue" in names
-    assert "theirs-queue" not in names
-    # Name-addressed lookups stay global: a unique name is an identity.
+    schedules = {s["schedule_name"] for s in dbos._sys_db.list_schedules()}
+    queues = {q.name for q in dbos._sys_db.list_queues()}
+    assert "mine" in schedules and "theirs" not in schedules
+    assert "mine-queue" in queues and "theirs-queue" not in queues
+    # Name-addressed lookups stay global: a globally unique name is an identity.
     assert dbos._sys_db.get_queue("theirs-queue") is not None
 
 
-def test_another_applications_version_does_not_demote(dbos: DBOS) -> None:
-    """Another application deploying must not make this one look stale, which is
-    what makes it stop dequeueing version-less workflows."""
+# ── Application versions ──────────────────────────────────────────────────────
+
+
+def test_latest_version_is_scoped(dbos: DBOS) -> None:
+    """Another application's deploy must not demote this one, but an unclaimed
+    newer row is an older-SDK peer's deploy and really does."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -497,15 +480,11 @@ def test_another_applications_version_does_not_demote(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    from dbos._utils import GlobalParams
+    assert (
+        dbos._sys_db.get_latest_application_version()["version_name"]
+        == GlobalParams.app_version
+    )
 
-    latest = dbos._sys_db.get_latest_application_version()
-    assert latest["version_name"] == GlobalParams.app_version
-
-
-def test_unclaimed_newer_version_does_demote(dbos: DBOS) -> None:
-    """A newer unclaimed version means an older-SDK peer deployed after this worker,
-    so it really is stale. Excluding these would break rolling upgrades."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -516,13 +495,15 @@ def test_unclaimed_newer_version_does_demote(dbos: DBOS) -> None:
                 application_name=None,
             )
         )
-    latest = dbos._sys_db.get_latest_application_version()
-    assert latest["version_name"] == "unclaimed-version"
+    assert (
+        dbos._sys_db.get_latest_application_version()["version_name"]
+        == "unclaimed-version"
+    )
 
 
 def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
-    """Rolling back to a pre-upgrade version needs no claiming step: unclaimed
-    rows are already inside the claiming scope."""
+    """Rolling back to a pre-upgrade version needs no claiming step, since
+    unclaimed rows are already inside the claiming scope."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -539,9 +520,9 @@ def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
     assert latest["application_name"] is None
 
 
-def test_create_application_version_claims_unclaimed_row(dbos: DBOS) -> None:
-    """Registering a version claims a pre-upgrade row, so a pinned
-    application_version does not stay unclaimed for the life of the deployment."""
+def test_create_application_version_claims_only_unclaimed_rows(dbos: DBOS) -> None:
+    """Claiming keeps a pinned application_version — whose string never changes,
+    so no fresh owned row is ever minted — from staying unclaimed forever."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
@@ -552,26 +533,6 @@ def test_create_application_version_claims_unclaimed_row(dbos: DBOS) -> None:
                 application_name=None,
             )
         )
-    dbos._sys_db.create_application_version("1.0.0")
-    with dbos._sys_db.engine.begin() as c:
-        row = c.execute(
-            sa.select(
-                SystemSchema.application_versions.c.application_name,
-                SystemSchema.application_versions.c.version_id,
-                SystemSchema.application_versions.c.version_timestamp,
-            ).where(SystemSchema.application_versions.c.version_name == "1.0.0")
-        ).fetchone()
-    assert row is not None
-    assert row[0] == APP_NAME
-    # Claiming must not recreate the row or promote it to latest.
-    assert row[1] == "pinned-version-id"
-    assert row[2] == 7
-
-
-def test_create_application_version_leaves_owned_rows_alone(dbos: DBOS) -> None:
-    """Re-registering an already-owned version is still a no-op, so a redeploy of
-    an unchanged version does not become a promotion."""
-    with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
                 version_id="owned-version-id",
@@ -581,54 +542,39 @@ def test_create_application_version_leaves_owned_rows_alone(dbos: DBOS) -> None:
                 application_name=APP_NAME,
             )
         )
+    dbos._sys_db.create_application_version("1.0.0")
     dbos._sys_db.create_application_version("2.0.0")
+
     with dbos._sys_db.engine.begin() as c:
-        row = c.execute(
-            sa.select(
-                SystemSchema.application_versions.c.version_id,
-                SystemSchema.application_versions.c.version_timestamp,
-            ).where(SystemSchema.application_versions.c.version_name == "2.0.0")
-        ).fetchone()
-    assert row == ("owned-version-id", 7)
-
-
-# ── Cross-application operations that must keep working ───────────────────────
-
-
-def test_id_addressed_reads_are_global(dbos: DBOS) -> None:
-    """Workflow IDs are unique, so identity operations are never scoped —
-    cross-application get_result and status depend on it."""
-    insert_foreign_workflow(dbos, "foreign-visible", status="SUCCESS")
-    status = dbos._sys_db.get_workflow_status("foreign-visible")
-    assert status is not None
-    assert status["application_name"] == OTHER_APP
-
-
-def test_enqueue_for_another_application(dbos: DBOS) -> None:
-    """Naming the target is the only way to enqueue across applications, so the
-    row must not be claimed by this one."""
-    Queue("cross-app-queue")
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return 23
-
-    handle = DBOS.enqueue_workflow_with_options(
-        {
-            "workflow_name": wf.__qualname__,
-            "queue_name": "cross-app-queue",
-            "application_name": OTHER_APP,
+        rows = {
+            r[0]: (r[1], r[2], r[3])
+            for r in c.execute(
+                sa.select(
+                    SystemSchema.application_versions.c.version_name,
+                    SystemSchema.application_versions.c.application_name,
+                    SystemSchema.application_versions.c.version_id,
+                    SystemSchema.application_versions.c.version_timestamp,
+                ).where(
+                    SystemSchema.application_versions.c.version_name.in_(
+                        ["1.0.0", "2.0.0"]
+                    )
+                )
+            )
         }
-    )
-    assert application_name_of(dbos, handle.workflow_id) == OTHER_APP
+    # Claimed, but neither recreated nor promoted to latest.
+    assert rows["1.0.0"] == (APP_NAME, "pinned-version-id", 7)
+    # Already owned, so re-registering is a no-op.
+    assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
 
-# ── Claiming pre-upgrade rows ─────────────────────────────────────────────────
+# ── Pre-upgrade rows and conflicts ────────────────────────────────────────────
 
 
-def test_re_registering_claims_unclaimed_rows(dbos: DBOS) -> None:
-    """Registration has no separate adoption step: the upsert writes the owner
-    itself, so re-registering a pre-upgrade row claims it."""
+def test_unclaimed_metadata_is_visible_then_claimed_on_registration(
+    dbos: DBOS,
+) -> None:
+    """Nothing needs claiming in advance — the claiming scope already includes
+    unclaimed rows — but re-registering claims them through the ordinary upsert."""
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.queues).values(
@@ -644,12 +590,16 @@ def test_re_registering_claims_unclaimed_rows(dbos: DBOS) -> None:
                 schedule_id="legacy-schedule-id",
                 schedule_name="legacy-schedule",
                 workflow_name="scheduled",
-                schedule="* * * * *",
+                schedule=daily_cron_far_from_now(),
                 status="ACTIVE",
                 context="null",
                 application_name=None,
             )
         )
+    assert "legacy-queue" in {q.name for q in dbos._sys_db.list_queues()}
+    assert "legacy-schedule" in {
+        s["schedule_name"] for s in dbos._sys_db.list_schedules()
+    }
 
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
@@ -665,7 +615,6 @@ def test_re_registering_claims_unclaimed_rows(dbos: DBOS) -> None:
             }
         ]
     )
-
     with dbos._sys_db.engine.begin() as c:
         queue_owner = c.execute(
             sa.select(SystemSchema.queues.c.application_name).where(
@@ -681,46 +630,18 @@ def test_re_registering_claims_unclaimed_rows(dbos: DBOS) -> None:
             )
         ).fetchone()
     assert queue_owner == APP_NAME
-    assert schedule_row is not None
-    assert schedule_row[0] == APP_NAME
     # Claiming must preserve identity, not recreate the row.
-    assert schedule_row[1] == "legacy-schedule-id"
+    assert schedule_row == (APP_NAME, "legacy-schedule-id")
 
 
-def test_unclaimed_rows_stay_visible_without_being_claimed(dbos: DBOS) -> None:
-    """Nothing needs claiming in advance: the claiming scope already includes
-    unclaimed rows, so a pre-upgrade queue and schedule are used as they are."""
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.queues).values(
-                queue_id="unclaimed-queue-id",
-                name="unclaimed-queue",
-                created_at=1,
-                updated_at=1,
-                application_name=None,
-            )
-        )
-        c.execute(
-            sa.insert(SystemSchema.workflow_schedules).values(
-                schedule_id="unclaimed-schedule-id",
-                schedule_name="unclaimed-schedule",
-                workflow_name="scheduled",
-                schedule=daily_cron_far_from_now(),
-                status="ACTIVE",
-                context="null",
-                application_name=None,
-            )
-        )
-    assert "unclaimed-queue" in {q.name for q in dbos._sys_db.list_queues()}
-    assert "unclaimed-schedule" in {
-        s["schedule_name"] for s in dbos._sys_db.list_schedules()
-    }
+def test_conflicting_names_across_applications_raise(dbos: DBOS) -> None:
+    """Names stay globally unique, so a collision is a conflict rather than a
+    silent overwrite of another application's configuration."""
 
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
 
-# ── Ownership conflicts ───────────────────────────────────────────────────────
-
-
-def test_queue_owned_by_another_application_raises(dbos: DBOS) -> None:
     with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.queues).values(
@@ -731,16 +652,6 @@ def test_queue_owned_by_another_application_raises(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    with pytest.raises(DBOSException, match="already registered by application"):
-        DBOS.register_queue("conflict-queue")
-
-
-def test_schedule_owned_by_another_application_raises(dbos: DBOS) -> None:
-    @DBOS.workflow()
-    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
-        pass
-
-    with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.workflow_schedules).values(
                 schedule_id="conflict-schedule-id",
@@ -752,16 +663,6 @@ def test_schedule_owned_by_another_application_raises(dbos: DBOS) -> None:
                 application_name=OTHER_APP,
             )
         )
-    with pytest.raises(DBOSException, match="already registered by application"):
-        DBOS.create_schedule(
-            schedule_name="conflict-schedule",
-            workflow_fn=scheduled,
-            schedule=daily_cron_far_from_now(),
-        )
-
-
-def test_version_owned_by_another_application_raises(dbos: DBOS) -> None:
-    with dbos._sys_db.engine.begin() as c:
         c.execute(
             sa.insert(SystemSchema.application_versions).values(
                 version_id="conflict-version-id",
@@ -772,165 +673,12 @@ def test_version_owned_by_another_application_raises(dbos: DBOS) -> None:
             )
         )
     with pytest.raises(DBOSException, match="already registered by application"):
+        DBOS.register_queue("conflict-queue")
+    with pytest.raises(DBOSException, match="already registered by application"):
+        DBOS.create_schedule(
+            schedule_name="conflict-schedule",
+            workflow_fn=scheduled,
+            schedule=daily_cron_far_from_now(),
+        )
+    with pytest.raises(DBOSException, match="already registered by application"):
         dbos._sys_db.create_application_version("conflict-version")
-
-
-# ── Observability filters: exact match, no default ────────────────────────────
-
-
-def test_list_workflows_filter_is_exact_and_optional(dbos: DBOS) -> None:
-    @DBOS.workflow()
-    def wf() -> int:
-        return 24
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 24
-    insert_foreign_workflow(dbos, "foreign-listed", status="SUCCESS")
-
-    unfiltered = {w.workflow_id for w in DBOS.list_workflows()}
-    assert {handle.workflow_id, "foreign-listed"} <= unfiltered
-
-    mine = {w.workflow_id for w in DBOS.list_workflows(application_name=APP_NAME)}
-    assert handle.workflow_id in mine
-    assert "foreign-listed" not in mine
-
-    theirs = {w.workflow_id for w in DBOS.list_workflows(application_name=OTHER_APP)}
-    assert theirs == {"foreign-listed"}
-
-
-def test_aggregates_filter_by_application(dbos: DBOS) -> None:
-    @DBOS.workflow()
-    def wf() -> int:
-        return 25
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 25
-    insert_foreign_workflow(dbos, "foreign-aggregated", status="SUCCESS")
-
-    rows = dbos._sys_db.get_workflow_aggregates(
-        group_by_name=True, select_count=True, application_name=[OTHER_APP]
-    )
-    assert [r["group"]["name"] for r in rows] == ["foreign_workflow"]
-
-
-# ── Steps carry the owner too ─────────────────────────────────────────────────
-
-
-def step_owners(dbos: DBOS, workflow_id: str) -> list[Any]:
-    with dbos._sys_db.engine.begin() as c:
-        return [
-            r[0]
-            for r in c.execute(
-                sa.select(SystemSchema.operation_outputs.c.application_name).where(
-                    SystemSchema.operation_outputs.c.workflow_uuid == workflow_id
-                )
-            )
-        ]
-
-
-def insert_foreign_step(
-    dbos: DBOS,
-    workflow_id: str,
-    *,
-    function_name: str,
-    application_name: Optional[str] = OTHER_APP,
-    completed_at: int = 1,
-) -> None:
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.operation_outputs).values(
-                workflow_uuid=workflow_id,
-                function_id=1,
-                function_name=function_name,
-                completed_at_epoch_ms=completed_at,
-                started_at_epoch_ms=completed_at,
-                application_name=application_name,
-            )
-        )
-
-
-def test_steps_carry_the_owner(dbos: DBOS) -> None:
-    """operation_outputs mirrors its parent workflow's owner, which is what lets
-    step observability filter without joining back to workflow_status."""
-
-    @DBOS.step()
-    def a_step() -> int:
-        return 1
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return a_step()
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 1
-    owners = step_owners(dbos, handle.workflow_id)
-    assert owners and set(owners) == {APP_NAME}
-
-
-def test_forked_steps_inherit_the_owner(dbos: DBOS) -> None:
-    @DBOS.step()
-    def a_step() -> int:
-        return 2
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return a_step()
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 2
-
-    forked = DBOS.fork_workflow(handle.workflow_id, 2)
-    assert forked.get_result() == 2
-    assert set(step_owners(dbos, forked.workflow_id)) == {APP_NAME}
-
-
-def test_step_aggregates_filter_by_application(dbos: DBOS) -> None:
-    @DBOS.step()
-    def a_step() -> int:
-        return 3
-
-    @DBOS.workflow()
-    def wf() -> int:
-        return a_step()
-
-    handle = DBOS.start_workflow(wf)
-    assert handle.get_result() == 3
-    insert_foreign_workflow(dbos, "foreign-stepped", status="SUCCESS")
-    insert_foreign_step(dbos, "foreign-stepped", function_name="their_step")
-
-    theirs = dbos._sys_db.get_step_aggregates(
-        group_by_function_name=True, select_count=True, application_name=[OTHER_APP]
-    )
-    assert [r["group"]["function_name"] for r in theirs] == ["their_step"]
-
-    mine = {
-        r["group"]["function_name"]
-        for r in dbos._sys_db.get_step_aggregates(
-            group_by_function_name=True, select_count=True, application_name=[APP_NAME]
-        )
-    }
-    assert "their_step" not in mine
-    assert mine  # this application's own steps are still counted
-
-
-def test_metrics_filter_by_application(dbos: DBOS) -> None:
-    from datetime import datetime as _dt
-
-    insert_foreign_workflow(dbos, "foreign-metric", status="SUCCESS")
-    insert_foreign_step(
-        dbos,
-        "foreign-metric",
-        function_name="their_metric_step",
-        completed_at=int(_dt.now(timezone.utc).timestamp() * 1000),
-    )
-    start = _dt.fromtimestamp(0, timezone.utc).isoformat()
-    end = (_dt.now(timezone.utc) + timedelta(hours=1)).isoformat()
-
-    theirs = dbos._sys_db.get_metrics(start, end, application_name=[OTHER_APP])
-    step_names = {m["metric_name"] for m in theirs if m["metric_type"] == "step_count"}
-    assert step_names == {"their_metric_step"}
-
-    mine = dbos._sys_db.get_metrics(start, end, application_name=[APP_NAME])
-    assert "their_metric_step" not in {
-        m["metric_name"] for m in mine if m["metric_type"] == "step_count"
-    }

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -12,8 +12,6 @@ from dbos._error import DBOSException
 from dbos._schemas.system_database import SystemSchema
 from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 
-from .conftest import retry_until_success
-
 APP_NAME = "test-app"  # matches conftest.default_config
 OTHER_APP = "other-app"
 # After any row written during the test; epoch ms is ~1.7e12, so 2**40 is the past.
@@ -118,13 +116,10 @@ def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
     def wf() -> int:
         return 5
 
-    workflow_ids = [
-        DBOS.start_workflow(wf).workflow_id,
-        served.enqueue(wf).workflow_id,
-    ]
-    # A queue this application serves, one it has never heard of, and the internal
-    # queue whose name every application shares.
-    for queue_name in ("served-queue", "never-served-queue", INTERNAL_QUEUE_NAME):
+    workflow_ids = [DBOS.start_workflow(wf).workflow_id, served.enqueue(wf).workflow_id]
+    # A queue this application serves and one it has never heard of: an earlier
+    # design consulted the queue here, and left the unknown one unclaimed.
+    for queue_name in ("served-queue", "never-served-queue"):
         workflow_ids.append(
             DBOS.enqueue_workflow_with_options(
                 {"workflow_name": wf.__qualname__, "queue_name": queue_name}
@@ -154,8 +149,6 @@ def test_explicit_application_name_wins(dbos: DBOS, client: DBOSClient) -> None:
     from_client: WorkflowHandle[int] = client.enqueue(options())
     assert application_name_of(dbos, from_runtime.workflow_id) == OTHER_APP
     assert application_name_of(dbos, from_client.workflow_id) == OTHER_APP
-    # Owned by another application, so this one leaves them enqueued.
-    assert status_of(dbos, from_runtime.workflow_id) == "ENQUEUED"
 
 
 def test_client_without_identity_writes_unclaimed_rows(
@@ -182,35 +175,17 @@ def test_client_without_identity_writes_unclaimed_rows(
     assert application_name_of(dbos, polled.workflow_id) == APP_NAME
 
 
-def test_scheduled_workflow_is_owned(dbos: DBOS) -> None:
-    """Scheduled workflows default to the internal queue, whose shared name cannot
-    route an unclaimed row."""
-    fired: list[str] = []
-
-    @DBOS.workflow()
-    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
-        workflow_id = DBOS.workflow_id
-        assert workflow_id is not None
-        fired.append(workflow_id)
-
-    DBOS.create_schedule(
-        schedule_name="owned-schedule",
-        workflow_fn=scheduled,
-        schedule="* * * * * *",
-    )
-    # Indexing raises until the schedule fires, which is what retry_until_success waits on.
-    workflow_id = retry_until_success(lambda: fired[0])
-    assert application_name_of(dbos, workflow_id) == APP_NAME
-
-
 def test_metadata_rows_are_owned(dbos: DBOS) -> None:
+    """Queue, schedule, and version rows, plus the workflows a schedule fires —
+    those land on the internal queue, whose shared name cannot route them."""
+
     @DBOS.workflow()
     def scheduled(scheduled_at: datetime, ctx: Any) -> None:
         pass
 
     DBOS.register_queue("registered-queue")
     DBOS.create_schedule(
-        schedule_name="owned-schedule-row",
+        schedule_name="owned-schedule",
         workflow_fn=scheduled,
         schedule=daily_cron_far_from_now(),
     )
@@ -220,11 +195,15 @@ def test_metadata_rows_are_owned(dbos: DBOS) -> None:
                 SystemSchema.queues.c.name == "registered-queue"
             )
         ).scalar()
-    schedule = dbos._sys_db.get_schedule("owned-schedule-row")
+    schedule = dbos._sys_db.get_schedule("owned-schedule")
     versions = dbos._sys_db.list_application_versions()
     assert queue_owner == APP_NAME
     assert schedule is not None and schedule["application_name"] == APP_NAME
     assert [v["application_name"] for v in versions] == [APP_NAME]
+
+    # trigger_schedule enqueues through the same path the cron loop uses.
+    fired = DBOS.trigger_schedule("owned-schedule")
+    assert application_name_of(dbos, fired.workflow_id) == APP_NAME
 
 
 def test_steps_carry_owner_and_forks_inherit_it(dbos: DBOS) -> None:
@@ -499,25 +478,6 @@ def test_latest_version_is_scoped(dbos: DBOS) -> None:
         dbos._sys_db.get_latest_application_version()["version_name"]
         == "unclaimed-version"
     )
-
-
-def test_can_roll_back_to_a_legacy_version(dbos: DBOS) -> None:
-    """Rolling back to a pre-upgrade version needs no claiming step, since
-    unclaimed rows are already inside the claiming scope."""
-    with dbos._sys_db.engine.begin() as c:
-        c.execute(
-            sa.insert(SystemSchema.application_versions).values(
-                version_id="legacy-version-id",
-                version_name="legacy-version",
-                version_timestamp=1,
-                created_at=1,
-                application_name=None,
-            )
-        )
-    dbos._sys_db.update_application_version_timestamp("legacy-version", FUTURE_MS)
-    latest = dbos._sys_db.get_latest_application_version()
-    assert latest["version_name"] == "legacy-version"
-    assert latest["application_name"] is None
 
 
 def test_create_application_version_claims_only_unclaimed_rows(dbos: DBOS) -> None:

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,22 +1,30 @@
-"""Tests that every row DBOS writes carries its owning application's name.
+"""Ownership of system database rows, and the isolation it buys.
 
-Nothing reads application_name yet, so these assert only that ownership is
-stamped correctly: rows that will run in this process are owned outright, and
-rows routed by a globally unique queue name are left unclaimed.
+Two scoping rules are exercised here and are deliberately different. Claiming —
+dequeue, recovery, enumeration, and the bulk delete/cancel — matches this
+application's rows plus unclaimed ones, so upgrading never strands in-flight
+work. The observability filters match an owner exactly and default to matching
+every application.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Optional
 
+import pytest
 import sqlalchemy as sa
 
 from dbos import DBOS, DBOSClient, Queue, WorkflowHandle
+from dbos._error import DBOSException
 from dbos._schemas.system_database import SystemSchema
 from dbos._utils import INTERNAL_QUEUE_NAME
 
 from .conftest import retry_until_success
 
 APP_NAME = "test-app"  # matches conftest.default_config
+OTHER_APP = "other-app"
+# Comfortably after any row DBOS writes during the test; epoch ms is ~1.7e12, so a
+# literal like 2**40 would silently be in the past.
+FUTURE_MS = int(datetime.now(timezone.utc).timestamp() * 1000) + 10**9
 
 
 def daily_cron_far_from_now() -> str:
@@ -158,8 +166,24 @@ def test_scheduled_workflow_is_owned(dbos: DBOS) -> None:
 
 
 def test_client_enqueue_is_unclaimed(dbos: DBOS, client: DBOSClient) -> None:
-    """A client has no application identity, so it writes unclaimed rows that the
-    application serving the queue picks up."""
+    """A client with no application identity writes unclaimed rows."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 10
+
+    # A queue no application polls, so the row stays exactly as written.
+    handle: WorkflowHandle[int] = client.enqueue(
+        {"workflow_name": wf.__qualname__, "queue_name": "unpolled-client-queue"}
+    )
+    assert application_name_of(dbos, handle.workflow_id) is None
+
+
+def test_unclaimed_workflow_is_adopted_on_dequeue(
+    dbos: DBOS, client: DBOSClient
+) -> None:
+    """Unclaimed rows are claimed by whichever application runs them, so the
+    unclaimed partition drains instead of needing a bulk backfill."""
     Queue("client-queue")
 
     @DBOS.workflow()
@@ -170,8 +194,7 @@ def test_client_enqueue_is_unclaimed(dbos: DBOS, client: DBOSClient) -> None:
         {"workflow_name": wf.__qualname__, "queue_name": "client-queue"}
     )
     assert handle.get_result() == 10
-    # Nothing filters by owner yet, so the unclaimed row still runs here.
-    assert application_name_of(dbos, handle.workflow_id) is None
+    assert application_name_of(dbos, handle.workflow_id) == APP_NAME
 
 
 def test_fork_inherits_owner(dbos: DBOS) -> None:
@@ -254,3 +277,466 @@ def test_export_import_round_trips_owner(dbos: DBOS) -> None:
     dbos._sys_db.delete_workflows([handle.workflow_id])
     dbos._sys_db.import_workflow(exported)
     assert application_name_of(dbos, handle.workflow_id) == APP_NAME
+
+
+# ── Isolation between applications ────────────────────────────────────────────
+#
+# The dbos fixture's application is "test-app". These tests write rows owned by a
+# second application directly, then assert "test-app" neither runs nor destroys
+# them. Writing the foreign rows rather than launching a second DBOS keeps this to
+# one process, which the shared test databases require.
+
+
+def insert_foreign_workflow(
+    dbos: DBOS,
+    workflow_id: str,
+    *,
+    status: str,
+    queue_name: Optional[str] = None,
+    application_name: Optional[str] = OTHER_APP,
+    created_at: int = 1,
+) -> None:
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.workflow_status).values(
+                workflow_uuid=workflow_id,
+                status=status,
+                name="foreign_workflow",
+                queue_name=queue_name,
+                created_at=created_at,
+                updated_at=created_at,
+                priority=0,
+                application_name=application_name,
+                inputs='{"args": [], "kwargs": {}}',
+            )
+        )
+
+
+def workflow_exists(dbos: DBOS, workflow_id: str) -> bool:
+    with dbos._sys_db.engine.begin() as c:
+        return (
+            c.execute(
+                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+                )
+            ).fetchone()
+            is not None
+        )
+
+
+def test_dequeue_skips_another_applications_workflow(dbos: DBOS) -> None:
+    queue = Queue("shared-name-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 20
+
+    insert_foreign_workflow(
+        dbos, "foreign-enqueued", status="ENQUEUED", queue_name=queue.name
+    )
+    # Something this application does own, on the same queue, must still run.
+    handle = queue.enqueue(wf)
+    assert handle.get_result() == 20
+
+    with dbos._sys_db.engine.begin() as c:
+        status = c.execute(
+            sa.select(SystemSchema.workflow_status.c.status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == "foreign-enqueued"
+            )
+        ).scalar()
+    assert status == "ENQUEUED"
+
+
+def test_internal_queue_is_scoped(dbos: DBOS) -> None:
+    """The internal queue's name is shared by every application, so ownership is
+    the only thing that can keep one application off another's workflows."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 21
+
+    insert_foreign_workflow(
+        dbos, "foreign-internal", status="ENQUEUED", queue_name=INTERNAL_QUEUE_NAME
+    )
+    handle = DBOS.enqueue_workflow_with_options(
+        {"workflow_name": wf.__qualname__, "queue_name": INTERNAL_QUEUE_NAME}
+    )
+    assert handle.get_result() == 21
+
+    with dbos._sys_db.engine.begin() as c:
+        status = c.execute(
+            sa.select(SystemSchema.workflow_status.c.status).where(
+                SystemSchema.workflow_status.c.workflow_uuid == "foreign-internal"
+            )
+        ).scalar()
+    assert status == "ENQUEUED"
+
+
+def test_recovery_skips_another_applications_workflow(dbos: DBOS) -> None:
+    """executor_id defaults to the literal "local", so it collides across
+    applications; ownership is what disambiguates recovery."""
+    from dbos._utils import GlobalParams
+
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.workflow_status).values(
+                workflow_uuid="foreign-pending",
+                status="PENDING",
+                name="foreign_workflow",
+                created_at=1,
+                updated_at=1,
+                priority=0,
+                executor_id=GlobalParams.executor_id,
+                application_version=GlobalParams.app_version,
+                application_name=OTHER_APP,
+                inputs='{"args": [], "kwargs": {}}',
+            )
+        )
+    pending = dbos._sys_db.get_pending_workflows(
+        GlobalParams.executor_id, GlobalParams.app_version
+    )
+    assert "foreign-pending" not in [p.workflow_id for p in pending]
+
+
+def test_garbage_collect_spares_another_application(dbos: DBOS) -> None:
+    """GC collects this application's rows and unclaimed ones — excluding
+    unclaimed would leak every pre-upgrade row forever — but never another
+    application's."""
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 22
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 22
+
+    insert_foreign_workflow(dbos, "foreign-old", status="SUCCESS")
+    insert_foreign_workflow(
+        dbos, "unclaimed-old", status="SUCCESS", application_name=None
+    )
+
+    dbos._sys_db.garbage_collect(
+        cutoff_epoch_timestamp_ms=int(datetime.now(timezone.utc).timestamp() * 1000)
+        + 1000,
+        rows_threshold=None,
+        batch_size=None,
+    )
+
+    assert workflow_exists(dbos, "foreign-old")
+    assert not workflow_exists(dbos, "unclaimed-old")
+    assert not workflow_exists(dbos, handle.workflow_id)
+
+
+def test_global_timeout_spares_another_application(dbos: DBOS) -> None:
+    from dbos._workflow_commands import global_timeout
+
+    insert_foreign_workflow(dbos, "foreign-inflight", status="ENQUEUED")
+    insert_foreign_workflow(
+        dbos, "unclaimed-inflight", status="ENQUEUED", application_name=None
+    )
+
+    global_timeout(dbos, int(datetime.now(timezone.utc).timestamp() * 1000) + 1000)
+
+    def status_of(workflow_id: str) -> Any:
+        with dbos._sys_db.engine.begin() as c:
+            return c.execute(
+                sa.select(SystemSchema.workflow_status.c.status).where(
+                    SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+                )
+            ).scalar()
+
+    assert status_of("foreign-inflight") == "ENQUEUED"
+    assert status_of("unclaimed-inflight") == "CANCELLED"
+
+
+def test_scheduler_skips_another_applications_schedule(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
+
+    DBOS.create_schedule(
+        schedule_name="mine",
+        workflow_fn=scheduled,
+        schedule=daily_cron_far_from_now(),
+    )
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id="foreign-schedule-id",
+                schedule_name="theirs",
+                workflow_name="foreign_workflow",
+                schedule="* * * * *",
+                status="ACTIVE",
+                context="null",
+                application_name=OTHER_APP,
+            )
+        )
+    names = {s["schedule_name"] for s in dbos._sys_db.list_schedules()}
+    assert "mine" in names
+    assert "theirs" not in names
+
+
+def test_queue_thread_skips_another_applications_queue(dbos: DBOS) -> None:
+    DBOS.register_queue("mine-queue")
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="foreign-queue-id",
+                name="theirs-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=OTHER_APP,
+            )
+        )
+    names = {q.name for q in dbos._sys_db.list_queues()}
+    assert "mine-queue" in names
+    assert "theirs-queue" not in names
+    # Name-addressed lookups stay global: a unique name is an identity.
+    assert dbos._sys_db.get_queue("theirs-queue") is not None
+
+
+def test_another_applications_version_does_not_demote(dbos: DBOS) -> None:
+    """Another application deploying must not make this one look stale, which is
+    what makes it stop dequeueing version-less workflows."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="foreign-version-id",
+                version_name="foreign-version",
+                version_timestamp=FUTURE_MS,
+                created_at=FUTURE_MS,
+                application_name=OTHER_APP,
+            )
+        )
+    from dbos._utils import GlobalParams
+
+    latest = dbos._sys_db.get_latest_application_version()
+    assert latest["version_name"] == GlobalParams.app_version
+
+
+def test_unclaimed_newer_version_does_demote(dbos: DBOS) -> None:
+    """An unclaimed version row that is newer means an older-SDK peer deployed
+    after this worker, so it really is stale. Excluding these would break rolling
+    upgrades, where the peer's rows carry no owner."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="unclaimed-version-id",
+                version_name="unclaimed-version",
+                version_timestamp=FUTURE_MS,
+                created_at=FUTURE_MS,
+                application_name=None,
+            )
+        )
+    latest = dbos._sys_db.get_latest_application_version()
+    assert latest["version_name"] == "unclaimed-version"
+
+
+def test_set_latest_version_adopts_a_legacy_row(dbos: DBOS) -> None:
+    """Naming a version explicitly is an operator action, so it claims the row —
+    which is what makes rolling back to a pre-upgrade version possible at all."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="legacy-version-id",
+                version_name="legacy-version",
+                version_timestamp=1,
+                created_at=1,
+                application_name=None,
+            )
+        )
+    dbos._sys_db.update_application_version_timestamp("legacy-version", FUTURE_MS)
+    latest = dbos._sys_db.get_latest_application_version()
+    assert latest["version_name"] == "legacy-version"
+    assert latest["application_name"] == APP_NAME
+
+
+# ── Cross-application operations that must keep working ───────────────────────
+
+
+def test_id_addressed_reads_are_global(dbos: DBOS) -> None:
+    """Workflow IDs are unique, so identity operations are never scoped —
+    cross-application get_result and status depend on it."""
+    insert_foreign_workflow(dbos, "foreign-visible", status="SUCCESS")
+    status = dbos._sys_db.get_workflow_status("foreign-visible")
+    assert status is not None
+    assert status["application_name"] == OTHER_APP
+
+
+def test_enqueue_for_another_application(dbos: DBOS) -> None:
+    """Naming the target is the only way to enqueue across applications, so the
+    row must not be claimed by this one."""
+    Queue("cross-app-queue")
+
+    @DBOS.workflow()
+    def wf() -> int:
+        return 23
+
+    handle = DBOS.enqueue_workflow_with_options(
+        {
+            "workflow_name": wf.__qualname__,
+            "queue_name": "cross-app-queue",
+            "application_name": OTHER_APP,
+        }
+    )
+    assert application_name_of(dbos, handle.workflow_id) == OTHER_APP
+
+
+# ── Adoption ──────────────────────────────────────────────────────────────────
+
+
+def test_registration_adopts_unclaimed_rows(dbos: DBOS) -> None:
+    """Adoption is per-name, so an application only ever claims rows for names it
+    declares itself."""
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="legacy-queue-id",
+                name="legacy-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=None,
+            )
+        )
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id="legacy-schedule-id",
+                schedule_name="legacy-schedule",
+                workflow_name="scheduled",
+                schedule="* * * * *",
+                status="ACTIVE",
+                context="null",
+                application_name=None,
+            )
+        )
+
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
+
+    DBOS.register_queue("legacy-queue")
+    DBOS.apply_schedules(
+        [
+            {
+                "schedule_name": "legacy-schedule",
+                "workflow_fn": scheduled,
+                "schedule": daily_cron_far_from_now(),
+            }
+        ]
+    )
+
+    with dbos._sys_db.engine.begin() as c:
+        queue_owner = c.execute(
+            sa.select(SystemSchema.queues.c.application_name).where(
+                SystemSchema.queues.c.name == "legacy-queue"
+            )
+        ).scalar()
+        schedule_row = c.execute(
+            sa.select(
+                SystemSchema.workflow_schedules.c.application_name,
+                SystemSchema.workflow_schedules.c.schedule_id,
+            ).where(
+                SystemSchema.workflow_schedules.c.schedule_name == "legacy-schedule"
+            )
+        ).fetchone()
+    assert queue_owner == APP_NAME
+    assert schedule_row is not None
+    assert schedule_row[0] == APP_NAME
+    # Adoption must preserve identity, not recreate the row.
+    assert schedule_row[1] == "legacy-schedule-id"
+
+
+# ── Ownership conflicts ───────────────────────────────────────────────────────
+
+
+def test_queue_owned_by_another_application_raises(dbos: DBOS) -> None:
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.queues).values(
+                queue_id="conflict-queue-id",
+                name="conflict-queue",
+                created_at=1,
+                updated_at=1,
+                application_name=OTHER_APP,
+            )
+        )
+    with pytest.raises(DBOSException, match="already registered by application"):
+        DBOS.register_queue("conflict-queue")
+
+
+def test_schedule_owned_by_another_application_raises(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def scheduled(scheduled_at: datetime, ctx: Any) -> None:
+        pass
+
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.workflow_schedules).values(
+                schedule_id="conflict-schedule-id",
+                schedule_name="conflict-schedule",
+                workflow_name="scheduled",
+                schedule="* * * * *",
+                status="ACTIVE",
+                context="null",
+                application_name=OTHER_APP,
+            )
+        )
+    with pytest.raises(DBOSException, match="already registered by application"):
+        DBOS.create_schedule(
+            schedule_name="conflict-schedule",
+            workflow_fn=scheduled,
+            schedule=daily_cron_far_from_now(),
+        )
+
+
+def test_version_owned_by_another_application_raises(dbos: DBOS) -> None:
+    with dbos._sys_db.engine.begin() as c:
+        c.execute(
+            sa.insert(SystemSchema.application_versions).values(
+                version_id="conflict-version-id",
+                version_name="conflict-version",
+                version_timestamp=1,
+                created_at=1,
+                application_name=OTHER_APP,
+            )
+        )
+    with pytest.raises(DBOSException, match="already registered by application"):
+        dbos._sys_db.create_application_version("conflict-version")
+
+
+# ── Observability filters: exact match, no default ────────────────────────────
+
+
+def test_list_workflows_filter_is_exact_and_optional(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 24
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 24
+    insert_foreign_workflow(dbos, "foreign-listed", status="SUCCESS")
+
+    unfiltered = {w.workflow_id for w in DBOS.list_workflows()}
+    assert {handle.workflow_id, "foreign-listed"} <= unfiltered
+
+    mine = {w.workflow_id for w in DBOS.list_workflows(application_name=APP_NAME)}
+    assert handle.workflow_id in mine
+    assert "foreign-listed" not in mine
+
+    theirs = {w.workflow_id for w in DBOS.list_workflows(application_name=OTHER_APP)}
+    assert theirs == {"foreign-listed"}
+
+
+def test_aggregates_filter_by_application(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def wf() -> int:
+        return 25
+
+    handle = DBOS.start_workflow(wf)
+    assert handle.get_result() == 25
+    insert_foreign_workflow(dbos, "foreign-aggregated", status="SUCCESS")
+
+    rows = dbos._sys_db.get_workflow_aggregates(
+        group_by_name=True, select_count=True, application_name=[OTHER_APP]
+    )
+    assert [r["group"]["name"] for r in rows] == ["foreign_workflow"]

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,12 +1,14 @@
 """Row ownership and the isolation it buys. Claiming (dequeue, recovery,
 enumeration, bulk delete) takes own plus unclaimed; filters match an owner exactly."""
 
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 import pytest
 import sqlalchemy as sa
 
+import dbos._conductor.protocol as p
 from dbos import DBOS, DBOSClient, Queue, WorkflowHandle
 from dbos._error import DBOSException
 from dbos._schemas.system_database import SystemSchema
@@ -329,6 +331,20 @@ def test_observability_filters_include_unclaimed_rows(dbos: DBOS) -> None:
     assert {m["metric_name"] for m in metrics if m["metric_type"] == "step_count"} == {
         "their_step"
     }
+
+    # The Conductor's metrics fan-out is per-application, so its request has to carry
+    # the predicate; one sent by a Conductor predating the field is still unscoped.
+    fields = {
+        "type": "get_metrics",
+        "request_id": "r",
+        "start_time": window_start,
+        "end_time": window_end,
+        "metric_class": "workflow_step_count",
+    }
+    assert p.GetMetricsRequest.from_json(
+        json.dumps({**fields, "application_name": [OTHER_APP]})
+    ).application_name == [OTHER_APP]
+    assert p.GetMetricsRequest.from_json(json.dumps(fields)).application_name is None
 
 
 # ── Isolation between applications ────────────────────────────────────────────

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -621,18 +621,9 @@ def test_versions_are_per_application(dbos: DBOS, client: DBOSClient) -> None:
     # Already owned, so re-registering is a no-op.
     assert rows["2.0.0"] == (APP_NAME, "owned-version-id", 7)
 
-    # A taken name is a silent no-op: launch must not fail over a shared version string.
-    dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
-    with dbos._sys_db.engine.begin() as c:
-        owners = {
-            r[0]
-            for r in c.execute(
-                sa.select(SystemSchema.application_versions.c.application_name).where(
-                    SystemSchema.application_versions.c.version_name == "1.0.0"
-                )
-            )
-        }
-    assert owners == {APP_NAME}
+    # A name another application holds is a collision, so the caller's launch fails.
+    with pytest.raises(DBOSException, match="already registered by application"):
+        dbos._sys_db.create_application_version("1.0.0", application_name=OTHER_APP)
 
     # Promoting a name another application owns is a collision, not a retiming.
     with pytest.raises(DBOSException, match="already registered by application"):

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -117,8 +117,7 @@ def test_runtime_stamps_its_own_application(dbos: DBOS) -> None:
         return 5
 
     workflow_ids = [DBOS.start_workflow(wf).workflow_id, served.enqueue(wf).workflow_id]
-    # A queue this application serves and one it has never heard of: an earlier
-    # design consulted the queue here, and left the unknown one unclaimed.
+    # An earlier design consulted the queue here, leaving the unknown one unclaimed.
     for queue_name in ("served-queue", "never-served-queue"):
         workflow_ids.append(
             DBOS.enqueue_workflow_with_options(

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,9 +1,10 @@
-"""Row ownership and the isolation it buys. Claiming (dequeue, recovery,
-enumeration, bulk delete) takes own plus unclaimed; filters match an owner exactly."""
+"""Row ownership and the isolation it buys. Every scope -- claiming (dequeue, recovery,
+bulk delete) and filtering alike -- takes an owner's rows plus the unclaimed ones."""
 
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from unittest.mock import patch
 
 import pytest
 import sqlalchemy as sa
@@ -1038,6 +1039,23 @@ def test_unclaimed_rows_can_be_adopted_without_a_rename(dbos: DBOS) -> None:
     assert step_owners(dbos, "legacy-wf") == {RENAMED_APP}
     # A peer's own rows are never in scope for an adoption.
     assert application_name_of(dbos, "peer-wf") == OTHER_APP
+
+
+def test_version_is_per_application(dbos: DBOS) -> None:
+    """Version names are global addresses, so two applications built from one workflow
+    source must not compute the same version and collide when they both register."""
+    registry = dbos._registry
+    assert registry.compute_app_version("app-a") != registry.compute_app_version(
+        "app-b"
+    )
+    assert registry.compute_app_version("app-a") == registry.compute_app_version(
+        "app-a"
+    )
+    # The unreadable-source fallback is per-application too, not one shared sentinel.
+    # A builtin has no retrievable source, which is what sends compute_app_version there.
+    with patch.object(registry, "workflow_info_map", {"wf": len}):
+        assert registry.compute_app_version("app-a") == "DEFAULT_VERSION-app-a"
+        assert registry.compute_app_version("app-b") == "DEFAULT_VERSION-app-b"
 
 
 def test_registration_conflict_points_at_the_rename_command(dbos: DBOS) -> None:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -20,7 +20,7 @@ from dbos._debug_trigger import DebugAction, DebugTriggers
 from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
 from dbos._registrations import get_dbos_func_name
-from dbos._utils import GlobalParams
+from dbos._utils import INTERNAL_QUEUE_NAME, GlobalParams
 from tests.conftest import set_workflow_status
 
 
@@ -837,19 +837,49 @@ def test_debounce_ownership_across_applications(dbos: DBOS, config: Any) -> None
             client.destroy()
 
 
-def test_debounce_rejects_application_name(dbos: DBOS, config: Any) -> None:
-    """A debounce always acts as the client's own application, so a divergent target
-    in the options is rejected rather than half-honored (stamped by the fresh
-    enqueue but ignored by the bounce, which scopes by client identity)."""
-    client = DBOSClient(system_database_url=config["system_database_url"])
+def test_debounce_targets_another_application(dbos: DBOS, config: Any) -> None:
+    """Both debouncers can act for a named application: the fresh enqueue stamps it,
+    later bounces from any caller naming the same target coalesce onto the holder,
+    and a caller resolving to a different target collides."""
+    client = DBOSClient(
+        system_database_url=config["system_database_url"], application_name="app-a"
+    )
+
+    @DBOS.workflow()
+    def wf(x: int) -> int:
+        return x
+
+    def owner_of(workflow_id: str) -> Any:
+        status = dbos._sys_db.get_workflow_status(workflow_id)
+        assert status is not None and status["status"] == "DELAYED"
+        return status["application_name"]
+
     try:
+        # Runtime debouncer acting for another application; a huge period keeps the holder DELAYED.
+        debouncer = Debouncer.create(wf, application_name="other-app")
+        first = debouncer.debounce("k", 1000000, 1)
+        assert owner_of(first.workflow_id) == "other-app"
+        assert debouncer.debounce("k", 1000000, 2).workflow_id == first.workflow_id
+
+        # Cross-application rows carry no version, so the target's latest version runs them.
+        status = dbos._sys_db.get_workflow_status(first.workflow_id)
+        assert status is not None and status["app_version"] is None
+
+        # A client with its own identity coalesces onto the same holder when it names the target.
         opts: Any = {
-            "workflow_name": "shared_wf",
-            "queue_name": "some-queue",
-            "application_name": "other-app",
+            "workflow_name": get_dbos_func_name(wf),
+            "queue_name": INTERNAL_QUEUE_NAME,
         }
-        with pytest.raises(DBOSException, match="application_name"):
-            DebouncerClient(client, opts).debounce("k", 1, 1)
+        targeted = DebouncerClient(client, opts, application_name="other-app")
+        assert targeted.debounce("k", 1000000, 3).workflow_id == first.workflow_id
+        assert owner_of(first.workflow_id) == "other-app"
+
+        # Without naming the target, the client acts as itself and collides.
+        with pytest.raises(DBOSQueueDeduplicatedError):
+            DebouncerClient(client, opts).debounce("k", 1, 4)
+        assert owner_of(first.workflow_id) == "other-app"
+
+        DBOS.cancel_workflow(first.workflow_id)
     finally:
         client.destroy()
 

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -837,6 +837,23 @@ def test_debounce_ownership_across_applications(dbos: DBOS, config: Any) -> None
             client.destroy()
 
 
+def test_debounce_rejects_application_name(dbos: DBOS, config: Any) -> None:
+    """A debounce always acts as the client's own application, so a divergent target
+    in the options is rejected rather than half-honored (stamped by the fresh
+    enqueue but ignored by the bounce, which scopes by client identity)."""
+    client = DBOSClient(system_database_url=config["system_database_url"])
+    try:
+        opts: Any = {
+            "workflow_name": "shared_wf",
+            "queue_name": "some-queue",
+            "application_name": "other-app",
+        }
+        with pytest.raises(DBOSException, match="application_name"):
+            DebouncerClient(client, opts).debounce("k", 1, 1)
+    finally:
+        client.destroy()
+
+
 def test_debounce_bounce_atomic_with_checkpoint(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -776,24 +776,35 @@ def test_debounce_key_collision_between_workflows(
     DBOS.cancel_workflow(handle_a.workflow_id)
 
 
-def test_debounce_collision_across_applications(dbos: DBOS, config: Any) -> None:
-    """A dedup key is a global address, so two applications contending for one is a
-    conflict. Extending the holder would run its owner's code against our inputs."""
+def test_debounce_ownership_across_applications(dbos: DBOS, config: Any) -> None:
+    """A dedup key is a global address, so bouncing claims the holder and a peer
+    contending for it collides rather than overwriting the owner's inputs."""
     queue_name = f"cross-app-queue-{uuid.uuid4()}"
     DBOS.register_queue(queue_name)
     url = config["system_database_url"]
+    nameless = DBOSClient(system_database_url=url)
     client_a = DBOSClient(system_database_url=url, application_name="app-a")
     client_b = DBOSClient(system_database_url=url, application_name="app-b")
+
+    def owner_of(workflow_id: str) -> Any:
+        status = dbos._sys_db.get_workflow_status(workflow_id)
+        assert status is not None and status["status"] == "DELAYED"
+        return status["application_name"]
+
     try:
         opts: Any = {"workflow_name": "shared_wf", "queue_name": queue_name}
-        # A huge period keeps app-a's workflow DELAYED, holding the key.
-        handle: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
+        # A huge period keeps the workflow DELAYED, holding the key.
+        handle: WorkflowHandle[int] = DebouncerClient(nameless, opts).debounce(
             "k", 1000000, 1
         )
-        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
-        assert status is not None
-        assert status["status"] == "DELAYED"
-        assert status["application_name"] == "app-a"
+        assert owner_of(handle.workflow_id) is None
+
+        # Bouncing an unclaimed holder claims it, as dequeue does.
+        again: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
+            "k", 1000000, 2
+        )
+        assert again.workflow_id == handle.workflow_id
+        assert owner_of(handle.workflow_id) == "app-a"
 
         # Pinned directly, so a regression fails here rather than by spinning until the timeout.
         assert (
@@ -813,65 +824,17 @@ def test_debounce_collision_across_applications(dbos: DBOS, config: Any) -> None
 
         # Same workflow name, same key, different application: a conflict, not a takeover.
         with pytest.raises(DBOSQueueDeduplicatedError):
-            DebouncerClient(client_b, opts).debounce("k", 1, 2)
-
-        # The holder is untouched, and its owner still coalesces onto it.
-        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
-        assert status is not None
-        assert status["status"] == "DELAYED"
-        assert status["application_name"] == "app-a"
-        again: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
-            "k", 1000000, 3
-        )
-        assert again.workflow_id == handle.workflow_id
-
-        DBOS.cancel_workflow(handle.workflow_id)
-    finally:
-        client_a.destroy()
-        client_b.destroy()
-
-
-def test_debounce_claims_an_unclaimed_holder(dbos: DBOS, config: Any) -> None:
-    """Bouncing an unclaimed holder claims it, as dequeue does. Left unclaimed, every
-    peer would coalesce onto the one workflow and the last bouncer's inputs would win.
-    """
-    queue_name = f"unclaimed-debounce-queue-{uuid.uuid4()}"
-    DBOS.register_queue(queue_name)
-    url = config["system_database_url"]
-    nameless = DBOSClient(system_database_url=url)
-    client_a = DBOSClient(system_database_url=url, application_name="app-a")
-    client_b = DBOSClient(system_database_url=url, application_name="app-b")
-    try:
-        opts: Any = {"workflow_name": "shared_wf", "queue_name": queue_name}
-        # A nameless client writes an unclaimed row, which no application owns yet.
-        handle: WorkflowHandle[int] = DebouncerClient(nameless, opts).debounce(
-            "k", 1000000, 1
-        )
-        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
-        assert status is not None and status["application_name"] is None
-
-        # app-a coalesces onto it and takes ownership in the same statement.
-        again: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
-            "k", 1000000, 2
-        )
-        assert again.workflow_id == handle.workflow_id
-        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
-        assert status is not None and status["application_name"] == "app-a"
-
-        # So app-b now collides instead of silently overwriting app-a's inputs.
-        with pytest.raises(DBOSQueueDeduplicatedError):
             DebouncerClient(client_b, opts).debounce("k", 1, 3)
+        assert owner_of(handle.workflow_id) == "app-a"
 
         # A nameless client has no identity to claim with, so it leaves the owner alone.
         DebouncerClient(nameless, opts).debounce("k", 1000000, 4)
-        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
-        assert status is not None and status["application_name"] == "app-a"
+        assert owner_of(handle.workflow_id) == "app-a"
 
         DBOS.cancel_workflow(handle.workflow_id)
     finally:
-        nameless.destroy()
-        client_a.destroy()
-        client_b.destroy()
+        for client in (nameless, client_a, client_b):
+            client.destroy()
 
 
 def test_debounce_bounce_atomic_with_checkpoint(

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -15,6 +15,7 @@ from dbos import (
 )
 from dbos._client import EnqueueOptions
 from dbos._context import SetEnqueueOptions, SetWorkflowTimeout
+from dbos._debouncer import _classify_bounce
 from dbos._debug_trigger import DebugAction, DebugTriggers
 from dbos._error import DBOSException, DBOSQueueDeduplicatedError
 from dbos._queue import Queue
@@ -773,6 +774,62 @@ def test_debounce_key_collision_between_workflows(
     assert handle_a2.workflow_id == handle_a.workflow_id
 
     DBOS.cancel_workflow(handle_a.workflow_id)
+
+
+def test_debounce_collision_across_applications(dbos: DBOS, config: Any) -> None:
+    """A dedup key is a global address, so two applications contending for one is a
+    conflict. Extending the holder would run its owner's code against our inputs."""
+    queue_name = f"cross-app-queue-{uuid.uuid4()}"
+    DBOS.register_queue(queue_name)
+    url = config["system_database_url"]
+    client_a = DBOSClient(system_database_url=url, application_name="app-a")
+    client_b = DBOSClient(system_database_url=url, application_name="app-b")
+    try:
+        opts: Any = {"workflow_name": "shared_wf", "queue_name": queue_name}
+        # A huge period keeps app-a's workflow DELAYED, holding the key.
+        handle: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
+            "k", 1000000, 1
+        )
+        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+        assert status is not None
+        assert status["status"] == "DELAYED"
+        assert status["application_name"] == "app-a"
+
+        # Pinned directly, so a regression fails here rather than by spinning until
+        # the suite timeout: a foreign holder never leaves DELAYED on our account.
+        assert (
+            _classify_bounce(
+                {
+                    "bounced_workflow_id": None,
+                    "holder_workflow_id": handle.workflow_id,
+                    "holder_is_debounced": True,
+                    "holder_workflow_name": "shared_wf",
+                    "holder_application_name": "app-a",
+                },
+                "shared_wf",
+                "app-b",
+            )
+            == "raise"
+        )
+
+        # Same workflow name, same key, different application: a conflict, not a takeover.
+        with pytest.raises(DBOSQueueDeduplicatedError):
+            DebouncerClient(client_b, opts).debounce("k", 1, 2)
+
+        # The holder is untouched, and its owner still coalesces onto it.
+        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+        assert status is not None
+        assert status["status"] == "DELAYED"
+        assert status["application_name"] == "app-a"
+        again: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
+            "k", 1000000, 3
+        )
+        assert again.workflow_id == handle.workflow_id
+
+        DBOS.cancel_workflow(handle.workflow_id)
+    finally:
+        client_a.destroy()
+        client_b.destroy()
 
 
 def test_debounce_bounce_atomic_with_checkpoint(

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -795,8 +795,7 @@ def test_debounce_collision_across_applications(dbos: DBOS, config: Any) -> None
         assert status["status"] == "DELAYED"
         assert status["application_name"] == "app-a"
 
-        # Pinned directly, so a regression fails here rather than by spinning until
-        # the suite timeout: a foreign holder never leaves DELAYED on our account.
+        # Pinned directly, so a regression fails here rather than by spinning until the timeout.
         assert (
             _classify_bounce(
                 {

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -831,6 +831,49 @@ def test_debounce_collision_across_applications(dbos: DBOS, config: Any) -> None
         client_b.destroy()
 
 
+def test_debounce_claims_an_unclaimed_holder(dbos: DBOS, config: Any) -> None:
+    """Bouncing an unclaimed holder claims it, as dequeue does. Left unclaimed, every
+    peer would coalesce onto the one workflow and the last bouncer's inputs would win.
+    """
+    queue_name = f"unclaimed-debounce-queue-{uuid.uuid4()}"
+    DBOS.register_queue(queue_name)
+    url = config["system_database_url"]
+    nameless = DBOSClient(system_database_url=url)
+    client_a = DBOSClient(system_database_url=url, application_name="app-a")
+    client_b = DBOSClient(system_database_url=url, application_name="app-b")
+    try:
+        opts: Any = {"workflow_name": "shared_wf", "queue_name": queue_name}
+        # A nameless client writes an unclaimed row, which no application owns yet.
+        handle: WorkflowHandle[int] = DebouncerClient(nameless, opts).debounce(
+            "k", 1000000, 1
+        )
+        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+        assert status is not None and status["application_name"] is None
+
+        # app-a coalesces onto it and takes ownership in the same statement.
+        again: WorkflowHandle[int] = DebouncerClient(client_a, opts).debounce(
+            "k", 1000000, 2
+        )
+        assert again.workflow_id == handle.workflow_id
+        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+        assert status is not None and status["application_name"] == "app-a"
+
+        # So app-b now collides instead of silently overwriting app-a's inputs.
+        with pytest.raises(DBOSQueueDeduplicatedError):
+            DebouncerClient(client_b, opts).debounce("k", 1, 3)
+
+        # A nameless client has no identity to claim with, so it leaves the owner alone.
+        DebouncerClient(nameless, opts).debounce("k", 1000000, 4)
+        status = dbos._sys_db.get_workflow_status(handle.workflow_id)
+        assert status is not None and status["application_name"] == "app-a"
+
+        DBOS.cancel_workflow(handle.workflow_id)
+    finally:
+        nameless.destroy()
+        client_a.destroy()
+        client_b.destroy()
+
+
 def test_debounce_bounce_atomic_with_checkpoint(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2852,7 +2852,7 @@ def test_partitioned_batch_dequeue_skips_requeued_rows(dbos: DBOS) -> None:
     # Resume onto another unpolled queue: the internal queue is live, and its worker would drain the row before the assertions below.
     resume_target = f"unpolled-resume-{uuid.uuid4().hex[:8]}"
 
-    # Fire between the candidate snapshot (starts WITH RECURSIVE) and the lock select (a plain SELECT ... IN).
+    # Fire between the candidate snapshot (starts WITH RECURSIVE) and the lock select, which is the sweep's only SELECT keyed on workflow_uuid.
     moved = threading.Event()
 
     def before_cursor_execute(
@@ -2864,7 +2864,11 @@ def test_partitioned_batch_dequeue_skips_requeued_rows(dbos: DBOS) -> None:
         executemany: bool,
     ) -> None:
         stmt = statement.lstrip().upper()
-        if not moved.is_set() and stmt.startswith("SELECT") and " IN " in stmt:
+        if (
+            not moved.is_set()
+            and stmt.startswith("SELECT")
+            and "WORKFLOW_UUID IN" in stmt
+        ):
             moved.set()  # Set first: resume_workflows itself runs a SELECT ... IN
             dbos._sys_db.resume_workflows([head_id], queue_name=resume_target)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -495,6 +495,7 @@ def test_schedule_thread_signature() -> None:
         "automatic_backfill": False,
         "cron_timezone": None,
         "queue_name": None,
+        "application_name": "app-a",
     }
     sig = _ScheduleThread.compute_signature(base)
 
@@ -504,6 +505,8 @@ def test_schedule_thread_signature() -> None:
         ("status", "PAUSED"),
         ("last_fired_at", "2020-01-01T00:00:00+00:00"),
         ("automatic_backfill", True),
+        # Ownership, not definition: re-owning a schedule must not restart its thread.
+        ("application_name", "app-b"),
     ]:
         assert _ScheduleThread.compute_signature({**base, field: value}) == sig  # type: ignore[misc]
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -227,9 +227,7 @@ def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
             ).fetchone()
             assert row == ("text", "YES"), f"{table}.application_name"
 
-        # Queue and schedule names are addresses, so they stay globally unique. A
-        # version is content, so its identity is (application_name, version_name),
-        # split across two partial indexes because a composite does not dedupe NULLs.
+        # Names stay global addresses; a version's identity is (application_name, version_name).
         uniques = {
             "uq_workflow_status_dedup_id",
             "queues_name_key",

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -214,7 +214,7 @@ _APPLICATION_NAME_TABLES = (
 
 def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
     """application_name is nullable everywhere it appears — NULL is what SDKs
-    predating it write — and it changes no existing unique, which stay global."""
+    predating it write — and only the version unique changes shape."""
     with dbos._sys_db.engine.connect() as connection:
         for table in _APPLICATION_NAME_TABLES:
             row = connection.execute(
@@ -227,11 +227,15 @@ def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
             ).fetchone()
             assert row == ("text", "YES"), f"{table}.application_name"
 
+        # Queue and schedule names are addresses, so they stay globally unique. A
+        # version is content, so its identity is (application_name, version_name),
+        # split across two partial indexes because a composite does not dedupe NULLs.
         uniques = {
             "uq_workflow_status_dedup_id",
             "queues_name_key",
             "workflow_schedules_schedule_name_key",
-            "application_versions_version_name_key",
+            "uq_application_versions_owned_name",
+            "uq_application_versions_unclaimed_name",
         }
         found = {
             row[0]

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -207,6 +207,9 @@ _APPLICATION_NAME_TABLES = (
     "queues",
     "workflow_schedules",
     "application_versions",
+    # Denormalized from the parent workflow so step observability can filter
+    # locally instead of joining back to workflow_status.
+    "operation_outputs",
 )
 
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -214,7 +214,7 @@ _APPLICATION_NAME_TABLES = (
 
 def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
     """application_name is nullable everywhere it appears — NULL is what SDKs
-    predating it write — and only the version unique changes shape."""
+    predating it write — and every name that addresses a row stays globally unique."""
     with dbos._sys_db.engine.connect() as connection:
         for table in _APPLICATION_NAME_TABLES:
             row = connection.execute(
@@ -227,13 +227,12 @@ def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
             ).fetchone()
             assert row == ("text", "YES"), f"{table}.application_name"
 
-        # Names stay global addresses; a version's identity is (application_name, version_name).
+        # Names stay global addresses, version names included.
         uniques = {
             "uq_workflow_status_dedup_id",
             "queues_name_key",
             "workflow_schedules_schedule_name_key",
-            "uq_application_versions_owned_name",
-            "uq_application_versions_unclaimed_name",
+            "application_versions_version_name_key",
         }
         found = {
             row[0]

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import click
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
@@ -265,7 +266,7 @@ def test_application_version_expand_indexes(dbos: DBOS, skip_with_sqlite: None) 
         insert(connection, "v1", "'app-a'")
         # One row per owner, unclaimed included; the last case is the not-yet-dropped constraint still refusing a peer.
         for version_id, owner in (("v2", "'app-a'"), ("v3", "NULL"), ("v4", "'app-b'")):
-            with pytest.raises(sa.exc.IntegrityError):
+            with pytest.raises(IntegrityError):
                 with connection.begin_nested():
                     insert(connection, version_id, owner)
         connection.execute(

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -227,12 +227,14 @@ def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
             ).fetchone()
             assert row == ("text", "YES"), f"{table}.application_name"
 
-        # Names stay global addresses, version names included.
+        # Names stay global addresses; version_name only until the contract migration, whose replacement key migration 106 already carries.
         uniques = {
             "uq_workflow_status_dedup_id",
             "queues_name_key",
             "workflow_schedules_schedule_name_key",
             "application_versions_version_name_key",
+            "uq_application_versions_owner_version",
+            "uq_application_versions_unclaimed_version",
         }
         found = {
             row[0]
@@ -245,6 +247,30 @@ def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
             )
         }
     assert found == uniques
+
+
+def test_application_version_expand_indexes(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """The expand half of retiring version_name's global uniqueness: the ownership-scoped
+    key exists and is enforced, and the constraint it will replace is still in place."""
+    av = "dbos.application_versions (version_id, version_name, application_name)"
+
+    def insert(connection: sa.Connection, version_id: str, owner: str) -> None:
+        connection.execute(
+            sa.text(
+                f"INSERT INTO {av} VALUES ('{version_id}', 'shared-version', {owner})"
+            )
+        )
+
+    with dbos._sys_db.engine.begin() as connection:
+        insert(connection, "v1", "'app-a'")
+        # One row per owner, unclaimed included; the last case is the not-yet-dropped constraint still refusing a peer.
+        for version_id, owner in (("v2", "'app-a'"), ("v3", "NULL"), ("v4", "'app-b'")):
+            with pytest.raises(sa.exc.IntegrityError):
+                with connection.begin_nested():
+                    insert(connection, version_id, owner)
+        connection.execute(
+            sa.text("DELETE FROM dbos.application_versions WHERE version_id = 'v1'")
+        )
 
 
 def test_enqueue_workflow_function_application_name(

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -212,9 +212,9 @@ _APPLICATION_NAME_TABLES = (
 )
 
 
-def test_application_name_columns(dbos: DBOS, skip_with_sqlite: None) -> None:
-    """application_name must be nullable on every table that carries it: NULL is
-    what SDKs predating the column write, and any application may claim it."""
+def test_application_name_schema(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """application_name is nullable everywhere it appears — NULL is what SDKs
+    predating it write — and it changes no existing unique, which stay global."""
     with dbos._sys_db.engine.connect() as connection:
         for table in _APPLICATION_NAME_TABLES:
             row = connection.execute(
@@ -227,30 +227,23 @@ def test_application_name_columns(dbos: DBOS, skip_with_sqlite: None) -> None:
             ).fetchone()
             assert row == ("text", "YES"), f"{table}.application_name"
 
-
-def test_application_name_leaves_uniques_global(
-    dbos: DBOS, skip_with_sqlite: None
-) -> None:
-    """Queue, schedule, and version names stay globally unique across applications,
-    so the deduplication index needs no application_name and none of these change."""
-    with dbos._sys_db.engine.connect() as connection:
+        uniques = {
+            "uq_workflow_status_dedup_id",
+            "queues_name_key",
+            "workflow_schedules_schedule_name_key",
+            "application_versions_version_name_key",
+        }
         found = {
             row[0]
             for row in connection.execute(
                 sa.text(
                     "SELECT indexname FROM pg_indexes WHERE schemaname='dbos' "
-                    "AND indexname IN ('uq_workflow_status_dedup_id', 'queues_name_key', "
-                    "'workflow_schedules_schedule_name_key', "
-                    "'application_versions_version_name_key')"
-                )
+                    "AND indexname = ANY(:names)"
+                ),
+                {"names": list(uniques)},
             )
         }
-    assert found == {
-        "uq_workflow_status_dedup_id",
-        "queues_name_key",
-        "workflow_schedules_schedule_name_key",
-        "application_versions_version_name_key",
-    }
+    assert found == uniques
 
 
 def test_enqueue_workflow_function_application_name(

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -207,8 +207,7 @@ _APPLICATION_NAME_TABLES = (
     "queues",
     "workflow_schedules",
     "application_versions",
-    # Denormalized from the parent workflow so step observability can filter
-    # locally instead of joining back to workflow_status.
+    # Denormalized from the parent so step observability filters without a join.
     "operation_outputs",
 )
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -202,6 +202,99 @@ def test_reset(
         DBOS.reset_system_database()
 
 
+_APPLICATION_NAME_TABLES = (
+    "workflow_status",
+    "queues",
+    "workflow_schedules",
+    "application_versions",
+)
+
+
+def test_application_name_columns(dbos: DBOS, skip_with_sqlite: None) -> None:
+    """application_name must be nullable on every table that carries it: NULL is
+    what SDKs predating the column write, and any application may claim it."""
+    with dbos._sys_db.engine.connect() as connection:
+        for table in _APPLICATION_NAME_TABLES:
+            row = connection.execute(
+                sa.text(
+                    "SELECT data_type, is_nullable FROM information_schema.columns "
+                    "WHERE table_schema='dbos' AND table_name=:t "
+                    "AND column_name='application_name'"
+                ),
+                {"t": table},
+            ).fetchone()
+            assert row == ("text", "YES"), f"{table}.application_name"
+
+
+def test_application_name_leaves_uniques_global(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """Queue, schedule, and version names stay globally unique across applications,
+    so the deduplication index needs no application_name and none of these change."""
+    with dbos._sys_db.engine.connect() as connection:
+        found = {
+            row[0]
+            for row in connection.execute(
+                sa.text(
+                    "SELECT indexname FROM pg_indexes WHERE schemaname='dbos' "
+                    "AND indexname IN ('uq_workflow_status_dedup_id', 'queues_name_key', "
+                    "'workflow_schedules_schedule_name_key', "
+                    "'application_versions_version_name_key')"
+                )
+            )
+        }
+    assert found == {
+        "uq_workflow_status_dedup_id",
+        "queues_name_key",
+        "workflow_schedules_schedule_name_key",
+        "application_versions_version_name_key",
+    }
+
+
+def test_enqueue_workflow_function_application_name(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """The SQL enqueue entry point takes application_name as a trailing optional
+    argument, so callers that predate it still enqueue (as unclaimed)."""
+    with dbos._sys_db.engine.begin() as connection:
+        overloads = connection.execute(
+            sa.text(
+                "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace "
+                "WHERE n.nspname='dbos' AND p.proname='enqueue_workflow'"
+            )
+        ).scalar()
+        # The migration must drop the previous signature, else calls are ambiguous.
+        assert overloads == 1
+
+        connection.execute(
+            sa.text(
+                "INSERT INTO dbos.queues (name, created_at, updated_at) "
+                "VALUES ('sql-fn-queue', 1, 1)"
+            )
+        )
+        old_style = connection.execute(
+            sa.text("SELECT dbos.enqueue_workflow('wf', 'sql-fn-queue')")
+        ).scalar()
+        new_style = connection.execute(
+            sa.text(
+                "SELECT dbos.enqueue_workflow(workflow_name => 'wf', "
+                "queue_name => 'sql-fn-queue', application_name => 'other-app')"
+            )
+        ).scalar()
+        owners = {
+            row[0]: row[1]
+            for row in connection.execute(
+                sa.text(
+                    "SELECT workflow_uuid, application_name FROM dbos.workflow_status "
+                    "WHERE workflow_uuid IN (:a, :b)"
+                ),
+                {"a": old_style, "b": new_style},
+            )
+        }
+    assert owners[old_style] is None
+    assert owners[new_style] == "other-app"
+
+
 def test_sqlite_systemdb_migration() -> None:
     """Test SQLite system database migration."""
     # Create a temporary SQLite database file
@@ -265,6 +358,17 @@ def test_sqlite_systemdb_migration() -> None:
             fk_result = connection.execute(sa.text("PRAGMA foreign_keys"))
             fk_enabled = fk_result.fetchone()
             assert fk_enabled and fk_enabled[0] == 1  # 1 means enabled
+
+            # application_name must be nullable everywhere it appears
+            for table in _APPLICATION_NAME_TABLES:
+                columns = {
+                    row[1]: row[3]  # name -> notnull
+                    for row in connection.execute(
+                        sa.text(f"PRAGMA table_info({table})")
+                    )
+                }
+                assert "application_name" in columns, table
+                assert columns["application_name"] == 0, table
 
         # Clean up
         sys_db.destroy()


### PR DESCRIPTION
This PR adds support for operating multiple applications (potentially in different languages) in a single system database. All DBOS objects (workflows, queues, schedules, versions) are now associated with an application name. If multiple applications share a system database, their objects are totally isolated by name. By specifying names, applications sharing a system database can freely interoperate (enqueue each other's workflows, etc.).