### PR TITLE
Add timeout support to fork_workflow

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -1135,6 +1135,7 @@ class DBOSClient:
         queue_name: Optional[str] = None,
         queue_partition_key: Optional[str] = None,
         replacement_children: Optional[dict[str, str]] = None,
+        timeout_seconds: Optional[float] = None,
     ) -> "WorkflowHandle[Any]":
         forked_workflow_id = fork_workflow(
             self._sys_db,
@@ -1144,6 +1145,7 @@ class DBOSClient:
             queue_name=queue_name,
             queue_partition_key=queue_partition_key,
             replacement_children=replacement_children,
+            timeout_seconds=timeout_seconds,
         )
         return WorkflowHandleClientPolling[Any](forked_workflow_id, self._sys_db)
 
@@ -1156,6 +1158,7 @@ class DBOSClient:
         queue_name: Optional[str] = None,
         queue_partition_key: Optional[str] = None,
         replacement_children: Optional[dict[str, str]] = None,
+        timeout_seconds: Optional[float] = None,
     ) -> "WorkflowHandleAsync[Any]":
         forked_workflow_id = await asyncio.to_thread(
             fork_workflow,
@@ -1166,6 +1169,7 @@ class DBOSClient:
             queue_name=queue_name,
             queue_partition_key=queue_partition_key,
             replacement_children=replacement_children,
+            timeout_seconds=timeout_seconds,
         )
         return WorkflowHandleClientAsyncPolling[Any](forked_workflow_id, self._sys_db)
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -2411,6 +2411,7 @@ class DBOS:
         queue_name: Optional[str] = None,
         queue_partition_key: Optional[str] = None,
         replacement_children: Optional[dict[str, str]] = None,
+        timeout_seconds: Optional[float] = None,
     ) -> WorkflowHandle[Any]:
         """Restart a workflow with a new workflow ID from a specific step"""
         check_async("fork_workflow")
@@ -2425,6 +2426,7 @@ class DBOS:
                 queue_name=queue_name,
                 queue_partition_key=queue_partition_key,
                 replacement_children=replacement_children,
+                timeout_seconds=timeout_seconds,
             )
 
         new_id = _get_dbos_instance()._sys_db.call_function_as_step(
@@ -2442,6 +2444,7 @@ class DBOS:
         queue_name: Optional[str] = None,
         queue_partition_key: Optional[str] = None,
         replacement_children: Optional[dict[str, str]] = None,
+        timeout_seconds: Optional[float] = None,
     ) -> WorkflowHandleAsync[Any]:
         """Restart a workflow with a new workflow ID from a specific step"""
         step_ctx_res = snapshot_step_context(reserve_sleep_id=False)
@@ -2458,6 +2461,7 @@ class DBOS:
                 queue_name=queue_name,
                 queue_partition_key=queue_partition_key,
                 replacement_children=replacement_children,
+                timeout_seconds=timeout_seconds,
             )
 
         new_id = await asyncio.to_thread(

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -1302,6 +1302,7 @@ class SystemDatabase(ABC):
         queue_name: Optional[str] = None,
         queue_partition_key: Optional[str] = None,
         replacement_children: Optional[dict[str, str]] = None,
+        workflow_timeout_ms: Optional[int] = None,
     ) -> list[str]:
         if not original_workflow_ids:
             return []
@@ -1372,6 +1373,7 @@ class SystemDatabase(ABC):
                             attributes=status[10],
                             # Inherit the source's owner so the fork runs on the same application; claim an unclaimed one, as dequeue does.
                             application_name=fork_owners[forked_workflow_id],
+                            workflow_timeout_ms=workflow_timeout_ms,
                         )
                         for original_workflow_id, forked_workflow_id, status in zip(
                             original_workflow_ids, forked_workflow_ids, statuses

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -35,7 +35,15 @@ def fork_workflow(
     queue_name: Optional[str] = None,
     queue_partition_key: Optional[str] = None,
     replacement_children: Optional[dict[str, str]] = None,
+    timeout_seconds: Optional[float] = None,
 ) -> str:
+    if timeout_seconds is not None and not timeout_seconds > 0:
+        raise Exception(
+            f"Invalid workflow timeout {timeout_seconds}. Timeouts must be positive."
+        )
+    workflow_timeout_ms = (
+        int(timeout_seconds * 1000) if timeout_seconds is not None else None
+    )
 
     ctx = get_local_dbos_context()
     if ctx is not None and len(ctx.id_assigned_for_next_workflow) > 0:
@@ -51,6 +59,7 @@ def fork_workflow(
         queue_name=queue_name,
         queue_partition_key=queue_partition_key,
         replacement_children=replacement_children,
+        workflow_timeout_ms=workflow_timeout_ms,
     )
     return forked_workflow_id
 

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -1272,6 +1272,34 @@ def test_fork_version(
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_fork_timeout(dbos: DBOS) -> None:
+    @DBOS.workflow()
+    def blocking_workflow() -> None:
+        while True:
+            DBOS.sleep(0.1)
+
+    workflow_id = str(uuid.uuid4())
+    with SetWorkflowID(workflow_id):
+        handle = DBOS.start_workflow(blocking_workflow)
+    DBOS.cancel_workflow(workflow_id)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        handle.get_result()
+
+    # Forking with a short timeout should cancel the forked workflow too.
+    forked_handle = DBOS.fork_workflow(workflow_id, 1, timeout_seconds=0.1)
+    assert forked_handle.get_status().workflow_timeout_ms == 100
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        forked_handle.get_result()
+    assert queue_entries_are_cleaned_up(dbos)
+
+    # Forking without a timeout should leave it unset.
+    no_timeout_handle = DBOS.fork_workflow(workflow_id, 1)
+    assert no_timeout_handle.get_status().workflow_timeout_ms is None
+    DBOS.cancel_workflow(no_timeout_handle.workflow_id)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        no_timeout_handle.get_result()
+
+
 def test_resume_and_fork_to_queue(dbos: DBOS) -> None:
     step_one_count = 0
     step_two_count = 0


### PR DESCRIPTION
## Description
fork_workflow lacked a timeout option that the TypeScript SDK's forkWorkflow has (timeoutMS), so forked workflows always ran with no timeout even when the original workflow had one. This adds a timeout_seconds parameter across the fork_workflow API surface.

## Implementation
- SystemDatabase.fork_workflow (dbos/_sys_db.py) accepts workflow_timeout_ms and sets it on the forked row's insert.
- _workflow_commands.fork_workflow accepts timeout_seconds, converts to ms (validated positive), following the existing seconds-based convention used by SetWorkflowTimeout.
- DBOS.fork_workflow / fork_workflow_async and DBOSClient.fork_workflow / fork_workflow_async pass timeout_seconds through.
- Deadline (workflow_deadline_epoch_ms) is not computed at fork time — it's computed lazily on dequeue, same as every other queued/enqueued workflow, so no new deadline logic was needed.
- Matches TS forkWorkflow's timeoutMS behavior; docs for this repo don't cover fork_workflow params (no docs/ dir here — docs live in the separate dbos-docs repo), so no doc changes included in this PR.

## Testing
Added test_fork_timeout in tests/test_workflow_management.py:
- Forks a blocked (infinite-loop) workflow with timeout_seconds=0.1, confirms workflow_timeout_ms is persisted on the forked workflow's status, and that it actually times out and is cancelled (DBOSAwaitedWorkflowCancelledError), plus queue cleanup.
- Forks the same workflow with no timeout, confirms workflow_timeout_ms stays unset.

Ran full tests/test_workflow_management.py locally against SQLite (38 passed) and mypy clean on touched files.