### PR TITLE
Reset System Database Through Truncation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -72,6 +72,8 @@ jobs:
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+          # Every consumer test uses a fresh group; the 3s default delays each one's first message.
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
           CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
     steps:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -792,25 +792,33 @@ class DBOS:
             raise
 
     @classmethod
-    def reset_system_database(cls) -> None:
+    def reset_system_database(cls, *, truncate: bool = False) -> None:
         """
         Destroy the DBOS system database. Useful for resetting the state of DBOS between tests.
         This is a destructive operation and should only be used in a test environment.
         More information on testing DBOS apps: https://docs.dbos.dev/python/tutorials/testing
+
+        If truncate is set, the system database is emptied instead of destroyed:
+        its schema survives, so the next launch skips migrations. This is much
+        faster, but keeps whatever schema version is already in place.
         """
         if _dbos_global_instance is not None:
-            _dbos_global_instance._reset_system_database()
+            _dbos_global_instance._reset_system_database(truncate=truncate)
         else:
             dbos_logger.warning(
                 "reset_system_database has no effect because global DBOS object does not exist"
             )
 
-    def _reset_system_database(self) -> None:
+    def _reset_system_database(self, *, truncate: bool = False) -> None:
         assert (
             not self._launched
         ), "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
 
-        SystemDatabase.reset_system_database(get_system_database_url(self._config))
+        SystemDatabase.reset_system_database(
+            get_system_database_url(self._config),
+            truncate=truncate,
+            schema=self._config.get("dbos_system_schema"),
+        )
 
     def _destroy(self, *, workflow_completion_timeout_sec: int) -> None:
         self._initialized = False

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -793,7 +793,11 @@ class DBOS:
 
     @classmethod
     def reset_system_database(
-        cls, *, system_database_url: Optional[str] = None, truncate: bool = False
+        cls,
+        *,
+        system_database_url: Optional[str] = None,
+        schema: Optional[str] = None,
+        truncate: bool = False,
     ) -> None:
         """
         Destroy the DBOS system database. Useful for resetting the state of DBOS between tests.
@@ -802,20 +806,30 @@ class DBOS:
 
         We recommend using `truncate=True` to empty the system database instead of destroying it;
         this is substantially faster.
+
+        `schema` names the system schema to empty, defaulting to the configured one.
         """
         if _dbos_global_instance is not None:
             _dbos_global_instance._reset_system_database(
-                system_database_url=system_database_url, truncate=truncate
+                system_database_url=system_database_url,
+                schema=schema,
+                truncate=truncate,
             )
         elif system_database_url is not None:
-            SystemDatabase.reset_system_database(system_database_url, truncate=truncate)
+            SystemDatabase.reset_system_database(
+                system_database_url, truncate=truncate, schema=schema
+            )
         else:
             dbos_logger.warning(
                 "reset_system_database has no effect because global DBOS object does not exist"
             )
 
     def _reset_system_database(
-        self, *, system_database_url: Optional[str] = None, truncate: bool = False
+        self,
+        *,
+        system_database_url: Optional[str] = None,
+        schema: Optional[str] = None,
+        truncate: bool = False,
     ) -> None:
         assert (
             not self._launched
@@ -828,7 +842,9 @@ class DBOS:
                 else get_system_database_url(self._config)
             ),
             truncate=truncate,
-            schema=self._config.get("dbos_system_schema"),
+            schema=(
+                schema if schema is not None else self._config.get("dbos_system_schema")
+            ),
         )
 
     def _destroy(self, *, workflow_completion_timeout_sec: int) -> None:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -792,30 +792,41 @@ class DBOS:
             raise
 
     @classmethod
-    def reset_system_database(cls, *, truncate: bool = False) -> None:
+    def reset_system_database(
+        cls, *, system_database_url: Optional[str] = None, truncate: bool = False
+    ) -> None:
         """
         Destroy the DBOS system database. Useful for resetting the state of DBOS between tests.
         This is a destructive operation and should only be used in a test environment.
         More information on testing DBOS apps: https://docs.dbos.dev/python/tutorials/testing
 
-        If truncate is set, the system database is emptied instead of destroyed:
-        its schema survives, so the next launch skips migrations. This is much
-        faster, but keeps whatever schema version is already in place.
+        We recommend using `truncate=True` to empty the system database instead of destroying it;
+        this is substantially faster.
         """
         if _dbos_global_instance is not None:
-            _dbos_global_instance._reset_system_database(truncate=truncate)
+            _dbos_global_instance._reset_system_database(
+                system_database_url=system_database_url, truncate=truncate
+            )
+        elif system_database_url is not None:
+            SystemDatabase.reset_system_database(system_database_url, truncate=truncate)
         else:
             dbos_logger.warning(
                 "reset_system_database has no effect because global DBOS object does not exist"
             )
 
-    def _reset_system_database(self, *, truncate: bool = False) -> None:
+    def _reset_system_database(
+        self, *, system_database_url: Optional[str] = None, truncate: bool = False
+    ) -> None:
         assert (
             not self._launched
         ), "The system database cannot be reset after DBOS is launched. Resetting the system database is a destructive operation that should only be used in a test environment."
 
         SystemDatabase.reset_system_database(
-            get_system_database_url(self._config),
+            (
+                system_database_url
+                if system_database_url is not None
+                else get_system_database_url(self._config)
+            ),
             truncate=truncate,
             schema=self._config.get("dbos_system_schema"),
         )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3565,11 +3565,7 @@ class SystemDatabase(ABC):
     ) -> None:
         """Reset the system database by calling the appropriate implementation.
 
-        By default the system database is destroyed outright, so the next launch
-        recreates and re-migrates it. With truncate=True the database and its
-        schema are left in place and only their rows are deleted, which is much
-        faster but keeps whatever schema version is already there.
-        """
+        truncate=True empties the tables instead, keeping the migrated schema."""
         if database_url.startswith("sqlite"):
             from ._sys_db_sqlite import SQLiteSystemDatabase
 

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -3560,16 +3560,26 @@ class SystemDatabase(ABC):
                     time.sleep(self._notification_listener_polling_interval_sec)
 
     @staticmethod
-    def reset_system_database(database_url: str) -> None:
-        """Reset the system database by calling the appropriate implementation."""
+    def reset_system_database(
+        database_url: str, *, truncate: bool = False, schema: Optional[str] = None
+    ) -> None:
+        """Reset the system database by calling the appropriate implementation.
+
+        By default the system database is destroyed outright, so the next launch
+        recreates and re-migrates it. With truncate=True the database and its
+        schema are left in place and only their rows are deleted, which is much
+        faster but keeps whatever schema version is already there.
+        """
         if database_url.startswith("sqlite"):
             from ._sys_db_sqlite import SQLiteSystemDatabase
 
-            SQLiteSystemDatabase._reset_system_database(database_url)
+            SQLiteSystemDatabase._reset_system_database(database_url, truncate=truncate)
         else:
             from ._sys_db_postgres import PostgresSystemDatabase
 
-            PostgresSystemDatabase._reset_system_database(database_url)
+            PostgresSystemDatabase._reset_system_database(
+                database_url, truncate=truncate, schema=schema
+            )
 
     @db_retry()
     def record_sleep(

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -138,6 +138,19 @@ class PostgresSystemDatabase(SystemDatabase):
             url = url.set(drivername="postgresql+psycopg")
         engine = sa.create_engine(url, connect_args={"connect_timeout": 10})
         try:
+            try:
+                # Evict other backends, as DROP DATABASE ... WITH (FORCE) does, or one
+                # holding a lock blocks the TRUNCATE. Its own transaction, and best
+                # effort: CockroachDB has no pg_terminate_backend, and a role may not signal.
+                with engine.begin() as conn:
+                    conn.execute(
+                        sa.text(
+                            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+                        )
+                    )
+            except Exception as e:
+                dbos_logger.debug(f"Could not evict connections before truncating: {e}")
             with engine.begin() as conn:
                 tables = [
                     table

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -171,6 +171,9 @@ class PostgresSystemDatabase(SystemDatabase):
                 # For small test tables, DELETE is far faster than TRUNCATE
                 for table in tables:
                     conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
+        except Exception as e:
+            # Best effort: an absent or unreachable database must not fail the caller.
+            dbos_logger.warning(f"Could not empty system database {url.database}: {e}")
         finally:
             engine.dispose()
 

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -140,7 +140,7 @@ class PostgresSystemDatabase(SystemDatabase):
         try:
             try:
                 # Evict other backends, as DROP DATABASE ... WITH (FORCE) does, or one
-                # holding a lock blocks the TRUNCATE. Its own transaction, and best
+                # holding a lock blocks the deletes. Its own transaction, and best
                 # effort: CockroachDB has no pg_terminate_backend, and a role may not signal.
                 with engine.begin() as conn:
                     conn.execute(
@@ -162,24 +162,15 @@ class PostgresSystemDatabase(SystemDatabase):
                     ).scalars()
                     if table != "dbos_migrations"
                 ]
-                if tables:
-                    # Count each table in one round trip, capped so a huge table is cheap.
-                    probe = ", ".join(
-                        f'(SELECT count(*) FROM (SELECT 1 FROM "{schema}"."{table}" '
-                        "LIMIT 10001) s)"
-                        for table in tables
+                if not tables:
+                    dbos_logger.warning(
+                        f'Found no tables to empty in schema "{schema}" of system '
+                        f"database {url.database}. If it uses a different schema, "
+                        "pass that schema to reset_system_database."
                     )
-                    counts = conn.execute(sa.text(f"SELECT {probe}")).one()
-                    bulky = []
-                    for table, rows in zip(tables, counts):
-                        # TRUNCATE rewrites a file per table and index at a flat cost DELETE beats below ~15k rows.
-                        if rows > 10000:
-                            bulky.append(table)
-                        elif rows:
-                            conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
-                    if bulky:
-                        targets = ", ".join(f'"{schema}"."{table}"' for table in bulky)
-                        conn.execute(sa.text(f"TRUNCATE TABLE {targets} CASCADE"))
+                # For small test tables, DELETE is far faster than TRUNCATE
+                for table in tables:
+                    conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
         except OperationalError:
             # An absent database holds no state, but the failure carries no SQLSTATE.
             if PostgresSystemDatabase._database_exists(database_url):

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -17,10 +17,6 @@ from ._sys_db import (
     _dbos_workflow_events_channel,
 )
 
-# TRUNCATE rewrites a file per table and per index at a flat cost, which DELETE only
-# overtakes around 15k rows on this schema. Below this, empty a table row by row.
-_TRUNCATE_ROW_THRESHOLD = 10_000
-
 
 class PostgresSystemDatabase(SystemDatabase):
     """PostgreSQL-specific implementation of SystemDatabase."""
@@ -170,13 +166,14 @@ class PostgresSystemDatabase(SystemDatabase):
                     # Count each table in one round trip, capped so a huge table is cheap.
                     probe = ", ".join(
                         f'(SELECT count(*) FROM (SELECT 1 FROM "{schema}"."{table}" '
-                        f"LIMIT {_TRUNCATE_ROW_THRESHOLD + 1}) s)"
+                        "LIMIT 10001) s)"
                         for table in tables
                     )
                     counts = conn.execute(sa.text(f"SELECT {probe}")).one()
                     bulky = []
                     for table, rows in zip(tables, counts):
-                        if rows > _TRUNCATE_ROW_THRESHOLD:
+                        # TRUNCATE rewrites a file per table and index at a flat cost DELETE beats below ~15k rows.
+                        if rows > 10000:
                             bulky.append(table)
                         elif rows:
                             conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, cast
 import psycopg
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 from dbos._migration import ensure_dbos_schema, run_dbos_migrations, should_migrate
 
@@ -129,13 +129,82 @@ class PostgresSystemDatabase(SystemDatabase):
         return dbapi_error.orig.sqlstate == "23503"  # type: ignore
 
     @staticmethod
-    def _reset_system_database(database_url: str) -> None:
-        """Reset the PostgreSQL system database by dropping it."""
+    def _truncate_system_database(database_url: str, schema: str) -> None:
+        """Empty every DBOS table in the system database, leaving the schema intact.
+
+        dbos_migrations is preserved: it records the schema version, so clearing it
+        would send the next launch through migrations the tables already have.
+        """
+        engine = sa.create_engine(
+            sa.make_url(database_url).set(drivername="postgresql+psycopg"),
+            connect_args={"connect_timeout": 10},
+        )
+        try:
+            with engine.begin() as conn:
+                tables = [
+                    table
+                    for table in conn.execute(
+                        sa.text(
+                            "SELECT tablename FROM pg_tables WHERE schemaname = :schema"
+                        ),
+                        {"schema": schema},
+                    ).scalars()
+                    if table != "dbos_migrations"
+                ]
+                if tables:
+                    targets = ", ".join(f'"{schema}"."{table}"' for table in tables)
+                    conn.execute(
+                        sa.text(f"TRUNCATE TABLE {targets} RESTART IDENTITY CASCADE")
+                    )
+        except OperationalError:
+            # An absent system database holds no state to reset. Connection failures
+            # carry no SQLSTATE, so ask the server whether the database is there.
+            if PostgresSystemDatabase._database_exists(database_url):
+                raise
+            dbos_logger.info(
+                f"System database {sa.make_url(database_url).database} does not exist, nothing to reset"
+            )
+        finally:
+            engine.dispose()
+
+    @staticmethod
+    def _database_exists(database_url: str) -> bool:
+        """Whether the database named in the URL exists, per the postgres database."""
+        url = sa.make_url(database_url)
+        engine = sa.create_engine(
+            url.set(database="postgres", drivername="postgresql+psycopg"),
+            connect_args={"connect_timeout": 10},
+        )
+        try:
+            with engine.connect() as conn:
+                return bool(
+                    conn.execute(
+                        sa.text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
+                        {"db_name": url.database},
+                    ).scalar()
+                )
+        except Exception:
+            # Cannot tell; let the caller surface its original failure.
+            return True
+        finally:
+            engine.dispose()
+
+    @staticmethod
+    def _reset_system_database(
+        database_url: str, *, truncate: bool = False, schema: Optional[str] = None
+    ) -> None:
+        """Reset the PostgreSQL system database by dropping it, or by emptying its tables."""
         system_db_url = sa.make_url(database_url)
         sysdb_name = system_db_url.database
 
         if sysdb_name is None:
             raise ValueError(f"System database name not found in URL {system_db_url}")
+
+        if truncate:
+            PostgresSystemDatabase._truncate_system_database(
+                database_url, schema if schema else "dbos"
+            )
+            return
 
         try:
             # Connect to postgres default database

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -133,10 +133,10 @@ class PostgresSystemDatabase(SystemDatabase):
         """Empty every DBOS table in the system database, leaving the schema intact.
 
         dbos_migrations is spared: clearing it would re-run applied migrations."""
-        engine = sa.create_engine(
-            sa.make_url(database_url).set(drivername="postgresql+psycopg"),
-            connect_args={"connect_timeout": 10},
-        )
+        url = sa.make_url(database_url)
+        if not url.drivername.startswith("cockroachdb"):
+            url = url.set(drivername="postgresql+psycopg")
+        engine = sa.create_engine(url, connect_args={"connect_timeout": 10})
         try:
             with engine.begin() as conn:
                 tables = [
@@ -151,9 +151,7 @@ class PostgresSystemDatabase(SystemDatabase):
                 ]
                 if tables:
                     targets = ", ".join(f'"{schema}"."{table}"' for table in tables)
-                    conn.execute(
-                        sa.text(f"TRUNCATE TABLE {targets} RESTART IDENTITY CASCADE")
-                    )
+                    conn.execute(sa.text(f"TRUNCATE TABLE {targets} CASCADE"))
         except OperationalError:
             # An absent database holds no state, but the failure carries no SQLSTATE.
             if PostgresSystemDatabase._database_exists(database_url):

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -152,7 +152,9 @@ class PostgresSystemDatabase(SystemDatabase):
                         )
                     )
             except Exception as e:
-                dbos_logger.debug(f"Could not evict connections before truncating: {e}")
+                dbos_logger.warning(
+                    f"Could not evict connections before truncating: {e}"
+                )
             with engine.begin() as conn:
                 tables = [
                     table

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -132,9 +132,7 @@ class PostgresSystemDatabase(SystemDatabase):
     def _truncate_system_database(database_url: str, schema: str) -> None:
         """Empty every DBOS table in the system database, leaving the schema intact.
 
-        dbos_migrations is preserved: it records the schema version, so clearing it
-        would send the next launch through migrations the tables already have.
-        """
+        dbos_migrations is spared: clearing it would re-run applied migrations."""
         engine = sa.create_engine(
             sa.make_url(database_url).set(drivername="postgresql+psycopg"),
             connect_args={"connect_timeout": 10},
@@ -157,8 +155,7 @@ class PostgresSystemDatabase(SystemDatabase):
                         sa.text(f"TRUNCATE TABLE {targets} RESTART IDENTITY CASCADE")
                     )
         except OperationalError:
-            # An absent system database holds no state to reset. Connection failures
-            # carry no SQLSTATE, so ask the server whether the database is there.
+            # An absent database holds no state, but the failure carries no SQLSTATE.
             if PostgresSystemDatabase._database_exists(database_url):
                 raise
             dbos_logger.info(

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, cast
 import psycopg
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import DBAPIError, OperationalError
+from sqlalchemy.exc import DBAPIError
 
 from dbos._migration import ensure_dbos_schema, run_dbos_migrations, should_migrate
 
@@ -171,35 +171,6 @@ class PostgresSystemDatabase(SystemDatabase):
                 # For small test tables, DELETE is far faster than TRUNCATE
                 for table in tables:
                     conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
-        except OperationalError:
-            # An absent database holds no state, but the failure carries no SQLSTATE.
-            if PostgresSystemDatabase._database_exists(database_url):
-                raise
-            dbos_logger.info(
-                f"System database {sa.make_url(database_url).database} does not exist, nothing to reset"
-            )
-        finally:
-            engine.dispose()
-
-    @staticmethod
-    def _database_exists(database_url: str) -> bool:
-        """Whether the database named in the URL exists, per the postgres database."""
-        url = sa.make_url(database_url)
-        engine = sa.create_engine(
-            url.set(database="postgres", drivername="postgresql+psycopg"),
-            connect_args={"connect_timeout": 10},
-        )
-        try:
-            with engine.connect() as conn:
-                return bool(
-                    conn.execute(
-                        sa.text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
-                        {"db_name": url.database},
-                    ).scalar()
-                )
-        except Exception:
-            # Cannot tell; let the caller surface its original failure.
-            return True
         finally:
             engine.dispose()
 

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -37,34 +37,30 @@ class PostgresSystemDatabase(SystemDatabase):
         """Run PostgreSQL-specific migrations."""
         system_db_url = self.engine.url
         sysdb_name = system_db_url.database
-        # Validate the engine can connect. Reaching for the postgres database to
-        # check existence first would cost a second connection on every launch, so
-        # only go there when this connection failed on the database being absent.
-        try:
-            with self.engine.connect() as conn:
-                conn.execute(sa.text("SELECT 1"))
-        except OperationalError as e:
-            if (
-                not self.created_engine
-                or f'database "{sysdb_name}" does not exist' not in str(e.orig)
-            ):
-                raise
-            assert sysdb_name is not None
-            engine = sa.create_engine(
-                system_db_url.set(database="postgres"), **self._engine_kwargs
-            )
+        # Unless we were provided an engine, if the system database does not already exist, create it
+        if self.created_engine:
             try:
+                engine = sa.create_engine(
+                    system_db_url.set(database="postgres"), **self._engine_kwargs
+                )
                 with engine.connect() as conn:
                     conn.execution_options(isolation_level="AUTOCOMMIT")
-                    dbos_logger.info(f"Creating system database {sysdb_name}")
-                    conn.execute(sa.text(f'CREATE DATABASE "{sysdb_name}"'))
+                    if not conn.execute(
+                        sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
+                        parameters={"db_name": sysdb_name},
+                    ).scalar():
+                        dbos_logger.info(f"Creating system database {sysdb_name}")
+                        conn.execute(sa.text(f'CREATE DATABASE "{sysdb_name}"'))
             except Exception:
-                # Tolerate a role that cannot create, or a concurrent launch that won.
                 dbos_logger.warning(
-                    f"Could not create system database {sysdb_name}. Continuing..."
+                    f"Could not connect to postgres database to verify existence of {sysdb_name}. Continuing..."
                 )
             finally:
                 engine.dispose()
+        else:
+            # If we were provided an engine, validate it can connect
+            with self.engine.connect() as conn:
+                conn.execute(sa.text("SELECT 1"))
 
         assert self.schema
         # Skip the advisory lock and migration work entirely if the schema

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -17,6 +17,10 @@ from ._sys_db import (
     _dbos_workflow_events_channel,
 )
 
+# TRUNCATE rewrites a file per table and per index at a flat cost, which DELETE only
+# overtakes around 15k rows on this schema. Below this, empty a table row by row.
+_TRUNCATE_ROW_THRESHOLD = 10_000
+
 
 class PostgresSystemDatabase(SystemDatabase):
     """PostgreSQL-specific implementation of SystemDatabase."""
@@ -163,8 +167,22 @@ class PostgresSystemDatabase(SystemDatabase):
                     if table != "dbos_migrations"
                 ]
                 if tables:
-                    targets = ", ".join(f'"{schema}"."{table}"' for table in tables)
-                    conn.execute(sa.text(f"TRUNCATE TABLE {targets} CASCADE"))
+                    # Count each table in one round trip, capped so a huge table is cheap.
+                    probe = ", ".join(
+                        f'(SELECT count(*) FROM (SELECT 1 FROM "{schema}"."{table}" '
+                        f"LIMIT {_TRUNCATE_ROW_THRESHOLD + 1}) s)"
+                        for table in tables
+                    )
+                    counts = conn.execute(sa.text(f"SELECT {probe}")).one()
+                    bulky = []
+                    for table, rows in zip(tables, counts):
+                        if rows > _TRUNCATE_ROW_THRESHOLD:
+                            bulky.append(table)
+                        elif rows:
+                            conn.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
+                    if bulky:
+                        targets = ", ".join(f'"{schema}"."{table}"' for table in bulky)
+                        conn.execute(sa.text(f"TRUNCATE TABLE {targets} CASCADE"))
         except OperationalError:
             # An absent database holds no state, but the failure carries no SQLSTATE.
             if PostgresSystemDatabase._database_exists(database_url):

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -37,30 +37,34 @@ class PostgresSystemDatabase(SystemDatabase):
         """Run PostgreSQL-specific migrations."""
         system_db_url = self.engine.url
         sysdb_name = system_db_url.database
-        # Unless we were provided an engine, if the system database does not already exist, create it
-        if self.created_engine:
+        # Validate the engine can connect. Reaching for the postgres database to
+        # check existence first would cost a second connection on every launch, so
+        # only go there when this connection failed on the database being absent.
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(sa.text("SELECT 1"))
+        except OperationalError as e:
+            if (
+                not self.created_engine
+                or f'database "{sysdb_name}" does not exist' not in str(e.orig)
+            ):
+                raise
+            assert sysdb_name is not None
+            engine = sa.create_engine(
+                system_db_url.set(database="postgres"), **self._engine_kwargs
+            )
             try:
-                engine = sa.create_engine(
-                    system_db_url.set(database="postgres"), **self._engine_kwargs
-                )
                 with engine.connect() as conn:
                     conn.execution_options(isolation_level="AUTOCOMMIT")
-                    if not conn.execute(
-                        sa.text("SELECT 1 FROM pg_database WHERE datname=:db_name"),
-                        parameters={"db_name": sysdb_name},
-                    ).scalar():
-                        dbos_logger.info(f"Creating system database {sysdb_name}")
-                        conn.execute(sa.text(f'CREATE DATABASE "{sysdb_name}"'))
+                    dbos_logger.info(f"Creating system database {sysdb_name}")
+                    conn.execute(sa.text(f'CREATE DATABASE "{sysdb_name}"'))
             except Exception:
+                # Tolerate a role that cannot create, or a concurrent launch that won.
                 dbos_logger.warning(
-                    f"Could not connect to postgres database to verify existence of {sysdb_name}. Continuing..."
+                    f"Could not create system database {sysdb_name}. Continuing..."
                 )
             finally:
                 engine.dispose()
-        else:
-            # If we were provided an engine, validate it can connect
-            with self.engine.connect() as conn:
-                conn.execute(sa.text("SELECT 1"))
 
         assert self.schema
         # Skip the advisory lock and migration work entirely if the schema

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -133,9 +133,7 @@ class PostgresSystemDatabase(SystemDatabase):
         """Empty every DBOS table in the system database, leaving the schema intact.
 
         dbos_migrations is spared: clearing it would re-run applied migrations."""
-        url = sa.make_url(database_url)
-        if not url.drivername.startswith("cockroachdb"):
-            url = url.set(drivername="postgresql+psycopg")
+        url = sa.make_url(database_url).set(drivername="postgresql+psycopg")
         engine = sa.create_engine(url, connect_args={"connect_timeout": 10})
         try:
             try:

--- a/dbos/_sys_db_postgres.py
+++ b/dbos/_sys_db_postgres.py
@@ -133,7 +133,11 @@ class PostgresSystemDatabase(SystemDatabase):
         """Empty every DBOS table in the system database, leaving the schema intact.
 
         dbos_migrations is spared: clearing it would re-run applied migrations."""
-        url = sa.make_url(database_url).set(drivername="postgresql+psycopg")
+        # The plain PostgreSQL dialect cannot connect to CockroachDB at all: it
+        # asserts on the server version string. Keep the caller's dialect there.
+        url = sa.make_url(database_url)
+        if not url.drivername.startswith("cockroachdb"):
+            url = url.set(drivername="postgresql+psycopg")
         engine = sa.create_engine(url, connect_args={"connect_timeout": 10})
         try:
             try:

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -141,8 +141,35 @@ class SQLiteSystemDatabase(SystemDatabase):
         return "FOREIGN KEY constraint failed" in str(dbapi_error.orig)
 
     @staticmethod
-    def _reset_system_database(database_url: str) -> None:
-        """Reset the SQLite system database by deleting the database file."""
+    def _truncate_system_database(database_url: str, db_path: str) -> None:
+        """Empty every DBOS table in the system database, leaving the file intact.
+
+        dbos_migrations is preserved: it records the schema version, so clearing it
+        would send the next launch through migrations the tables already have.
+        """
+        if not os.path.exists(db_path):
+            dbos_logger.info(f"SQLite database file does not exist: {db_path}")
+            return
+        engine = sa.create_engine(database_url)
+        try:
+            with engine.begin() as conn:
+                tables = [
+                    table
+                    for table in conn.execute(
+                        sa.text("SELECT name FROM sqlite_master WHERE type='table'")
+                    ).scalars()
+                    if table != "dbos_migrations" and not table.startswith("sqlite_")
+                ]
+                # SQLite has no TRUNCATE, and foreign keys are off by default on a
+                # bare connection, so unordered deletes are safe here.
+                for table in tables:
+                    conn.execute(sa.text(f'DELETE FROM "{table}"'))
+        finally:
+            engine.dispose()
+
+    @staticmethod
+    def _reset_system_database(database_url: str, *, truncate: bool = False) -> None:
+        """Reset the SQLite system database by deleting the file, or by emptying its tables."""
 
         # Parse the SQLite database URL to get the file path
         url = sa.make_url(database_url)
@@ -150,6 +177,10 @@ class SQLiteSystemDatabase(SystemDatabase):
 
         if db_path is None:
             raise ValueError(f"System database path not found in URL {url}")
+
+        if truncate:
+            SQLiteSystemDatabase._truncate_system_database(database_url, db_path)
+            return
 
         try:
             if os.path.exists(db_path):

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -144,9 +144,7 @@ class SQLiteSystemDatabase(SystemDatabase):
     def _truncate_system_database(database_url: str, db_path: str) -> None:
         """Empty every DBOS table in the system database, leaving the file intact.
 
-        dbos_migrations is preserved: it records the schema version, so clearing it
-        would send the next launch through migrations the tables already have.
-        """
+        dbos_migrations is spared: clearing it would re-run applied migrations."""
         if not os.path.exists(db_path):
             dbos_logger.info(f"SQLite database file does not exist: {db_path}")
             return
@@ -160,8 +158,7 @@ class SQLiteSystemDatabase(SystemDatabase):
                     ).scalars()
                     if table != "dbos_migrations" and not table.startswith("sqlite_")
                 ]
-                # SQLite has no TRUNCATE, and foreign keys are off by default on a
-                # bare connection, so unordered deletes are safe here.
+                # SQLite has no TRUNCATE; foreign keys are off here, so order is free.
                 for table in tables:
                     conn.execute(sa.text(f'DELETE FROM "{table}"'))
         finally:

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -169,6 +169,9 @@ class SQLiteSystemDatabase(SystemDatabase):
                 # SQLite has no TRUNCATE; foreign keys are off here, so order is free.
                 for table in tables:
                     conn.execute(sa.text(f'DELETE FROM "{table}"'))
+        except Exception as e:
+            # Best effort, as the Postgres path is: a locked file must not fail the caller.
+            dbos_logger.warning(f"Could not empty system database {db_path}: {e}")
         finally:
             engine.dispose()
 

--- a/dbos/_sys_db_sqlite.py
+++ b/dbos/_sys_db_sqlite.py
@@ -149,6 +149,14 @@ class SQLiteSystemDatabase(SystemDatabase):
             dbos_logger.info(f"SQLite database file does not exist: {db_path}")
             return
         engine = sa.create_engine(database_url)
+
+        @event.listens_for(engine, "connect")
+        def set_sqlite_immediate(dbapi_conn: Any, connection_record: Any) -> None:
+            # As _create_engine does, so a competing writer is waited out rather than
+            # failing at sqlite3's 5s default. Foreign keys stay off: see below.
+            dbapi_conn.isolation_level = "IMMEDIATE"
+            dbapi_conn.execute("PRAGMA busy_timeout=30000")
+
         try:
             with engine.begin() as conn:
                 tables = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,9 +123,7 @@ def db_engine() -> Generator[sa.Engine, Any, None]:
 def _truncate_application_database(application_database_url: str) -> None:
     """Empty every table in the application database, leaving its schemas intact.
 
-    Covers DBOS's own transaction_outputs plus whatever tables tests create, so a
-    workflow ID reused across tests cannot replay a stale transaction output.
-    """
+    Stale transaction_outputs would let a reused workflow ID replay."""
     engine = sa.create_engine(
         sa.make_url(application_database_url).set(drivername="postgresql+psycopg"),
         connect_args={"connect_timeout": 30},
@@ -162,9 +160,7 @@ def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
     names = [str(sa.make_url(url).database) for url in (app_db_url, sys_db_url)]
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
-        # DROP DATABASE ... WITH (FORCE) evicted leaked connections for us, and
-        # truncation needs that too: a thread an earlier test failed to stop can
-        # block TRUNCATE, or write into the database the next test just emptied.
+        # As DROP DATABASE ... WITH (FORCE) did: a leaked thread blocks or defeats TRUNCATE.
         connection.execute(
             sa.text(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
@@ -197,11 +193,7 @@ def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
 def cleanup_test_databases(db_engine: sa.Engine) -> None:
     """Give the test empty databases, without dropping them.
 
-    Truncating is several times faster than dropping, because the next launch
-    finds its schema already migrated. Tests that need the databases or the DBOS
-    schema to be genuinely absent, or that leave a schema truncation cannot
-    repair, must use drop_test_databases instead.
-    """
+    Tests needing them genuinely absent must use drop_test_databases instead."""
     _reset_test_databases(db_engine, drop=False)
 
 
@@ -209,11 +201,7 @@ def cleanup_test_databases(db_engine: sa.Engine) -> None:
 def drop_test_databases(db_engine: sa.Engine) -> Generator[None, Any, None]:
     """cleanup_test_databases, but dropping the databases outright.
 
-    For tests that need the databases (or the DBOS schema inside them) to not
-    exist, that must exercise a from-scratch migration, or that leave behind a
-    schema truncation cannot repair. Drops on both sides, so neither this test
-    nor the next one inherits the damage.
-    """
+    Drops on both sides, so damage escapes into neither test."""
     _reset_test_databases(db_engine, drop=True)
     yield
     _reset_test_databases(db_engine, drop=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,43 +120,24 @@ def db_engine() -> Generator[sa.Engine, Any, None]:
     engine.dispose()
 
 
-def _clear_dbos_env_vars() -> None:
-    os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None
-    os.environ.pop("DBOS__APPVERSION") if "DBOS__APPVERSION" in os.environ else None
-    os.environ.pop("DBOS__APPID") if "DBOS__APPID" in os.environ else None
-
-
-def _truncate_application_database(
-    application_database_url: str, db_engine: sa.Engine
-) -> None:
+def _truncate_application_database(application_database_url: str) -> None:
     """Empty every table in the application database, leaving its schemas intact.
 
     Covers DBOS's own transaction_outputs plus whatever tables tests create, so a
     workflow ID reused across tests cannot replay a stale transaction output.
     """
-    app_db_name = sa.make_url(application_database_url).database
-    with db_engine.connect() as connection:
-        if not connection.execute(
-            sa.text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
-            {"db_name": app_db_name},
-        ).scalar():
-            # An absent application database holds no state to reset.
-            return
-
     engine = sa.create_engine(
         sa.make_url(application_database_url).set(drivername="postgresql+psycopg"),
         connect_args={"connect_timeout": 30},
     )
     try:
         with engine.begin() as connection:
-            tables = list(
-                connection.execute(
-                    sa.text(
-                        "SELECT schemaname, tablename FROM pg_tables "
-                        "WHERE schemaname NOT IN ('pg_catalog', 'information_schema')"
-                    )
+            tables = connection.execute(
+                sa.text(
+                    "SELECT schemaname, tablename FROM pg_tables "
+                    "WHERE schemaname NOT IN ('pg_catalog', 'information_schema')"
                 )
-            )
+            ).all()
             if tables:
                 targets = ", ".join(f'"{schema}"."{table}"' for schema, table in tables)
                 connection.execute(
@@ -166,37 +147,54 @@ def _truncate_application_database(
         engine.dispose()
 
 
-def _terminate_connections(db_names: Tuple[str, ...], db_engine: sa.Engine) -> None:
-    """Evict anything still connected to the test databases.
+def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
+    """Hand the test empty shared databases, by dropping them or by emptying them."""
+    # Stop any DBOS an earlier test left running before touching its databases.
+    DBOS.destroy(destroy_registry=True)
+    for var in ("DBOS__VMID", "DBOS__APPVERSION", "DBOS__APPID"):
+        os.environ.pop(var, None)
 
-    DROP DATABASE ... WITH (FORCE) used to do this for us. Truncation needs it too:
-    a thread an earlier test failed to stop can hold locks that block TRUNCATE, or
-    write rows into the database the next test just emptied.
-    """
+    # SQLite needs no reset here: sqlite_path is a fresh file per test.
+    if using_sqlite():
+        return
+
+    app_db_url, sys_db_url = postgres_urls()
+    names = [str(sa.make_url(url).database) for url in (app_db_url, sys_db_url)]
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
+        # DROP DATABASE ... WITH (FORCE) evicted leaked connections for us, and
+        # truncation needs that too: a thread an earlier test failed to stop can
+        # block TRUNCATE, or write into the database the next test just emptied.
         connection.execute(
             sa.text(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                "WHERE datname = ANY(:db_names) AND pid <> pg_backend_pid()"
+                "WHERE datname = ANY(:names) AND pid <> pg_backend_pid()"
             ),
-            {"db_names": list(db_names)},
+            {"names": names},
+        )
+        if drop:
+            for name in names:
+                connection.execute(
+                    sa.text(f"DROP DATABASE IF EXISTS {name} WITH (FORCE)")
+                )
+            return
+        # An absent database holds no state to empty, and connecting to one errors.
+        present = set(
+            connection.execute(
+                sa.text("SELECT datname FROM pg_database WHERE datname = ANY(:names)"),
+                {"names": names},
+            ).scalars()
         )
 
-
-def _drop_databases(db_names: Tuple[str, ...], db_engine: sa.Engine) -> None:
-    if not db_names:
-        return
-    with db_engine.connect() as connection:
-        connection.execution_options(isolation_level="AUTOCOMMIT")
-        for db_name in db_names:
-            connection.execute(
-                sa.text(f"DROP DATABASE IF EXISTS {db_name} WITH (FORCE)")
-            )
+    app_db_name, sys_db_name = names
+    if sys_db_name in present:
+        SystemDatabase.reset_system_database(sys_db_url, truncate=True)
+    if app_db_name in present:
+        _truncate_application_database(app_db_url)
 
 
 @pytest.fixture()
-def cleanup_test_databases(config: DBOSConfig, db_engine: sa.Engine) -> None:
+def cleanup_test_databases(db_engine: sa.Engine) -> None:
     """Give the test empty databases, without dropping them.
 
     Truncating is several times faster than dropping, because the next launch
@@ -204,35 +202,11 @@ def cleanup_test_databases(config: DBOSConfig, db_engine: sa.Engine) -> None:
     schema to be genuinely absent, or that leave a schema truncation cannot
     repair, must use drop_test_databases instead.
     """
-    assert config["application_database_url"] is not None
-    assert config["system_database_url"] is not None
-
-    # Stop any DBOS an earlier test left running before emptying its database.
-    DBOS.destroy(destroy_registry=True)
-
-    # SQLite needs no reset here: sqlite_path is a fresh file per test.
-    if not using_sqlite():
-        app_db_url = config["application_database_url"]
-        sys_db_url = config["system_database_url"]
-        _terminate_connections(
-            (
-                str(sa.make_url(app_db_url).database),
-                str(sa.make_url(sys_db_url).database),
-            ),
-            db_engine,
-        )
-        SystemDatabase.reset_system_database(
-            sys_db_url, truncate=True, schema=config.get("dbos_system_schema")
-        )
-        _truncate_application_database(app_db_url, db_engine)
-
-    _clear_dbos_env_vars()
+    _reset_test_databases(db_engine, drop=False)
 
 
 @pytest.fixture()
-def drop_test_databases(
-    config: DBOSConfig, db_engine: sa.Engine
-) -> Generator[None, Any, None]:
+def drop_test_databases(db_engine: sa.Engine) -> Generator[None, Any, None]:
     """cleanup_test_databases, but dropping the databases outright.
 
     For tests that need the databases (or the DBOS schema inside them) to not
@@ -240,31 +214,9 @@ def drop_test_databases(
     schema truncation cannot repair. Drops on both sides, so neither this test
     nor the next one inherits the damage.
     """
-    assert config["application_database_url"] is not None
-    assert config["system_database_url"] is not None
-    # Named up front, since tests are free to repoint config elsewhere.
-    # SQLite needs no drop here: sqlite_path is a fresh file per test.
-    db_names: Tuple[str, ...] = (
-        ()
-        if using_sqlite()
-        else tuple(
-            name
-            for name in (
-                sa.make_url(config["application_database_url"]).database,
-                sa.make_url(config["system_database_url"]).database,
-            )
-            if name is not None
-        )
-    )
-
-    DBOS.destroy(destroy_registry=True)
-    _drop_databases(db_names, db_engine)
-    _clear_dbos_env_vars()
-
+    _reset_test_databases(db_engine, drop=True)
     yield
-
-    DBOS.destroy(destroy_registry=True)
-    _drop_databases(db_names, db_engine)
+    _reset_test_databases(db_engine, drop=True)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, InMemoryLogE
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from dbos import DBOS, DBOSClient, DBOSConfig
+from dbos import DBOS, DBOSClient, DBOSConfig, run_dbos_database_migrations
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import SystemDatabase
 from dbos._sys_db_postgres import PostgresSystemDatabase
@@ -208,6 +208,37 @@ def drop_test_databases(db_engine: sa.Engine) -> Generator[None, Any, None]:
     _reset_test_databases(db_engine, drop=True)
     yield
     _reset_test_databases(db_engine, drop=True)
+
+
+@pytest.fixture()
+def migrated_system_database(db_engine: sa.Engine) -> None:
+    """cleanup_test_databases, but the system database is left present and migrated.
+
+    For tests running SQL directly instead of launching DBOS: a preceding
+    drop_test_databases test leaves the shared databases absent."""
+    _reset_test_databases(db_engine, drop=False)
+    if not using_sqlite():
+        run_dbos_database_migrations(postgres_urls()[1])
+
+
+def ensure_application_database() -> None:
+    """Create the shared application database if a drop_test_databases test removed it.
+
+    For tests connecting to it directly, which DBOS is not there to recreate it for."""
+    url = sa.make_url(postgres_urls()[0]).set(drivername="postgresql+psycopg")
+    engine = sa.create_engine(
+        url.set(database="postgres"), connect_args={"connect_timeout": 30}
+    )
+    try:
+        with engine.connect() as connection:
+            connection.execution_options(isolation_level="AUTOCOMMIT")
+            if not connection.execute(
+                sa.text("SELECT 1 FROM pg_database WHERE datname = :name"),
+                {"name": url.database},
+            ).scalar():
+                connection.execute(sa.text(f'CREATE DATABASE "{url.database}"'))
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,33 +120,151 @@ def db_engine() -> Generator[sa.Engine, Any, None]:
     engine.dispose()
 
 
+def _clear_dbos_env_vars() -> None:
+    os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None
+    os.environ.pop("DBOS__APPVERSION") if "DBOS__APPVERSION" in os.environ else None
+    os.environ.pop("DBOS__APPID") if "DBOS__APPID" in os.environ else None
+
+
+def _truncate_application_database(
+    application_database_url: str, db_engine: sa.Engine
+) -> None:
+    """Empty every table in the application database, leaving its schemas intact.
+
+    Covers DBOS's own transaction_outputs plus whatever tables tests create, so a
+    workflow ID reused across tests cannot replay a stale transaction output.
+    """
+    app_db_name = sa.make_url(application_database_url).database
+    with db_engine.connect() as connection:
+        if not connection.execute(
+            sa.text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
+            {"db_name": app_db_name},
+        ).scalar():
+            # An absent application database holds no state to reset.
+            return
+
+    engine = sa.create_engine(
+        sa.make_url(application_database_url).set(drivername="postgresql+psycopg"),
+        connect_args={"connect_timeout": 30},
+    )
+    try:
+        with engine.begin() as connection:
+            tables = list(
+                connection.execute(
+                    sa.text(
+                        "SELECT schemaname, tablename FROM pg_tables "
+                        "WHERE schemaname NOT IN ('pg_catalog', 'information_schema')"
+                    )
+                )
+            )
+            if tables:
+                targets = ", ".join(f'"{schema}"."{table}"' for schema, table in tables)
+                connection.execute(
+                    sa.text(f"TRUNCATE TABLE {targets} RESTART IDENTITY CASCADE")
+                )
+    finally:
+        engine.dispose()
+
+
+def _terminate_connections(db_names: Tuple[str, ...], db_engine: sa.Engine) -> None:
+    """Evict anything still connected to the test databases.
+
+    DROP DATABASE ... WITH (FORCE) used to do this for us. Truncation needs it too:
+    a thread an earlier test failed to stop can hold locks that block TRUNCATE, or
+    write rows into the database the next test just emptied.
+    """
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(
+            sa.text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = ANY(:db_names) AND pid <> pg_backend_pid()"
+            ),
+            {"db_names": list(db_names)},
+        )
+
+
+def _drop_databases(db_names: Tuple[str, ...], db_engine: sa.Engine) -> None:
+    if not db_names:
+        return
+    with db_engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        for db_name in db_names:
+            connection.execute(
+                sa.text(f"DROP DATABASE IF EXISTS {db_name} WITH (FORCE)")
+            )
+
+
 @pytest.fixture()
 def cleanup_test_databases(config: DBOSConfig, db_engine: sa.Engine) -> None:
+    """Give the test empty databases, without dropping them.
+
+    Truncating is several times faster than dropping, because the next launch
+    finds its schema already migrated. Tests that need the databases or the DBOS
+    schema to be genuinely absent, or that leave a schema truncation cannot
+    repair, must use drop_test_databases instead.
+    """
     assert config["application_database_url"] is not None
     assert config["system_database_url"] is not None
 
-    # Stop any DBOS an earlier test left running before dropping its database.
+    # Stop any DBOS an earlier test left running before emptying its database.
     DBOS.destroy(destroy_registry=True)
 
     # SQLite needs no reset here: sqlite_path is a fresh file per test.
     if not using_sqlite():
-        # For PostgreSQL, drop the databases
-        app_db_name = sa.make_url(config["application_database_url"]).database
-        sys_db_name = sa.make_url(config["system_database_url"]).database
+        app_db_url = config["application_database_url"]
+        sys_db_url = config["system_database_url"]
+        _terminate_connections(
+            (
+                str(sa.make_url(app_db_url).database),
+                str(sa.make_url(sys_db_url).database),
+            ),
+            db_engine,
+        )
+        SystemDatabase.reset_system_database(
+            sys_db_url, truncate=True, schema=config.get("dbos_system_schema")
+        )
+        _truncate_application_database(app_db_url, db_engine)
 
-        with db_engine.connect() as connection:
-            connection.execution_options(isolation_level="AUTOCOMMIT")
-            connection.execute(
-                sa.text(f"DROP DATABASE IF EXISTS {app_db_name} WITH (FORCE)")
-            )
-            connection.execute(
-                sa.text(f"DROP DATABASE IF EXISTS {sys_db_name} WITH (FORCE)")
-            )
+    _clear_dbos_env_vars()
 
-    # Clean up environment variables
-    os.environ.pop("DBOS__VMID") if "DBOS__VMID" in os.environ else None
-    os.environ.pop("DBOS__APPVERSION") if "DBOS__APPVERSION" in os.environ else None
-    os.environ.pop("DBOS__APPID") if "DBOS__APPID" in os.environ else None
+
+@pytest.fixture()
+def drop_test_databases(
+    config: DBOSConfig, db_engine: sa.Engine
+) -> Generator[None, Any, None]:
+    """cleanup_test_databases, but dropping the databases outright.
+
+    For tests that need the databases (or the DBOS schema inside them) to not
+    exist, that must exercise a from-scratch migration, or that leave behind a
+    schema truncation cannot repair. Drops on both sides, so neither this test
+    nor the next one inherits the damage.
+    """
+    assert config["application_database_url"] is not None
+    assert config["system_database_url"] is not None
+    # Named up front, since tests are free to repoint config elsewhere.
+    # SQLite needs no drop here: sqlite_path is a fresh file per test.
+    db_names: Tuple[str, ...] = (
+        ()
+        if using_sqlite()
+        else tuple(
+            name
+            for name in (
+                sa.make_url(config["application_database_url"]).database,
+                sa.make_url(config["system_database_url"]).database,
+            )
+            if name is not None
+        )
+    )
+
+    DBOS.destroy(destroy_registry=True)
+    _drop_databases(db_names, db_engine)
+    _clear_dbos_env_vars()
+
+    yield
+
+    DBOS.destroy(destroy_registry=True)
+    _drop_databases(db_names, db_engine)
 
 
 @pytest.fixture()
@@ -160,6 +278,18 @@ def dbos(
     #     launch themselves.
     # If your test is tricky and has a problem with this, use a different
     #   fixture that does not launch.
+    dbos = DBOS(config=config)
+    DBOS.launch()
+
+    yield dbos
+    DBOS.destroy(destroy_registry=True)
+
+
+@pytest.fixture()
+def dbos_dropped_databases(
+    config: DBOSConfig, drop_test_databases: None
+) -> Generator[DBOS, Any, None]:
+    """The dbos fixture on dropped databases, so launch migrates from scratch."""
     dbos = DBOS(config=config)
     DBOS.launch()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,14 @@ def _truncate_application_database(application_database_url: str) -> None:
     )
     try:
         with engine.begin() as connection:
+            # As the system database truncate does: a leaked lock would block the TRUNCATE.
+            connection.execute(
+                sa.text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+                )
+            )
+        with engine.begin() as connection:
             tables = connection.execute(
                 sa.text(
                     "SELECT schemaname, tablename FROM pg_tables "
@@ -164,14 +172,6 @@ def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
     names = [str(sa.make_url(url).database) for url in (app_db_url, sys_db_url)]
     with db_engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
-        # As DROP DATABASE ... WITH (FORCE) did: a leaked thread blocks or defeats TRUNCATE.
-        connection.execute(
-            sa.text(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                "WHERE datname = ANY(:names) AND pid <> pg_backend_pid()"
-            ),
-            {"names": names},
-        )
         if drop:
             for name in names:
                 connection.execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,10 @@ def _truncate_application_database(application_database_url: str) -> None:
         engine.dispose()
 
 
+# Whether this session has dropped the shared databases yet.
+_databases_dropped = False
+
+
 def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
     """Hand the test empty shared databases, by dropping them or by emptying them."""
     # Stop any DBOS an earlier test left running before touching its databases.
@@ -166,6 +170,13 @@ def _reset_test_databases(db_engine: sa.Engine, *, drop: bool) -> None:
     # SQLite needs no reset here: sqlite_path is a fresh file per test.
     if using_sqlite():
         return
+
+    # A run killed mid-test can leave the schema half-migrated, which truncation
+    # spares and the next launch then fails on. One drop per session repairs it.
+    global _databases_dropped
+    if not _databases_dropped:
+        _databases_dropped = True
+        drop = True
 
     app_db_url, sys_db_url = postgres_urls()
     names = [str(sa.make_url(url).database) for url in (app_db_url, sys_db_url)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def _truncate_application_database(application_database_url: str) -> None:
     )
     try:
         with engine.begin() as connection:
-            # As the system database truncate does: a leaked lock would block the TRUNCATE.
+            # As the system database reset does: a leaked writer's locks block these deletes.
             connection.execute(
                 sa.text(
                     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
@@ -148,11 +148,10 @@ def _truncate_application_database(application_database_url: str) -> None:
                     "WHERE schemaname NOT IN ('pg_catalog', 'information_schema')"
                 )
             ).all()
-            if tables:
-                targets = ", ".join(f'"{schema}"."{table}"' for schema, table in tables)
-                connection.execute(
-                    sa.text(f"TRUNCATE TABLE {targets} RESTART IDENTITY CASCADE")
-                )
+            # Test tables hold a handful of rows and no foreign keys, so unordered
+            # deletes are both correct and far cheaper than TRUNCATE's file rewrite.
+            for schema, table in tables:
+                connection.execute(sa.text(f'DELETE FROM "{schema}"."{table}"'))
     finally:
         engine.dispose()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,10 @@ def default_config(sqlite_path: Path) -> DBOSConfig:
         ),
         "enable_otlp": False,
         "notification_listener_polling_interval_sec": 0.01,
+        # Kafka consumers enqueue onto the internal queues, whose 1s default poll
+        # otherwise dominates every consumer test. Tests asserting on that default
+        # pop this key.
+        "kafka_queue_polling_interval_sec": 0.05,
     }
 
 

--- a/tests/test_cockroachdb.py
+++ b/tests/test_cockroachdb.py
@@ -186,8 +186,7 @@ def test_cockroachdb_reset_truncate() -> None:
         assert len(DBOS.list_workflows()) == 1
         DBOS.destroy()
 
-        # CockroachDB's TRUNCATE accepts no RESTART IDENTITY, so a Postgres-only
-        # statement would fail here rather than empty the tables.
+        # Truncation must empty the tables using only SQL CockroachDB accepts.
         DBOS(config=config)
         DBOS.reset_system_database(truncate=True)
 

--- a/tests/test_cockroachdb.py
+++ b/tests/test_cockroachdb.py
@@ -172,11 +172,14 @@ def test_cockroachdb_reset_truncate() -> None:
         DBOS.set_event("key", "value")
         return DBOS.workflow_id
 
+    sys_db_engine = create_engine(test_url)
+    # A second engine for the post-truncation read: truncation evicts the pool above.
+    check_engine = create_engine(test_url)
     config: DBOSConfig = {
         "name": "cockroachdb-truncate-test",
         "system_database_url": test_url,
         "use_listen_notify": False,
-        "system_database_engine": create_engine(test_url),
+        "system_database_engine": sys_db_engine,
     }
     try:
         DBOS(config=config)
@@ -191,7 +194,7 @@ def test_cockroachdb_reset_truncate() -> None:
         DBOS.reset_system_database(truncate=True)
 
         # The database survives, fully migrated, so the relaunch runs no migrations
-        with create_engine(test_url).connect() as conn:
+        with check_engine.connect() as conn:
             assert (
                 conn.execute(
                     text(f"SELECT count(*) FROM {db_name}.dbos.workflow_status")
@@ -203,3 +206,10 @@ def test_cockroachdb_reset_truncate() -> None:
         assert DBOS.get_event(workflow_id, "key", timeout_seconds=0) is None
     finally:
         DBOS.destroy(destroy_registry=True)
+        # DBOS never disposes an engine it was handed, and no fixture knows this database.
+        sys_db_engine.dispose()
+        check_engine.dispose()
+        cleanup_engine = create_engine(database_url, isolation_level="AUTOCOMMIT")
+        with cleanup_engine.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS {db_name} CASCADE"))
+        cleanup_engine.dispose()

--- a/tests/test_cockroachdb.py
+++ b/tests/test_cockroachdb.py
@@ -149,3 +149,58 @@ def test_cockroachdb_fork() -> None:
         assert any(w.workflow_id == forked.workflow_id for w in not_forked_from_list)
     finally:
         DBOS.destroy(destroy_registry=True)
+
+
+def test_cockroachdb_reset_truncate() -> None:
+    database_url = os.environ.get("DBOS_COCKROACHDB_URL")
+    if database_url is None:
+        pytest.skip("No CockroachDB database URL provided")
+
+    db_name = "dbos_test_truncate"
+    default_engine = create_engine(database_url, isolation_level="AUTOCOMMIT")
+    with default_engine.connect() as conn:
+        conn.execute(text(f"DROP DATABASE IF EXISTS {db_name} CASCADE"))
+        conn.execute(text(f"CREATE DATABASE {db_name}"))
+    default_engine.dispose()
+
+    parsed = urlparse(database_url)
+    test_url = urlunparse(parsed._replace(path=f"/{db_name}"))
+
+    @DBOS.workflow()
+    def workflow() -> str:
+        assert DBOS.workflow_id
+        DBOS.set_event("key", "value")
+        return DBOS.workflow_id
+
+    config: DBOSConfig = {
+        "name": "cockroachdb-truncate-test",
+        "system_database_url": test_url,
+        "use_listen_notify": False,
+        "system_database_engine": create_engine(test_url),
+    }
+    try:
+        DBOS(config=config)
+        DBOS.launch()
+        workflow_id = workflow()
+        assert DBOS.get_event(workflow_id, "key") == "value"
+        assert len(DBOS.list_workflows()) == 1
+        DBOS.destroy()
+
+        # CockroachDB's TRUNCATE accepts no RESTART IDENTITY, so a Postgres-only
+        # statement would fail here rather than empty the tables.
+        DBOS(config=config)
+        DBOS.reset_system_database(truncate=True)
+
+        # The database survives, fully migrated, so the relaunch runs no migrations
+        with create_engine(test_url).connect() as conn:
+            assert (
+                conn.execute(
+                    text(f"SELECT count(*) FROM {db_name}.dbos.workflow_status")
+                ).scalar()
+                == 0
+            )
+        DBOS.launch()
+        assert DBOS.list_workflows() == []
+        assert DBOS.get_event(workflow_id, "key", timeout_seconds=0) is None
+    finally:
+        DBOS.destroy(destroy_registry=True)

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -19,7 +19,7 @@ from dbos._datasource_sqlite import SqliteAsyncDatasource, SqliteSyncDatasource
 from dbos._error import DBOSException
 from dbos._schemas.datasource_database import DatasourceSchema
 from dbos._schemas.system_database import SystemSchema
-from tests.conftest import postgres_urls
+from tests.conftest import ensure_application_database, postgres_urls
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -28,8 +28,12 @@ from tests.conftest import postgres_urls
 
 def _skip_if_pg_unreachable(raw_pg_url: str) -> None:
     try:
+        # Probe the maintenance database: the shared application database may have
+        # been dropped by a drop_test_databases test, which is not unreachability.
         engine = sa.create_engine(
-            sa.make_url(raw_pg_url).set(drivername="postgresql+psycopg"),
+            sa.make_url(raw_pg_url)
+            .set(drivername="postgresql+psycopg")
+            .set(database="postgres"),
             connect_args={"connect_timeout": 3},
         )
         with engine.connect():
@@ -112,6 +116,7 @@ def sync_ds(
         if not url.startswith("postgresql"):
             pytest.skip("not a PostgreSQL environment")
         _skip_if_pg_unreachable(url)
+        ensure_application_database()
         schema = f"ds_test_{uuid.uuid4().hex[:8]}"
         ds = SQLAlchemyDatasource.create(
             url.replace("postgresql://", "postgresql+psycopg://"), schema=schema
@@ -138,6 +143,7 @@ async def async_ds(
         if not url.startswith("postgresql"):
             pytest.skip("not a PostgreSQL environment")
         _skip_if_pg_unreachable(url)
+        ensure_application_database()
         schema = f"ds_test_{uuid.uuid4().hex[:8]}"
         ds = await AsyncSQLAlchemyDatasource.create(
             url.replace("postgresql://", "postgresql+psycopg://"), schema=schema

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2583,8 +2583,9 @@ def test_custom_database(
 
 
 def test_custom_schema(
-    config: DBOSConfig, cleanup_test_databases: None, skip_with_sqlite: None
+    config: DBOSConfig, drop_test_databases: None, skip_with_sqlite: None
 ) -> None:
+    # Needs a dropped database: it asserts the default "dbos" schema is absent.
     DBOS.destroy(destroy_registry=True)
     config["dbos_system_schema"] = "F8nny_sCHem@-n@m3"
     dbos = DBOS(config=config)
@@ -2641,10 +2642,11 @@ def test_custom_schema(
 
 def test_custom_engine(
     config: DBOSConfig,
-    cleanup_test_databases: None,
+    drop_test_databases: None,
     db_engine: sa.Engine,
     skip_with_sqlite: None,
 ) -> None:
+    # Needs a dropped database: it asserts launch fails before the database exists.
     DBOS.destroy(destroy_registry=True)
     assert config["system_database_url"]
     config["application_database_url"] = None

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2638,6 +2638,8 @@ def test_custom_schema(
     steps = client.list_workflow_steps(handle.workflow_id)
     assert len(steps) == 4
     assert "transaction" in steps[0]["function_name"]
+    # A live client would outlive the teardown drop and reconnect to the next test's database
+    client.destroy()
 
 
 def test_custom_engine(
@@ -2713,6 +2715,7 @@ def test_custom_engine(
     steps = client.list_workflow_steps(handle.workflow_id)
     assert len(steps) == 3
     assert "setEvent" in steps[0]["function_name"]
+    client.destroy()
 
     # Test custom engine with client and no URL
     client = DBOSClient(
@@ -2722,6 +2725,8 @@ def test_custom_engine(
     steps = client.list_workflow_steps(handle.workflow_id)
     assert len(steps) == 3
     assert "setEvent" in steps[0]["function_name"]
+    # A live client would outlive the teardown drop and reconnect to the next test's database
+    client.destroy()
 
 
 def test_get_events(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2727,6 +2727,8 @@ def test_custom_engine(
     assert "setEvent" in steps[0]["function_name"]
     # A live client would outlive the teardown drop and reconnect to the next test's database
     client.destroy()
+    # DBOS never disposes an engine it was handed, so this test owns it
+    engine.dispose()
 
 
 def test_get_events(dbos: DBOS) -> None:

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -38,41 +38,42 @@ from dbos._logger import dbos_logger
 #           CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
 NUM_EVENTS = 3
-# Generous, since an undrained flush is reported as "Kafka not available" and skips the test.
+# Generous, since a broker that is up but slow to drain must not be mistaken for a failure.
 FLUSH_TIMEOUT_SEC = 30
 
 
-def send_test_messages(server: str, topic: str) -> bool:
+def _producer_or_skip(server: str) -> Producer:
+    """A producer for a reachable broker, skipping the test if there is none.
 
+    Only unreachability skips: a broker that fails to deliver is a real failure."""
+
+    def on_error(err: KafkaError) -> NoReturn:
+        raise Exception(err)
+
+    producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
     try:
-
-        def on_error(err: KafkaError) -> NoReturn:
-            raise Exception(err)
-
-        producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
-
-        for i in range(NUM_EVENTS):
-            producer.produce(
-                topic, key=f"test message key {i}", value=f"test message value {i}"
-            )
-
-        # flush() serves delivery callbacks and waits; poll() would only block its full timeout.
-        return producer.flush(FLUSH_TIMEOUT_SEC) == 0
-    except Exception as e:
-        return False
-
-
-def produce_one_message(server: str, topic: str) -> bool:
-    try:
-
-        def on_error(err: KafkaError) -> NoReturn:
-            raise Exception(err)
-
-        producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
-        producer.produce(topic, key=b"offset-loss-key", value=b"offset-loss-value")
-        return producer.flush(FLUSH_TIMEOUT_SEC) == 0
+        producer.list_topics(timeout=10)
     except Exception:
-        return False
+        pytest.skip("Kafka not available")
+    return producer
+
+
+def send_test_messages(server: str, topic: str) -> None:
+    producer = _producer_or_skip(server)
+
+    for i in range(NUM_EVENTS):
+        producer.produce(
+            topic, key=f"test message key {i}", value=f"test message value {i}"
+        )
+
+    # flush() serves delivery callbacks and waits; poll() would only block its full timeout.
+    assert producer.flush(FLUSH_TIMEOUT_SEC) == 0, f"undelivered messages to {topic}"
+
+
+def produce_one_message(server: str, topic: str) -> None:
+    producer = _producer_or_skip(server)
+    producer.produce(topic, key=b"offset-loss-key", value=b"offset-loss-value")
+    assert producer.flush(FLUSH_TIMEOUT_SEC) == 0, f"undelivered message to {topic}"
 
 
 def test_kafka_no_offset_loss_on_relaunch(
@@ -86,8 +87,7 @@ def test_kafka_no_offset_loss_on_relaunch(
     topic = f"dbos-kafka-offsetloss-{suffix}"
     group_id = f"dbos-kafka-offsetloss-{suffix}"
 
-    if not produce_one_message(server, topic):
-        pytest.skip("Kafka not available")
+    produce_one_message(server, topic)
 
     # Wrap the real Consumer that dbos._kafka uses so we can pause inside consume().
     original_consumer_cls = Consumer
@@ -159,8 +159,7 @@ def test_kafka(dbos: DBOS) -> None:
     server = "localhost:9092"
     topic = f"dbos-kafka-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     @DBOS.kafka_consumer(
         {
@@ -191,8 +190,7 @@ def test_kafka_async(dbos: DBOS) -> None:
     server = "localhost:9092"
     topic = f"dbos-kafka-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     @DBOS.kafka_consumer(
         {
@@ -223,8 +221,7 @@ def test_kafka_in_order(dbos: DBOS) -> None:
     server = "localhost:9092"
     topic = f"dbos-kafka-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     with pytest.warns(DeprecationWarning):
 
@@ -260,11 +257,9 @@ def test_kafka_no_groupid(dbos: DBOS) -> None:
     topic1 = f"dbos-kafka-{random.randrange(1_000_000_000, 2_000_000_000)}"
     topic2 = f"dbos-kafka-{random.randrange(2_000_000_000, 3_000_000_000)}"
 
-    if not send_test_messages(server, topic1):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic1)
 
-    if not send_test_messages(server, topic2):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic2)
 
     @DBOS.kafka_consumer(
         {
@@ -315,7 +310,7 @@ def test_kafka_partition_ordering(dbos: DBOS) -> None:
     for p in range(num_partitions):
         for i in range(num_per_partition):
             producer.produce(topic, partition=p, value=f"{i}")
-    producer.flush(10)
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     lock = threading.Lock()
     seen: dict[int, list[int]] = {p: [] for p in range(num_partitions)}
@@ -362,8 +357,7 @@ def test_kafka_db_outage(dbos: DBOS, monkeypatch: pytest.MonkeyPatch) -> None:
     server = "localhost:9092"
     topic = f"dbos-kafka-outage-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     fail_remaining = 3
     failures_injected = 0
@@ -415,8 +409,7 @@ def test_kafka_listen_queues_still_polls_consumer(
     server = "localhost:9092"
     topic = f"dbos-kafka-listen-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     DBOS.destroy(destroy_registry=True)
     DBOS(config=config)
@@ -459,8 +452,7 @@ def test_kafka_listen_queues_polls_db_backed_consumer_queue(
     server = "localhost:9092"
     topic = f"dbos-kafka-dbq-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     # Persist a database-backed queue via the public API: it lives in the DB, not the
     # in-memory registry. The fixture instance is launched, so _sys_db is available.
@@ -511,14 +503,10 @@ def test_kafka_throughput(
     topic = f"dbos-kafka-bench-{random.randrange(1_000_000_000)}"
     num_messages = 1000
 
-    try:
-        producer = Producer({"bootstrap.servers": server})
-        for i in range(num_messages):
-            producer.produce(topic, value=f"message-{i}")
-        if producer.flush(10) > 0:
-            pytest.skip("Kafka not available")
-    except Exception:
-        pytest.skip("Kafka not available")
+    producer = _producer_or_skip(server)
+    for i in range(num_messages):
+        producer.produce(topic, value=f"message-{i}")
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     inserted_total = 0
     first_insert_at: Optional[float] = None
@@ -589,8 +577,7 @@ def test_kafka_two_groups_same_topic(dbos: DBOS) -> None:
     server = "localhost:9092"
     topic = f"dbos-kafka-fanout-{random.randrange(1_000_000_000)}"
 
-    if not send_test_messages(server, topic):
-        pytest.skip("Kafka not available")
+    send_test_messages(server, topic)
 
     lock = threading.Lock()
     seen: dict[str, set[int]] = {"a": set(), "b": set()}
@@ -653,8 +640,7 @@ def test_kafka_two_ordered_consumers_same_topic(dbos: DBOS) -> None:
     producer = Producer({"bootstrap.servers": server})
     for i in range(num_messages):
         producer.produce(topic, partition=0, value=f"{i}")
-    if producer.flush(10) > 0:
-        pytest.skip("Kafka not available")
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     lock = threading.Lock()
     seen: dict[str, list[int]] = {"a": [], "b": []}
@@ -976,8 +962,7 @@ def test_kafka_ordering_across_batches(dbos: DBOS) -> None:
     for p in range(num_partitions):
         for i in range(num_per_partition):
             producer.produce(topic, partition=p, value=f"{i}")
-    if producer.flush(10) > 0:
-        pytest.skip("Kafka not available")
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     lock = threading.Lock()
     seen: dict[int, list[int]] = {p: [] for p in range(num_partitions)}
@@ -1033,8 +1018,7 @@ def test_kafka_topic_ordering_multi_partition(dbos: DBOS) -> None:
     for p in range(num_partitions):
         for i in range(num_per_partition):
             producer.produce(topic, partition=p, value=f"{i}")
-    if producer.flush(10) > 0:
-        pytest.skip("Kafka not available")
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     lock = threading.Lock()
     seen: dict[int, list[int]] = {p: [] for p in range(num_partitions)}
@@ -2087,8 +2071,7 @@ def test_kafka_custom_queue(dbos: DBOS) -> None:
     producer = Producer({"bootstrap.servers": server})
     for i in range(num_messages):
         producer.produce(topic, partition=0, value=f"{i}")
-    if producer.flush(10) > 0:
-        pytest.skip("Kafka not available")
+    assert producer.flush(10) == 0, f"undelivered messages to {topic}"
 
     queue_name = f"kafka-custom-q-{random.randrange(1_000_000_000)}"
     DBOS.register_queue(queue_name, concurrency=1)

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -33,6 +33,8 @@ from dbos._logger import dbos_logger
 #           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 #           KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
 #           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+#           # Every test uses a fresh group; the 3s default delays each one's first message.
+#           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 #           CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
 NUM_EVENTS = 3
@@ -52,13 +54,10 @@ def send_test_messages(server: str, topic: str) -> bool:
                 topic, key=f"test message key {i}", value=f"test message value {i}"
             )
 
-        producer.poll(10)
-        producer.flush(10)
-        return True
+        # flush() serves delivery callbacks and waits; poll() would only block its full timeout.
+        return producer.flush(10) == 0
     except Exception as e:
         return False
-    finally:
-        pass
 
 
 def produce_one_message(server: str, topic: str) -> bool:
@@ -69,9 +68,7 @@ def produce_one_message(server: str, topic: str) -> bool:
 
         producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
         producer.produce(topic, key=b"offset-loss-key", value=b"offset-loss-value")
-        producer.poll(10)
-        producer.flush(10)
-        return True
+        return producer.flush(10) == 0
     except Exception:
         return False
 
@@ -516,7 +513,6 @@ def test_kafka_throughput(
         producer = Producer({"bootstrap.servers": server})
         for i in range(num_messages):
             producer.produce(topic, value=f"message-{i}")
-        producer.poll(10)
         if producer.flush(10) > 0:
             pytest.skip("Kafka not available")
     except Exception:
@@ -848,6 +844,8 @@ def test_kafka_queue_polling_interval_default(
     from dbos._kafka import KAFKA_QUEUE_NAME
 
     DBOS.destroy(destroy_registry=True)
+    # Drop the fixture's speed-up value: this test is about the unconfigured path.
+    del config["kafka_queue_polling_interval_sec"]
     suffix = random.randrange(1_000_000_000)
 
     @DBOS.kafka_consumer(

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -38,6 +38,8 @@ from dbos._logger import dbos_logger
 #           CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
 NUM_EVENTS = 3
+# Generous, since an undrained flush is reported as "Kafka not available" and skips the test.
+FLUSH_TIMEOUT_SEC = 30
 
 
 def send_test_messages(server: str, topic: str) -> bool:
@@ -55,7 +57,7 @@ def send_test_messages(server: str, topic: str) -> bool:
             )
 
         # flush() serves delivery callbacks and waits; poll() would only block its full timeout.
-        return producer.flush(10) == 0
+        return producer.flush(FLUSH_TIMEOUT_SEC) == 0
     except Exception as e:
         return False
 
@@ -68,7 +70,7 @@ def produce_one_message(server: str, topic: str) -> bool:
 
         producer = Producer({"bootstrap.servers": server, "error_cb": on_error})
         producer.produce(topic, key=b"offset-loss-key", value=b"offset-loss-value")
-        return producer.flush(10) == 0
+        return producer.flush(FLUSH_TIMEOUT_SEC) == 0
     except Exception:
         return False
 

--- a/tests/test_pgsql_client.py
+++ b/tests/test_pgsql_client.py
@@ -324,7 +324,9 @@ def test_pgsql_enqueue_wrong_appver(
     assert wf_status.app_version == "0123456789abcdef"
 
 
-def test_pgsql_enqueue_idempotent(config: DBOSConfig, skip_with_sqlite: None) -> None:
+def test_pgsql_enqueue_idempotent(
+    config: DBOSConfig, migrated_system_database: None, skip_with_sqlite: None
+) -> None:
     """Test enqueue_workflow idempotent behavior."""
     DBOS.destroy(destroy_registry=True)
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -20,7 +20,11 @@ from dbos._sys_db import SystemDatabase
 from dbos.cli.migration import print_dbos_migrations, print_dbos_user_role_sql
 
 
-def test_systemdb_migration(dbos: DBOS, skip_with_sqlite: None) -> None:
+def test_systemdb_migration(
+    dbos_dropped_databases: DBOS, skip_with_sqlite: None
+) -> None:
+    # Needs a dropped database so this exercises a from-scratch migration.
+    dbos = dbos_dropped_databases
     # Make sure all tables exist
     with dbos._sys_db.engine.connect() as connection:
         sql = SystemSchema.workflow_status.select()
@@ -51,9 +55,10 @@ def test_systemdb_migration(dbos: DBOS, skip_with_sqlite: None) -> None:
 def test_systemdb_migration_custom_schema(
     config: DBOSConfig,
     skip_with_sqlite: None,
-    cleanup_test_databases: None,
+    drop_test_databases: None,
 ) -> None:
-
+    # Needs a dropped database: it asserts the default "dbos" schema is absent,
+    # and leaves behind a schema of its own.
     config["application_database_url"] = None
     schema = "F8nny_sCHem@-n@m3"
     config["dbos_system_schema"] = schema
@@ -90,9 +95,13 @@ def test_systemdb_migration_custom_schema(
 def test_two_schemas_isolated_in_one_process(
     config: DBOSConfig,
     skip_with_sqlite: None,
-    cleanup_test_databases: None,
+    drop_test_databases: None,
 ) -> None:
-    """Two system databases with different schemas must stay isolated within one process."""
+    """Two system databases with different schemas must stay isolated within one process.
+
+    Needs a dropped database: it counts the rows in schemas it creates itself,
+    which truncation of the default schema would neither empty nor remove.
+    """
     sys_db_url = config["system_database_url"]
     assert sys_db_url is not None
 
@@ -201,6 +210,62 @@ def test_reset(
     # Verify that resetting after launch throws
     with pytest.raises(AssertionError):
         DBOS.reset_system_database()
+
+
+def test_reset_truncate(
+    config: DBOSConfig,
+    db_engine: sa.Engine,
+    cleanup_test_databases: None,
+    skip_with_sqlite: None,
+) -> None:
+    """Truncating empties the tables but leaves the database and its migrated schema."""
+    DBOS.destroy(destroy_registry=True)
+    dbos = DBOS(config=config)
+
+    @DBOS.workflow()
+    def workflow() -> str:
+        assert DBOS.workflow_id
+        DBOS.set_event(DBOS.workflow_id, DBOS.workflow_id)
+        return DBOS.workflow_id
+
+    DBOS.launch()
+    workflow_id = workflow()
+    assert DBOS.get_event(workflow_id, workflow_id) == workflow_id
+    assert len(DBOS.list_workflows()) == 1
+    sysdb_name = dbos._sys_db.engine.url.database
+    latest_version = len(get_dbos_migrations("dbos", True))
+
+    DBOS.destroy()
+    dbos = DBOS(config=config)
+    DBOS.reset_system_database(truncate=True)
+
+    # Unlike a reset, the database itself survives
+    with db_engine.connect() as c:
+        count: int = c.execute(
+            sa.text(f"SELECT COUNT(*) FROM pg_database WHERE datname = '{sysdb_name}'")
+        ).scalar_one()
+        assert count == 1
+
+    DBOS.launch()
+    assert DBOS.list_workflows() == []
+    with dbos._sys_db.engine.connect() as c:
+        assert (
+            c.execute(
+                sa.select(sa.func.count()).select_from(SystemSchema.workflow_events)
+            ).scalar_one()
+            == 0
+        )
+        # The schema survives fully migrated, so the launch above ran no migrations
+        assert (
+            c.execute(sa.text('SELECT version FROM "dbos".dbos_migrations')).scalar()
+            == latest_version
+        )
+    assert should_migrate(dbos._sys_db.engine, "dbos", True) is False
+
+    # Truncating after launch is refused, same as resetting
+    with pytest.raises(AssertionError):
+        DBOS.reset_system_database(truncate=True)
+    DBOS.destroy()
 
 
 _APPLICATION_NAME_TABLES = (
@@ -392,6 +457,31 @@ def test_sqlite_systemdb_migration() -> None:
                 }
                 assert "application_name" in columns, table
                 assert columns["application_name"] == 0, table
+
+        # Test truncating the system database: the rows go, the schema stays
+        with sys_db.engine.begin() as connection:
+            connection.execute(
+                SystemSchema.application_versions.insert().values(
+                    version_id="v1",
+                    version_name="v1",
+                    version_timestamp=1,
+                    created_at=1,
+                )
+            )
+        SystemDatabase.reset_system_database(sqlite_url, truncate=True)
+        assert os.path.exists(temp_db_path)
+        with sys_db.engine.connect() as connection:
+            assert (
+                connection.execute(
+                    sa.select(sa.func.count()).select_from(
+                        SystemSchema.application_versions
+                    )
+                ).scalar_one()
+                == 0
+            )
+            assert connection.execute(
+                sa.text("SELECT version FROM dbos_migrations")
+            ).scalar() == len(sqlite_migrations)
 
         # Clean up
         sys_db.destroy()
@@ -742,13 +832,17 @@ def test_version_not_bumped_on_migration_failure(
         assert version == final_version
 
 
-def test_should_migrate(dbos: DBOS, skip_with_sqlite: None) -> None:
+def test_should_migrate(dbos_dropped_databases: DBOS, skip_with_sqlite: None) -> None:
     """should_migrate must return True when the schema is missing, the
     dbos_migrations table is missing, or the recorded version is behind the
-    latest; and False once the schema is fully migrated."""
+    latest; and False once the schema is fully migrated.
+
+    Needs a dropped database: it ends with dbos_migrations gone, which only a
+    drop can put right.
+    """
     from dbos._migration import should_migrate
 
-    engine = dbos._sys_db.engine
+    engine = dbos_dropped_databases._sys_db.engine
     schema = "dbos"
     latest_version = len(get_dbos_migrations(schema, True))
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -325,59 +325,68 @@ def test_reset_explicit_url(
                 ).scalar()
             )
 
-    # No global DBOS object: the URL and schema alone are enough to reset
-    DBOS.destroy(destroy_registry=True)
-    other_db = SystemDatabase.create(
-        system_database_url=other_db_url,
-        engine_kwargs={},
-        engine=None,
-        schema=other_schema,
-        serializer=DefaultSerializer(),
-        executor_id=None,
-    )
-    other_db.run_migrations()
-    version_row = SystemSchema.application_versions.insert().values(
-        version_id="v1", version_name="v1", version_timestamp=1, created_at=1
-    )
-    count = sa.select(sa.func.count()).select_from(SystemSchema.application_versions)
-    with other_db.engine.begin() as c:
-        c.execute(version_row)
-        assert c.execute(count).scalar_one() == 1
+    try:
+        # No global DBOS object: the URL and schema alone are enough to reset
+        DBOS.destroy(destroy_registry=True)
+        other_db = SystemDatabase.create(
+            system_database_url=other_db_url,
+            engine_kwargs={},
+            engine=None,
+            schema=other_schema,
+            serializer=DefaultSerializer(),
+            executor_id=None,
+        )
+        other_db.run_migrations()
+        version_row = SystemSchema.application_versions.insert().values(
+            version_id="v1", version_name="v1", version_timestamp=1, created_at=1
+        )
+        count = sa.select(sa.func.count()).select_from(
+            SystemSchema.application_versions
+        )
+        with other_db.engine.begin() as c:
+            c.execute(version_row)
+            assert c.execute(count).scalar_one() == 1
 
-    # Without the schema, truncation would find no tables and only warn
-    DBOS.reset_system_database(
-        system_database_url=other_db_url, schema=other_schema, truncate=True
-    )
-    # Truncation evicts every other connection, this test's pool included
-    other_db.engine.dispose()
-    with other_db.engine.begin() as c:
-        assert c.execute(count).scalar_one() == 0
-    other_db.destroy()
-    assert other_db_exists()
+        # Without the schema, truncation would find no tables and only warn
+        DBOS.reset_system_database(
+            system_database_url=other_db_url, schema=other_schema, truncate=True
+        )
+        # Truncation evicts every other connection, this test's pool included
+        other_db.engine.dispose()
+        with other_db.engine.begin() as c:
+            assert c.execute(count).scalar_one() == 0
+        other_db.destroy()
+        assert other_db_exists()
 
-    # Dropping needs no schema, and takes the database with it
-    DBOS.reset_system_database(system_database_url=other_db_url)
-    assert not other_db_exists()
+        # Dropping needs no schema, and takes the database with it
+        DBOS.reset_system_database(system_database_url=other_db_url)
+        assert not other_db_exists()
 
-    # With a global DBOS object, the explicit URL wins over its configuration
-    DBOS(config=config)
+        # With a global DBOS object, the explicit URL wins over its configuration
+        DBOS(config=config)
 
-    @DBOS.workflow()
-    def workflow() -> str:
-        assert DBOS.workflow_id
-        return DBOS.workflow_id
+        @DBOS.workflow()
+        def workflow() -> str:
+            assert DBOS.workflow_id
+            return DBOS.workflow_id
 
-    DBOS.launch()
-    workflow_id = workflow()
-    DBOS.destroy()
-    DBOS(config=config)
-    # Truncating the now-absent database is a no-op, not an error
-    DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
+        DBOS.launch()
+        workflow_id = workflow()
+        DBOS.destroy()
+        DBOS(config=config)
+        # Truncating the now-absent database is a no-op, not an error
+        DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
 
-    # The configured system database is untouched
-    DBOS.launch()
-    assert [w.workflow_id for w in DBOS.list_workflows()] == [workflow_id]
-    DBOS.destroy()
+        # The configured system database is untouched
+        DBOS.launch()
+        assert [w.workflow_id for w in DBOS.list_workflows()] == [workflow_id]
+        DBOS.destroy()
+    finally:
+        # No fixture knows about this database, and a leaked one keeps its
+        # application_versions row, failing every later run on the insert above.
+        with db_engine.connect() as c:
+            c.execution_options(isolation_level="AUTOCOMMIT")
+            c.execute(sa.text(f"DROP DATABASE IF EXISTS {other_db_name} WITH (FORCE)"))
 
 
 _APPLICATION_NAME_TABLES = (
@@ -871,13 +880,17 @@ def test_concurrent_migrations(db_engine: sa.Engine, skip_with_sqlite: None) -> 
         )
 
 
-def test_online_migrations_are_idempotent(dbos: DBOS, skip_with_sqlite: None) -> None:
+def test_online_migrations_are_idempotent(
+    dbos_dropped_databases: DBOS, skip_with_sqlite: None
+) -> None:
     """Re-running every migration from the first online one onward against an
     already-migrated schema must succeed without error. Guards against
-    missing IF [NOT] EXISTS clauses in any drop/create migration."""
+    missing IF [NOT] EXISTS clauses in any drop/create migration.
+
+    Needs a dropped database: it rewinds dbos_migrations, which truncation spares."""
     from dbos._migration import _ONLINE_MIGRATIONS, run_dbos_migrations
 
-    engine = dbos._sys_db.engine
+    engine = dbos_dropped_databases._sys_db.engine
     schema = "dbos"
     rewind_to = min(_ONLINE_MIGRATIONS) - 1
     final_version = len(get_dbos_migrations(schema, True))
@@ -898,15 +911,17 @@ def test_online_migrations_are_idempotent(dbos: DBOS, skip_with_sqlite: None) ->
 
 
 def test_version_not_bumped_on_migration_failure(
-    dbos: DBOS, skip_with_sqlite: None
+    dbos_dropped_databases: DBOS, skip_with_sqlite: None
 ) -> None:
     """If a migration raises mid-flight, the version counter must stay at the
-    prior value so the runner re-attempts it on the next start."""
+    prior value so the runner re-attempts it on the next start.
+
+    Needs a dropped database: it rewinds dbos_migrations, which truncation spares."""
     from unittest.mock import patch
 
     from dbos._migration import run_dbos_migrations
 
-    engine = dbos._sys_db.engine
+    engine = dbos_dropped_databases._sys_db.engine
     schema = "dbos"
     rewind_to_version = 31  # one before migration 32
     final_version = len(get_dbos_migrations(schema, True))
@@ -986,13 +1001,18 @@ def test_should_migrate(dbos_dropped_databases: DBOS, skip_with_sqlite: None) ->
     )
 
 
-def test_runner_resumes_after_invalid_index(dbos: DBOS, skip_with_sqlite: None) -> None:
+def test_runner_resumes_after_invalid_index(
+    dbos_dropped_databases: DBOS, skip_with_sqlite: None
+) -> None:
     """Simulate a CREATE INDEX CONCURRENTLY that crashed mid-build (leaving an
     INVALID index) and verify the runner cleans it up and re-runs the
-    migration on the next start."""
+    migration on the next start.
+
+    Needs a dropped database: it plants an invalid index and rewinds
+    dbos_migrations, which truncation spares."""
     from dbos._migration import run_dbos_migrations
 
-    engine = dbos._sys_db.engine
+    engine = dbos_dropped_databases._sys_db.engine
     schema = "dbos"
     target_index = "idx_workflow_status_in_flight"
     rewind_to_version = 31  # one before migration 32 which builds target_index

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -265,6 +265,38 @@ def test_reset_truncate(
     DBOS.destroy()
 
 
+def test_reset_truncate_evicts_connections(
+    config: DBOSConfig, cleanup_test_databases: None, skip_with_sqlite: None
+) -> None:
+    """Truncating evicts other connections, as DROP DATABASE ... WITH (FORCE) did.
+
+    A leaked transaction holding a lock would otherwise block TRUNCATE forever."""
+    sys_db_url = config["system_database_url"]
+    assert sys_db_url is not None
+    DBOS.destroy(destroy_registry=True)
+    DBOS(config=config)
+    DBOS.launch()
+    DBOS.destroy()
+
+    # Stand in for a thread an earlier test failed to stop: an open transaction
+    # holding a lock TRUNCATE needs.
+    squatter = sa.create_engine(sys_db_url)
+    connection = squatter.connect()
+    read_status = sa.text('SELECT count(*) FROM "dbos".workflow_status')
+    connection.execute(read_status)
+
+    try:
+        DBOS(config=config)
+        DBOS.reset_system_database(truncate=True)
+        # The squatter's connection is gone, so its next statement fails
+        with pytest.raises(sa.exc.DBAPIError):
+            connection.execute(read_status)
+    finally:
+        connection.invalidate()
+        squatter.dispose()
+        DBOS.destroy()
+
+
 def test_reset_explicit_url(
     config: DBOSConfig,
     db_engine: sa.Engine,
@@ -316,6 +348,8 @@ def test_reset_explicit_url(
     DBOS.reset_system_database(
         system_database_url=other_db_url, schema=other_schema, truncate=True
     )
+    # Truncation evicts every other connection, this test's pool included
+    other_db.engine.dispose()
     with other_db.engine.begin() as c:
         assert c.execute(count).scalar_one() == 0
     other_db.destroy()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import click
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
@@ -374,9 +374,8 @@ def test_reset_explicit_url(
         workflow_id = workflow()
         DBOS.destroy()
         DBOS(config=config)
-        # Truncating the now-absent database surfaces the connection failure
-        with pytest.raises(OperationalError):
-            DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
+        # Truncating the now-absent database warns, rather than raising
+        DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
 
         # The configured system database is untouched
         DBOS.launch()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -57,8 +57,7 @@ def test_systemdb_migration_custom_schema(
     skip_with_sqlite: None,
     drop_test_databases: None,
 ) -> None:
-    # Needs a dropped database: it asserts the default "dbos" schema is absent,
-    # and leaves behind a schema of its own.
+    # Needs a dropped database: asserts the "dbos" schema is absent, leaves its own.
     config["application_database_url"] = None
     schema = "F8nny_sCHem@-n@m3"
     config["dbos_system_schema"] = schema
@@ -99,9 +98,7 @@ def test_two_schemas_isolated_in_one_process(
 ) -> None:
     """Two system databases with different schemas must stay isolated within one process.
 
-    Needs a dropped database: it counts the rows in schemas it creates itself,
-    which truncation of the default schema would neither empty nor remove.
-    """
+    Needs a dropped database: truncation spares the schemas this creates itself."""
     sys_db_url = config["system_database_url"]
     assert sys_db_url is not None
 
@@ -901,9 +898,7 @@ def test_should_migrate(dbos_dropped_databases: DBOS, skip_with_sqlite: None) ->
     dbos_migrations table is missing, or the recorded version is behind the
     latest; and False once the schema is fully migrated.
 
-    Needs a dropped database: it ends with dbos_migrations gone, which only a
-    drop can put right.
-    """
+    Needs a dropped database: it ends with dbos_migrations gone."""
     from dbos._migration import should_migrate
 
     engine = dbos_dropped_databases._sys_db.engine

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -271,8 +271,8 @@ def test_reset_explicit_url(
     cleanup_test_databases: None,
     skip_with_sqlite: None,
 ) -> None:
-    """An explicit system database URL is reset in place of the configured one,
-    with or without a global DBOS object."""
+    """An explicit system database URL and schema are reset in place of the
+    configured ones, with or without a global DBOS object."""
     sys_db_url = config["system_database_url"]
     assert sys_db_url is not None
     other_db_url = (
@@ -281,6 +281,7 @@ def test_reset_explicit_url(
         .render_as_string(hide_password=False)
     )
     other_db_name = sa.make_url(other_db_url).database
+    other_schema = "F8nny_sCHem@-n@m3"
 
     def other_db_exists() -> bool:
         with db_engine.connect() as c:
@@ -292,19 +293,35 @@ def test_reset_explicit_url(
                 ).scalar()
             )
 
-    # No global DBOS object: the URL alone is enough to migrate and then destroy
+    # No global DBOS object: the URL and schema alone are enough to reset
     DBOS.destroy(destroy_registry=True)
     other_db = SystemDatabase.create(
         system_database_url=other_db_url,
         engine_kwargs={},
         engine=None,
-        schema="dbos",
+        schema=other_schema,
         serializer=DefaultSerializer(),
         executor_id=None,
     )
     other_db.run_migrations()
+    version_row = SystemSchema.application_versions.insert().values(
+        version_id="v1", version_name="v1", version_timestamp=1, created_at=1
+    )
+    count = sa.select(sa.func.count()).select_from(SystemSchema.application_versions)
+    with other_db.engine.begin() as c:
+        c.execute(version_row)
+        assert c.execute(count).scalar_one() == 1
+
+    # Without the schema, truncation would find no tables and silently do nothing
+    DBOS.reset_system_database(
+        system_database_url=other_db_url, schema=other_schema, truncate=True
+    )
+    with other_db.engine.begin() as c:
+        assert c.execute(count).scalar_one() == 0
     other_db.destroy()
     assert other_db_exists()
+
+    # Dropping needs no schema, and takes the database with it
     DBOS.reset_system_database(system_database_url=other_db_url)
     assert not other_db_exists()
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import click
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
@@ -374,8 +374,9 @@ def test_reset_explicit_url(
         workflow_id = workflow()
         DBOS.destroy()
         DBOS(config=config)
-        # Truncating the now-absent database is a no-op, not an error
-        DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
+        # Truncating the now-absent database surfaces the connection failure
+        with pytest.raises(OperationalError):
+            DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
 
         # The configured system database is untouched
         DBOS.launch()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -344,7 +344,7 @@ def test_reset_explicit_url(
         c.execute(version_row)
         assert c.execute(count).scalar_one() == 1
 
-    # Without the schema, truncation would find no tables and silently do nothing
+    # Without the schema, truncation would find no tables and only warn
     DBOS.reset_system_database(
         system_database_url=other_db_url, schema=other_schema, truncate=True
     )

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -172,8 +172,13 @@ def test_two_schemas_isolated_in_one_process(
 
 
 def test_reset(
-    config: DBOSConfig, db_engine: sa.Engine, skip_with_sqlite: None
+    config: DBOSConfig,
+    db_engine: sa.Engine,
+    cleanup_test_databases: None,
+    skip_with_sqlite: None,
 ) -> None:
+    # Asserts workflow_status is empty at launch, so it needs the databases emptied
+    # rather than whatever the preceding test happened to leave behind.
     DBOS.destroy()
     dbos = DBOS(config=config)
     DBOS.launch()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -268,6 +268,70 @@ def test_reset_truncate(
     DBOS.destroy()
 
 
+def test_reset_explicit_url(
+    config: DBOSConfig,
+    db_engine: sa.Engine,
+    cleanup_test_databases: None,
+    skip_with_sqlite: None,
+) -> None:
+    """An explicit system database URL is reset in place of the configured one,
+    with or without a global DBOS object."""
+    sys_db_url = config["system_database_url"]
+    assert sys_db_url is not None
+    other_db_url = (
+        sa.make_url(sys_db_url)
+        .set(database="reset_explicit_url_test")
+        .render_as_string(hide_password=False)
+    )
+    other_db_name = sa.make_url(other_db_url).database
+
+    def other_db_exists() -> bool:
+        with db_engine.connect() as c:
+            return bool(
+                c.execute(
+                    sa.text(
+                        f"SELECT 1 FROM pg_database WHERE datname = '{other_db_name}'"
+                    )
+                ).scalar()
+            )
+
+    # No global DBOS object: the URL alone is enough to migrate and then destroy
+    DBOS.destroy(destroy_registry=True)
+    other_db = SystemDatabase.create(
+        system_database_url=other_db_url,
+        engine_kwargs={},
+        engine=None,
+        schema="dbos",
+        serializer=DefaultSerializer(),
+        executor_id=None,
+    )
+    other_db.run_migrations()
+    other_db.destroy()
+    assert other_db_exists()
+    DBOS.reset_system_database(system_database_url=other_db_url)
+    assert not other_db_exists()
+
+    # With a global DBOS object, the explicit URL wins over its configuration
+    DBOS(config=config)
+
+    @DBOS.workflow()
+    def workflow() -> str:
+        assert DBOS.workflow_id
+        return DBOS.workflow_id
+
+    DBOS.launch()
+    workflow_id = workflow()
+    DBOS.destroy()
+    DBOS(config=config)
+    # Truncating the now-absent database is a no-op, not an error
+    DBOS.reset_system_database(system_database_url=other_db_url, truncate=True)
+
+    # The configured system database is untouched
+    DBOS.launch()
+    assert [w.workflow_id for w in DBOS.list_workflows()] == [workflow_id]
+    DBOS.destroy()
+
+
 _APPLICATION_NAME_TABLES = (
     "workflow_status",
     "queues",

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import click
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 
 # Public API
 from dbos import DBOS, DBOSConfig, run_dbos_database_migrations
@@ -289,7 +289,7 @@ def test_reset_truncate_evicts_connections(
         DBOS(config=config)
         DBOS.reset_system_database(truncate=True)
         # The squatter's connection is gone, so its next statement fails
-        with pytest.raises(sa.exc.DBAPIError):
+        with pytest.raises(DBAPIError):
             connection.execute(read_status)
     finally:
         connection.invalidate()


### PR DESCRIPTION
To speed up tests, reset the system database by truncating it instead of dropping and recreating it.