### PR TITLE
Improved Partition Queue Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ You can add queues to your workflows in just a couple lines of code.
 They don't require a separate queueing service or message broker&mdash;just Postgres.
 
 ```python
-from dbos import DBOS, Queue
+from dbos import DBOS
 
-queue = Queue("example_queue")
+# Register your queues after calling DBOS.launch()
+DBOS.register_queue("example_queue")
 
 @DBOS.step()
 def process_task(task):
@@ -98,7 +99,7 @@ def process_tasks(tasks):
   task_handles = []
   # Enqueue each task so all tasks are processed concurrently.
   for task in tasks:
-    handle = queue.enqueue(process_task, task)
+    handle = DBOS.enqueue_workflow("example_queue", process_task, task)
     task_handles.append(handle)
   # Wait for each task to complete and retrieve its result.
   # Return the results of all tasks.

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -419,9 +419,9 @@ class DBOSClient:
         :param application_name: The application that owns this queue and polls
             it. Defaults to the client's own application. Registering a queue
             already owned by a different application raises.
-        :param concurrency: Deprecated.
-        :param priority_enabled: Deprecated.
-        :param partition_queue: Deprecated.
+        :param concurrency: Deprecated. Use ``global_concurrency``.
+        :param priority_enabled: Deprecated. Priority is always enabled.
+        :param partition_queue: Deprecated. Use the ``partition_*`` limits.
 
         :returns: A :class:`Queue` bound to this client's system database.
         """

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -400,10 +400,9 @@ class DBOSClient:
         :param worker_concurrency: Maximum number of workflows from this queue
             that may be running on a single executor at once. ``None`` means no
             per-executor limit. May be combined with ``concurrency``.
-        :param priority_enabled: When ``True``, callers may set a workflow
-            priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
-            are dequeued first. When ``False``, supplying a priority raises an
-            error at enqueue time.
+        :param priority_enabled: Deprecated and ignored. Every queue dequeues in
+            priority order, so ``SetEnqueueOptions(priority=...)`` takes effect
+            whatever this is set to.
         :param partition_queue: Deprecated in favor of ``partition_concurrency``.
             When ``True``, every enqueue must specify a ``queue_partition_key`` and
             the concurrency, worker_concurrency, and limiter limits are all applied

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -368,6 +368,8 @@ class DBOSClient:
         *,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
         polling_interval_sec: float = 1.0,
@@ -387,7 +389,14 @@ class DBOSClient:
             default) means no global limit.
         :param partition_concurrency: Maximum number of workflows from any one
             partition of this queue that may be running globally (across all
-            executors) at once. Setting it makes the queue partitioned, so every
+            executors) at once.
+        :param partition_worker_concurrency: Maximum number of workflows from any
+            one partition of this queue that may be running on a single executor at
+            once.
+        :param partition_limiter: Rate limit applied to each partition separately,
+            of the form ``{"limit": int, "period": float}``.
+
+            Setting any ``partition_*`` limit makes the queue partitioned, so every
             enqueue must specify a ``queue_partition_key``, while
             ``global_concurrency``, ``worker_concurrency``, and ``limiter`` continue
             to apply to the queue as a whole. Deduplication is not supported on
@@ -424,6 +433,8 @@ class DBOSClient:
             worker_concurrency=worker_concurrency,
             global_concurrency=global_concurrency,
             partition_concurrency=partition_concurrency,
+            partition_worker_concurrency=partition_worker_concurrency,
+            partition_limiter=partition_limiter,
             partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
@@ -451,6 +462,13 @@ class DBOSClient:
             priority_enabled=priority_enabled,
             partition_queue=partition_queue,
             partition_concurrency=partition_concurrency,
+            partition_worker_concurrency=partition_worker_concurrency,
+            partition_rate_limit_max=(
+                partition_limiter["limit"] if partition_limiter else None
+            ),
+            partition_rate_limit_period_sec=(
+                partition_limiter["period"] if partition_limiter else None
+            ),
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
             application_name=application_name,
@@ -467,6 +485,8 @@ class DBOSClient:
         *,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
         polling_interval_sec: float = 1.0,
@@ -483,6 +503,8 @@ class DBOSClient:
                 name,
                 global_concurrency=global_concurrency,
                 partition_concurrency=partition_concurrency,
+                partition_worker_concurrency=partition_worker_concurrency,
+                partition_limiter=partition_limiter,
                 limiter=limiter,
                 worker_concurrency=worker_concurrency,
                 polling_interval_sec=polling_interval_sec,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -367,6 +367,8 @@ class DBOSClient:
         name: str,
         *,
         concurrency: Optional[int] = None,
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
@@ -379,9 +381,18 @@ class DBOSClient:
 
         :param name: Unique name of the queue. Used as the lookup key in the
             ``queues`` table and on every ``enqueue`` call.
-        :param concurrency: Maximum number of workflows from this queue that may
-            be running globally (across all executors) at once. ``None`` (the
+        :param concurrency: Deprecated in favor of ``global_concurrency``, or of
+            ``partition_concurrency`` when combined with ``partition_queue``.
+        :param global_concurrency: Maximum number of workflows from this queue that
+            may be running globally (across all executors) at once. ``None`` (the
             default) means no global limit.
+        :param partition_concurrency: Maximum number of workflows from any one
+            partition of this queue that may be running globally (across all
+            executors) at once. Setting it makes the queue partitioned, so every
+            enqueue must specify a ``queue_partition_key``, while
+            ``global_concurrency``, ``worker_concurrency``, and ``limiter`` continue
+            to apply to the queue as a whole. Deduplication is not supported on
+            partitioned queues.
         :param limiter: Rate limit configuration of the form
             ``{"limit": int, "period": float}``. At most ``limit`` workflows
             from the queue will start within any rolling window of ``period``
@@ -393,10 +404,11 @@ class DBOSClient:
             priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
             are dequeued first. When ``False``, supplying a priority raises an
             error at enqueue time.
-        :param partition_queue: When ``True``, every enqueue must specify a
-            ``queue_partition_key`` and concurrency / worker_concurrency limits
-            are applied per partition rather than to the queue as a whole.
-            Deduplication is not supported on partitioned queues.
+        :param partition_queue: Deprecated in favor of ``partition_concurrency``.
+            When ``True``, every enqueue must specify a ``queue_partition_key`` and
+            the concurrency, worker_concurrency, and limiter limits are all applied
+            per partition rather than to the queue as a whole. Deduplication is not
+            supported on partitioned queues.
         :param polling_interval_sec: How often (in seconds) the worker thread
             wakes up to look for runnable workflows on this queue. Smaller
             values reduce dequeue latency at the cost of more database load.
@@ -417,6 +429,9 @@ class DBOSClient:
         Queue._validate_queue(
             concurrency=concurrency,
             worker_concurrency=worker_concurrency,
+            global_concurrency=global_concurrency,
+            partition_concurrency=partition_concurrency,
+            partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
         )
@@ -434,12 +449,15 @@ class DBOSClient:
 
         inserted = self._sys_db.upsert_queue(
             name=name,
-            concurrency=concurrency,
+            concurrency=(
+                concurrency if global_concurrency is None else global_concurrency
+            ),
             worker_concurrency=worker_concurrency,
             rate_limit_max=limiter["limit"] if limiter else None,
             rate_limit_period_sec=limiter["period"] if limiter else None,
             priority_enabled=priority_enabled,
             partition_queue=partition_queue,
+            partition_concurrency=partition_concurrency,
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
             application_name=application_name,
@@ -455,6 +473,8 @@ class DBOSClient:
         name: str,
         *,
         concurrency: Optional[int] = None,
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
@@ -468,6 +488,8 @@ class DBOSClient:
             lambda: self.register_queue(
                 name,
                 concurrency=concurrency,
+                global_concurrency=global_concurrency,
+                partition_concurrency=partition_concurrency,
                 limiter=limiter,
                 worker_concurrency=worker_concurrency,
                 priority_enabled=priority_enabled,

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -366,23 +366,22 @@ class DBOSClient:
         self,
         name: str,
         *,
-        concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "always_update",
         application_name: Optional[str] = None,
+        # Deprecated, retained for backwards compatibility
+        concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
         :param name: Unique name of the queue. Used as the lookup key in the
             ``queues`` table and on every ``enqueue`` call.
-        :param concurrency: Deprecated in favor of ``global_concurrency``, or of
-            ``partition_concurrency`` when combined with ``partition_queue``.
         :param global_concurrency: Maximum number of workflows from this queue that
             may be running globally (across all executors) at once. ``None`` (the
             default) means no global limit.
@@ -399,15 +398,7 @@ class DBOSClient:
             seconds. ``None`` disables rate limiting.
         :param worker_concurrency: Maximum number of workflows from this queue
             that may be running on a single executor at once. ``None`` means no
-            per-executor limit. May be combined with ``concurrency``.
-        :param priority_enabled: Deprecated and ignored. Every queue dequeues in
-            priority order, so ``SetEnqueueOptions(priority=...)`` takes effect
-            whatever this is set to.
-        :param partition_queue: Deprecated in favor of ``partition_concurrency``.
-            When ``True``, every enqueue must specify a ``queue_partition_key`` and
-            the concurrency, worker_concurrency, and limiter limits are all applied
-            per partition rather than to the queue as a whole. Deduplication is not
-            supported on partitioned queues.
+            per-executor limit. May be combined with ``global_concurrency``.
         :param polling_interval_sec: How often (in seconds) the worker thread
             wakes up to look for runnable workflows on this queue. Smaller
             values reduce dequeue latency at the cost of more database load.
@@ -419,6 +410,9 @@ class DBOSClient:
         :param application_name: The application that owns this queue and polls
             it. Defaults to the client's own application. Registering a queue
             already owned by a different application raises.
+        :param concurrency: Deprecated.
+        :param priority_enabled: Deprecated.
+        :param partition_queue: Deprecated.
 
         :returns: A :class:`Queue` bound to this client's system database.
         """
@@ -471,31 +465,32 @@ class DBOSClient:
         self,
         name: str,
         *,
-        concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         worker_concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "always_update",
         application_name: Optional[str] = None,
+        # Deprecated, retained for backwards compatibility
+        concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> Queue:
         """Async version of :meth:`register_queue`."""
         return await asyncio.to_thread(
             lambda: self.register_queue(
                 name,
-                concurrency=concurrency,
                 global_concurrency=global_concurrency,
                 partition_concurrency=partition_concurrency,
                 limiter=limiter,
                 worker_concurrency=worker_concurrency,
-                priority_enabled=priority_enabled,
-                partition_queue=partition_queue,
                 polling_interval_sec=polling_interval_sec,
                 on_conflict=on_conflict,
                 application_name=application_name,
+                concurrency=concurrency,
+                priority_enabled=priority_enabled,
+                partition_queue=partition_queue,
             )
         )
 

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -894,6 +894,7 @@ class QueueOutput:
     partition_queue: bool
     polling_interval_sec: float
     application_name: Optional[str]
+    partition_concurrency: Optional[int] = None
 
     @classmethod
     def from_queue(cls, q: "Queue") -> "QueueOutput":
@@ -907,6 +908,7 @@ class QueueOutput:
             partition_queue=q._partition_queue,
             polling_interval_sec=q._polling_interval_sec,
             application_name=q.application_name,
+            partition_concurrency=q._partition_concurrency,
         )
 
 

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -895,6 +895,9 @@ class QueueOutput:
     polling_interval_sec: float
     application_name: Optional[str]
     partition_concurrency: Optional[int] = None
+    partition_worker_concurrency: Optional[int] = None
+    partition_rate_limit_max: Optional[int] = None
+    partition_rate_limit_period_sec: Optional[float] = None
 
     @classmethod
     def from_queue(cls, q: "Queue") -> "QueueOutput":
@@ -909,6 +912,13 @@ class QueueOutput:
             polling_interval_sec=q._polling_interval_sec,
             application_name=q.application_name,
             partition_concurrency=q._partition_concurrency,
+            partition_worker_concurrency=q._partition_worker_concurrency,
+            partition_rate_limit_max=(
+                q._partition_limiter["limit"] if q._partition_limiter else None
+            ),
+            partition_rate_limit_period_sec=(
+                q._partition_limiter["period"] if q._partition_limiter else None
+            ),
         )
 
 

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -889,12 +889,24 @@ class ActiveWorkflowById:
         with self._lock:
             return list(self._m.keys())
 
-    def count_for_queue(
-        self, queue_name: str, queue_partition_key: Optional[str] = None
+    def count_for_queue(self, queue_name: str) -> int:
+        """
+        Count the number of active workflows associated with a given queue,
+        across every partition of it.
+        """
+        with self._lock:
+            return sum(
+                1
+                for bucket in self._m.values()
+                if bucket is not None and bucket[0] == queue_name
+            )
+
+    def count_for_partition(
+        self, queue_name: str, queue_partition_key: Optional[str]
     ) -> int:
         """
-        Count the number of active workflows associated with a given queue
-        (and partition key, if the queue is partitioned).
+        Count the number of active workflows associated with one partition of a
+        given queue.
         """
         target = (queue_name, queue_partition_key)
         with self._lock:

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -935,6 +935,8 @@ class DBOS:
         *,
         worker_concurrency: Optional[int] = None,
         concurrency: Optional[int] = None,
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,
@@ -948,9 +950,18 @@ class DBOS:
         :param worker_concurrency: Maximum number of workflows from this queue
             that may be running on a single executor at once. ``None`` means no
             per-executor limit. May be combined with ``concurrency``.
-        :param concurrency: Maximum number of workflows from this queue that may
-            be running globally (across all executors) at once. ``None`` (the
+        :param concurrency: Deprecated in favor of ``global_concurrency``, or of
+            ``partition_concurrency`` when combined with ``partition_queue``.
+        :param global_concurrency: Maximum number of workflows from this queue that
+            may be running globally (across all executors) at once. ``None`` (the
             default) means no global limit.
+        :param partition_concurrency: Maximum number of workflows from any one
+            partition of this queue that may be running globally (across all
+            executors) at once. Setting it makes the queue partitioned, so every
+            enqueue must specify a ``queue_partition_key``, while
+            ``global_concurrency``, ``worker_concurrency``, and ``limiter`` continue
+            to apply to the queue as a whole. Deduplication is not supported on
+            partitioned queues.
         :param limiter: Rate limit configuration of the form
             ``{"limit": int, "period": float}``. At most ``limit`` workflows
             from the queue will start within any rolling window of ``period``
@@ -959,10 +970,11 @@ class DBOS:
             priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
             are dequeued first. When ``False``, supplying a priority raises an
             error at enqueue time.
-        :param partition_queue: When ``True``, every enqueue must specify a
-            ``queue_partition_key`` and concurrency / worker_concurrency limits
-            are applied per partition rather than to the queue as a whole.
-            Deduplication is not supported on partitioned queues.
+        :param partition_queue: Deprecated in favor of ``partition_concurrency``.
+            When ``True``, every enqueue must specify a ``queue_partition_key`` and
+            the concurrency, worker_concurrency, and limiter limits are all applied
+            per partition rather than to the queue as a whole. Deduplication is not
+            supported on partitioned queues.
         :param polling_interval_sec: How often (in seconds) the worker thread
             wakes up to look for runnable workflows on this queue.
         :param on_conflict: Behavior when a queue with the same name already
@@ -984,6 +996,9 @@ class DBOS:
         Queue._validate_queue(
             concurrency=concurrency,
             worker_concurrency=worker_concurrency,
+            global_concurrency=global_concurrency,
+            partition_concurrency=partition_concurrency,
+            partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
         )
@@ -999,12 +1014,15 @@ class DBOS:
 
         inserted = dbos._sys_db.upsert_queue(
             name=name,
-            concurrency=concurrency,
+            concurrency=(
+                concurrency if global_concurrency is None else global_concurrency
+            ),
             worker_concurrency=worker_concurrency,
             rate_limit_max=limiter["limit"] if limiter else None,
             rate_limit_period_sec=limiter["period"] if limiter else None,
             priority_enabled=priority_enabled,
             partition_queue=partition_queue,
+            partition_concurrency=partition_concurrency,
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
         )
@@ -1026,6 +1044,8 @@ class DBOS:
         *,
         worker_concurrency: Optional[int] = None,
         concurrency: Optional[int] = None,
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,
@@ -1039,6 +1059,8 @@ class DBOS:
                 name,
                 worker_concurrency=worker_concurrency,
                 concurrency=concurrency,
+                global_concurrency=global_concurrency,
+                partition_concurrency=partition_concurrency,
                 limiter=limiter,
                 priority_enabled=priority_enabled,
                 partition_queue=partition_queue,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -936,6 +936,8 @@ class DBOS:
         worker_concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         limiter: Optional[QueueRateLimit] = None,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "update_if_latest_version",
@@ -956,7 +958,14 @@ class DBOS:
             default) means no global limit.
         :param partition_concurrency: Maximum number of workflows from any one
             partition of this queue that may be running globally (across all
-            executors) at once. Setting it makes the queue partitioned, so every
+            executors) at once.
+        :param partition_worker_concurrency: Maximum number of workflows from any
+            one partition of this queue that may be running on a single executor at
+            once.
+        :param partition_limiter: Rate limit applied to each partition separately,
+            of the form ``{"limit": int, "period": float}``.
+
+            Setting any ``partition_*`` limit makes the queue partitioned, so every
             enqueue must specify a ``queue_partition_key``, while
             ``global_concurrency``, ``worker_concurrency``, and ``limiter`` continue
             to apply to the queue as a whole. Deduplication is not supported on
@@ -992,6 +1001,8 @@ class DBOS:
             worker_concurrency=worker_concurrency,
             global_concurrency=global_concurrency,
             partition_concurrency=partition_concurrency,
+            partition_worker_concurrency=partition_worker_concurrency,
+            partition_limiter=partition_limiter,
             partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
@@ -1017,6 +1028,13 @@ class DBOS:
             priority_enabled=priority_enabled,
             partition_queue=partition_queue,
             partition_concurrency=partition_concurrency,
+            partition_worker_concurrency=partition_worker_concurrency,
+            partition_rate_limit_max=(
+                partition_limiter["limit"] if partition_limiter else None
+            ),
+            partition_rate_limit_period_sec=(
+                partition_limiter["period"] if partition_limiter else None
+            ),
             polling_interval_sec=polling_interval_sec,
             update_existing=update_existing,
         )
@@ -1039,6 +1057,8 @@ class DBOS:
         worker_concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         limiter: Optional[QueueRateLimit] = None,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "update_if_latest_version",
@@ -1055,6 +1075,8 @@ class DBOS:
                 worker_concurrency=worker_concurrency,
                 global_concurrency=global_concurrency,
                 partition_concurrency=partition_concurrency,
+                partition_worker_concurrency=partition_worker_concurrency,
+                partition_limiter=partition_limiter,
                 limiter=limiter,
                 polling_interval_sec=polling_interval_sec,
                 on_conflict=on_conflict,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -934,14 +934,15 @@ class DBOS:
         name: str,
         *,
         worker_concurrency: Optional[int] = None,
-        concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "update_if_latest_version",
+        # Deprecated, retained for backwards compatibility
+        concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> Queue:
         """
         Register a queue and persist its configuration to the system database.
@@ -950,8 +951,6 @@ class DBOS:
         :param worker_concurrency: Maximum number of workflows from this queue
             that may be running on a single executor at once. ``None`` means no
             per-executor limit. May be combined with ``concurrency``.
-        :param concurrency: Deprecated in favor of ``global_concurrency``, or of
-            ``partition_concurrency`` when combined with ``partition_queue``.
         :param global_concurrency: Maximum number of workflows from this queue that
             may be running globally (across all executors) at once. ``None`` (the
             default) means no global limit.
@@ -966,14 +965,6 @@ class DBOS:
             ``{"limit": int, "period": float}``. At most ``limit`` workflows
             from the queue will start within any rolling window of ``period``
             seconds. ``None`` disables rate limiting.
-        :param priority_enabled: Deprecated and ignored. Every queue dequeues in
-            priority order, so ``SetEnqueueOptions(priority=...)`` takes effect
-            whatever this is set to.
-        :param partition_queue: Deprecated in favor of ``partition_concurrency``.
-            When ``True``, every enqueue must specify a ``queue_partition_key`` and
-            the concurrency, worker_concurrency, and limiter limits are all applied
-            per partition rather than to the queue as a whole. Deduplication is not
-            supported on partitioned queues.
         :param polling_interval_sec: How often (in seconds) the worker thread
             wakes up to look for runnable workflows on this queue.
         :param on_conflict: Behavior when a queue with the same name already
@@ -988,6 +979,10 @@ class DBOS:
 
             A queue already registered by a different application raises in every
             mode: the name is its address, so a collision is not ours to resolve.
+
+        :param concurrency: Deprecated.
+        :param priority_enabled: Deprecated.
+        :param partition_queue: Deprecated.
 
         :returns: A :class:`Queue` reflecting the persisted configuration.
         """
@@ -1042,14 +1037,15 @@ class DBOS:
         name: str,
         *,
         worker_concurrency: Optional[int] = None,
-        concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
         limiter: Optional[QueueRateLimit] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         polling_interval_sec: float = 1.0,
         on_conflict: QueueConflictResolution = "update_if_latest_version",
+        # Deprecated, retained for backwards compatibility
+        concurrency: Optional[int] = None,
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> Queue:
         """Async version of :meth:`register_queue`."""
         await cls._configure_asyncio_thread_pool()
@@ -1057,14 +1053,14 @@ class DBOS:
             lambda: cls.register_queue(
                 name,
                 worker_concurrency=worker_concurrency,
-                concurrency=concurrency,
                 global_concurrency=global_concurrency,
                 partition_concurrency=partition_concurrency,
                 limiter=limiter,
-                priority_enabled=priority_enabled,
-                partition_queue=partition_queue,
                 polling_interval_sec=polling_interval_sec,
                 on_conflict=on_conflict,
+                concurrency=concurrency,
+                priority_enabled=priority_enabled,
+                partition_queue=partition_queue,
             )
         )
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -966,10 +966,9 @@ class DBOS:
             ``{"limit": int, "period": float}``. At most ``limit`` workflows
             from the queue will start within any rolling window of ``period``
             seconds. ``None`` disables rate limiting.
-        :param priority_enabled: When ``True``, callers may set a workflow
-            priority via ``SetEnqueueOptions(priority=...)`` and lower numbers
-            are dequeued first. When ``False``, supplying a priority raises an
-            error at enqueue time.
+        :param priority_enabled: Deprecated and ignored. Every queue dequeues in
+            priority order, so ``SetEnqueueOptions(priority=...)`` takes effect
+            whatever this is set to.
         :param partition_queue: Deprecated in favor of ``partition_concurrency``.
             When ``True``, every enqueue must specify a ``queue_partition_key`` and
             the concurrency, worker_concurrency, and limiter limits are all applied

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -989,9 +989,9 @@ class DBOS:
             A queue already registered by a different application raises in every
             mode: the name is its address, so a collision is not ours to resolve.
 
-        :param concurrency: Deprecated.
-        :param priority_enabled: Deprecated.
-        :param partition_queue: Deprecated.
+        :param concurrency: Deprecated. Use ``global_concurrency``.
+        :param priority_enabled: Deprecated. Priority is always enabled.
+        :param partition_queue: Deprecated. Use the ``partition_*`` limits.
 
         :returns: A :class:`Queue` reflecting the persisted configuration.
         """

--- a/dbos/_kafka.py
+++ b/dbos/_kafka.py
@@ -455,13 +455,12 @@ def kafka_consumer(
                 else _get_or_create_queue(dbosreg, KAFKA_QUEUE_NAME).name
             )
         else:
-            # One shared partitioned queue: concurrency=1 is enforced per partition
-            # key, so execution is serial per key and parallel across keys.
+            # One shared partitioned queue: a per-partition concurrency of 1 makes
+            # execution serial per partition key and parallel across keys.
             consumer_queue_name = _get_or_create_queue(
                 dbosreg,
                 KAFKA_ORDERED_QUEUE_NAME,
-                partition_queue=True,
-                concurrency=1,
+                partition_concurrency=1,
             ).name
 
         # This process runs the poller and enqueues onto the consumer's queue, so it must poll it even under a listen_queues filter.

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -1132,6 +1132,12 @@ def get_dbos_migration_hundredseven(schema: str, is_cockroach: bool) -> str:
     WHERE "application_name" IS NULL"""
 
 
+def get_dbos_migration_hundredeight(schema: str) -> str:
+    return f"""
+ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_concurrency" INT4 DEFAULT NULL;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -1194,6 +1200,7 @@ def get_dbos_migrations(
         get_dbos_migration_hundredfive(schema, is_cockroach),
         get_dbos_migration_hundredsix(schema),
         get_dbos_migration_hundredseven(schema, is_cockroach),
+        get_dbos_migration_hundredeight(schema),
     ]
 
 
@@ -1495,6 +1502,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
     WHERE "application_name" IS NULL;
 """
 
+sqlite_migration_hundredeight = (
+    'ALTER TABLE queues ADD COLUMN "partition_concurrency" INTEGER DEFAULT NULL'
+)
+
 _sqlite_history = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1554,4 +1565,5 @@ sqlite_migrations = [
     "",
     sqlite_migration_hundredsix,
     sqlite_migration_hundredseven,
+    sqlite_migration_hundredeight,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -1133,13 +1133,9 @@ def get_dbos_migration_hundredseven(schema: str, is_cockroach: bool) -> str:
 
 
 def get_dbos_migration_hundredeight(schema: str) -> str:
+    # Any of these being set partitions the queue; each applies per partition.
     return f"""
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_concurrency" INT4 DEFAULT NULL;
-"""
-
-
-def get_dbos_migration_hundrednine(schema: str) -> str:
-    return f"""
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_worker_concurrency" INT4 DEFAULT NULL;
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_rate_limit_max" INT4 DEFAULT NULL;
 ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_rate_limit_period_sec" DOUBLE PRECISION DEFAULT NULL;
@@ -1209,7 +1205,6 @@ def get_dbos_migrations(
         get_dbos_migration_hundredsix(schema),
         get_dbos_migration_hundredseven(schema, is_cockroach),
         get_dbos_migration_hundredeight(schema),
-        get_dbos_migration_hundrednine(schema),
     ]
 
 
@@ -1511,11 +1506,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uq_application_versions_unclaimed_version"
     WHERE "application_name" IS NULL;
 """
 
-sqlite_migration_hundredeight = (
-    'ALTER TABLE queues ADD COLUMN "partition_concurrency" INTEGER DEFAULT NULL'
-)
-
-sqlite_migration_hundrednine = """
+# Any of these being set partitions the queue; each applies per partition.
+sqlite_migration_hundredeight = """
+ALTER TABLE queues ADD COLUMN "partition_concurrency" INTEGER DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "partition_worker_concurrency" INTEGER DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "partition_rate_limit_max" INTEGER DEFAULT NULL;
 ALTER TABLE queues ADD COLUMN "partition_rate_limit_period_sec" REAL DEFAULT NULL;
@@ -1581,5 +1574,4 @@ sqlite_migrations = [
     sqlite_migration_hundredsix,
     sqlite_migration_hundredseven,
     sqlite_migration_hundredeight,
-    sqlite_migration_hundrednine,
 ]

--- a/dbos/_migration.py
+++ b/dbos/_migration.py
@@ -1138,6 +1138,14 @@ ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_concurrency"
 """
 
 
+def get_dbos_migration_hundrednine(schema: str) -> str:
+    return f"""
+ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_worker_concurrency" INT4 DEFAULT NULL;
+ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_rate_limit_max" INT4 DEFAULT NULL;
+ALTER TABLE "{schema}"."queues" ADD COLUMN IF NOT EXISTS "partition_rate_limit_period_sec" DOUBLE PRECISION DEFAULT NULL;
+"""
+
+
 def get_dbos_migrations(
     schema: str, use_listen_notify: bool, is_cockroach: bool = False
 ) -> list[str]:
@@ -1201,6 +1209,7 @@ def get_dbos_migrations(
         get_dbos_migration_hundredsix(schema),
         get_dbos_migration_hundredseven(schema, is_cockroach),
         get_dbos_migration_hundredeight(schema),
+        get_dbos_migration_hundrednine(schema),
     ]
 
 
@@ -1506,6 +1515,12 @@ sqlite_migration_hundredeight = (
     'ALTER TABLE queues ADD COLUMN "partition_concurrency" INTEGER DEFAULT NULL'
 )
 
+sqlite_migration_hundrednine = """
+ALTER TABLE queues ADD COLUMN "partition_worker_concurrency" INTEGER DEFAULT NULL;
+ALTER TABLE queues ADD COLUMN "partition_rate_limit_max" INTEGER DEFAULT NULL;
+ALTER TABLE queues ADD COLUMN "partition_rate_limit_period_sec" REAL DEFAULT NULL;
+"""
+
 _sqlite_history = [
     sqlite_migration_one,
     sqlite_migration_two,
@@ -1566,4 +1581,5 @@ sqlite_migrations = [
     sqlite_migration_hundredsix,
     sqlite_migration_hundredseven,
     sqlite_migration_hundredeight,
+    sqlite_migration_hundrednine,
 ]

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -355,6 +355,7 @@ class Queue:
 
     @property
     def concurrency(self) -> Optional[int]:
+        """Deprecated. Use global_concurrency."""
         if self.database_backed_queue:
             _warn_sync_db_call_in_async_context(
                 "Queue.concurrency", "Queue.get_concurrency_async"
@@ -363,12 +364,14 @@ class Queue:
         return self._concurrency
 
     async def get_concurrency_async(self) -> Optional[int]:
+        """Deprecated. Use get_global_concurrency_async."""
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
         return self._concurrency
 
     def set_concurrency(self, value: Optional[int]) -> None:
+        """Deprecated. Use set_global_concurrency."""
         self._require_database_backed()
         _warn_sync_db_call_in_async_context(
             "Queue.set_concurrency", "Queue.set_concurrency_async"
@@ -381,6 +384,7 @@ class Queue:
         self._concurrency = value
 
     async def set_concurrency_async(self, value: Optional[int]) -> None:
+        """Deprecated. Use set_global_concurrency_async."""
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_concurrency, value)
 
@@ -635,7 +639,7 @@ class Queue:
 
     @property
     def priority_enabled(self) -> bool:
-        """Deprecated."""
+        """Deprecated. Priority is always enabled."""
         if self.database_backed_queue:
             _warn_sync_db_call_in_async_context(
                 "Queue.priority_enabled", "Queue.get_priority_enabled_async"
@@ -644,12 +648,14 @@ class Queue:
         return self._priority_enabled
 
     async def get_priority_enabled_async(self) -> bool:
+        """Deprecated. Priority is always enabled."""
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
         return self._priority_enabled
 
     def set_priority_enabled(self, value: bool) -> None:
+        """Deprecated. Priority is always enabled."""
         self._require_database_backed()
         _warn_sync_db_call_in_async_context(
             "Queue.set_priority_enabled", "Queue.set_priority_enabled_async"
@@ -658,11 +664,13 @@ class Queue:
         self._priority_enabled = value
 
     async def set_priority_enabled_async(self, value: bool) -> None:
+        """Deprecated. Priority is always enabled."""
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_priority_enabled, value)
 
     @property
     def partition_queue(self) -> bool:
+        """Deprecated. Use the partition_* limits."""
         if self.database_backed_queue:
             _warn_sync_db_call_in_async_context(
                 "Queue.partition_queue", "Queue.get_partition_queue_async"
@@ -671,12 +679,14 @@ class Queue:
         return self._partition_queue
 
     async def get_partition_queue_async(self) -> bool:
+        """Deprecated. Use the partition_* limits."""
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
         return self._partition_queue
 
     def set_partition_queue(self, value: bool) -> None:
+        """Deprecated. Use the set_partition_* setters."""
         self._require_database_backed()
         _warn_sync_db_call_in_async_context(
             "Queue.set_partition_queue", "Queue.set_partition_queue_async"
@@ -692,6 +702,7 @@ class Queue:
         self._partition_queue = value
 
     async def set_partition_queue_async(self, value: bool) -> None:
+        """Deprecated. Use the set_partition_*_async setters."""
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_partition_queue, value)
 

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import random
 import threading
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -66,6 +67,18 @@ class QueueRateLimit(TypedDict):
     period: float
 
 
+@dataclass
+class ResolvedQueueLimits:
+    """A queue's limits, each resolved to the scope it is enforced at."""
+
+    global_concurrency: Optional[int]
+    worker_concurrency: Optional[int]
+    limiter: Optional[QueueRateLimit]
+    partition_concurrency: Optional[int]
+    partition_worker_concurrency: Optional[int]
+    partition_limiter: Optional[QueueRateLimit]
+
+
 class Queue:
     """
     Workflow queue.
@@ -81,6 +94,8 @@ class Queue:
         limiter: Optional[QueueRateLimit] = None,
         *,  # Disable positional arguments from here on
         worker_concurrency: Optional[int] = None,
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
         priority_enabled: bool = False,
         partition_queue: bool = False,
         polling_interval_sec: float = DEFAULT_QUEUE_POLLING_INTERVAL_SEC,
@@ -88,12 +103,18 @@ class Queue:
         client_system_database: Optional["SystemDatabase"] = None,
         application_name: Optional[str] = None,
     ) -> None:
-        Queue._validate_queue(
-            concurrency=concurrency,
-            worker_concurrency=worker_concurrency,
-            polling_interval_sec=polling_interval_sec,
-            limiter=limiter,
-        )
+        # Rows are validated when written, and a row legitimately carries both
+        # partition_queue and partition_concurrency, which no caller may combine.
+        if not database_backed_queue:
+            Queue._validate_queue(
+                concurrency=concurrency,
+                worker_concurrency=worker_concurrency,
+                global_concurrency=global_concurrency,
+                partition_concurrency=partition_concurrency,
+                partition_queue=partition_queue,
+                polling_interval_sec=polling_interval_sec,
+                limiter=limiter,
+            )
         self.name = name
         self.database_backed_queue = database_backed_queue
         # Owner from the queues table; None for in-memory and pre-upgrade queues.
@@ -102,13 +123,18 @@ class Queue:
         # DBOS singleton's. This allows a DBOSClient to manipulate queues
         # without depending on a launched DBOS process.
         self._client_system_database = client_system_database
-        # Local cache of configurable params. Property getters consult this
-        # for in-memory queues and the database for database-backed queues.
-        self._concurrency = concurrency
+        # Local cache of configurable params, mirroring the queues-table columns.
+        # Property getters consult this for in-memory queues and the database for
+        # database-backed queues.
+        self._concurrency = (
+            concurrency if global_concurrency is None else global_concurrency
+        )
         self._worker_concurrency = worker_concurrency
         self._limiter = limiter
         self._priority_enabled = priority_enabled
-        self._partition_queue = partition_queue
+        # Partitioning is inferred from partition_concurrency; the deprecated flag tracks it.
+        self._partition_queue = partition_queue or partition_concurrency is not None
+        self._partition_concurrency = partition_concurrency
         self._polling_interval_sec = polling_interval_sec
 
         # Database-backed queues skip the in-memory global registry; their
@@ -130,15 +156,41 @@ class Queue:
         worker_concurrency: Optional[int],
         polling_interval_sec: float,
         limiter: Optional[QueueRateLimit],
+        global_concurrency: Optional[int] = None,
+        partition_concurrency: Optional[int] = None,
+        partition_queue: bool = False,
     ) -> None:
         """Validate queue configuration parameters, raising ValueError on bad input."""
+        if concurrency is not None and global_concurrency is not None:
+            raise ValueError(
+                "concurrency is deprecated in favor of global_concurrency; set only one of them"
+            )
+        if partition_queue and partition_concurrency is not None:
+            raise ValueError(
+                "partition_queue is deprecated in favor of partition_concurrency; set only one of them"
+            )
+        if partition_concurrency is not None and partition_concurrency < 1:
+            raise ValueError("partition_concurrency must be at least 1")
+        # Under the deprecated partition_queue spelling, concurrency is itself a
+        # per-partition limit, so the worker_concurrency check below compares like with like.
+        queue_concurrency = (
+            concurrency if global_concurrency is None else global_concurrency
+        )
         if (
             worker_concurrency is not None
-            and concurrency is not None
-            and worker_concurrency > concurrency
+            and queue_concurrency is not None
+            and worker_concurrency > queue_concurrency
         ):
             raise ValueError(
                 "concurrency must be greater than or equal to worker_concurrency"
+            )
+        if (
+            partition_concurrency is not None
+            and queue_concurrency is not None
+            and partition_concurrency > queue_concurrency
+        ):
+            raise ValueError(
+                "global_concurrency must be greater than or equal to partition_concurrency"
             )
         if polling_interval_sec <= 0.0:
             raise ValueError("polling_interval_sec must be positive")
@@ -146,6 +198,57 @@ class Queue:
             limiter.get("limit") is None or limiter.get("period") is None
         ):
             raise ValueError("limiter must specify both 'limit' and 'period'")
+
+    def _is_legacy_partitioned(self) -> bool:
+        """True when the queue uses the deprecated partition_queue spelling, under
+        which concurrency, worker_concurrency, and limiter all apply per partition."""
+        return self._partition_queue and self._partition_concurrency is None
+
+    def _resolve_limits(self) -> ResolvedQueueLimits:
+        """Resolve every limit to the scope it is enforced at."""
+        if self._is_legacy_partitioned():
+            return ResolvedQueueLimits(
+                global_concurrency=None,
+                worker_concurrency=None,
+                limiter=None,
+                partition_concurrency=self._concurrency,
+                partition_worker_concurrency=self._worker_concurrency,
+                partition_limiter=self._limiter,
+            )
+        return ResolvedQueueLimits(
+            global_concurrency=self._concurrency,
+            worker_concurrency=self._worker_concurrency,
+            limiter=self._limiter,
+            partition_concurrency=self._partition_concurrency,
+            partition_worker_concurrency=None,
+            partition_limiter=None,
+        )
+
+    def _require_not_legacy_partitioned(self, field: str) -> None:
+        """Reject a write that would re-scope the other limits on a legacy queue."""
+        if self._is_legacy_partitioned():
+            raise DBOSException(
+                f"Cannot set {field} on queue {self.name}: it is registered with the "
+                "deprecated partition_queue option, under which concurrency, "
+                "worker_concurrency, and limiter apply per partition. Re-register the "
+                "queue with partition_concurrency instead."
+            )
+
+    def _check_concurrency_bounds(self, value: Optional[int]) -> None:
+        """Validate a new concurrency against the cached sibling limits."""
+        if value is None:
+            return
+        if self._worker_concurrency is not None and self._worker_concurrency > value:
+            raise ValueError(
+                "worker_concurrency must be less than or equal to concurrency"
+            )
+        if (
+            self._partition_concurrency is not None
+            and self._partition_concurrency > value
+        ):
+            raise ValueError(
+                "partition_concurrency must be less than or equal to global_concurrency"
+            )
 
     def _require_database_backed(self) -> None:
         if not self.database_backed_queue:
@@ -179,6 +282,7 @@ class Queue:
         self._limiter = latest._limiter
         self._priority_enabled = latest._priority_enabled
         self._partition_queue = latest._partition_queue
+        self._partition_concurrency = latest._partition_concurrency
         self._polling_interval_sec = latest._polling_interval_sec
         self.application_name = latest.application_name
 
@@ -213,20 +317,88 @@ class Queue:
         # Refresh the local cache so the cross-field check below validates
         # against the latest worker_concurrency stored in the database.
         self._refresh_fields(self._read_from_db())
-        if (
-            value is not None
-            and self._worker_concurrency is not None
-            and self._worker_concurrency > value
-        ):
-            raise ValueError(
-                "worker_concurrency must be less than or equal to concurrency"
-            )
+        self._check_concurrency_bounds(value)
         self._write_to_db({"concurrency": value})
         self._concurrency = value
 
     async def set_concurrency_async(self, value: Optional[int]) -> None:
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_concurrency, value)
+
+    @property
+    def global_concurrency(self) -> Optional[int]:
+        if self.database_backed_queue:
+            _warn_sync_db_call_in_async_context(
+                "Queue.global_concurrency", "Queue.get_global_concurrency_async"
+            )
+            self._refresh_fields(self._read_from_db())
+        return self._resolve_limits().global_concurrency
+
+    async def get_global_concurrency_async(self) -> Optional[int]:
+        if self.database_backed_queue:
+            await self._configure_thread_pool()
+            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
+        return self._resolve_limits().global_concurrency
+
+    def set_global_concurrency(self, value: Optional[int]) -> None:
+        self._require_database_backed()
+        _warn_sync_db_call_in_async_context(
+            "Queue.set_global_concurrency", "Queue.set_global_concurrency_async"
+        )
+        # Refresh the local cache so the mode and cross-field checks below see
+        # the latest configuration stored in the database.
+        self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("global_concurrency")
+        self._check_concurrency_bounds(value)
+        self._write_to_db({"concurrency": value})
+        self._concurrency = value
+
+    async def set_global_concurrency_async(self, value: Optional[int]) -> None:
+        await self._configure_thread_pool()
+        await asyncio.to_thread(self.set_global_concurrency, value)
+
+    @property
+    def partition_concurrency(self) -> Optional[int]:
+        if self.database_backed_queue:
+            _warn_sync_db_call_in_async_context(
+                "Queue.partition_concurrency", "Queue.get_partition_concurrency_async"
+            )
+            self._refresh_fields(self._read_from_db())
+        return self._resolve_limits().partition_concurrency
+
+    async def get_partition_concurrency_async(self) -> Optional[int]:
+        if self.database_backed_queue:
+            await self._configure_thread_pool()
+            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
+        return self._resolve_limits().partition_concurrency
+
+    def set_partition_concurrency(self, value: Optional[int]) -> None:
+        self._require_database_backed()
+        _warn_sync_db_call_in_async_context(
+            "Queue.set_partition_concurrency", "Queue.set_partition_concurrency_async"
+        )
+        if value is not None and value < 1:
+            raise ValueError("partition_concurrency must be at least 1")
+        self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("partition_concurrency")
+        if (
+            value is not None
+            and self._concurrency is not None
+            and value > self._concurrency
+        ):
+            raise ValueError(
+                "partition_concurrency must be less than or equal to global_concurrency"
+            )
+        # Partitioning is inferred from the limit, so the deprecated flag follows it.
+        self._write_to_db(
+            {"partition_concurrency": value, "partition_queue": value is not None}
+        )
+        self._partition_concurrency = value
+        self._partition_queue = value is not None
+
+    async def set_partition_concurrency_async(self, value: Optional[int]) -> None:
+        await self._configure_thread_pool()
+        await asyncio.to_thread(self.set_partition_concurrency, value)
 
     @property
     def worker_concurrency(self) -> Optional[int]:
@@ -349,6 +521,13 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_partition_queue", "Queue.set_partition_queue_async"
         )
+        # Refresh so the check below sees the latest partition_concurrency.
+        self._refresh_fields(self._read_from_db())
+        if self._partition_concurrency is not None:
+            raise DBOSException(
+                f"Cannot set partition_queue on queue {self.name}: it is partitioned "
+                "via partition_concurrency. Use set_partition_concurrency instead."
+            )
         self._write_to_db({"partition_queue": value})
         self._partition_queue = value
 
@@ -704,7 +883,11 @@ def log_queue(q: Queue) -> None:
     are omitted, matching ``Queue: <name> (concurrency=…, worker_concurrency=…,
     limit=N/Ts, priority, partitioned)``."""
     opts = []
-    if q._concurrency is not None:
+    if q._partition_concurrency is not None:
+        if q._concurrency is not None:
+            opts.append(f"global_concurrency={q._concurrency}")
+        opts.append(f"partition_concurrency={q._partition_concurrency}")
+    elif q._concurrency is not None:
         opts.append(f"concurrency={q._concurrency}")
     if q._worker_concurrency is not None:
         opts.append(f"worker_concurrency={q._worker_concurrency}")

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -96,12 +96,14 @@ class Queue:
         worker_concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         polling_interval_sec: float = DEFAULT_QUEUE_POLLING_INTERVAL_SEC,
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
         application_name: Optional[str] = None,
+        # Deprecated, retained for backwards compatibility. concurrency and limiter
+        # keep their positional slots above: moving them would rebind Queue("q", 5).
+        priority_enabled: bool = False,
+        partition_queue: bool = False,
     ) -> None:
         # Rows are validated when written, and a row legitimately carries both
         # partition_queue and partition_concurrency, which no caller may combine.
@@ -476,7 +478,7 @@ class Queue:
 
     @property
     def priority_enabled(self) -> bool:
-        """Deprecated and ignored: every queue dequeues in priority order."""
+        """Deprecated."""
         if self.database_backed_queue:
             _warn_sync_db_call_in_async_context(
                 "Queue.priority_enabled", "Queue.get_priority_enabled_async"

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -180,6 +180,10 @@ class Queue:
             raise ValueError(
                 "partition_queue is deprecated in favor of the partition_* limits; set only one of them"
             )
+        if partition_queue and global_concurrency is not None:
+            raise ValueError(
+                "partition_queue applies every limit per partition, so it cannot be combined with global_concurrency; use partition_concurrency instead"
+            )
         if partition_concurrency is not None and partition_concurrency < 1:
             raise ValueError("partition_concurrency must be at least 1")
         if partition_limiter is not None and (
@@ -222,6 +226,14 @@ class Queue:
         ):
             raise ValueError(
                 "global_concurrency must be greater than or equal to partition_concurrency"
+            )
+        if (
+            partition_worker_concurrency is not None
+            and queue_concurrency is not None
+            and partition_worker_concurrency > queue_concurrency
+        ):
+            raise ValueError(
+                "concurrency must be greater than or equal to partition_worker_concurrency"
             )
         if polling_interval_sec <= 0.0:
             raise ValueError("polling_interval_sec must be positive")
@@ -495,6 +507,10 @@ class Queue:
             ):
                 raise ValueError(
                     "partition_worker_concurrency must be less than or equal to worker_concurrency"
+                )
+            if self._concurrency is not None and value > self._concurrency:
+                raise ValueError(
+                    "partition_worker_concurrency must be less than or equal to concurrency"
                 )
         partitioned = self._partitioned_after(_partition_worker_concurrency=value)
         self._write_to_db(
@@ -818,19 +834,16 @@ def queue_worker_thread(
             except Exception as e:
                 dbos.logger.error(f"Error executing workflow {id}: {e}")
 
-    def worker_budget(limits: ResolvedQueueLimits, claimed: int = 0) -> int:
-        """Room left under this worker's queue-wide concurrency limit, counting rows
-        already claimed this sweep: dispatch is asynchronous, so the active set does
-        not count them yet."""
+    def worker_budget(limits: ResolvedQueueLimits, running: int) -> int:
+        """Room left under this worker's queue-wide concurrency limit, given how many of
+        its workflows are already running or claimed."""
+        if limits.partition_worker_concurrency == 0:
+            # Zero per partition pauses this worker: no partition may run anything here, and the batched sweep enforces no per-partition worker limit of its own.
+            return 0
         if limits.worker_concurrency is None:
-            # A legacy per-partition worker limit is enforced per partition instead, except for zero, which stops this worker dequeueing at all.
-            return 0 if limits.partition_worker_concurrency == 0 else sys.maxsize
-        return max(
-            0,
-            limits.worker_concurrency
-            - dbos._active_workflows_set.count_for_queue(queue.name)
-            - claimed,
-        )
+            # A non-zero per-partition worker limit is enforced per partition instead.
+            return sys.maxsize
+        return max(0, limits.worker_concurrency - running)
 
     while not stop_event.is_set():
         # Reload database-backed queue config once per iteration so dynamic
@@ -879,7 +892,9 @@ def queue_worker_thread(
                 and limits.partition_limiter is None
             ):
                 # Optimization: Batch dequeue if partition concurrency is 1
-                max_tasks = worker_budget(limits)
+                max_tasks = worker_budget(
+                    limits, dbos._active_workflows_set.count_for_queue(queue.name)
+                )
                 if max_tasks > 0:
                     dequeued_workflows = (
                         dbos._sys_db.start_queued_partitioned_workflows(
@@ -894,9 +909,11 @@ def queue_worker_thread(
                 # Iterate through partitions one at a time in random order to prevent starvation.
                 partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                 random.shuffle(partition_keys)
+                # Snapshot once: re-reading would count this sweep's own claims twice, since dispatch is asynchronous and `claimed` already accounts for them.
+                running = dbos._active_workflows_set.count_for_queue(queue.name)
                 claimed = 0
                 for key in partition_keys:
-                    if worker_budget(limits, claimed) <= 0:
+                    if worker_budget(limits, running + claimed) <= 0:
                         break
                     try:
                         dequeued_workflows = dbos._sys_db.start_queued_workflows(
@@ -904,8 +921,7 @@ def queue_worker_thread(
                             GlobalParams.executor_id,
                             GlobalParams.app_version,
                             key,
-                            dbos._active_workflows_set.count_for_queue(queue.name)
-                            + claimed,
+                            running + claimed,
                             dbos._active_workflows_set.count_for_partition(
                                 queue.name, key
                             ),

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -103,11 +103,10 @@ class Queue:
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
         application_name: Optional[str] = None,
-        # Deprecated, retained for backwards compatibility. concurrency and limiter keep their positional slots above: moving them would rebind Queue("q", 5).
+        # Deprecated, retained for backwards compatibility
         priority_enabled: bool = False,
         partition_queue: bool = False,
     ) -> None:
-        # Rows are validated when written, and a row legitimately carries both partition_queue and the partition limits, which no caller may combine.
         if not database_backed_queue:
             Queue._validate_queue(
                 concurrency=concurrency,
@@ -128,7 +127,6 @@ class Queue:
         # DBOS singleton's. This allows a DBOSClient to manipulate queues
         # without depending on a launched DBOS process.
         self._client_system_database = client_system_database
-        # Local cache of the queues-table columns; getters consult it for in-memory queues and the database for database-backed ones.
         self._concurrency = (
             concurrency if global_concurrency is None else global_concurrency
         )
@@ -138,7 +136,7 @@ class Queue:
         self._partition_concurrency = partition_concurrency
         self._partition_worker_concurrency = partition_worker_concurrency
         self._partition_limiter = partition_limiter
-        # Partitioning is inferred from any per-partition limit; the deprecated flag tracks it.
+        # Partitioning is inferred from any per-partition limit
         self._partition_queue = partition_queue or self._has_partition_limits()
         self._polling_interval_sec = polling_interval_sec
 
@@ -212,7 +210,7 @@ class Queue:
             raise ValueError(
                 "worker_concurrency must be greater than or equal to partition_worker_concurrency"
             )
-        # Under the deprecated partition_queue spelling concurrency is itself a per-partition limit, so the worker_concurrency check below compares like with like.
+        # In the deprecated partition_queue mode concurrency is itself a per-partition limit, so the worker_concurrency check below compares like with like.
         queue_concurrency = (
             concurrency if global_concurrency is None else global_concurrency
         )
@@ -262,7 +260,7 @@ class Queue:
         return any(value is not None for value in values.values())
 
     def _is_legacy_partitioned(self) -> bool:
-        """True when the queue uses the deprecated partition_queue spelling, under
+        """True when the queue uses the deprecated partition_queue mode, under
         which concurrency, worker_concurrency, and limiter all apply per partition."""
         return self._partition_queue and not self._has_partition_limits()
 
@@ -856,10 +854,8 @@ def queue_worker_thread(
             limits.partition_worker_concurrency is not None
             and limits.partition_worker_concurrency <= 0
         ):
-            # Zero per partition pauses this worker: no partition may run anything here, and the batched sweep enforces no per-partition worker limit of its own.
             return 0
         if limits.worker_concurrency is None:
-            # A non-zero per-partition worker limit is enforced per partition instead.
             return sys.maxsize
         return max(0, limits.worker_concurrency - running)
 

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -734,9 +734,13 @@ def queue_worker_thread(
                     )
                     start_dequeued_workflows(dequeued_workflows)
             else:
-                # Every other partitioned config sweeps one partition at a time.
+                # Every other partitioned config sweeps one partition at a time, in
+                # random order: a budget that runs out partway through would otherwise
+                # strand the same keys every sweep.
+                partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
+                random.shuffle(partition_keys)
                 claimed = 0
-                for key in dbos._sys_db.get_queue_partitions(queue.name):
+                for key in partition_keys:
                     if worker_budget(limits, claimed) <= 0:
                         break
                     try:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import random
+import sys
 import threading
 from dataclasses import dataclass
 from typing import (
@@ -657,6 +658,21 @@ def queue_worker_thread(
             except Exception as e:
                 dbos.logger.error(f"Error executing workflow {id}: {e}")
 
+    def worker_budget(limits: ResolvedQueueLimits, claimed: int = 0) -> int:
+        """Room left under this worker's queue-wide concurrency limit, counting rows
+        already claimed this sweep: dispatch is asynchronous, so the active set does
+        not count them yet."""
+        if limits.worker_concurrency is None:
+            # A legacy per-partition worker limit is enforced per partition instead,
+            # except for zero, which stops this worker dequeueing at all.
+            return 0 if limits.partition_worker_concurrency == 0 else sys.maxsize
+        return max(
+            0,
+            limits.worker_concurrency
+            - dbos._active_workflows_set.count_for_queue(queue.name)
+            - claimed,
+        )
+
     while not stop_event.is_set():
         # Reload database-backed queue config once per iteration so dynamic
         # changes (concurrency, polling interval, etc.) take effect without
@@ -687,30 +703,52 @@ def queue_worker_thread(
             return
 
         try:
-            if (
-                queue._partition_queue
-                and queue._concurrency == 1
-                and queue._limiter is None
-                and queue._worker_concurrency != 0
-            ):
-                # Batched path: one transaction claims every partition's head (valid only for concurrency=1, see start_queued_partitioned_workflows).
-                dequeued_workflows = dbos._sys_db.start_queued_partitioned_workflows(
+            limits = queue._resolve_limits()
+            if not queue._partition_queue:
+                dequeued_workflows = dbos._sys_db.start_queued_workflows(
                     queue,
                     GlobalParams.executor_id,
                     GlobalParams.app_version,
+                    None,
+                    dbos._active_workflows_set.count_for_queue(queue.name),
                 )
                 start_dequeued_workflows(dequeued_workflows)
-            elif queue._partition_queue:
+            elif (
+                limits.partition_concurrency == 1
+                and limits.global_concurrency is None
+                and limits.limiter is None
+                and limits.partition_limiter is None
+            ):
+                # Batched path: one transaction claims every partition's head. Only this
+                # worker's own budget bounds it, so nothing peers must also see is at
+                # stake (see start_queued_partitioned_workflows).
+                max_tasks = worker_budget(limits)
+                if max_tasks > 0:
+                    dequeued_workflows = (
+                        dbos._sys_db.start_queued_partitioned_workflows(
+                            queue,
+                            GlobalParams.executor_id,
+                            GlobalParams.app_version,
+                            max_tasks,
+                        )
+                    )
+                    start_dequeued_workflows(dequeued_workflows)
+            else:
                 # Every other partitioned config sweeps one partition at a time.
-                queue_partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
-                for key in queue_partition_keys:
+                claimed = 0
+                for key in dbos._sys_db.get_queue_partitions(queue.name):
+                    if worker_budget(limits, claimed) <= 0:
+                        break
                     try:
                         dequeued_workflows = dbos._sys_db.start_queued_workflows(
                             queue,
                             GlobalParams.executor_id,
                             GlobalParams.app_version,
                             key,
-                            dbos._active_workflows_set.count_for_queue(queue.name),
+                            # Rows claimed earlier in this sweep dispatch asynchronously,
+                            # so the active set does not count them yet.
+                            dbos._active_workflows_set.count_for_queue(queue.name)
+                            + claimed,
                             dbos._active_workflows_set.count_for_partition(
                                 queue.name, key
                             ),
@@ -723,19 +761,8 @@ def queue_worker_thread(
                         ):
                             continue
                         raise
+                    claimed += len(dequeued_workflows)
                     start_dequeued_workflows(dequeued_workflows)
-            else:
-                local_running_count = dbos._active_workflows_set.count_for_queue(
-                    queue.name
-                )
-                dequeued_workflows = dbos._sys_db.start_queued_workflows(
-                    queue,
-                    GlobalParams.executor_id,
-                    GlobalParams.app_version,
-                    None,
-                    local_running_count,
-                )
-                start_dequeued_workflows(dequeued_workflows)
         except OperationalError as e:
             if isinstance(e.orig, errors.LockNotAvailable):
                 # Another worker is dequeueing this queue right now; retry next

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -103,13 +103,11 @@ class Queue:
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
         application_name: Optional[str] = None,
-        # Deprecated, retained for backwards compatibility. concurrency and limiter
-        # keep their positional slots above: moving them would rebind Queue("q", 5).
+        # Deprecated, retained for backwards compatibility. concurrency and limiter keep their positional slots above: moving them would rebind Queue("q", 5).
         priority_enabled: bool = False,
         partition_queue: bool = False,
     ) -> None:
-        # Rows are validated when written, and a row legitimately carries both
-        # partition_queue and the partition limits, which no caller may combine.
+        # Rows are validated when written, and a row legitimately carries both partition_queue and the partition limits, which no caller may combine.
         if not database_backed_queue:
             Queue._validate_queue(
                 concurrency=concurrency,
@@ -130,9 +128,7 @@ class Queue:
         # DBOS singleton's. This allows a DBOSClient to manipulate queues
         # without depending on a launched DBOS process.
         self._client_system_database = client_system_database
-        # Local cache of configurable params, mirroring the queues-table columns.
-        # Property getters consult this for in-memory queues and the database for
-        # database-backed queues.
+        # Local cache of the queues-table columns; getters consult it for in-memory queues and the database for database-backed ones.
         self._concurrency = (
             concurrency if global_concurrency is None else global_concurrency
         )
@@ -207,8 +203,7 @@ class Queue:
             raise ValueError(
                 "worker_concurrency must be greater than or equal to partition_worker_concurrency"
             )
-        # Under the deprecated partition_queue spelling, concurrency is itself a
-        # per-partition limit, so the worker_concurrency check below compares like with like.
+        # Under the deprecated partition_queue spelling concurrency is itself a per-partition limit, so the worker_concurrency check below compares like with like.
         queue_concurrency = (
             concurrency if global_concurrency is None else global_concurrency
         )
@@ -408,8 +403,6 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_global_concurrency", "Queue.set_global_concurrency_async"
         )
-        # Refresh the local cache so the mode and cross-field checks below see
-        # the latest configuration stored in the database.
         self._refresh_fields(self._read_from_db())
         self._require_not_legacy_partitioned("global_concurrency")
         self._check_concurrency_bounds(value)
@@ -830,8 +823,7 @@ def queue_worker_thread(
         already claimed this sweep: dispatch is asynchronous, so the active set does
         not count them yet."""
         if limits.worker_concurrency is None:
-            # A legacy per-partition worker limit is enforced per partition instead,
-            # except for zero, which stops this worker dequeueing at all.
+            # A legacy per-partition worker limit is enforced per partition instead, except for zero, which stops this worker dequeueing at all.
             return 0 if limits.partition_worker_concurrency == 0 else sys.maxsize
         return max(
             0,
@@ -886,9 +878,7 @@ def queue_worker_thread(
                 and limits.limiter is None
                 and limits.partition_limiter is None
             ):
-                # Batched path: one transaction claims every partition's head. Only this
-                # worker's own budget bounds it, so nothing peers must also see is at
-                # stake (see start_queued_partitioned_workflows).
+                # Optimization: Batch dequeue if partition concurrency is 1
                 max_tasks = worker_budget(limits)
                 if max_tasks > 0:
                     dequeued_workflows = (
@@ -901,9 +891,7 @@ def queue_worker_thread(
                     )
                     start_dequeued_workflows(dequeued_workflows)
             else:
-                # Every other partitioned config sweeps one partition at a time, in
-                # random order: a budget that runs out partway through would otherwise
-                # strand the same keys every sweep.
+                # Iterate through partitions one at a time in random order to prevent starvation.
                 partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                 random.shuffle(partition_keys)
                 claimed = 0
@@ -916,8 +904,6 @@ def queue_worker_thread(
                             GlobalParams.executor_id,
                             GlobalParams.app_version,
                             key,
-                            # Rows claimed earlier in this sweep dispatch asynchronously,
-                            # so the active set does not count them yet.
                             dbos._active_workflows_set.count_for_queue(queue.name)
                             + claimed,
                             dbos._active_workflows_set.count_for_partition(

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -704,16 +704,16 @@ def queue_worker_thread(
                 # Every other partitioned config sweeps one partition at a time.
                 queue_partition_keys = dbos._sys_db.get_queue_partitions(queue.name)
                 for key in queue_partition_keys:
-                    local_running_count = dbos._active_workflows_set.count_for_queue(
-                        queue.name, key
-                    )
                     try:
                         dequeued_workflows = dbos._sys_db.start_queued_workflows(
                             queue,
                             GlobalParams.executor_id,
                             GlobalParams.app_version,
                             key,
-                            local_running_count,
+                            dbos._active_workflows_set.count_for_queue(queue.name),
+                            dbos._active_workflows_set.count_for_partition(
+                                queue.name, key
+                            ),
                         )
                     except OperationalError as e:
                         # Lock held or claim raced by another worker: skip just this partition, no queue-wide backoff.
@@ -726,7 +726,7 @@ def queue_worker_thread(
                     start_dequeued_workflows(dequeued_workflows)
             else:
                 local_running_count = dbos._active_workflows_set.count_for_queue(
-                    queue.name, None
+                    queue.name
                 )
                 dequeued_workflows = dbos._sys_db.start_queued_workflows(
                     queue,

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -186,6 +186,11 @@ class Queue:
             )
         if partition_concurrency is not None and partition_concurrency < 1:
             raise ValueError("partition_concurrency must be at least 1")
+        if (
+            partition_worker_concurrency is not None
+            and partition_worker_concurrency < 1
+        ):
+            raise ValueError("partition_worker_concurrency must be at least 1")
         if partition_limiter is not None and (
             partition_limiter.get("limit") is None
             or partition_limiter.get("period") is None
@@ -449,14 +454,18 @@ class Queue:
             raise ValueError("partition_concurrency must be at least 1")
         self._refresh_fields(self._read_from_db())
         self._require_not_legacy_partitioned("partition_concurrency")
-        if (
-            value is not None
-            and self._concurrency is not None
-            and value > self._concurrency
-        ):
-            raise ValueError(
-                "partition_concurrency must be less than or equal to global_concurrency"
-            )
+        if value is not None:
+            if self._concurrency is not None and value > self._concurrency:
+                raise ValueError(
+                    "partition_concurrency must be less than or equal to global_concurrency"
+                )
+            if (
+                self._partition_worker_concurrency is not None
+                and self._partition_worker_concurrency > value
+            ):
+                raise ValueError(
+                    "partition_concurrency must be greater than or equal to partition_worker_concurrency"
+                )
         # Partitioning is inferred from the limits, so the deprecated flag follows them.
         partitioned = self._partitioned_after(_partition_concurrency=value)
         self._write_to_db(
@@ -491,6 +500,8 @@ class Queue:
             "Queue.set_partition_worker_concurrency",
             "Queue.set_partition_worker_concurrency_async",
         )
+        if value is not None and value < 1:
+            raise ValueError("partition_worker_concurrency must be at least 1")
         self._refresh_fields(self._read_from_db())
         self._require_not_legacy_partitioned("partition_worker_concurrency")
         if value is not None:
@@ -575,13 +586,13 @@ class Queue:
                 "Queue.worker_concurrency", "Queue.get_worker_concurrency_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._worker_concurrency
+        return self._resolve_limits().worker_concurrency
 
     async def get_worker_concurrency_async(self) -> Optional[int]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._worker_concurrency
+        return self._resolve_limits().worker_concurrency
 
     def set_worker_concurrency(self, value: Optional[int]) -> None:
         self._require_database_backed()
@@ -617,13 +628,13 @@ class Queue:
                 "Queue.limiter", "Queue.get_limiter_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._limiter
+        return self._resolve_limits().limiter
 
     async def get_limiter_async(self) -> Optional[QueueRateLimit]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._limiter
+        return self._resolve_limits().limiter
 
     def set_limiter(self, value: Optional[QueueRateLimit]) -> None:
         self._require_database_backed()
@@ -837,7 +848,10 @@ def queue_worker_thread(
     def worker_budget(limits: ResolvedQueueLimits, running: int) -> int:
         """Room left under this worker's queue-wide concurrency limit, given how many of
         its workflows are already running or claimed."""
-        if limits.partition_worker_concurrency == 0:
+        if (
+            limits.partition_worker_concurrency is not None
+            and limits.partition_worker_concurrency <= 0
+        ):
             # Zero per partition pauses this worker: no partition may run anything here, and the batched sweep enforces no per-partition worker limit of its own.
             return 0
         if limits.worker_concurrency is None:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -602,6 +602,7 @@ class Queue:
         # Refresh the local cache so the cross-field check below validates
         # against the latest concurrency stored in the database.
         self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("worker_concurrency")
         if value is not None:
             if self._concurrency is not None and value > self._concurrency:
                 raise ValueError(
@@ -645,6 +646,9 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_limiter", "Queue.set_limiter_async"
         )
+        # Refresh so the check below sees the latest partition limits.
+        self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("limiter")
         self._write_to_db(
             {
                 "rate_limit_max": value["limit"] if value else None,

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -97,6 +97,8 @@ class Queue:
         worker_concurrency: Optional[int] = None,
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         polling_interval_sec: float = DEFAULT_QUEUE_POLLING_INTERVAL_SEC,
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
@@ -107,13 +109,15 @@ class Queue:
         partition_queue: bool = False,
     ) -> None:
         # Rows are validated when written, and a row legitimately carries both
-        # partition_queue and partition_concurrency, which no caller may combine.
+        # partition_queue and the partition limits, which no caller may combine.
         if not database_backed_queue:
             Queue._validate_queue(
                 concurrency=concurrency,
                 worker_concurrency=worker_concurrency,
                 global_concurrency=global_concurrency,
                 partition_concurrency=partition_concurrency,
+                partition_worker_concurrency=partition_worker_concurrency,
+                partition_limiter=partition_limiter,
                 partition_queue=partition_queue,
                 polling_interval_sec=polling_interval_sec,
                 limiter=limiter,
@@ -135,9 +139,11 @@ class Queue:
         self._worker_concurrency = worker_concurrency
         self._limiter = limiter
         self._priority_enabled = priority_enabled
-        # Partitioning is inferred from partition_concurrency; the deprecated flag tracks it.
-        self._partition_queue = partition_queue or partition_concurrency is not None
         self._partition_concurrency = partition_concurrency
+        self._partition_worker_concurrency = partition_worker_concurrency
+        self._partition_limiter = partition_limiter
+        # Partitioning is inferred from any per-partition limit; the deprecated flag tracks it.
+        self._partition_queue = partition_queue or self._has_partition_limits()
         self._polling_interval_sec = polling_interval_sec
 
         # Database-backed queues skip the in-memory global registry; their
@@ -161,6 +167,8 @@ class Queue:
         limiter: Optional[QueueRateLimit],
         global_concurrency: Optional[int] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_limiter: Optional[QueueRateLimit] = None,
         partition_queue: bool = False,
     ) -> None:
         """Validate queue configuration parameters, raising ValueError on bad input."""
@@ -168,12 +176,37 @@ class Queue:
             raise ValueError(
                 "concurrency is deprecated in favor of global_concurrency; set only one of them"
             )
-        if partition_queue and partition_concurrency is not None:
+        if partition_queue and (
+            partition_concurrency is not None
+            or partition_worker_concurrency is not None
+            or partition_limiter is not None
+        ):
             raise ValueError(
-                "partition_queue is deprecated in favor of partition_concurrency; set only one of them"
+                "partition_queue is deprecated in favor of the partition_* limits; set only one of them"
             )
         if partition_concurrency is not None and partition_concurrency < 1:
             raise ValueError("partition_concurrency must be at least 1")
+        if partition_limiter is not None and (
+            partition_limiter.get("limit") is None
+            or partition_limiter.get("period") is None
+        ):
+            raise ValueError("partition_limiter must specify both 'limit' and 'period'")
+        if (
+            partition_worker_concurrency is not None
+            and partition_concurrency is not None
+            and partition_worker_concurrency > partition_concurrency
+        ):
+            raise ValueError(
+                "partition_concurrency must be greater than or equal to partition_worker_concurrency"
+            )
+        if (
+            partition_worker_concurrency is not None
+            and worker_concurrency is not None
+            and partition_worker_concurrency > worker_concurrency
+        ):
+            raise ValueError(
+                "worker_concurrency must be greater than or equal to partition_worker_concurrency"
+            )
         # Under the deprecated partition_queue spelling, concurrency is itself a
         # per-partition limit, so the worker_concurrency check below compares like with like.
         queue_concurrency = (
@@ -202,10 +235,24 @@ class Queue:
         ):
             raise ValueError("limiter must specify both 'limit' and 'period'")
 
+    def _has_partition_limits(self) -> bool:
+        """True when any per-partition limit is set, which is what partitions a queue."""
+        return self._partitioned_after()
+
+    def _partitioned_after(self, **overrides: Any) -> bool:
+        """Whether the queue is still partitioned once these fields take these values."""
+        values: dict[str, Any] = {
+            "_partition_concurrency": self._partition_concurrency,
+            "_partition_worker_concurrency": self._partition_worker_concurrency,
+            "_partition_limiter": self._partition_limiter,
+        }
+        values.update(overrides)
+        return any(value is not None for value in values.values())
+
     def _is_legacy_partitioned(self) -> bool:
         """True when the queue uses the deprecated partition_queue spelling, under
         which concurrency, worker_concurrency, and limiter all apply per partition."""
-        return self._partition_queue and self._partition_concurrency is None
+        return self._partition_queue and not self._has_partition_limits()
 
     def _resolve_limits(self) -> ResolvedQueueLimits:
         """Resolve every limit to the scope it is enforced at."""
@@ -223,8 +270,8 @@ class Queue:
             worker_concurrency=self._worker_concurrency,
             limiter=self._limiter,
             partition_concurrency=self._partition_concurrency,
-            partition_worker_concurrency=None,
-            partition_limiter=None,
+            partition_worker_concurrency=self._partition_worker_concurrency,
+            partition_limiter=self._partition_limiter,
         )
 
     def _require_not_legacy_partitioned(self, field: str) -> None:
@@ -234,7 +281,7 @@ class Queue:
                 f"Cannot set {field} on queue {self.name}: it is registered with the "
                 "deprecated partition_queue option, under which concurrency, "
                 "worker_concurrency, and limiter apply per partition. Re-register the "
-                "queue with partition_concurrency instead."
+                "queue with the partition_* limits instead."
             )
 
     def _check_concurrency_bounds(self, value: Optional[int]) -> None:
@@ -251,6 +298,13 @@ class Queue:
         ):
             raise ValueError(
                 "partition_concurrency must be less than or equal to global_concurrency"
+            )
+        if (
+            self._partition_worker_concurrency is not None
+            and self._partition_worker_concurrency > value
+        ):
+            raise ValueError(
+                "partition_worker_concurrency must be less than or equal to concurrency"
             )
 
     def _require_database_backed(self) -> None:
@@ -286,6 +340,8 @@ class Queue:
         self._priority_enabled = latest._priority_enabled
         self._partition_queue = latest._partition_queue
         self._partition_concurrency = latest._partition_concurrency
+        self._partition_worker_concurrency = latest._partition_worker_concurrency
+        self._partition_limiter = latest._partition_limiter
         self._polling_interval_sec = latest._polling_interval_sec
         self.application_name = latest.application_name
 
@@ -392,16 +448,112 @@ class Queue:
             raise ValueError(
                 "partition_concurrency must be less than or equal to global_concurrency"
             )
-        # Partitioning is inferred from the limit, so the deprecated flag follows it.
+        # Partitioning is inferred from the limits, so the deprecated flag follows them.
+        partitioned = self._partitioned_after(_partition_concurrency=value)
         self._write_to_db(
-            {"partition_concurrency": value, "partition_queue": value is not None}
+            {"partition_concurrency": value, "partition_queue": partitioned}
         )
         self._partition_concurrency = value
-        self._partition_queue = value is not None
+        self._partition_queue = partitioned
 
     async def set_partition_concurrency_async(self, value: Optional[int]) -> None:
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_partition_concurrency, value)
+
+    @property
+    def partition_worker_concurrency(self) -> Optional[int]:
+        if self.database_backed_queue:
+            _warn_sync_db_call_in_async_context(
+                "Queue.partition_worker_concurrency",
+                "Queue.get_partition_worker_concurrency_async",
+            )
+            self._refresh_fields(self._read_from_db())
+        return self._resolve_limits().partition_worker_concurrency
+
+    async def get_partition_worker_concurrency_async(self) -> Optional[int]:
+        if self.database_backed_queue:
+            await self._configure_thread_pool()
+            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
+        return self._resolve_limits().partition_worker_concurrency
+
+    def set_partition_worker_concurrency(self, value: Optional[int]) -> None:
+        self._require_database_backed()
+        _warn_sync_db_call_in_async_context(
+            "Queue.set_partition_worker_concurrency",
+            "Queue.set_partition_worker_concurrency_async",
+        )
+        self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("partition_worker_concurrency")
+        if value is not None:
+            if (
+                self._partition_concurrency is not None
+                and value > self._partition_concurrency
+            ):
+                raise ValueError(
+                    "partition_worker_concurrency must be less than or equal to partition_concurrency"
+                )
+            if (
+                self._worker_concurrency is not None
+                and value > self._worker_concurrency
+            ):
+                raise ValueError(
+                    "partition_worker_concurrency must be less than or equal to worker_concurrency"
+                )
+        partitioned = self._partitioned_after(_partition_worker_concurrency=value)
+        self._write_to_db(
+            {"partition_worker_concurrency": value, "partition_queue": partitioned}
+        )
+        self._partition_worker_concurrency = value
+        self._partition_queue = partitioned
+
+    async def set_partition_worker_concurrency_async(
+        self, value: Optional[int]
+    ) -> None:
+        await self._configure_thread_pool()
+        await asyncio.to_thread(self.set_partition_worker_concurrency, value)
+
+    @property
+    def partition_limiter(self) -> Optional[QueueRateLimit]:
+        if self.database_backed_queue:
+            _warn_sync_db_call_in_async_context(
+                "Queue.partition_limiter", "Queue.get_partition_limiter_async"
+            )
+            self._refresh_fields(self._read_from_db())
+        return self._resolve_limits().partition_limiter
+
+    async def get_partition_limiter_async(self) -> Optional[QueueRateLimit]:
+        if self.database_backed_queue:
+            await self._configure_thread_pool()
+            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
+        return self._resolve_limits().partition_limiter
+
+    def set_partition_limiter(self, value: Optional[QueueRateLimit]) -> None:
+        self._require_database_backed()
+        if value is not None and (
+            value.get("limit") is None or value.get("period") is None
+        ):
+            raise ValueError("partition_limiter must specify both 'limit' and 'period'")
+        _warn_sync_db_call_in_async_context(
+            "Queue.set_partition_limiter", "Queue.set_partition_limiter_async"
+        )
+        self._refresh_fields(self._read_from_db())
+        self._require_not_legacy_partitioned("partition_limiter")
+        partitioned = self._partitioned_after(_partition_limiter=value)
+        self._write_to_db(
+            {
+                "partition_rate_limit_max": value["limit"] if value else None,
+                "partition_rate_limit_period_sec": value["period"] if value else None,
+                "partition_queue": partitioned,
+            }
+        )
+        self._partition_limiter = value
+        self._partition_queue = partitioned
+
+    async def set_partition_limiter_async(
+        self, value: Optional[QueueRateLimit]
+    ) -> None:
+        await self._configure_thread_pool()
+        await asyncio.to_thread(self.set_partition_limiter, value)
 
     @property
     def worker_concurrency(self) -> Optional[int]:
@@ -426,14 +578,18 @@ class Queue:
         # Refresh the local cache so the cross-field check below validates
         # against the latest concurrency stored in the database.
         self._refresh_fields(self._read_from_db())
-        if (
-            value is not None
-            and self._concurrency is not None
-            and value > self._concurrency
-        ):
-            raise ValueError(
-                "worker_concurrency must be less than or equal to concurrency"
-            )
+        if value is not None:
+            if self._concurrency is not None and value > self._concurrency:
+                raise ValueError(
+                    "worker_concurrency must be less than or equal to concurrency"
+                )
+            if (
+                self._partition_worker_concurrency is not None
+                and self._partition_worker_concurrency > value
+            ):
+                raise ValueError(
+                    "partition_worker_concurrency must be less than or equal to worker_concurrency"
+                )
         self._write_to_db({"worker_concurrency": value})
         self._worker_concurrency = value
 
@@ -525,12 +681,12 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_partition_queue", "Queue.set_partition_queue_async"
         )
-        # Refresh so the check below sees the latest partition_concurrency.
+        # Refresh so the check below sees the latest partition limits.
         self._refresh_fields(self._read_from_db())
-        if self._partition_concurrency is not None:
+        if self._has_partition_limits():
             raise DBOSException(
                 f"Cannot set partition_queue on queue {self.name}: it is partitioned "
-                "via partition_concurrency. Use set_partition_concurrency instead."
+                "by its partition_* limits. Clear those instead."
             )
         self._write_to_db({"partition_queue": value})
         self._partition_queue = value
@@ -913,16 +1069,23 @@ def log_queue(q: Queue) -> None:
     are omitted, matching ``Queue: <name> (concurrency=…, worker_concurrency=…,
     limit=N/Ts, priority, partitioned)``."""
     opts = []
-    if q._partition_concurrency is not None:
+    if q._has_partition_limits():
         if q._concurrency is not None:
             opts.append(f"global_concurrency={q._concurrency}")
-        opts.append(f"partition_concurrency={q._partition_concurrency}")
     elif q._concurrency is not None:
         opts.append(f"concurrency={q._concurrency}")
     if q._worker_concurrency is not None:
         opts.append(f"worker_concurrency={q._worker_concurrency}")
     if q._limiter is not None:
         opts.append(f"limit={q._limiter['limit']}/{q._limiter['period']}s")
+    if q._partition_concurrency is not None:
+        opts.append(f"partition_concurrency={q._partition_concurrency}")
+    if q._partition_worker_concurrency is not None:
+        opts.append(f"partition_worker_concurrency={q._partition_worker_concurrency}")
+    if q._partition_limiter is not None:
+        opts.append(
+            f"partition_limit={q._partition_limiter['limit']}/{q._partition_limiter['period']}s"
+        )
     if q._priority_enabled:
         opts.append("priority")
     if q._partition_queue:

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -476,6 +476,7 @@ class Queue:
 
     @property
     def priority_enabled(self) -> bool:
+        """Deprecated and ignored: every queue dequeues in priority order."""
         if self.database_backed_queue:
             _warn_sync_db_call_in_async_context(
                 "Queue.priority_enabled", "Queue.get_priority_enabled_async"
@@ -580,10 +581,6 @@ class Queue:
         # Skip validation for database-backed queues to avoid a roundtrip fetching the queue
         if self.database_backed_queue:
             return
-        if ctx is not None and ctx.priority is not None and not self._priority_enabled:
-            raise Exception(
-                f"Priority is not enabled for queue {self.name}. Setting priority will not have any effect."
-            )
         if self._partition_queue and (ctx is None or ctx.queue_partition_key is None):
             raise Exception(
                 f"A workflow cannot be enqueued on partitioned queue {self.name} without a partition key"

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -339,8 +339,11 @@ class SystemSchema:
         Column("rate_limit_period_sec", Float, nullable=True),
         Column("priority_enabled", Boolean, nullable=False, server_default="false"),
         Column("partition_queue", Boolean, nullable=False, server_default="false"),
-        # Set means the queue is partitioned and this limit applies per partition.
+        # Any of these being set means the queue is partitioned; each applies per partition.
         Column("partition_concurrency", Integer, nullable=True),
+        Column("partition_worker_concurrency", Integer, nullable=True),
+        Column("partition_rate_limit_max", Integer, nullable=True),
+        Column("partition_rate_limit_period_sec", Float, nullable=True),
         Column("polling_interval_sec", Float, nullable=False, server_default="1.0"),
         Column("created_at", BigInteger, nullable=False),
         Column("updated_at", BigInteger, nullable=False),

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -339,6 +339,8 @@ class SystemSchema:
         Column("rate_limit_period_sec", Float, nullable=True),
         Column("priority_enabled", Boolean, nullable=False, server_default="false"),
         Column("partition_queue", Boolean, nullable=False, server_default="false"),
+        # Set means the queue is partitioned and this limit applies per partition.
+        Column("partition_concurrency", Integer, nullable=True),
         Column("polling_interval_sec", Float, nullable=False, server_default="1.0"),
         Column("created_at", BigInteger, nullable=False),
         Column("updated_at", BigInteger, nullable=False),

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4202,28 +4202,36 @@ class SystemDatabase(ABC):
         app_version: str,
         queue_partition_key: Optional[str],
         local_running_count: int = 0,
+        partition_local_running_count: int = 0,
     ) -> List[str]:
         start_time_ms = int(time.time() * 1000)
-        # Use the queue's locally cached private state to avoid recursive DB
+        ws = SystemSchema.workflow_status
+        # Resolve from the queue's locally cached private state to avoid recursive DB
         # reads via the @property getters within this transaction.
-        if queue._limiter is not None:
-            limiter_period_ms = int(queue._limiter["period"] * 1000)
+        limits = queue._resolve_limits()
+        # Budgets peer workers also spend, at either scope: those need a consistent snapshot.
+        has_shared_budget = (
+            limits.global_concurrency is not None
+            or limits.partition_concurrency is not None
+            or limits.limiter is not None
+            or limits.partition_limiter is not None
+        )
         with self.engine.begin() as c:
             # Default to READ COMMITTED except with global concurrency limits or rate limits
-            if self.engine.dialect.name == "postgresql" and (
-                queue._concurrency is not None or queue._limiter is not None
-            ):
+            if self.engine.dialect.name == "postgresql" and has_shared_budget:
                 c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
 
-            # If there is a limiter, compute how many functions have started in its period.
-            if queue._limiter is not None:
+            def rate_limit_remaining(
+                limiter: "QueueRateLimit", partition_scoped: bool
+            ) -> int:
+                """Slots left in this limiter's rolling window, at the scope it applies to."""
                 query = (
                     sa.select(sa.func.count())
-                    .select_from(SystemSchema.workflow_status)
-                    .where(SystemSchema.workflow_status.c.queue_name == queue.name)
-                    .where(SystemSchema.workflow_status.c.rate_limited == True)
+                    .select_from(ws)
+                    .where(ws.c.queue_name == queue.name)
+                    .where(ws.c.rate_limited == True)
                     .where(
-                        SystemSchema.workflow_status.c.status.notin_(
+                        ws.c.status.notin_(
                             [
                                 WorkflowStatusString.ENQUEUED.value,
                                 WorkflowStatusString.DELAYED.value,
@@ -4232,68 +4240,88 @@ class SystemDatabase(ABC):
                     )
                     # Database clock on both sides, as the claim stamps started_at_epoch_ms with it.
                     .where(
-                        SystemSchema.workflow_status.c.started_at_epoch_ms
-                        > self._now_ms_sql() - limiter_period_ms
+                        ws.c.started_at_epoch_ms
+                        > self._now_ms_sql() - int(limiter["period"] * 1000)
                     )
                     # Count only what this application would dequeue, matching the select below.
-                    .where(
-                        self._name_filter(
-                            SystemSchema.workflow_status.c.application_name,
-                            self.app_name,
-                        )
-                    )
+                    .where(self._name_filter(ws.c.application_name, self.app_name))
                 )
-                if queue_partition_key is not None:
-                    query = query.where(
-                        SystemSchema.workflow_status.c.queue_partition_key
-                        == queue_partition_key
-                    )
-                num_recent_queries = c.execute(query).fetchone()[0]  # type: ignore
-                if num_recent_queries >= queue._limiter["limit"]:
-                    return []
+                if partition_scoped:
+                    query = query.where(ws.c.queue_partition_key == queue_partition_key)
+                return limiter["limit"] - (c.execute(query).scalar() or 0)
 
-            # Compute max_tasks, the number of workflows that can be dequeued given the rate limit and the local and global concurrency limits.
+            def pending_count(partition_scoped: bool) -> int:
+                """Workflows already running, which peer workers count against too.
+
+                Kept as its own query per scope: the partition-scoped predicate rides
+                idx_workflow_status_partition_dequeue_v2, which a queue-wide scan loses.
+                """
+                query = (
+                    sa.select(sa.func.count())
+                    .select_from(ws)
+                    .where(ws.c.queue_name == queue.name)
+                    .where(ws.c.status == WorkflowStatusString.PENDING.value)
+                    .where(self._name_filter(ws.c.application_name, self.app_name))
+                )
+                if partition_scoped:
+                    query = query.where(ws.c.queue_partition_key == queue_partition_key)
+                return c.execute(query).scalar() or 0
+
+            # Compute max_tasks, the number of workflows that can be dequeued given every
+            # limit in force, each counted at the scope it is enforced at. In-memory terms
+            # come first so an exhausted worker budget costs no queries.
             max_tasks = sys.maxsize
 
-            if queue._limiter is not None:
-                # Bound the claim by the limiter's remaining slots so a backlogged queue locks only what it can start.
-                max_tasks = queue._limiter["limit"] - num_recent_queries
-
-            if queue._worker_concurrency is not None:
+            if limits.worker_concurrency is not None:
                 # Use the in-memory registry for this worker's running count — avoids a DB round trip.
                 max_tasks = min(
-                    max_tasks, max(0, queue._worker_concurrency - local_running_count)
+                    max_tasks, max(0, limits.worker_concurrency - local_running_count)
                 )
+            if limits.partition_worker_concurrency is not None:
+                max_tasks = min(
+                    max_tasks,
+                    max(
+                        0,
+                        limits.partition_worker_concurrency
+                        - partition_local_running_count,
+                    ),
+                )
+            if max_tasks <= 0:
+                return []
 
-            if queue._concurrency is not None:
-                # Global concurrency still requires a DB query since other workers may be running workflows too.
-                global_pending_query = (
-                    sa.select(sa.func.count())
-                    .select_from(SystemSchema.workflow_status)
-                    .where(SystemSchema.workflow_status.c.queue_name == queue.name)
-                    .where(
-                        SystemSchema.workflow_status.c.status
-                        == WorkflowStatusString.PENDING.value
-                    )
-                    .where(
-                        self._name_filter(
-                            SystemSchema.workflow_status.c.application_name,
-                            self.app_name,
-                        )
-                    )
+            if limits.limiter is not None:
+                # Bound the claim by the limiter's remaining slots so a backlogged queue locks only what it can start.
+                max_tasks = min(max_tasks, rate_limit_remaining(limits.limiter, False))
+            if limits.partition_limiter is not None:
+                max_tasks = min(
+                    max_tasks, rate_limit_remaining(limits.partition_limiter, True)
                 )
-                if queue_partition_key is not None:
-                    global_pending_query = global_pending_query.where(
-                        SystemSchema.workflow_status.c.queue_partition_key
-                        == queue_partition_key
-                    )
-                global_pending_workflows = c.execute(global_pending_query).scalar() or 0
-                if global_pending_workflows > queue._concurrency:
+            if max_tasks <= 0:
+                return []
+
+            if limits.global_concurrency is not None:
+                # Global concurrency still requires a DB query since other workers may be running workflows too.
+                global_pending_workflows = pending_count(False)
+                if global_pending_workflows > limits.global_concurrency:
                     dbos_logger.warning(
-                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({queue._concurrency})"
+                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({limits.global_concurrency})"
                     )
-                available_tasks = max(0, queue._concurrency - global_pending_workflows)
-                max_tasks = min(max_tasks, available_tasks)
+                max_tasks = min(
+                    max_tasks,
+                    max(0, limits.global_concurrency - global_pending_workflows),
+                )
+            if limits.partition_concurrency is not None:
+                partition_pending_workflows = pending_count(True)
+                if partition_pending_workflows > limits.partition_concurrency:
+                    dbos_logger.warning(
+                        f"The total number of pending workflows ({partition_pending_workflows}) on partition {queue_partition_key} of queue {queue.name} exceeds the partition concurrency limit ({limits.partition_concurrency})"
+                    )
+                max_tasks = min(
+                    max_tasks,
+                    max(0, limits.partition_concurrency - partition_pending_workflows),
+                )
+            if max_tasks <= 0:
+                return []
 
             latest_version = c.execute(
                 sa.select(SystemSchema.application_versions.c.version_name)
@@ -4322,7 +4350,7 @@ class SystemDatabase(ABC):
             # Only dequeue workflows of the local version; version-less ones only when this worker runs the latest version.
             # A rate limit is a global budget like concurrency: skip_locked would hand a peer
             # disjoint rows, letting it spend the same budget against its own pre-claim snapshot.
-            skip_locks = queue._concurrency is None and queue._limiter is None
+            skip_locks = not has_shared_budget
             query = (
                 sa.select(
                     SystemSchema.workflow_status.c.workflow_uuid,
@@ -4394,7 +4422,8 @@ class SystemDatabase(ABC):
                         # Claim it, so the unclaimed partition drains as workflows run.
                         application_name=self.app_name,
                         started_at_epoch_ms=self._now_ms_sql(),
-                        rate_limited=queue._limiter is not None,
+                        rate_limited=limits.limiter is not None
+                        or limits.partition_limiter is not None,
                         # Count this dispatch against the DLQ limit; no later insert does it.
                         recovery_attempts=SystemSchema.workflow_status.c.recovery_attempts
                         + 1,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4463,7 +4463,8 @@ class SystemDatabase(ABC):
         max_tasks: int = sys.maxsize,
     ) -> List[str]:
         """Dequeue every partition's head-of-line workflow in one transaction, at most
-        min(max_tasks, PARTITIONED_DEQUEUE_SWEEP_CAP) per sweep. Valid only when per-partition
+        min(max_tasks, PARTITIONED_DEQUEUE_SWEEP_CAP) per sweep and in random partition
+        order so a bounded sweep does not always favor the same keys. Valid only when per-partition
         concurrency is 1 and worker concurrency is the sole other limit: all workers rank the
         same head, so guarded flips admit at most one row per partition, and a per-worker
         budget binds nothing peers must also see. Callers pass that budget as max_tasks.
@@ -4550,6 +4551,10 @@ class SystemDatabase(ABC):
             )
             # This worker's own budget bounds the sweep alongside the bind-param cap.
             sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
+            # Random order, not partition order: a budget below the partition count would
+            # otherwise spend itself on the same lowest keys every sweep, and peers would
+            # all contend for those same heads. Costs a sort of the partition set.
+            sweep_order = sa.func.random()
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.
                 head = head_query.lateral("head")
@@ -4558,7 +4563,7 @@ class SystemDatabase(ABC):
                     .select_from(partitions.join(head, sa.true()))
                     .where(partitions.c.pk.isnot(None))
                     .where(~pending_probe)
-                    .order_by(partitions.c.pk.asc())
+                    .order_by(sweep_order)
                     .limit(sweep_limit)
                 )
             else:
@@ -4575,7 +4580,7 @@ class SystemDatabase(ABC):
                 cand_query = (
                     sa.select(heads.c.workflow_uuid)
                     .where(heads.c.workflow_uuid.isnot(None))
-                    .order_by(heads.c.pk.asc())
+                    .order_by(sweep_order)
                     .limit(sweep_limit)
                 )
             candidate_ids = [row[0] for row in c.execute(cand_query).fetchall()]

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4460,14 +4460,20 @@ class SystemDatabase(ABC):
         queue: "Queue",
         executor_id: str,
         app_version: str,
+        max_tasks: int = sys.maxsize,
     ) -> List[str]:
         """Dequeue every partition's head-of-line workflow in one transaction, at most
-        PARTITIONED_DEQUEUE_SWEEP_CAP per sweep. Valid only for concurrency=1, no-limiter queues:
-        all workers rank the same head, so guarded flips admit at most one row per partition.
+        min(max_tasks, PARTITIONED_DEQUEUE_SWEEP_CAP) per sweep. Valid only when per-partition
+        concurrency is 1 and worker concurrency is the sole other limit: all workers rank the
+        same head, so guarded flips admit at most one row per partition, and a per-worker
+        budget binds nothing peers must also see. Callers pass that budget as max_tasks.
         """
-        assert queue._concurrency == 1
-        assert queue._limiter is None
+        limits = queue._resolve_limits()
         assert queue._partition_queue
+        assert limits.partition_concurrency == 1
+        assert limits.global_concurrency is None
+        assert limits.limiter is None
+        assert limits.partition_limiter is None
         start_time_ms = int(time.time() * 1000)
         ws = SystemSchema.workflow_status
         with self.engine.begin() as c:
@@ -4542,6 +4548,8 @@ class SystemDatabase(ABC):
                 .where(ws.c.queue_partition_key == partitions.c.pk)
                 .exists()
             )
+            # This worker's own budget bounds the sweep alongside the bind-param cap.
+            sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.
                 head = head_query.lateral("head")
@@ -4551,7 +4559,7 @@ class SystemDatabase(ABC):
                     .where(partitions.c.pk.isnot(None))
                     .where(~pending_probe)
                     .order_by(partitions.c.pk.asc())
-                    .limit(self.PARTITIONED_DEQUEUE_SWEEP_CAP)
+                    .limit(sweep_limit)
                 )
             else:
                 # SQLite has no LATERAL; a correlated scalar subquery probes each head, with version-ineligible (NULL-head) partitions filtered in the outer select.
@@ -4568,7 +4576,7 @@ class SystemDatabase(ABC):
                     sa.select(heads.c.workflow_uuid)
                     .where(heads.c.workflow_uuid.isnot(None))
                     .order_by(heads.c.pk.asc())
-                    .limit(self.PARTITIONED_DEQUEUE_SWEEP_CAP)
+                    .limit(sweep_limit)
                 )
             candidate_ids = [row[0] for row in c.execute(cand_query).fetchall()]
             if not candidate_ids:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4540,12 +4540,17 @@ class SystemDatabase(ABC):
             )
             # This worker's own budget bounds the sweep alongside the bind-param cap.
             sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
-            # Probe partitions in random order to prevent starvation
+            # When local concurrency is constrained, probe partitions in random order to prevent starvation
+            sweep_order = (
+                partitions.c.pk.asc()
+                if max_tasks >= self.PARTITIONED_DEQUEUE_SWEEP_CAP
+                else sa.func.random()
+            )
             chosen = (
                 sa.select(partitions.c.pk)
                 .where(partitions.c.pk.isnot(None))
                 .where(~pending_probe)
-                .order_by(sa.func.random())
+                .order_by(sweep_order)
                 .limit(sweep_limit)
                 .subquery("chosen")
             )

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4467,12 +4467,9 @@ class SystemDatabase(ABC):
         app_version: str,
         max_tasks: int = sys.maxsize,
     ) -> List[str]:
-        """Dequeue every partition's head-of-line workflow in one transaction, at most
-        min(max_tasks, PARTITIONED_DEQUEUE_SWEEP_CAP) per sweep and in random partition
-        order so a bounded sweep does not always favor the same keys. Valid only when per-partition
-        concurrency is 1 and worker concurrency is the sole other limit: all workers rank the
-        same head, so guarded flips admit at most one row per partition, and a per-worker
-        budget binds nothing peers must also see. Callers pass that budget as max_tasks.
+        """Batch dequeue from a partitioned queue, optimized for the specific
+        case where partition_concurrency=1. All other cases iterate and dequeue
+        from each active partition successively.
         """
         limits = queue._resolve_limits()
         assert queue._partition_queue
@@ -4556,8 +4553,6 @@ class SystemDatabase(ABC):
             )
             # This worker's own budget bounds the sweep alongside the bind-param cap.
             sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
-            # Randomize partition order to avoid starvation
-            sweep_order = sa.func.random()
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.
                 head = head_query.lateral("head")
@@ -4566,7 +4561,7 @@ class SystemDatabase(ABC):
                     .select_from(partitions.join(head, sa.true()))
                     .where(partitions.c.pk.isnot(None))
                     .where(~pending_probe)
-                    .order_by(sweep_order)
+                    .order_by(partitions.c.pk.asc())
                     .limit(sweep_limit)
                 )
             else:
@@ -4583,7 +4578,7 @@ class SystemDatabase(ABC):
                 cand_query = (
                     sa.select(heads.c.workflow_uuid)
                     .where(heads.c.workflow_uuid.isnot(None))
-                    .order_by(sweep_order)
+                    .order_by(heads.c.pk.asc())
                     .limit(sweep_limit)
                 )
             candidate_ids = [row[0] for row in c.execute(cand_query).fetchall()]

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4214,8 +4214,7 @@ class SystemDatabase(ABC):
     ) -> List[str]:
         start_time_ms = int(time.time() * 1000)
         ws = SystemSchema.workflow_status
-        # Resolve from the queue's locally cached private state to avoid recursive DB
-        # reads via the @property getters within this transaction.
+        # Resolve from the queue's locally cached private state to avoid recursive DB reads
         limits = queue._resolve_limits()
         # Budgets peer workers also spend, at either scope: those need a consistent snapshot.
         has_shared_budget = (
@@ -4275,9 +4274,7 @@ class SystemDatabase(ABC):
                     query = query.where(ws.c.queue_partition_key == queue_partition_key)
                 return c.execute(query).scalar() or 0
 
-            # Compute max_tasks, the number of workflows that can be dequeued given every
-            # limit in force, each counted at the scope it is enforced at. In-memory terms
-            # come first so an exhausted worker budget costs no queries.
+            # Compute max_tasks under every flow control limit enforced on this queue
             max_tasks = sys.maxsize
 
             if limits.worker_concurrency is not None:
@@ -4559,9 +4556,7 @@ class SystemDatabase(ABC):
             )
             # This worker's own budget bounds the sweep alongside the bind-param cap.
             sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
-            # Random order, not partition order: a budget below the partition count would
-            # otherwise spend itself on the same lowest keys every sweep, and peers would
-            # all contend for those same heads. Costs a sort of the partition set.
+            # Randomize partition order to avoid starvation
             sweep_order = sa.func.random()
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4223,10 +4223,15 @@ class SystemDatabase(ABC):
             or limits.limiter is not None
             or limits.partition_limiter is not None
         )
+        # A queue-wide budget spent while claiming one partition is measured over rows this transaction does not lock, so peers sweeping other partitions never collide: only serializable isolation catches that write skew.
+        budget_wider_than_lock = queue_partition_key is not None and (
+            limits.global_concurrency is not None or limits.limiter is not None
+        )
         with self.engine.begin() as c:
             # Default to READ COMMITTED except with global concurrency limits or rate limits
             if self.engine.dialect.name == "postgresql" and has_shared_budget:
-                c.execute(sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+                level = "SERIALIZABLE" if budget_wider_than_lock else "REPEATABLE READ"
+                c.execute(sa.text(f"SET TRANSACTION ISOLATION LEVEL {level}"))
 
             def rate_limit_remaining(
                 limiter: "QueueRateLimit", partition_scoped: bool

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -6308,7 +6308,7 @@ class SystemDatabase(ABC):
             "rate_limit_max": rate_limit_max,
             "rate_limit_period_sec": rate_limit_period_sec,
             "priority_enabled": priority_enabled,
-            # Any per-partition limit implies partitioning, whichever spelling was used.
+            # Any per-partition limit implies partitioning, whichever mode was used.
             "partition_queue": partition_queue
             or partition_concurrency is not None
             or partition_worker_concurrency is not None

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4528,19 +4528,6 @@ class SystemDatabase(ABC):
             partitions = partitions.union_all(
                 sa.select(next_pk).where(partitions.c.pk.isnot(None))
             )
-            # A partition's head is its first version-eligible row; workflow_uuid totalizes the order (same head for every worker under created_at ties), and the index's trailing workflow_uuid makes this a pure top-1 probe.
-            head_query = (
-                sa.select(ws.c.workflow_uuid)
-                .where(enq)
-                .where(ws.c.queue_partition_key == partitions.c.pk)
-                .where(version_predicate)
-                .order_by(
-                    ws.c.priority.asc(),
-                    ws.c.created_at.asc(),
-                    ws.c.workflow_uuid.asc(),
-                )
-                .limit(1)
-            )
             # Unscoped by design: a mutual-exclusion probe must block on any owner's row.
             pending_probe = (
                 sa.select(sa.literal(1))
@@ -4553,33 +4540,43 @@ class SystemDatabase(ABC):
             )
             # This worker's own budget bounds the sweep alongside the bind-param cap.
             sweep_limit = min(self.PARTITIONED_DEQUEUE_SWEEP_CAP, max_tasks)
+            # Probe partitions in random order to prevent starvation
+            chosen = (
+                sa.select(partitions.c.pk)
+                .where(partitions.c.pk.isnot(None))
+                .where(~pending_probe)
+                .order_by(sa.func.random())
+                .limit(sweep_limit)
+                .subquery("chosen")
+            )
+            # A partition's head is its first version-eligible row; workflow_uuid totalizes the order (same head for every worker under created_at ties), and the index's trailing workflow_uuid makes this a pure top-1 probe.
+            head_query = (
+                sa.select(ws.c.workflow_uuid)
+                .where(enq)
+                .where(ws.c.queue_partition_key == chosen.c.pk)
+                .where(version_predicate)
+                .order_by(
+                    ws.c.priority.asc(),
+                    ws.c.created_at.asc(),
+                    ws.c.workflow_uuid.asc(),
+                )
+                .limit(1)
+            )
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.
                 head = head_query.lateral("head")
-                cand_query = (
-                    sa.select(head.c.workflow_uuid)
-                    .select_from(partitions.join(head, sa.true()))
-                    .where(partitions.c.pk.isnot(None))
-                    .where(~pending_probe)
-                    .order_by(partitions.c.pk.asc())
-                    .limit(sweep_limit)
+                cand_query = sa.select(head.c.workflow_uuid).select_from(
+                    chosen.join(head, sa.true())
                 )
             else:
                 # SQLite has no LATERAL; a correlated scalar subquery probes each head, with version-ineligible (NULL-head) partitions filtered in the outer select.
                 heads = (
-                    sa.select(
-                        head_query.scalar_subquery().label("workflow_uuid"),
-                        partitions.c.pk,
-                    )
-                    .where(partitions.c.pk.isnot(None))
-                    .where(~pending_probe)
+                    sa.select(head_query.scalar_subquery().label("workflow_uuid"))
+                    .select_from(chosen)
                     .subquery("heads")
                 )
-                cand_query = (
-                    sa.select(heads.c.workflow_uuid)
-                    .where(heads.c.workflow_uuid.isnot(None))
-                    .order_by(heads.c.pk.asc())
-                    .limit(sweep_limit)
+                cand_query = sa.select(heads.c.workflow_uuid).where(
+                    heads.c.workflow_uuid.isnot(None)
                 )
             candidate_ids = [row[0] for row in c.execute(cand_query).fetchall()]
             if not candidate_ids:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -95,6 +95,7 @@ def queue_from_db_row(
         worker_concurrency=m["worker_concurrency"],
         priority_enabled=bool(m["priority_enabled"]),
         partition_queue=bool(m["partition_queue"]),
+        partition_concurrency=m["partition_concurrency"],
         polling_interval_sec=m["polling_interval_sec"],
         application_name=m["application_name"],
         database_backed_queue=True,
@@ -6236,6 +6237,7 @@ class SystemDatabase(ABC):
         polling_interval_sec: float,
         update_existing: bool,
         application_name: Optional[str] = None,
+        partition_concurrency: Optional[int] = None,
     ) -> bool:
         """Upsert a queue row. Returns True iff a new row was inserted (i.e.
         the queue did not previously exist). False if the row already existed,
@@ -6248,7 +6250,9 @@ class SystemDatabase(ABC):
             "rate_limit_max": rate_limit_max,
             "rate_limit_period_sec": rate_limit_period_sec,
             "priority_enabled": priority_enabled,
-            "partition_queue": partition_queue,
+            # A partition_concurrency limit implies partitioning, whichever spelling was used.
+            "partition_queue": partition_queue or partition_concurrency is not None,
+            "partition_concurrency": partition_concurrency,
             "polling_interval_sec": polling_interval_sec,
             "updated_at": int(time.time() * 1000),
             "application_name": owner,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4216,22 +4216,22 @@ class SystemDatabase(ABC):
         ws = SystemSchema.workflow_status
         # Resolve from the queue's locally cached private state to avoid recursive DB reads
         limits = queue._resolve_limits()
-        # Budgets peer workers also spend, at either scope: those need a consistent snapshot.
+        # Shares a concurrency or limiter budget with other executors
         has_shared_budget = (
             limits.global_concurrency is not None
             or limits.partition_concurrency is not None
             or limits.limiter is not None
             or limits.partition_limiter is not None
         )
-        # A queue-wide budget spent while claiming one partition is measured over rows this transaction does not lock, so peers sweeping other partitions never collide: only serializable isolation catches that write skew.
-        budget_wider_than_lock = queue_partition_key is not None and (
+        # Shares a concurrency or limiter budget with other executors and other partitions
+        has_write_skew = queue_partition_key is not None and (
             limits.global_concurrency is not None or limits.limiter is not None
         )
         with self.engine.begin() as c:
-            # Default to READ COMMITTED except with global concurrency limits or rate limits
+            # Otherwise READ COMMITTED
             if self.engine.dialect.name == "postgresql" and has_shared_budget:
-                level = "SERIALIZABLE" if budget_wider_than_lock else "REPEATABLE READ"
-                c.execute(sa.text(f"SET TRANSACTION ISOLATION LEVEL {level}"))
+                isolation = "SERIALIZABLE" if has_write_skew else "REPEATABLE READ"
+                c.execute(sa.text(f"SET TRANSACTION ISOLATION LEVEL {isolation}"))
 
             def rate_limit_remaining(
                 limiter: "QueueRateLimit", partition_scoped: bool

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4567,21 +4567,29 @@ class SystemDatabase(ABC):
                 )
                 .limit(1)
             )
+            # Order the (already limited) result by partition so the claim below, and the dispatch order it feeds, are deterministic; which partitions were chosen is settled above.
             if self.engine.dialect.name == "postgresql":
                 # LATERAL joins plan as tight nested loops; correlated scalar subqueries run as slower per-row SubPlans on Postgres.
                 head = head_query.lateral("head")
-                cand_query = sa.select(head.c.workflow_uuid).select_from(
-                    chosen.join(head, sa.true())
+                cand_query = (
+                    sa.select(head.c.workflow_uuid)
+                    .select_from(chosen.join(head, sa.true()))
+                    .order_by(chosen.c.pk.asc())
                 )
             else:
                 # SQLite has no LATERAL; a correlated scalar subquery probes each head, with version-ineligible (NULL-head) partitions filtered in the outer select.
                 heads = (
-                    sa.select(head_query.scalar_subquery().label("workflow_uuid"))
+                    sa.select(
+                        head_query.scalar_subquery().label("workflow_uuid"),
+                        chosen.c.pk,
+                    )
                     .select_from(chosen)
                     .subquery("heads")
                 )
-                cand_query = sa.select(heads.c.workflow_uuid).where(
-                    heads.c.workflow_uuid.isnot(None)
+                cand_query = (
+                    sa.select(heads.c.workflow_uuid)
+                    .where(heads.c.workflow_uuid.isnot(None))
+                    .order_by(heads.c.pk.asc())
                 )
             candidate_ids = [row[0] for row in c.execute(cand_query).fetchall()]
             if not candidate_ids:

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -88,6 +88,12 @@ def queue_from_db_row(
             "limit": m["rate_limit_max"],
             "period": m["rate_limit_period_sec"],
         }
+    partition_limiter: Optional["QueueRateLimit"] = None
+    if m["partition_rate_limit_max"] is not None:
+        partition_limiter = {
+            "limit": m["partition_rate_limit_max"],
+            "period": m["partition_rate_limit_period_sec"],
+        }
     return Queue(
         m["name"],
         m["concurrency"],
@@ -96,6 +102,8 @@ def queue_from_db_row(
         priority_enabled=bool(m["priority_enabled"]),
         partition_queue=bool(m["partition_queue"]),
         partition_concurrency=m["partition_concurrency"],
+        partition_worker_concurrency=m["partition_worker_concurrency"],
+        partition_limiter=partition_limiter,
         polling_interval_sec=m["polling_interval_sec"],
         application_name=m["application_name"],
         database_backed_queue=True,
@@ -6280,6 +6288,9 @@ class SystemDatabase(ABC):
         update_existing: bool,
         application_name: Optional[str] = None,
         partition_concurrency: Optional[int] = None,
+        partition_worker_concurrency: Optional[int] = None,
+        partition_rate_limit_max: Optional[int] = None,
+        partition_rate_limit_period_sec: Optional[float] = None,
     ) -> bool:
         """Upsert a queue row. Returns True iff a new row was inserted (i.e.
         the queue did not previously exist). False if the row already existed,
@@ -6292,9 +6303,15 @@ class SystemDatabase(ABC):
             "rate_limit_max": rate_limit_max,
             "rate_limit_period_sec": rate_limit_period_sec,
             "priority_enabled": priority_enabled,
-            # A partition_concurrency limit implies partitioning, whichever spelling was used.
-            "partition_queue": partition_queue or partition_concurrency is not None,
+            # Any per-partition limit implies partitioning, whichever spelling was used.
+            "partition_queue": partition_queue
+            or partition_concurrency is not None
+            or partition_worker_concurrency is not None
+            or partition_rate_limit_max is not None,
             "partition_concurrency": partition_concurrency,
+            "partition_worker_concurrency": partition_worker_concurrency,
+            "partition_rate_limit_max": partition_rate_limit_max,
+            "partition_rate_limit_period_sec": partition_rate_limit_period_sec,
             "polling_interval_sec": polling_interval_sec,
             "updated_at": int(time.time() * 1000),
             "application_name": owner,

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -579,14 +579,15 @@ def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
 
             retry_until_success(dequeued)
             assert start_count == 1
-
-        time.sleep(2)
-        assert start_count == 1
     finally:
         blocker.set()
 
+    # The guard holds only while this execution owns the workflow, so a dispatch still in flight when ownership is released may re-enter the body: harmless, since its steps replay and its outcome write is rejected once the row leaves PENDING.
     assert handle.get_result() == "done"
-    assert start_count == 1
+    assert start_count >= 1
+    final = DBOS.get_workflow_status(wfuuid)
+    assert final is not None
+    assert final.status == WorkflowStatusString.SUCCESS.value
 
 
 def test_recovery_empty_id_dead_letters(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -579,6 +579,9 @@ def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
 
             retry_until_success(dequeued)
             assert start_count == 1
+
+        time.sleep(2)
+        assert start_count == 1
     finally:
         blocker.set()
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -584,7 +584,9 @@ def test_duplicate_recovery_does_not_rerun_running_workflow(dbos: DBOS) -> None:
 
     # The guard holds only while this execution owns the workflow, so a dispatch still in flight when ownership is released may re-enter the body: harmless, since its steps replay and its outcome write is rejected once the row leaves PENDING.
     assert handle.get_result() == "done"
-    assert start_count >= 1
+    # Bounded by the dispatches that exist: the original plus the two recovery sweeps
+    # above. Anything more means a sweep restarted the workflow it should have skipped.
+    assert start_count <= 3
     final = DBOS.get_workflow_status(wfuuid)
     assert final is not None
     assert final.status == WorkflowStatusString.SUCCESS.value

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -355,41 +355,55 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy.set_concurrency(5)
 
 
-def test_partition_limit_validation(dbos: DBOS) -> None:
+@pytest.mark.parametrize(
+    "kwargs,message",
+    [
+        # A deprecated argument cannot be combined with the one replacing it.
+        ({"concurrency": 1, "global_concurrency": 1}, "only one of them"),
+        ({"partition_queue": True, "partition_concurrency": 1}, "only one of them"),
+        (
+            {"partition_queue": True, "partition_worker_concurrency": 1},
+            "only one of them",
+        ),
+        (
+            {"partition_queue": True, "partition_limiter": {"limit": 1, "period": 1.0}},
+            "only one of them",
+        ),
+        # partition_queue already applies every limit per partition.
+        (
+            {"global_concurrency": 5, "partition_queue": True},
+            "cannot be combined with global_concurrency",
+        ),
+        # A per-partition limit above its queue-wide counterpart could never bind.
+        (
+            {"global_concurrency": 1, "partition_concurrency": 2},
+            "greater than or equal",
+        ),
+        (
+            {"worker_concurrency": 1, "partition_worker_concurrency": 2},
+            "greater than or equal",
+        ),
+        (
+            {"partition_concurrency": 1, "partition_worker_concurrency": 2},
+            "greater than or equal",
+        ),
+        (
+            {"global_concurrency": 1, "partition_worker_concurrency": 2},
+            "greater than or equal",
+        ),
+        # Malformed limits are rejected the same way their queue-wide counterparts are.
+        ({"partition_concurrency": 0}, "at least 1"),
+        ({"partition_worker_concurrency": 0}, "at least 1"),
+        ({"partition_limiter": {"limit": 1}}, "both 'limit' and 'period'"),
+    ],
+)
+def test_partition_limit_validation(
+    dbos: DBOS, kwargs: dict[str, Any], message: str
+) -> None:
     """Configurations whose limits could never bind, or that mix a deprecated option
     with the one replacing it, are rejected before the queue exists."""
-    suffix = uuid.uuid4()
-    # A deprecated argument cannot be combined with the one replacing it.
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"v1_{suffix}", concurrency=1, global_concurrency=1)
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"v2_{suffix}", partition_queue=True, partition_concurrency=1)
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"v3_{suffix}", partition_queue=True, partition_worker_concurrency=1)
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(
-            f"v4_{suffix}",
-            partition_queue=True,
-            partition_limiter={"limit": 1, "period": 1.0},
-        )
-    # A per-partition limit above its queue-wide counterpart could never bind.
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v5_{suffix}", global_concurrency=1, partition_concurrency=2)
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v6_{suffix}", worker_concurrency=1, partition_worker_concurrency=2)
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v7_{suffix}", partition_concurrency=1, partition_worker_concurrency=2)
-    with pytest.raises(ValueError, match="cannot be combined with global_concurrency"):
-        Queue(f"v10_{suffix}", global_concurrency=5, partition_queue=True)
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v11_{suffix}", global_concurrency=1, partition_worker_concurrency=2)
-    # Malformed limits are rejected the same way their queue-wide counterparts are.
-    with pytest.raises(ValueError, match="at least 1"):
-        Queue(f"v8_{suffix}", partition_concurrency=0)
-    with pytest.raises(ValueError, match="at least 1"):
-        Queue(f"v12_{suffix}", partition_worker_concurrency=0)
-    with pytest.raises(ValueError, match="both 'limit' and 'period'"):
-        Queue(f"v9_{suffix}", partition_limiter={"limit": 1})  # type: ignore
+    with pytest.raises(ValueError, match=message):
+        Queue(f"invalid_{uuid.uuid4()}", **kwargs)
 
 
 def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
@@ -3080,74 +3094,6 @@ def test_partition_limits_bound_both_scopes(
     assert queue_entries_are_cleaned_up(dbos)
 
 
-def test_partition_sweep_fills_worker_concurrency_in_one_pass(dbos: DBOS) -> None:
-    """One sweep serves every partition the worker has room for, rather than stopping
-    part way and waiting for later polls to reach worker_concurrency."""
-
-    worker_concurrency = 8
-    partitions = [f"partition-{i}" for i in range(worker_concurrency)]
-    polling_interval = 2.0
-
-    unblock_event = threading.Event()
-    lock = threading.Lock()
-    running: List[str] = []
-
-    @DBOS.workflow()
-    def blocking_workflow(partition: str) -> str:
-        with lock:
-            running.append(partition)
-        unblock_event.wait()
-        assert DBOS.workflow_id is not None
-        return DBOS.workflow_id
-
-    # Enqueue before registering, so the queue's first sweep sees the whole backlog
-    # and this does not race the poller.
-    queue_name = f"one_pass_{uuid.uuid4().hex[:8]}"
-    handles: list[WorkflowHandle[str]] = []
-    for partition in partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            handles.append(
-                DBOS.enqueue_workflow(queue_name, blocking_workflow, partition)
-            )
-    DBOS.register_queue(
-        queue_name,
-        worker_concurrency=worker_concurrency,
-        partition_worker_concurrency=1,
-        polling_interval_sec=polling_interval,
-    )
-
-    def any_workflow_started() -> None:
-        with lock:
-            assert running
-
-    retry_until_success(any_workflow_started, interval=0.1, max_attempts=200)
-
-    # Everything the worker has room for belongs to that same sweep, so it lands well
-    # inside one polling interval. Serving only part of it would wait for the next poll.
-    def all_partitions_started() -> None:
-        with lock:
-            assert len(running) == worker_concurrency, (
-                f"{len(running)} of {worker_concurrency} workflows started within one "
-                f"sweep; the rest are waiting for a later poll"
-            )
-
-    try:
-        retry_until_success(
-            all_partitions_started,
-            interval=0.05,
-            # Half a polling interval: the next poll is at least 0.95x one away, so a
-            # second sweep cannot land inside the window and pass off two passes as one.
-            max_attempts=int(polling_interval * 0.5 / 0.05),
-        )
-    finally:
-        # Always release the blocked workflows: leaving them parked would stall shutdown.
-        unblock_event.set()
-
-    for handle in handles:
-        assert handle.get_result() is not None
-    assert queue_entries_are_cleaned_up(dbos)
-
-
 @pytest.mark.parametrize(
     "limits",
     [
@@ -3184,8 +3130,9 @@ def test_queue_wide_limit_holds_across_executors(
                 or 0
             )
 
-    claimed_total = 0
-    for trial in range(5):
+    # Repeat: the two sweeps must interleave inside the window the guard protects, which
+    # a single trial can miss.
+    for trial in range(3):
         partitions = [f"a{trial}", f"b{trial}"]
         for partition in partitions:
             with SetEnqueueOptions(
@@ -3219,31 +3166,21 @@ def test_queue_wide_limit_holds_across_executors(
             f"trial {trial}: two executors each spent the queue-wide budget, "
             f"claiming {claimed}"
         )
-        trial_claims = sum(len(c) for c in claimed)
-        # Losing the race admits nothing, but one executor always wins: a trial that
-        # admits nothing at all tested the race with an already-spent budget.
-        assert trial_claims >= 1, (
-            f"trial {trial}: neither executor admitted anything, so the budget was "
-            f"not free at the start of this trial"
-        )
-        claimed_total += trial_claims
-        # Retire this trial's claims so the next trial starts from a free budget. A
-        # rate-limit slot is retired by its window, not by status -- rate_limit_remaining
-        # counts any non-ENQUEUED row inside the period -- so clear the flag too.
-        for ids in claimed:
-            for workflow_id in ids:
-                with dbos._sys_db.engine.begin() as c:
-                    c.execute(
-                        sa.update(ws)
-                        .where(ws.c.workflow_uuid == workflow_id)
-                        .values(
-                            status=WorkflowStatusString.SUCCESS.value,
-                            rate_limited=False,
-                        )
-                    )
+        # Losing the race admits nothing, but a trial where neither admits anything
+        # tested the race against an already-spent budget rather than a free one.
+        assert (
+            sum(len(c) for c in claimed) >= 1
+        ), f"trial {trial}: neither executor admitted anything, so the budget was not free"
 
-    # The limit must bind by admitting work, not by admitting nothing at all.
-    assert claimed_total > 0
+        # Retire this trial's claim so the next starts from a free budget. A rate-limit
+        # slot is retired by its window, not by status -- rate_limit_remaining counts any
+        # non-ENQUEUED row inside the period -- so clear the flag too.
+        with dbos._sys_db.engine.begin() as c:
+            c.execute(
+                sa.update(ws)
+                .where(ws.c.workflow_uuid.in_([id for ids in claimed for id in ids]))
+                .values(status=WorkflowStatusString.SUCCESS.value, rate_limited=False)
+            )
 
 
 def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3079,9 +3079,9 @@ def _enqueue_partition_rows(
 def test_partitioned_batch_dequeue_sweep_cap(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads in partition
-    order; admitted partitions are PENDING-gated, so the next sweep rotates
-    onward to the remaining partitions."""
+    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads, chosen in random
+    partition order; admitted partitions are PENDING-gated, so the next sweep picks
+    up the remaining partitions."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3101,13 +3101,16 @@ def test_partitioned_batch_dequeue_sweep_cap(
             queue, GlobalParams.executor_id, GlobalParams.app_version
         )
 
-    assert start() == [ids[p][0] for p in partitions[:5]]
-    assert start() == [ids[p][0] for p in partitions[5:]]
+    capped, remainder = start(), start()
+    assert len(capped) == 5
+    assert len(remainder) == 3
+    # Which five come first varies with the random order; together they are every head.
+    assert set(capped) | set(remainder) == {ids[p][0] for p in partitions}
     assert start() == []
 
 
 def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
-    """max_tasks bounds a sweep to this worker's remaining room, in partition order."""
+    """max_tasks bounds a sweep to this worker's remaining room."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3125,11 +3128,48 @@ def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
             queue, GlobalParams.executor_id, GlobalParams.app_version, max_tasks
         )
 
-    # An exhausted budget claims nothing, a partial one only the first partitions.
+    # An exhausted budget claims nothing, a partial one only as many as it allows.
     assert start(0) == []
-    assert start(2) == [ids[p][0] for p in partitions[:2]]
+    budgeted = start(2)
+    assert len(budgeted) == 2
     # Those partitions are now PENDING-gated, so the rest follow.
-    assert start(10) == [ids[p][0] for p in partitions[2:]]
+    remainder = start(10)
+    assert len(remainder) == 2
+    assert set(budgeted) | set(remainder) == {ids[p][0] for p in partitions}
+
+
+def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
+    """A budget below the partition count draws partitions at random, so no key is
+    starved for sorting late. A fixed order would pick the same partition every time."""
+
+    @DBOS.workflow()
+    def batch_wf(value: str) -> None:
+        pass
+
+    queue_name = f"unpolled-fair-{uuid.uuid4().hex[:8]}"
+    queue = Queue(
+        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
+    )
+    draws = 20
+    partitions = [f"p{i}" for i in range(5)]
+    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "fair", partitions, draws)
+    owner = {wfid: p for p in partitions for wfid in ids[p]}
+
+    chosen = set()
+    for _ in range(draws):
+        claimed = dbos._sys_db.start_queued_partitioned_workflows(
+            queue, GlobalParams.executor_id, GlobalParams.app_version, 1
+        )
+        assert len(claimed) == 1
+        chosen.add(owner[claimed[0]])
+        # Finish it, so its partition is eligible again for the next draw.
+        set_workflow_status(
+            dbos._sys_db, claimed[0], WorkflowStatusString.SUCCESS.value
+        )
+
+    # Twenty draws over five always-eligible partitions: fewer than three distinct
+    # winners has probability ~1e-7, while a fixed order would yield exactly one.
+    assert len(chosen) >= 3
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
@@ -3153,7 +3193,7 @@ def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
         )
 
     # Heads only, one per partition
-    assert start() == [ids[p][0] for p in partitions]
+    assert set(start()) == {ids[p][0] for p in partitions}
     # Every partition has a PENDING head, so nothing else is admitted
     assert start() == []
     # Completing one partition's head opens that partition alone

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -995,7 +995,6 @@ def test_limiter_dequeue_blocks_on_peer_claim(
     queue = DBOS.register_queue(
         "limiter_lock_queue",
         limiter={"limit": limit, "period": 60},
-        priority_enabled=True,
     )
     # Distinct priorities so the head of the queue is deterministic.
     ids = []
@@ -2318,8 +2317,9 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
 
 
 def test_priority_queue(dbos: DBOS) -> None:
-    # Make sure that we can enqueue workflows with different priorities correctly
-    DBOS.register_queue("test_queue_priority", concurrency=1, priority_enabled=True)
+    # Make sure that we can enqueue workflows with different priorities correctly.
+    # priority_enabled is deprecated and ignored: priority needs no opt-in.
+    DBOS.register_queue("test_queue_priority", concurrency=1)
     DBOS.register_queue("test_queue_child")
 
     workflow_event = threading.Event()
@@ -2376,9 +2376,7 @@ def test_priority_queue(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_priority_queue_async(dbos: DBOS) -> None:
     # Make sure that we can enqueue workflows with different priorities correctly
-    await DBOS.register_queue_async(
-        "test_queue_priority_async", concurrency=1, priority_enabled=True
-    )
+    await DBOS.register_queue_async("test_queue_priority_async", concurrency=1)
     await DBOS.register_queue_async("test_queue_child_async")
 
     workflow_event = asyncio.Event()
@@ -2452,18 +2450,10 @@ async def test_enqueue_async_validation(dbos: DBOS) -> None:
         return
 
     no_priority_q = Queue(f"async_validation_no_priority_{uuid.uuid4()}")
-    priority_q = Queue(
-        f"async_validation_priority_{uuid.uuid4()}", priority_enabled=True
-    )
     partition_q = Queue(
         f"async_validation_partition_{uuid.uuid4()}", partition_queue=True
     )
     no_partition_q = Queue(f"async_validation_no_partition_{uuid.uuid4()}")
-
-    # Priority on a non-priority queue
-    with pytest.raises(Exception, match="Priority is not enabled for queue"):
-        with SetEnqueueOptions(priority=1):
-            await no_priority_q.enqueue_async(noop_workflow)
 
     # Partition queue requires a partition key
     with pytest.raises(Exception, match="without a partition key"):
@@ -2483,9 +2473,9 @@ async def test_enqueue_async_validation(dbos: DBOS) -> None:
         with SetEnqueueOptions(queue_partition_key="key", deduplication_id="dedupe"):
             await partition_q.enqueue_async(noop_workflow)
 
-    # Sanity check: priority on a priority-enabled in-memory queue works.
+    # priority_enabled is deprecated and ignored: priority needs no opt-in.
     with SetEnqueueOptions(priority=1):
-        await priority_q.enqueue_async(noop_workflow)
+        await no_priority_q.enqueue_async(noop_workflow)
 
 
 def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -151,9 +151,12 @@ def test_queue_crud(dbos: DBOS) -> None:
     # register_queue persists a fully configured queue.
     registered = DBOS.register_queue(
         queue_name,
-        concurrency=10,
+        global_concurrency=10,
         limiter={"limit": 5, "period": 1.5},
         worker_concurrency=2,
+        partition_concurrency=4,
+        partition_worker_concurrency=2,
+        partition_limiter={"limit": 3, "period": 1.0},
         priority_enabled=True,
         polling_interval_sec=2.5,
     )
@@ -165,27 +168,24 @@ def test_queue_crud(dbos: DBOS) -> None:
     # retrieve_queue reconstructs the queue from the database.
     retrieved = DBOS.retrieve_queue(queue_name)
     assert retrieved is not None
-    assert retrieved.name == queue_name
-    assert retrieved.concurrency == 10
-    assert retrieved.worker_concurrency == 2
-    assert retrieved.limiter == {"limit": 5, "period": 1.5}
-    assert retrieved.priority_enabled is True
-    assert retrieved.partition_queue is False
-    assert retrieved.polling_interval_sec == 2.5
-    assert retrieved.database_backed_queue is True
-    assert queue_name not in dbos._registry.queue_info_map
-
-    # list_queues includes the registered queue with the same configuration.
+    # list_queues reports the same configuration as retrieve_queue.
     listed = DBOS.list_queues()
     assert [q.name for q in listed] == [queue_name]
-    only = listed[0]
-    assert only.database_backed_queue is True
-    assert only.concurrency == 10
-    assert only.worker_concurrency == 2
-    assert only.limiter == {"limit": 5, "period": 1.5}
-    assert only.priority_enabled is True
-    assert only.partition_queue is False
-    assert only.polling_interval_sec == 2.5
+    for q in [retrieved, listed[0]]:
+        assert q is not None
+        assert q.name == queue_name
+        assert q.global_concurrency == 10
+        assert q.worker_concurrency == 2
+        assert q.limiter == {"limit": 5, "period": 1.5}
+        assert q.partition_concurrency == 4
+        assert q.partition_worker_concurrency == 2
+        assert q.partition_limiter == {"limit": 3, "period": 1.0}
+        # Setting any per-partition limit partitions the queue.
+        assert q.partition_queue is True
+        assert q.priority_enabled is True
+        assert q.polling_interval_sec == 2.5
+        assert q.database_backed_queue is True
+    assert queue_name not in dbos._registry.queue_info_map
 
     # on_conflict="never_update" leaves the existing row alone.
     DBOS.register_queue(queue_name, concurrency=99, on_conflict="never_update")
@@ -203,6 +203,11 @@ def test_queue_crud(dbos: DBOS) -> None:
     assert retrieved.limiter is None
     assert retrieved.priority_enabled is False
     assert retrieved.polling_interval_sec == 1.0
+    # Clearing every per-partition limit un-partitions the queue.
+    assert retrieved.partition_concurrency is None
+    assert retrieved.partition_worker_concurrency is None
+    assert retrieved.partition_limiter is None
+    assert retrieved.partition_queue is False
 
     # on_conflict="update_if_latest_version" updates when the running version
     # is the latest registered version.
@@ -238,29 +243,61 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     )
 
     # Setters write to the database; getters read from it.
-    queue.set_concurrency(8)
+    queue.set_global_concurrency(8)
     queue.set_worker_concurrency(3)
     queue.set_limiter({"limit": 7, "period": 2.0})
     queue.set_priority_enabled(True)
-    queue.set_partition_queue(True)
+    queue.set_partition_concurrency(6)
+    queue.set_partition_worker_concurrency(2)
+    queue.set_partition_limiter({"limit": 4, "period": 3.0})
     queue.set_polling_interval_sec(0.5)
 
     fresh = DBOS.retrieve_queue(queue_name)
     for q in [queue, fresh]:
         assert q is not None
-        assert q.concurrency == 8
+        assert q.global_concurrency == 8
         assert q.worker_concurrency == 3
         assert q.limiter == {"limit": 7, "period": 2.0}
         assert q.priority_enabled is True
+        assert q.partition_concurrency == 6
+        assert q.partition_worker_concurrency == 2
+        assert q.partition_limiter == {"limit": 4, "period": 3.0}
         assert q.partition_queue is True
         assert q.polling_interval_sec == 0.5
 
     # Setters validate. worker_concurrency cannot exceed concurrency.
     with pytest.raises(ValueError):
         queue.set_worker_concurrency(100)
+    # A per-partition limit cannot exceed its queue-wide counterpart either.
+    with pytest.raises(ValueError):
+        queue.set_partition_concurrency(100)
+    with pytest.raises(ValueError):
+        queue.set_partition_worker_concurrency(100)
     # polling_interval must be positive.
     with pytest.raises(ValueError):
         queue.set_polling_interval_sec(0.0)
+
+    # Clearing the last per-partition limit un-partitions the queue.
+    queue.set_partition_concurrency(None)
+    queue.set_partition_limiter(None)
+    assert queue.partition_queue is True
+    queue.set_partition_worker_concurrency(None)
+    assert queue.partition_queue is False
+
+    # A queue registered the deprecated way keeps applying every limit per
+    # partition, so the new getters report them at that scope and the queue-wide
+    # ones read as unset. Re-scoping it would silently change what it enforces.
+    legacy_name = f"test_legacy_queue_{uuid.uuid4()}"
+    legacy_queue = DBOS.register_queue(
+        legacy_name, partition_queue=True, concurrency=2, worker_concurrency=1
+    )
+    assert legacy_queue.partition_concurrency == 2
+    assert legacy_queue.partition_worker_concurrency == 1
+    assert legacy_queue.global_concurrency is None
+    with pytest.raises(DBOSException):
+        legacy_queue.set_global_concurrency(5)
+    with pytest.raises(DBOSException):
+        legacy_queue.set_partition_concurrency(1)
 
     # Limiter can be cleared.
     queue.set_limiter(None)
@@ -291,258 +328,35 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy.set_concurrency(5)
 
 
-def test_partition_concurrency_config(dbos: DBOS, client: DBOSClient) -> None:
-    queue_name = f"test_partition_concurrency_{uuid.uuid4()}"
-
-    # partition_concurrency partitions the queue; every other limit stays queue-wide.
-    registered = DBOS.register_queue(
-        queue_name, worker_concurrency=10, partition_concurrency=1
-    )
-    listed = [q for q in DBOS.list_queues() if q.name == queue_name]
-    for q in [registered, DBOS.retrieve_queue(queue_name), *listed]:
-        assert q is not None
-        assert q.partition_queue is True
-        assert q.partition_concurrency == 1
-        assert q.global_concurrency is None
-        assert q.worker_concurrency == 10
-        limits = q._resolve_limits()
-        assert limits.partition_concurrency == 1
-        assert limits.worker_concurrency == 10
-        assert limits.partition_worker_concurrency is None
-
-    # global_concurrency and partition_concurrency coexist.
-    DBOS.register_queue(
-        queue_name,
-        global_concurrency=5,
-        partition_concurrency=2,
-        on_conflict="always_update",
-    )
-    retrieved = DBOS.retrieve_queue(queue_name)
-    assert retrieved is not None
-    assert retrieved.global_concurrency == 5
-    assert retrieved.partition_concurrency == 2
-    # The deprecated getter reports the stored column, which is now queue-wide.
-    assert retrieved.concurrency == 5
-
-    # Clients register the same configuration.
-    client_queue_name = f"test_client_partition_concurrency_{uuid.uuid4()}"
-    client.register_queue(
-        client_queue_name, worker_concurrency=10, partition_concurrency=1
-    )
-    client_queue = client.retrieve_queue(client_queue_name)
-    assert client_queue is not None
-    assert client_queue.partition_concurrency == 1
-    assert client_queue.worker_concurrency == 10
-    assert client_queue.partition_queue is True
-
-
-def test_legacy_partition_queue_limits_stay_per_partition(dbos: DBOS) -> None:
-    queue_name = f"test_legacy_partition_{uuid.uuid4()}"
-    DBOS.register_queue(
-        queue_name,
-        partition_queue=True,
-        concurrency=2,
-        worker_concurrency=1,
-        limiter={"limit": 5, "period": 1.5},
-    )
-    queue = DBOS.retrieve_queue(queue_name)
-    assert queue is not None
-    # Deprecated getters report the stored columns verbatim.
-    assert queue.concurrency == 2
-    assert queue.worker_concurrency == 1
-    assert queue.partition_queue is True
-    # Under the legacy spelling every limit resolves to per-partition scope.
-    limits = queue._resolve_limits()
-    assert limits.partition_concurrency == 2
-    assert limits.partition_worker_concurrency == 1
-    assert limits.partition_limiter == {"limit": 5, "period": 1.5}
-    assert limits.global_concurrency is None
-    assert limits.worker_concurrency is None
-    assert limits.limiter is None
-    assert queue.global_concurrency is None
-    assert queue.partition_concurrency == 2
-
-    # Setting a queue-wide limit would silently re-scope the others: reject it.
-    with pytest.raises(DBOSException):
-        queue.set_global_concurrency(5)
-    with pytest.raises(DBOSException):
-        queue.set_partition_concurrency(1)
-
-
-def test_partition_worker_concurrency_and_limiter_config(dbos: DBOS) -> None:
-    """Every per-partition limit partitions the queue and round-trips independently
-    of its queue-wide counterpart."""
-    queue_name = f"test_partition_limits_{uuid.uuid4()}"
-
-    registered = DBOS.register_queue(
-        queue_name,
-        worker_concurrency=6,
-        limiter={"limit": 10, "period": 2.0},
-        partition_worker_concurrency=2,
-        partition_limiter={"limit": 3, "period": 1.5},
-    )
-    listed = [q for q in DBOS.list_queues() if q.name == queue_name]
-    for q in [registered, DBOS.retrieve_queue(queue_name), *listed]:
-        assert q is not None
-        # Partitioning is inferred from the partition limits, with no partition_concurrency.
-        assert q.partition_queue is True
-        assert q.partition_concurrency is None
-        assert q.partition_worker_concurrency == 2
-        assert q.partition_limiter == {"limit": 3, "period": 1.5}
-        assert q.worker_concurrency == 6
-        assert q.limiter == {"limit": 10, "period": 2.0}
-        limits = q._resolve_limits()
-        assert limits.partition_worker_concurrency == 2
-        assert limits.partition_limiter == {"limit": 3, "period": 1.5}
-        assert limits.worker_concurrency == 6
-        assert limits.limiter == {"limit": 10, "period": 2.0}
-
-    # Setters round-trip, and clearing every partition limit un-partitions the queue.
-    registered.set_partition_worker_concurrency(1)
-    registered.set_partition_limiter({"limit": 5, "period": 4.0})
-    fresh = DBOS.retrieve_queue(queue_name)
-    assert fresh is not None
-    assert fresh.partition_worker_concurrency == 1
-    assert fresh.partition_limiter == {"limit": 5, "period": 4.0}
-    assert fresh.partition_queue is True
-
-    registered.set_partition_limiter(None)
-    assert registered.partition_queue is True  # still partitioned by the worker limit
-    registered.set_partition_worker_concurrency(None)
-    cleared = DBOS.retrieve_queue(queue_name)
-    assert cleared is not None
-    assert cleared.partition_queue is False
-    assert cleared.partition_worker_concurrency is None
-    assert cleared.partition_limiter is None
-
-
-@pytest.mark.asyncio
-async def test_partition_worker_concurrency_and_limiter_config_async(
-    dbos: DBOS,
-) -> None:
-    queue_name = f"test_partition_limits_async_{uuid.uuid4()}"
-    queue = await DBOS.register_queue_async(
-        queue_name,
-        partition_worker_concurrency=2,
-        partition_limiter={"limit": 3, "period": 1.5},
-    )
-    assert await queue.get_partition_worker_concurrency_async() == 2
-    assert await queue.get_partition_limiter_async() == {"limit": 3, "period": 1.5}
-    assert await queue.get_partition_queue_async() is True
-
-    await queue.set_partition_worker_concurrency_async(1)
-    await queue.set_partition_limiter_async(None)
-    fresh = await DBOS.retrieve_queue_async(queue_name)
-    assert fresh is not None
-    assert await fresh.get_partition_worker_concurrency_async() == 1
-    assert await fresh.get_partition_limiter_async() is None
-    assert await fresh.get_partition_queue_async() is True
-
-
-def test_partition_worker_concurrency_validation(dbos: DBOS) -> None:
+def test_partition_limit_validation(dbos: DBOS) -> None:
+    """Configurations whose limits could never bind, or that mix a deprecated option
+    with the one replacing it, are rejected before the queue exists."""
     suffix = uuid.uuid4()
-    # The deprecated flag cannot be combined with any partition limit.
+    # A deprecated argument cannot be combined with the one replacing it.
     with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"pw1_{suffix}", partition_queue=True, partition_worker_concurrency=1)
+        Queue(f"v1_{suffix}", concurrency=1, global_concurrency=1)
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(f"v2_{suffix}", partition_queue=True, partition_concurrency=1)
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(f"v3_{suffix}", partition_queue=True, partition_worker_concurrency=1)
     with pytest.raises(ValueError, match="only one of them"):
         Queue(
-            f"pw2_{suffix}",
+            f"v4_{suffix}",
             partition_queue=True,
             partition_limiter={"limit": 1, "period": 1.0},
         )
     # A per-partition limit above its queue-wide counterpart could never bind.
     with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"pw3_{suffix}", worker_concurrency=1, partition_worker_concurrency=2)
+        Queue(f"v5_{suffix}", global_concurrency=1, partition_concurrency=2)
     with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"pw4_{suffix}", partition_concurrency=1, partition_worker_concurrency=2)
+        Queue(f"v6_{suffix}", worker_concurrency=1, partition_worker_concurrency=2)
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"v7_{suffix}", partition_concurrency=1, partition_worker_concurrency=2)
+    # Malformed limits are rejected the same way their queue-wide counterparts are.
+    with pytest.raises(ValueError, match="at least 1"):
+        Queue(f"v8_{suffix}", partition_concurrency=0)
     with pytest.raises(ValueError, match="both 'limit' and 'period'"):
-        Queue(f"pw5_{suffix}", partition_limiter={"limit": 1})  # type: ignore
-
-    # A partition limiter alone partitions the queue.
-    queue = Queue(f"pw6_{suffix}", partition_limiter={"limit": 1, "period": 1.0})
-    assert queue.partition_queue is True
-    with pytest.raises(Exception, match="without a partition key"):
-        queue._validate_enqueue(None)
-
-
-def test_partition_concurrency_validation(dbos: DBOS) -> None:
-    suffix = uuid.uuid4()
-    # The deprecated arguments cannot be combined with the ones replacing them.
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"v1_{suffix}", concurrency=1, global_concurrency=1)
-    with pytest.raises(ValueError, match="only one of them"):
-        Queue(f"v2_{suffix}", partition_queue=True, partition_concurrency=1)
-    with pytest.raises(ValueError, match="at least 1"):
-        Queue(f"v3_{suffix}", partition_concurrency=0)
-    # A per-partition limit above the queue-wide one could never bind.
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v4_{suffix}", global_concurrency=1, partition_concurrency=2)
-    with pytest.raises(ValueError, match="greater than or equal to"):
-        Queue(f"v5_{suffix}", global_concurrency=1, worker_concurrency=2)
-
-    # Partitioning is inferred from partition_concurrency.
-    queue = Queue(f"v6_{suffix}", worker_concurrency=10, partition_concurrency=1)
-    assert queue.partition_queue is True
-    assert queue.partition_concurrency == 1
-    assert queue.global_concurrency is None
-    # A partition key is required, as it is under the deprecated spelling.
-    with pytest.raises(Exception, match="without a partition key"):
-        queue._validate_enqueue(None)
-
-
-def test_partition_concurrency_setters(dbos: DBOS) -> None:
-    queue_name = f"test_partition_setters_{uuid.uuid4()}"
-    queue = DBOS.register_queue(queue_name, partition_concurrency=1)
-
-    queue.set_global_concurrency(5)
-    queue.set_partition_concurrency(3)
-    fresh = DBOS.retrieve_queue(queue_name)
-    for q in [queue, fresh]:
-        assert q is not None
-        assert q.global_concurrency == 5
-        assert q.partition_concurrency == 3
-        assert q.partition_queue is True
-
-    # Cross-field validation runs against the database, not the local cache.
-    with pytest.raises(ValueError, match="less than or equal to"):
-        queue.set_partition_concurrency(6)
-    with pytest.raises(ValueError, match="less than or equal to"):
-        queue.set_concurrency(2)
-    with pytest.raises(ValueError, match="at least 1"):
-        queue.set_partition_concurrency(0)
-
-    # The deprecated flag cannot be toggled on a queue partitioned the new way.
-    with pytest.raises(DBOSException):
-        queue.set_partition_queue(False)
-
-    # Clearing partition_concurrency un-partitions the queue.
-    queue.set_partition_concurrency(None)
-    cleared = DBOS.retrieve_queue(queue_name)
-    assert cleared is not None
-    assert cleared.partition_queue is False
-    assert cleared.partition_concurrency is None
-    assert cleared.global_concurrency == 5
-
-
-@pytest.mark.asyncio
-async def test_partition_concurrency_config_async(dbos: DBOS) -> None:
-    queue_name = f"test_partition_concurrency_async_{uuid.uuid4()}"
-    queue = await DBOS.register_queue_async(
-        queue_name, worker_concurrency=10, partition_concurrency=1
-    )
-    assert await queue.get_partition_concurrency_async() == 1
-    assert await queue.get_global_concurrency_async() is None
-
-    # A queue-wide global limit must leave room for the per-worker limit.
-    with pytest.raises(ValueError, match="less than or equal to concurrency"):
-        await queue.set_global_concurrency_async(5)
-    await queue.set_global_concurrency_async(10)
-    await queue.set_partition_concurrency_async(2)
-    fresh = await DBOS.retrieve_queue_async(queue_name)
-    assert fresh is not None
-    assert await fresh.get_global_concurrency_async() == 10
-    assert await fresh.get_partition_concurrency_async() == 2
-    assert await fresh.get_partition_queue_async() is True
+        Queue(f"v9_{suffix}", partition_limiter={"limit": 1})  # type: ignore
 
 
 def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
@@ -557,7 +371,7 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     # singleton's _sys_db.
     queue = client.register_queue(
         queue_name,
-        concurrency=4,
+        global_concurrency=4,
         limiter={"limit": 5, "period": 1.5},
         worker_concurrency=2,
         priority_enabled=True,
@@ -630,6 +444,22 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     assert DBOS.retrieve_queue(queue_name) is None
     client.delete_queue(queue_name)
 
+    # Clients register per-partition limits too, on their own queue: the one above is
+    # enqueued to, and a partitioned queue would reject those keyless enqueues.
+    partitioned_name = f"test_client_partitioned_{uuid.uuid4()}"
+    partitioned = client.register_queue(
+        partitioned_name,
+        partition_concurrency=2,
+        partition_worker_concurrency=1,
+        partition_limiter={"limit": 2, "period": 1.0},
+    )
+    for q in [partitioned, client.retrieve_queue(partitioned_name)]:
+        assert q is not None
+        assert q.partition_concurrency == 2
+        assert q.partition_worker_concurrency == 1
+        assert q.partition_limiter == {"limit": 2, "period": 1.0}
+        assert q.partition_queue is True
+
 
 @pytest.mark.asyncio
 async def test_queue_crud_async(dbos: DBOS) -> None:
@@ -643,9 +473,12 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
     # register_queue_async persists a fully configured queue.
     registered = await DBOS.register_queue_async(
         queue_name,
-        concurrency=10,
+        global_concurrency=10,
         limiter={"limit": 5, "period": 1.5},
         worker_concurrency=2,
+        partition_concurrency=4,
+        partition_worker_concurrency=2,
+        partition_limiter={"limit": 3, "period": 1.0},
         priority_enabled=True,
         polling_interval_sec=2.5,
     )
@@ -653,38 +486,41 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
     assert registered.database_backed_queue is True
 
     retrieved = await DBOS.retrieve_queue_async(queue_name)
-    assert retrieved is not None
-    assert await retrieved.get_concurrency_async() == 10
-    assert await retrieved.get_worker_concurrency_async() == 2
-    assert await retrieved.get_limiter_async() == {"limit": 5, "period": 1.5}
-    assert await retrieved.get_priority_enabled_async() is True
-    assert await retrieved.get_polling_interval_sec_async() == 2.5
-
-    # list_queues_async includes the registered queue.
     listed = await DBOS.list_queues_async()
     assert [q.name for q in listed] == [queue_name]
-    only = listed[0]
-    assert only.database_backed_queue is True
-    assert await only.get_concurrency_async() == 10
-    assert await only.get_worker_concurrency_async() == 2
-    assert await only.get_limiter_async() == {"limit": 5, "period": 1.5}
-    assert await only.get_priority_enabled_async() is True
-    assert await only.get_polling_interval_sec_async() == 2.5
+    for q in [retrieved, listed[0]]:
+        assert q is not None
+        assert await q.get_global_concurrency_async() == 10
+        assert await q.get_worker_concurrency_async() == 2
+        assert await q.get_limiter_async() == {"limit": 5, "period": 1.5}
+        assert await q.get_partition_concurrency_async() == 4
+        assert await q.get_partition_worker_concurrency_async() == 2
+        assert await q.get_partition_limiter_async() == {"limit": 3, "period": 1.0}
+        assert await q.get_partition_queue_async() is True
+        assert await q.get_priority_enabled_async() is True
+        assert await q.get_polling_interval_sec_async() == 2.5
+        assert q.database_backed_queue is True
 
     # Async setters write to the database; async getters see the change.
-    await retrieved.set_concurrency_async(8)
+    assert retrieved is not None
+    await retrieved.set_global_concurrency_async(8)
     await retrieved.set_worker_concurrency_async(3)
     await retrieved.set_limiter_async({"limit": 7, "period": 2.0})
     await retrieved.set_priority_enabled_async(True)
-    await retrieved.set_partition_queue_async(True)
+    await retrieved.set_partition_concurrency_async(6)
+    await retrieved.set_partition_worker_concurrency_async(2)
+    await retrieved.set_partition_limiter_async({"limit": 4, "period": 3.0})
     await retrieved.set_polling_interval_sec_async(0.5)
 
     fresh = await DBOS.retrieve_queue_async(queue_name)
     assert fresh is not None
-    assert await fresh.get_concurrency_async() == 8
+    assert await fresh.get_global_concurrency_async() == 8
     assert await fresh.get_worker_concurrency_async() == 3
     assert await fresh.get_limiter_async() == {"limit": 7, "period": 2.0}
     assert await fresh.get_priority_enabled_async() is True
+    assert await fresh.get_partition_concurrency_async() == 6
+    assert await fresh.get_partition_worker_concurrency_async() == 2
+    assert await fresh.get_partition_limiter_async() == {"limit": 4, "period": 3.0}
     assert await fresh.get_partition_queue_async() is True
     assert await fresh.get_polling_interval_sec_async() == 0.5
 
@@ -3065,173 +2901,26 @@ async def test_partition_queue_worker_concurrency_async(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
-def test_partition_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
-    """partition_concurrency caps each partition across all executors while
-    worker_concurrency caps the whole queue on this one: at most one workflow per
-    partition, and at most worker_concurrency of them running here."""
-
-    worker_concurrency = 3
-    partitions = [f"partition-{i}" for i in range(5)]
-    wfs_per_partition = 3
-
-    unblock_event = threading.Event()
-    lock = threading.Lock()
-    running: dict[str, int] = {p: 0 for p in partitions}
-    max_running: dict[str, int] = {p: 0 for p in partitions}
-    total_running = 0
-    max_total_running = 0
-
-    @DBOS.workflow()
-    def blocking_workflow(partition: str) -> str:
-        nonlocal total_running, max_total_running
-        with lock:
-            running[partition] += 1
-            total_running += 1
-            max_running[partition] = max(max_running[partition], running[partition])
-            max_total_running = max(max_total_running, total_running)
-        unblock_event.wait()
-        with lock:
-            running[partition] -= 1
-            total_running -= 1
-        assert DBOS.workflow_id is not None
-        return DBOS.workflow_id
-
-    queue = DBOS.register_queue(
-        "partition_and_worker_queue",
-        partition_concurrency=1,
-        worker_concurrency=worker_concurrency,
-        polling_interval_sec=0.5,
-    )
-
-    handles: list[WorkflowHandle[str]] = []
-    for partition in partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            for _ in range(wfs_per_partition):
-                handles.append(
-                    DBOS.enqueue_workflow(queue.name, blocking_workflow, partition)
-                )
-
-    # The worker saturates its queue-wide limit, drawing from distinct partitions.
-    def worker_saturated() -> None:
-        with lock:
-            assert total_running == worker_concurrency
-
-    retry_until_success(worker_saturated)
-
-    # Let several polling intervals pass: neither limit is ever exceeded, and the two partitions with no room stay blocked rather than sharing the worker's.
-    time.sleep(2)
-    with lock:
-        assert max_total_running == worker_concurrency
-        assert all(max_running[p] <= 1 for p in partitions)
-
-    unblock_event.set()
-    for handle in handles:
-        assert handle.get_result() is not None
-
-    # Every partition ran, and none ever ran two at once, through the drain as well.
-    with lock:
-        assert max_total_running == worker_concurrency
-        assert all(max_running[p] == 1 for p in partitions)
-
-    assert queue_entries_are_cleaned_up(dbos)
-
-
-def test_partition_and_global_concurrency_across_executors(dbos: DBOS) -> None:
-    """global_concurrency caps the queue across executors while partition_concurrency
-    caps each partition: a second executor may take a different partition, but neither
-    a partition already running one nor anything once the queue-wide budget is spent."""
-
-    @DBOS.workflow()
-    def noop() -> str:
-        return "done"
-
-    # A version this executor never runs, so the live queue worker leaves these rows alone.
-    parked_version = "parked-version"
-    queue = DBOS.register_queue(
-        "partition_global_queue", global_concurrency=3, partition_concurrency=1
-    )
-    ids: dict[str, List[str]] = {}
-    for partition, rows in [("p0", 2), ("p1", 1), ("p2", 1), ("p3", 1)]:
-        ids[partition] = []
-        for priority in range(1, rows + 1):
-            # Distinct priorities so a partition's head is deterministic.
-            with SetEnqueueOptions(
-                queue_partition_key=partition,
-                app_version=parked_version,
-                priority=priority,
-            ):
-                ids[partition].append(
-                    DBOS.enqueue_workflow(queue.name, noop).workflow_id
-                )
-
-    def claim(executor: str, partition: str) -> List[str]:
-        return dbos._sys_db.start_queued_workflows(
-            queue, executor, parked_version, partition
-        )
-
-    assert claim("executor-a", "p0") == [ids["p0"][0]]
-    # p0's follower is held back by partition_concurrency, though the queue has room.
-    assert claim("executor-b", "p0") == []
-    # Other partitions are free until the queue-wide budget runs out.
-    assert claim("executor-b", "p1") == [ids["p1"][0]]
-    assert claim("executor-a", "p2") == [ids["p2"][0]]
-    assert claim("executor-b", "p3") == []
-    # Freeing a queue-wide slot admits the idle partition.
-    set_workflow_status(dbos._sys_db, ids["p1"][0], WorkflowStatusString.SUCCESS.value)
-    assert claim("executor-b", "p3") == [ids["p3"][0]]
-
-
-def test_partition_concurrency_dequeue_blocks_on_peer_claim(
-    dbos: DBOS, skip_with_sqlite: None
+@pytest.mark.parametrize(
+    "limits,per_partition,queue_wide",
+    [
+        # Per-partition concurrency with a queue-wide per-worker limit: the batched sweep.
+        ({"partition_concurrency": 1, "worker_concurrency": 3}, 1, 3),
+        # Per-partition concurrency above one, with a queue-wide global limit: the sweep loop.
+        ({"partition_concurrency": 2, "global_concurrency": 3}, 2, 3),
+        # Both limits on the per-worker axis at once.
+        ({"partition_worker_concurrency": 2, "worker_concurrency": 3}, 2, 3),
+    ],
+    ids=["partition-and-worker", "partition-and-global", "partition-and-worker-axis"],
+)
+def test_partition_limits_bound_both_scopes(
+    dbos: DBOS, limits: dict[str, Any], per_partition: int, queue_wide: int
 ) -> None:
-    """A per-partition budget is shared across workers just as a queue-wide one is, so
-    a peer mid-claim must block the dequeue rather than be skipped past."""
+    """A per-partition limit caps each partition while the queue-wide limit caps them
+    together: the queue saturates at the queue-wide limit, no partition ever exceeds
+    its own, and every workflow still completes."""
 
-    @DBOS.workflow()
-    def noop() -> str:
-        return "done"
-
-    parked_version = "parked-version"
-    queue = DBOS.register_queue("partition_lock_queue", partition_concurrency=1)
-    ids = []
-    for priority in (1, 2):
-        with SetEnqueueOptions(
-            queue_partition_key="p0", app_version=parked_version, priority=priority
-        ):
-            ids.append(DBOS.enqueue_workflow(queue.name, noop).workflow_id)
-
-    ws = SystemSchema.workflow_status
-    head = (
-        sa.select(ws.c.workflow_uuid)
-        .where(ws.c.queue_name == queue.name)
-        .where(ws.c.status == WorkflowStatusString.ENQUEUED.value)
-        .order_by(ws.c.priority.asc(), ws.c.created_at.asc())
-        .limit(1)
-        .with_for_update()
-    )
-    with dbos._sys_db.engine.begin() as peer:
-        # A peer dequeuer holding an open claim on the partition's only free slot.
-        assert [row[0] for row in peer.execute(head)] == ids[:1]
-        with pytest.raises(OperationalError) as exc_info:
-            dbos._sys_db.start_queued_workflows(
-                queue, "test-executor", parked_version, "p0"
-            )
-    assert isinstance(exc_info.value.orig, errors.LockNotAvailable)
-
-    for id in ids:
-        status = dbos._sys_db.get_workflow_status(id)
-        assert status is not None
-        assert status["status"] == WorkflowStatusString.ENQUEUED.value
-
-
-def test_partition_concurrency_with_global_concurrency(dbos: DBOS) -> None:
-    """partition_concurrency above one routes to the per-partition sweep, where the
-    queue-wide global_concurrency still bounds every partition together."""
-
-    global_concurrency = 3
-    partition_concurrency = 2
     partitions = [f"partition-{i}" for i in range(4)]
-
     unblock_event = threading.Event()
     lock = threading.Lock()
     running: dict[str, int] = {p: 0 for p in partitions}
@@ -3255,10 +2944,9 @@ def test_partition_concurrency_with_global_concurrency(dbos: DBOS) -> None:
         return DBOS.workflow_id
 
     queue = DBOS.register_queue(
-        "partition_and_global_queue",
-        global_concurrency=global_concurrency,
-        partition_concurrency=partition_concurrency,
+        f"partition_limits_{uuid.uuid4().hex[:8]}",
         polling_interval_sec=0.5,
+        **limits,
     )
 
     handles: list[WorkflowHandle[str]] = []
@@ -3271,89 +2959,23 @@ def test_partition_concurrency_with_global_concurrency(dbos: DBOS) -> None:
 
     def queue_saturated() -> None:
         with lock:
-            assert total_running == global_concurrency
+            assert total_running == queue_wide
 
     retry_until_success(queue_saturated)
 
-    # Let several polling intervals pass: neither limit is ever exceeded.
+    # Let several polling intervals pass: neither limit is ever exceeded, and the partitions with no room stay blocked rather than borrowing another's.
     time.sleep(2)
     with lock:
-        assert max_total_running == global_concurrency
-        assert all(max_running[p] <= partition_concurrency for p in partitions)
+        assert max_total_running == queue_wide
+        assert all(max_running[p] <= per_partition for p in partitions)
 
     unblock_event.set()
     for handle in handles:
         assert handle.get_result() is not None
 
     with lock:
-        assert max_total_running == global_concurrency
-        assert all(max_running[p] <= partition_concurrency for p in partitions)
-    assert queue_entries_are_cleaned_up(dbos)
-
-
-def test_partition_worker_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
-    """Both worker limits bind at once: each partition runs at most
-    partition_worker_concurrency here, and the queue at most worker_concurrency."""
-
-    worker_concurrency = 3
-    partition_worker_concurrency = 2
-    partitions = [f"partition-{i}" for i in range(3)]
-
-    unblock_event = threading.Event()
-    lock = threading.Lock()
-    running: dict[str, int] = {p: 0 for p in partitions}
-    max_running: dict[str, int] = {p: 0 for p in partitions}
-    total_running = 0
-    max_total_running = 0
-
-    @DBOS.workflow()
-    def blocking_workflow(partition: str) -> str:
-        nonlocal total_running, max_total_running
-        with lock:
-            running[partition] += 1
-            total_running += 1
-            max_running[partition] = max(max_running[partition], running[partition])
-            max_total_running = max(max_total_running, total_running)
-        unblock_event.wait()
-        with lock:
-            running[partition] -= 1
-            total_running -= 1
-        assert DBOS.workflow_id is not None
-        return DBOS.workflow_id
-
-    queue = DBOS.register_queue(
-        "partition_worker_queue",
-        worker_concurrency=worker_concurrency,
-        partition_worker_concurrency=partition_worker_concurrency,
-        polling_interval_sec=0.5,
-    )
-
-    handles: list[WorkflowHandle[str]] = []
-    for partition in partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            for _ in range(3):
-                handles.append(
-                    DBOS.enqueue_workflow(queue.name, blocking_workflow, partition)
-                )
-
-    def worker_saturated() -> None:
-        with lock:
-            assert total_running == worker_concurrency
-
-    retry_until_success(worker_saturated)
-
-    time.sleep(2)
-    with lock:
-        assert max_total_running == worker_concurrency
-        assert all(max_running[p] <= partition_worker_concurrency for p in partitions)
-
-    unblock_event.set()
-    for handle in handles:
-        assert handle.get_result() is not None
-
-    with lock:
-        assert max_total_running == worker_concurrency
-        assert all(max_running[p] <= partition_worker_concurrency for p in partitions)
+        assert max_total_running == queue_wide
+        assert all(max_running[p] <= per_partition for p in partitions)
     assert queue_entries_are_cleaned_up(dbos)
 
 
@@ -3400,56 +3022,6 @@ def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
         if status != WorkflowStatusString.ENQUEUED.value
     ]
     assert len(set(started_partitions)) == queue_limit
-
-
-def test_partition_concurrency_with_queue_wide_limiter(dbos: DBOS) -> None:
-    """A limiter alongside partition_concurrency is queue-wide: it spends its budget
-    across all partitions, not once per partition."""
-
-    @DBOS.workflow()
-    def noop(tag: str) -> str:
-        return tag
-
-    limit = 3
-    partitions = [f"p{i}" for i in range(5)]
-    queue = DBOS.register_queue(
-        "partition_limiter_queue",
-        partition_concurrency=1,
-        limiter={"limit": limit, "period": 60},
-        polling_interval_sec=0.25,
-    )
-
-    ids = []
-    for partition in partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            ids.append(DBOS.enqueue_workflow(queue.name, noop, partition).workflow_id)
-
-    def statuses() -> List[str]:
-        return [dbos._sys_db.get_workflow_status(id)["status"] for id in ids]  # type: ignore
-
-    # Were the limiter per partition, every partition would start its own workflow.
-    def limiter_budget_spent() -> None:
-        assert statuses().count(WorkflowStatusString.SUCCESS.value) == limit
-
-    retry_until_success(limiter_budget_spent)
-
-    # Several polling intervals later the rest are still waiting on the rolling window.
-    time.sleep(1)
-    final = statuses()
-    assert final.count(WorkflowStatusString.SUCCESS.value) == limit
-    assert final.count(WorkflowStatusString.ENQUEUED.value) == len(partitions) - limit
-
-    # Claims made under a limiter are stamped so the window can count them.
-    ws = SystemSchema.workflow_status
-    with dbos._sys_db.engine.begin() as c:
-        rows = c.execute(
-            sa.select(ws.c.status, ws.c.rate_limited).where(
-                ws.c.queue_name == queue.name
-            )
-        ).fetchall()
-    started = [rate_limited for status, rate_limited in rows if status != "ENQUEUED"]
-    assert len(started) == limit
-    assert all(started)
 
 
 def _enqueue_partition_rows(
@@ -3514,69 +3086,6 @@ def test_partitioned_batch_dequeue_sweep_cap(
     assert start() == [ids[p][0] for p in partitions[:5]]
     assert start() == [ids[p][0] for p in partitions[5:]]
     assert start() == []
-
-
-def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
-    """max_tasks bounds a sweep to this worker's remaining room."""
-
-    @DBOS.workflow()
-    def batch_wf(value: str) -> None:
-        pass
-
-    queue_name = f"unpolled-budget-{uuid.uuid4().hex[:8]}"
-    queue = Queue(
-        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
-    )
-    partitions = [f"p{i}" for i in range(4)]
-    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "budget", partitions, 1)
-
-    def start(max_tasks: int) -> List[str]:
-        return dbos._sys_db.start_queued_partitioned_workflows(
-            queue, GlobalParams.executor_id, GlobalParams.app_version, max_tasks
-        )
-
-    # An exhausted budget claims nothing, a partial one only as many as it allows.
-    assert start(0) == []
-    budgeted = start(2)
-    assert len(budgeted) == 2
-    # Those partitions are now PENDING-gated, so the rest follow.
-    remainder = start(10)
-    assert len(remainder) == 2
-    assert set(budgeted) | set(remainder) == {ids[p][0] for p in partitions}
-
-
-def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
-    """A caller budget below the partition count draws partitions at random, so no key
-    is starved for sorting late. A fixed order would pick the same partition every time.
-    """
-
-    @DBOS.workflow()
-    def batch_wf(value: str) -> None:
-        pass
-
-    queue_name = f"unpolled-fair-{uuid.uuid4().hex[:8]}"
-    queue = Queue(
-        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
-    )
-    draws = 20
-    partitions = [f"p{i}" for i in range(5)]
-    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "fair", partitions, draws)
-    owner = {wfid: p for p in partitions for wfid in ids[p]}
-
-    chosen = set()
-    for _ in range(draws):
-        claimed = dbos._sys_db.start_queued_partitioned_workflows(
-            queue, GlobalParams.executor_id, GlobalParams.app_version, 1
-        )
-        assert len(claimed) == 1
-        chosen.add(owner[claimed[0]])
-        # Finish it, so its partition is eligible again for the next draw.
-        set_workflow_status(
-            dbos._sys_db, claimed[0], WorkflowStatusString.SUCCESS.value
-        )
-
-    # Twenty draws over five always-eligible partitions: fewer than three distinct winners has probability ~1e-7, while a fixed order would yield exactly one.
-    assert len(chosen) >= 3
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -352,6 +352,10 @@ def test_partition_limit_validation(dbos: DBOS) -> None:
         Queue(f"v6_{suffix}", worker_concurrency=1, partition_worker_concurrency=2)
     with pytest.raises(ValueError, match="greater than or equal to"):
         Queue(f"v7_{suffix}", partition_concurrency=1, partition_worker_concurrency=2)
+    with pytest.raises(ValueError, match="cannot be combined with global_concurrency"):
+        Queue(f"v10_{suffix}", global_concurrency=5, partition_queue=True)
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"v11_{suffix}", global_concurrency=1, partition_worker_concurrency=2)
     # Malformed limits are rejected the same way their queue-wide counterparts are.
     with pytest.raises(ValueError, match="at least 1"):
         Queue(f"v8_{suffix}", partition_concurrency=0)
@@ -3032,6 +3036,72 @@ def test_partition_limits_bound_both_scopes(
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_partition_sweep_fills_worker_concurrency_in_one_pass(dbos: DBOS) -> None:
+    """One sweep serves every partition the worker has room for, rather than stopping
+    part way and waiting for later polls to reach worker_concurrency."""
+
+    worker_concurrency = 8
+    partitions = [f"partition-{i}" for i in range(worker_concurrency)]
+    polling_interval = 2.0
+
+    unblock_event = threading.Event()
+    lock = threading.Lock()
+    running: List[str] = []
+
+    @DBOS.workflow()
+    def blocking_workflow(partition: str) -> str:
+        with lock:
+            running.append(partition)
+        unblock_event.wait()
+        assert DBOS.workflow_id is not None
+        return DBOS.workflow_id
+
+    # Enqueue before registering, so the queue's first sweep sees the whole backlog
+    # and this does not race the poller.
+    queue_name = f"one_pass_{uuid.uuid4().hex[:8]}"
+    handles: list[WorkflowHandle[str]] = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            handles.append(
+                DBOS.enqueue_workflow(queue_name, blocking_workflow, partition)
+            )
+    DBOS.register_queue(
+        queue_name,
+        worker_concurrency=worker_concurrency,
+        partition_worker_concurrency=1,
+        polling_interval_sec=polling_interval,
+    )
+
+    def any_workflow_started() -> None:
+        with lock:
+            assert running
+
+    retry_until_success(any_workflow_started, interval=0.1, max_attempts=200)
+
+    # Everything the worker has room for belongs to that same sweep, so it lands well
+    # inside one polling interval. Serving only part of it would wait for the next poll.
+    def all_partitions_started() -> None:
+        with lock:
+            assert len(running) == worker_concurrency, (
+                f"{len(running)} of {worker_concurrency} workflows started within one "
+                f"sweep; the rest are waiting for a later poll"
+            )
+
+    try:
+        retry_until_success(
+            all_partitions_started,
+            interval=0.05,
+            max_attempts=int(polling_interval / 0.05),
+        )
+    finally:
+        # Always release the blocked workflows: leaving them parked would stall shutdown.
+        unblock_event.set()
+
+    for handle in handles:
+        assert handle.get_result() is not None
+    assert queue_entries_are_cleaned_up(dbos)
+
+
 def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
     """Both rate limits bind at once: each partition spends its own window, and the
     queue-wide window caps the total across partitions."""
@@ -3317,8 +3387,8 @@ def test_partitioned_queue_fallback_routing(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A partitioned config the batched path does not support -- a rate limiter --
-    routes to the per-partition sweep and drains. worker_concurrency=0 (the
-    pause-dequeue idiom) exhausts this worker's budget before either path runs.
+    routes to the per-partition sweep and drains. A zero worker limit at either scope
+    (the pause-dequeue idiom) exhausts this worker's budget before either path runs.
     """
 
     @DBOS.workflow()
@@ -3338,6 +3408,16 @@ def test_partitioned_queue_fallback_routing(
         concurrency=1,
         worker_concurrency=0,
         partition_queue=True,
+        polling_interval_sec=0.25,
+    )
+
+    # Paused per partition, not queue-wide: the batched path enforces no per-partition
+    # worker limit itself, so the budget must stop it before it runs.
+    partition_paused_queue = Queue(
+        f"partition_paused_{uuid.uuid4().hex[:8]}",
+        partition_concurrency=1,
+        partition_worker_concurrency=0,
+        worker_concurrency=5,
         polling_interval_sec=0.25,
     )
 
@@ -3365,6 +3445,8 @@ def test_partitioned_queue_fallback_routing(
             handles.append(limiter_queue.enqueue(routed_wf, f"limited-{partition}"))
     with SetEnqueueOptions(queue_partition_key="p0"):
         paused_handle = paused_queue.enqueue(routed_wf, "paused")
+    with SetEnqueueOptions(queue_partition_key="p0"):
+        partition_paused_handle = partition_paused_queue.enqueue(routed_wf, "pp")
 
     for handle in handles:
         assert handle.get_result()
@@ -3378,6 +3460,12 @@ def test_partitioned_queue_fallback_routing(
     assert paused_queue.name not in batched_queues
     assert paused_queue.name not in swept_queues
     assert paused_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
+    assert partition_paused_queue.name not in batched_queues
+    assert partition_paused_queue.name not in swept_queues
+    assert (
+        partition_paused_handle.get_status().status
+        == WorkflowStatusString.ENQUEUED.value
+    )
 
 
 def test_partitioned_batch_dequeue_version_gating(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3056,9 +3056,10 @@ def test_partition_limits_bound_both_scopes(
         assert DBOS.workflow_id is not None
         return DBOS.workflow_id
 
+    polling_interval = 0.5
     queue = DBOS.register_queue(
         f"partition_limits_{uuid.uuid4().hex[:8]}",
-        polling_interval_sec=0.5,
+        polling_interval_sec=polling_interval,
         **limits,
     )
 
@@ -3078,7 +3079,7 @@ def test_partition_limits_bound_both_scopes(
         retry_until_success(queue_saturated)
 
         # Let several polling intervals pass: neither limit is ever exceeded, and the partitions with no room stay blocked rather than borrowing another's.
-        time.sleep(2)
+        time.sleep(4 * polling_interval)
         with lock:
             assert max_total_running == queue_wide
             assert all(max_running[p] <= per_partition for p in partitions)
@@ -3115,7 +3116,13 @@ def test_queue_wide_limit_holds_across_executors(
 
     # A version this executor never runs, so the live queue worker leaves these rows alone.
     parked_version = "parked-version"
-    queue = DBOS.register_queue(f"cross_executor_{uuid.uuid4().hex[:8]}", **limits)
+    # Park the live worker as well: its own serializable sweeps read the same predicate
+    # these threads write, so it can join their conflict graph and abort one of them.
+    queue = DBOS.register_queue(
+        f"cross_executor_{uuid.uuid4().hex[:8]}",
+        polling_interval_sec=3600.0,
+        **limits,
+    )
     ws = SystemSchema.workflow_status
 
     def pending_count() -> int:
@@ -3153,24 +3160,33 @@ def test_queue_wide_limit_holds_across_executors(
                 # Losing the race is the correct outcome; admitting is not.
                 pass
 
-        threads = [
-            threading.Thread(target=sweep, args=(i, p))
-            for i, p in enumerate(partitions)
-        ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+        # Losing the race admits nothing, but an attempt where neither admits anything
+        # raced an already-spent budget rather than a free one, so it tested nothing.
+        # Serializable isolation can abort both sweeps, so re-race until one wins. The
+        # guard below is checked on every attempt regardless of who won.
+        for _ in range(10):
+            barrier = threading.Barrier(len(partitions))
+            claimed = [[] for _ in partitions]
+            threads = [
+                threading.Thread(target=sweep, args=(i, p))
+                for i, p in enumerate(partitions)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
 
-        assert pending_count() <= 1, (
-            f"trial {trial}: two executors each spent the queue-wide budget, "
-            f"claiming {claimed}"
-        )
-        # Losing the race admits nothing, but a trial where neither admits anything
-        # tested the race against an already-spent budget rather than a free one.
-        assert (
-            sum(len(c) for c in claimed) >= 1
-        ), f"trial {trial}: neither executor admitted anything, so the budget was not free"
+            assert pending_count() <= 1, (
+                f"trial {trial}: two executors each spent the queue-wide budget, "
+                f"claiming {claimed}"
+            )
+            if sum(len(c) for c in claimed) >= 1:
+                break
+        else:
+            pytest.fail(
+                f"trial {trial}: no sweep ever admitted a workflow, so every attempt "
+                "raced an already-spent budget"
+            )
 
         # Retire this trial's claim so the next starts from a free budget. A rate-limit
         # slot is retired by its window, not by status -- rate_limit_remaining counts any
@@ -3193,11 +3209,12 @@ def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
 
     queue_limit, partition_limit = 3, 1
     partitions = [f"p{i}" for i in range(4)]
+    polling_interval = 0.25
     queue = DBOS.register_queue(
         "partition_and_queue_limiter",
         limiter={"limit": queue_limit, "period": 60},
         partition_limiter={"limit": partition_limit, "period": 60},
-        polling_interval_sec=0.25,
+        polling_interval_sec=polling_interval,
     )
 
     ids = []
@@ -3217,7 +3234,8 @@ def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
 
     retry_until_success(limiter_budget_spent)
 
-    time.sleep(1)
+    # Several polling intervals with no further admission: both windows stay spent.
+    time.sleep(4 * polling_interval)
     final = statuses()
     assert final.count(WorkflowStatusString.SUCCESS.value) == queue_limit
     started_partitions = [
@@ -3495,8 +3513,10 @@ def test_partitioned_queue_fallback_routing(
 
     batched_queues: List[str] = []
     swept_queues: List[str] = []
+    polled_queues: List[str] = []
     real_batched = dbos._sys_db.start_queued_partitioned_workflows
     real_single = dbos._sys_db.start_queued_workflows
+    real_count = dbos._active_workflows_set.count_for_queue
 
     def spying_batched(queue_arg: Queue, *args: Any, **kwargs: Any) -> List[str]:
         batched_queues.append(queue_arg.name)
@@ -3506,10 +3526,17 @@ def test_partitioned_queue_fallback_routing(
         swept_queues.append(queue_arg.name)
         return real_single(queue_arg, *args, **kwargs)
 
+    # Every dequeue branch counts this worker's running workflows before deciding what
+    # to claim, so this records that a queue's worker reached the branch at all.
+    def spying_count(queue_name: str) -> int:
+        polled_queues.append(queue_name)
+        return real_count(queue_name)
+
     monkeypatch.setattr(
         dbos._sys_db, "start_queued_partitioned_workflows", spying_batched
     )
     monkeypatch.setattr(dbos._sys_db, "start_queued_workflows", spying_single)
+    monkeypatch.setattr(dbos._active_workflows_set, "count_for_queue", spying_count)
 
     handles = []
     for partition in ["p0", "p1"]:
@@ -3526,7 +3553,13 @@ def test_partitioned_queue_fallback_routing(
 
     retry_until_success(limiter_queue_swept, interval=0.1, max_attempts=100)
     assert limiter_queue.name not in batched_queues
-    # The paused queue polls on the same interval, so it has had its turn by now.
+
+    # Wait for proof the paused queue's worker actually polled, so the assertions below
+    # record that its zero budget stopped it rather than that it never got a turn.
+    def paused_queue_polled() -> None:
+        assert paused_queue.name in polled_queues
+
+    retry_until_success(paused_queue_polled, interval=0.1, max_attempts=100)
     assert paused_queue.name not in batched_queues
     assert paused_queue.name not in swept_queues
     assert paused_handle.get_status().status == WorkflowStatusString.ENQUEUED.value

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -988,16 +988,15 @@ def test_multiple_queues(dbos: DBOS) -> None:
     handle2 = DBOS.enqueue_workflow("test_concurrency_queue", workflow_two)
 
     @DBOS.workflow()
-    def limited_workflow(var1: str, var2: str) -> float:
+    def limited_workflow(var1: str, var2: str) -> None:
         assert var1 == "abc" and var2 == "123"
-        return time.time()
 
     limit = 5
     period = 1.8
+    period_ms = int(period * 1000)
     DBOS.register_queue("test_limit_queue", limiter={"limit": limit, "period": period})
 
-    handles: list[WorkflowHandle[float]] = []
-    times: list[float] = []
+    handles: list[WorkflowHandle[None]] = []
 
     # Launch a number of tasks equal to three times the limit.
     # This should lead to three "waves" of the limit tasks being
@@ -1008,22 +1007,20 @@ def test_multiple_queues(dbos: DBOS) -> None:
         h = DBOS.enqueue_workflow("test_limit_queue", limited_workflow, "abc", "123")
         handles.append(h)
     for h in handles:
-        times.append(h.get_result())
+        h.get_result()
 
-    # Verify that each "wave" of tasks started at the ~same time. Use a
-    # generous tolerance: under CI load tasks within a wave can be spread
-    # out by hundreds of ms even though the limiter released them together.
-    for wave in range(num_waves):
-        for i in range(wave * limit, (wave + 1) * limit - 1):
-            assert times[i + 1] - times[i] < 1.0
+    # Time the limiter by dequeued_at, the database-side timestamp it actually gates
+    # on, as test_limiter does: a wall clock read inside the workflow body also
+    # measures executor pickup and how a wave splits across polls.
+    dequeued_at: list[int] = []
+    for h in handles:
+        status = h.get_status()
+        assert status.dequeued_at is not None
+        dequeued_at.append(status.dequeued_at)
+    dequeued_at.sort()
 
-    # Verify that the gap between "waves" is ~equal to the period. The
-    # tolerance has to cover the same intra-wave skew (since we're
-    # comparing the first task of each wave, not the wave start times),
-    # so use a window wider than the worst-case intra-wave spread.
-    for wave in range(num_waves - 1):
-        assert times[limit * (wave + 1)] - times[limit * wave] > period - 1.0
-        assert times[limit * (wave + 1)] - times[limit * wave] < period + 1.0
+    for i in range(len(dequeued_at) - limit):
+        assert dequeued_at[i + limit] - dequeued_at[i] >= period_ms - 10
 
     # Verify all workflows get the SUCCESS status eventually
     for h in handles:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3489,9 +3489,9 @@ def _enqueue_partition_rows(
 def test_partitioned_batch_dequeue_sweep_cap(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads, drawn in random
-    partition order; admitted partitions are PENDING-gated, so the next sweep picks
-    up the remaining partitions."""
+    """A sweep bounded only by PARTITIONED_DEQUEUE_SWEEP_CAP admits that many heads in
+    partition order; admitted partitions are PENDING-gated, so the next sweep rotates
+    onward to the remaining partitions."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3511,11 +3511,8 @@ def test_partitioned_batch_dequeue_sweep_cap(
             queue, GlobalParams.executor_id, GlobalParams.app_version
         )
 
-    capped, remainder = start(), start()
-    assert len(capped) == 5
-    assert len(remainder) == 3
-    # Which five come first varies with the random order; together they are every head.
-    assert set(capped) | set(remainder) == {ids[p][0] for p in partitions}
+    assert start() == [ids[p][0] for p in partitions[:5]]
+    assert start() == [ids[p][0] for p in partitions[5:]]
     assert start() == []
 
 
@@ -3549,8 +3546,9 @@ def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
 
 
 def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
-    """A budget below the partition count draws partitions at random, so no key is
-    starved for sorting late. A fixed order would pick the same partition every time."""
+    """A caller budget below the partition count draws partitions at random, so no key
+    is starved for sorting late. A fixed order would pick the same partition every time.
+    """
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3602,7 +3600,7 @@ def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
         )
 
     # Heads only, one per partition
-    assert set(start()) == {ids[p][0] for p in partitions}
+    assert start() == [ids[p][0] for p in partitions]
     # Every partition has a PENDING head, so nothing else is admitted
     assert start() == []
     # Completing one partition's head opens that partition alone

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2861,7 +2861,8 @@ def test_partition_serialization_failure_skips_key(
         executor_id: str,
         app_version: str,
         queue_partition_key: Any = None,
-        local_running_count: int = 0,
+        *args: Any,
+        **kwargs: Any,
     ) -> List[str]:
         if (
             poison_active.is_set()
@@ -2874,7 +2875,8 @@ def test_partition_serialization_failure_skips_key(
             executor_id,
             app_version,
             queue_partition_key,
-            local_running_count,
+            *args,
+            **kwargs,
         )
 
     monkeypatch.setattr(dbos._sys_db, "start_queued_workflows", poisoned_start)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -315,6 +315,16 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy_queue.set_global_concurrency(5)
     with pytest.raises(DBOSException):
         legacy_queue.set_partition_concurrency(1)
+    # Every queue-wide setter is blocked too, not just the renamed ones: their getters
+    # read as None here, so a read-modify-write would otherwise clear the per-partition
+    # limit the queue actually enforces.
+    with pytest.raises(DBOSException):
+        legacy_queue.set_worker_concurrency(legacy_queue.worker_concurrency)
+    with pytest.raises(DBOSException):
+        legacy_queue.set_limiter(legacy_queue.limiter)
+    # The limits it actually enforces are untouched by the rejected writes.
+    assert legacy_queue.partition_worker_concurrency == 1
+    assert legacy_queue.partition_limiter == {"limit": 7, "period": 2.0}
 
     # Limiter can be cleared.
     queue.set_limiter(None)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -291,6 +291,164 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         legacy.set_concurrency(5)
 
 
+def test_partition_concurrency_config(dbos: DBOS, client: DBOSClient) -> None:
+    queue_name = f"test_partition_concurrency_{uuid.uuid4()}"
+
+    # partition_concurrency partitions the queue; every other limit stays queue-wide.
+    registered = DBOS.register_queue(
+        queue_name, worker_concurrency=10, partition_concurrency=1
+    )
+    listed = [q for q in DBOS.list_queues() if q.name == queue_name]
+    for q in [registered, DBOS.retrieve_queue(queue_name), *listed]:
+        assert q is not None
+        assert q.partition_queue is True
+        assert q.partition_concurrency == 1
+        assert q.global_concurrency is None
+        assert q.worker_concurrency == 10
+        limits = q._resolve_limits()
+        assert limits.partition_concurrency == 1
+        assert limits.worker_concurrency == 10
+        assert limits.partition_worker_concurrency is None
+
+    # global_concurrency and partition_concurrency coexist.
+    DBOS.register_queue(
+        queue_name,
+        global_concurrency=5,
+        partition_concurrency=2,
+        on_conflict="always_update",
+    )
+    retrieved = DBOS.retrieve_queue(queue_name)
+    assert retrieved is not None
+    assert retrieved.global_concurrency == 5
+    assert retrieved.partition_concurrency == 2
+    # The deprecated getter reports the stored column, which is now queue-wide.
+    assert retrieved.concurrency == 5
+
+    # Clients register the same configuration.
+    client_queue_name = f"test_client_partition_concurrency_{uuid.uuid4()}"
+    client.register_queue(
+        client_queue_name, worker_concurrency=10, partition_concurrency=1
+    )
+    client_queue = client.retrieve_queue(client_queue_name)
+    assert client_queue is not None
+    assert client_queue.partition_concurrency == 1
+    assert client_queue.worker_concurrency == 10
+    assert client_queue.partition_queue is True
+
+
+def test_legacy_partition_queue_limits_stay_per_partition(dbos: DBOS) -> None:
+    queue_name = f"test_legacy_partition_{uuid.uuid4()}"
+    DBOS.register_queue(
+        queue_name,
+        partition_queue=True,
+        concurrency=2,
+        worker_concurrency=1,
+        limiter={"limit": 5, "period": 1.5},
+    )
+    queue = DBOS.retrieve_queue(queue_name)
+    assert queue is not None
+    # Deprecated getters report the stored columns verbatim.
+    assert queue.concurrency == 2
+    assert queue.worker_concurrency == 1
+    assert queue.partition_queue is True
+    # Under the legacy spelling every limit resolves to per-partition scope.
+    limits = queue._resolve_limits()
+    assert limits.partition_concurrency == 2
+    assert limits.partition_worker_concurrency == 1
+    assert limits.partition_limiter == {"limit": 5, "period": 1.5}
+    assert limits.global_concurrency is None
+    assert limits.worker_concurrency is None
+    assert limits.limiter is None
+    assert queue.global_concurrency is None
+    assert queue.partition_concurrency == 2
+
+    # Setting a queue-wide limit would silently re-scope the others: reject it.
+    with pytest.raises(DBOSException):
+        queue.set_global_concurrency(5)
+    with pytest.raises(DBOSException):
+        queue.set_partition_concurrency(1)
+
+
+def test_partition_concurrency_validation(dbos: DBOS) -> None:
+    suffix = uuid.uuid4()
+    # The deprecated arguments cannot be combined with the ones replacing them.
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(f"v1_{suffix}", concurrency=1, global_concurrency=1)
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(f"v2_{suffix}", partition_queue=True, partition_concurrency=1)
+    with pytest.raises(ValueError, match="at least 1"):
+        Queue(f"v3_{suffix}", partition_concurrency=0)
+    # A per-partition limit above the queue-wide one could never bind.
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"v4_{suffix}", global_concurrency=1, partition_concurrency=2)
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"v5_{suffix}", global_concurrency=1, worker_concurrency=2)
+
+    # Partitioning is inferred from partition_concurrency.
+    queue = Queue(f"v6_{suffix}", worker_concurrency=10, partition_concurrency=1)
+    assert queue.partition_queue is True
+    assert queue.partition_concurrency == 1
+    assert queue.global_concurrency is None
+    # A partition key is required, as it is under the deprecated spelling.
+    with pytest.raises(Exception, match="without a partition key"):
+        queue._validate_enqueue(None)
+
+
+def test_partition_concurrency_setters(dbos: DBOS) -> None:
+    queue_name = f"test_partition_setters_{uuid.uuid4()}"
+    queue = DBOS.register_queue(queue_name, partition_concurrency=1)
+
+    queue.set_global_concurrency(5)
+    queue.set_partition_concurrency(3)
+    fresh = DBOS.retrieve_queue(queue_name)
+    for q in [queue, fresh]:
+        assert q is not None
+        assert q.global_concurrency == 5
+        assert q.partition_concurrency == 3
+        assert q.partition_queue is True
+
+    # Cross-field validation runs against the database, not the local cache.
+    with pytest.raises(ValueError, match="less than or equal to"):
+        queue.set_partition_concurrency(6)
+    with pytest.raises(ValueError, match="less than or equal to"):
+        queue.set_concurrency(2)
+    with pytest.raises(ValueError, match="at least 1"):
+        queue.set_partition_concurrency(0)
+
+    # The deprecated flag cannot be toggled on a queue partitioned the new way.
+    with pytest.raises(DBOSException):
+        queue.set_partition_queue(False)
+
+    # Clearing partition_concurrency un-partitions the queue.
+    queue.set_partition_concurrency(None)
+    cleared = DBOS.retrieve_queue(queue_name)
+    assert cleared is not None
+    assert cleared.partition_queue is False
+    assert cleared.partition_concurrency is None
+    assert cleared.global_concurrency == 5
+
+
+@pytest.mark.asyncio
+async def test_partition_concurrency_config_async(dbos: DBOS) -> None:
+    queue_name = f"test_partition_concurrency_async_{uuid.uuid4()}"
+    queue = await DBOS.register_queue_async(
+        queue_name, worker_concurrency=10, partition_concurrency=1
+    )
+    assert await queue.get_partition_concurrency_async() == 1
+    assert await queue.get_global_concurrency_async() is None
+
+    # A queue-wide global limit must leave room for the per-worker limit.
+    with pytest.raises(ValueError, match="less than or equal to concurrency"):
+        await queue.set_global_concurrency_async(5)
+    await queue.set_global_concurrency_async(10)
+    await queue.set_partition_concurrency_async(2)
+    fresh = await DBOS.retrieve_queue_async(queue_name)
+    assert fresh is not None
+    assert await fresh.get_global_concurrency_async() == 10
+    assert await fresh.get_partition_concurrency_async() == 2
+    assert await fresh.get_partition_queue_async() is True
+
+
 def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     queue_name = f"test_client_queue_{uuid.uuid4()}"
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -369,6 +369,102 @@ def test_legacy_partition_queue_limits_stay_per_partition(dbos: DBOS) -> None:
         queue.set_partition_concurrency(1)
 
 
+def test_partition_worker_concurrency_and_limiter_config(dbos: DBOS) -> None:
+    """Every per-partition limit partitions the queue and round-trips independently
+    of its queue-wide counterpart."""
+    queue_name = f"test_partition_limits_{uuid.uuid4()}"
+
+    registered = DBOS.register_queue(
+        queue_name,
+        worker_concurrency=6,
+        limiter={"limit": 10, "period": 2.0},
+        partition_worker_concurrency=2,
+        partition_limiter={"limit": 3, "period": 1.5},
+    )
+    listed = [q for q in DBOS.list_queues() if q.name == queue_name]
+    for q in [registered, DBOS.retrieve_queue(queue_name), *listed]:
+        assert q is not None
+        # Partitioning is inferred from the partition limits, with no partition_concurrency.
+        assert q.partition_queue is True
+        assert q.partition_concurrency is None
+        assert q.partition_worker_concurrency == 2
+        assert q.partition_limiter == {"limit": 3, "period": 1.5}
+        assert q.worker_concurrency == 6
+        assert q.limiter == {"limit": 10, "period": 2.0}
+        limits = q._resolve_limits()
+        assert limits.partition_worker_concurrency == 2
+        assert limits.partition_limiter == {"limit": 3, "period": 1.5}
+        assert limits.worker_concurrency == 6
+        assert limits.limiter == {"limit": 10, "period": 2.0}
+
+    # Setters round-trip, and clearing every partition limit un-partitions the queue.
+    registered.set_partition_worker_concurrency(1)
+    registered.set_partition_limiter({"limit": 5, "period": 4.0})
+    fresh = DBOS.retrieve_queue(queue_name)
+    assert fresh is not None
+    assert fresh.partition_worker_concurrency == 1
+    assert fresh.partition_limiter == {"limit": 5, "period": 4.0}
+    assert fresh.partition_queue is True
+
+    registered.set_partition_limiter(None)
+    assert registered.partition_queue is True  # still partitioned by the worker limit
+    registered.set_partition_worker_concurrency(None)
+    cleared = DBOS.retrieve_queue(queue_name)
+    assert cleared is not None
+    assert cleared.partition_queue is False
+    assert cleared.partition_worker_concurrency is None
+    assert cleared.partition_limiter is None
+
+
+@pytest.mark.asyncio
+async def test_partition_worker_concurrency_and_limiter_config_async(
+    dbos: DBOS,
+) -> None:
+    queue_name = f"test_partition_limits_async_{uuid.uuid4()}"
+    queue = await DBOS.register_queue_async(
+        queue_name,
+        partition_worker_concurrency=2,
+        partition_limiter={"limit": 3, "period": 1.5},
+    )
+    assert await queue.get_partition_worker_concurrency_async() == 2
+    assert await queue.get_partition_limiter_async() == {"limit": 3, "period": 1.5}
+    assert await queue.get_partition_queue_async() is True
+
+    await queue.set_partition_worker_concurrency_async(1)
+    await queue.set_partition_limiter_async(None)
+    fresh = await DBOS.retrieve_queue_async(queue_name)
+    assert fresh is not None
+    assert await fresh.get_partition_worker_concurrency_async() == 1
+    assert await fresh.get_partition_limiter_async() is None
+    assert await fresh.get_partition_queue_async() is True
+
+
+def test_partition_worker_concurrency_validation(dbos: DBOS) -> None:
+    suffix = uuid.uuid4()
+    # The deprecated flag cannot be combined with any partition limit.
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(f"pw1_{suffix}", partition_queue=True, partition_worker_concurrency=1)
+    with pytest.raises(ValueError, match="only one of them"):
+        Queue(
+            f"pw2_{suffix}",
+            partition_queue=True,
+            partition_limiter={"limit": 1, "period": 1.0},
+        )
+    # A per-partition limit above its queue-wide counterpart could never bind.
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"pw3_{suffix}", worker_concurrency=1, partition_worker_concurrency=2)
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        Queue(f"pw4_{suffix}", partition_concurrency=1, partition_worker_concurrency=2)
+    with pytest.raises(ValueError, match="both 'limit' and 'period'"):
+        Queue(f"pw5_{suffix}", partition_limiter={"limit": 1})  # type: ignore
+
+    # A partition limiter alone partitions the queue.
+    queue = Queue(f"pw6_{suffix}", partition_limiter={"limit": 1, "period": 1.0})
+    assert queue.partition_queue is True
+    with pytest.raises(Exception, match="without a partition key"):
+        queue._validate_enqueue(None)
+
+
 def test_partition_concurrency_validation(dbos: DBOS) -> None:
     suffix = uuid.uuid4()
     # The deprecated arguments cannot be combined with the ones replacing them.
@@ -3195,6 +3291,118 @@ def test_partition_concurrency_with_global_concurrency(dbos: DBOS) -> None:
         assert max_total_running == global_concurrency
         assert all(max_running[p] <= partition_concurrency for p in partitions)
     assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_partition_worker_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
+    """Both worker limits bind at once: each partition runs at most
+    partition_worker_concurrency here, and the queue at most worker_concurrency."""
+
+    worker_concurrency = 3
+    partition_worker_concurrency = 2
+    partitions = [f"partition-{i}" for i in range(3)]
+
+    unblock_event = threading.Event()
+    lock = threading.Lock()
+    running: dict[str, int] = {p: 0 for p in partitions}
+    max_running: dict[str, int] = {p: 0 for p in partitions}
+    total_running = 0
+    max_total_running = 0
+
+    @DBOS.workflow()
+    def blocking_workflow(partition: str) -> str:
+        nonlocal total_running, max_total_running
+        with lock:
+            running[partition] += 1
+            total_running += 1
+            max_running[partition] = max(max_running[partition], running[partition])
+            max_total_running = max(max_total_running, total_running)
+        unblock_event.wait()
+        with lock:
+            running[partition] -= 1
+            total_running -= 1
+        assert DBOS.workflow_id is not None
+        return DBOS.workflow_id
+
+    queue = DBOS.register_queue(
+        "partition_worker_queue",
+        worker_concurrency=worker_concurrency,
+        partition_worker_concurrency=partition_worker_concurrency,
+        polling_interval_sec=0.5,
+    )
+
+    handles: list[WorkflowHandle[str]] = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(3):
+                handles.append(
+                    DBOS.enqueue_workflow(queue.name, blocking_workflow, partition)
+                )
+
+    def worker_saturated() -> None:
+        with lock:
+            assert total_running == worker_concurrency
+
+    retry_until_success(worker_saturated)
+
+    time.sleep(2)
+    with lock:
+        assert max_total_running == worker_concurrency
+        assert all(max_running[p] <= partition_worker_concurrency for p in partitions)
+
+    unblock_event.set()
+    for handle in handles:
+        assert handle.get_result() is not None
+
+    with lock:
+        assert max_total_running == worker_concurrency
+        assert all(max_running[p] <= partition_worker_concurrency for p in partitions)
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
+    """Both rate limits bind at once: each partition spends its own window, and the
+    queue-wide window caps the total across partitions."""
+
+    @DBOS.workflow()
+    def noop(tag: str) -> str:
+        return tag
+
+    queue_limit, partition_limit = 3, 1
+    partitions = [f"p{i}" for i in range(4)]
+    queue = DBOS.register_queue(
+        "partition_and_queue_limiter",
+        limiter={"limit": queue_limit, "period": 60},
+        partition_limiter={"limit": partition_limit, "period": 60},
+        polling_interval_sec=0.25,
+    )
+
+    ids = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(2):
+                ids.append(
+                    DBOS.enqueue_workflow(queue.name, noop, partition).workflow_id
+                )
+
+    def statuses() -> List[str]:
+        return [dbos._sys_db.get_workflow_status(id)["status"] for id in ids]  # type: ignore
+
+    # The queue-wide window caps the total at three, one from each of three partitions:
+    # the per-partition window admits only one apiece.
+    def limiter_budget_spent() -> None:
+        assert statuses().count(WorkflowStatusString.SUCCESS.value) == queue_limit
+
+    retry_until_success(limiter_budget_spent)
+
+    time.sleep(1)
+    final = statuses()
+    assert final.count(WorkflowStatusString.SUCCESS.value) == queue_limit
+    started_partitions = [
+        dbos._sys_db.get_workflow_status(id)["queue_partition_key"]  # type: ignore
+        for id, status in zip(ids, final)
+        if status != WorkflowStatusString.ENQUEUED.value
+    ]
+    assert len(set(started_partitions)) == queue_limit
 
 
 def test_partition_concurrency_with_queue_wide_limiter(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3042,6 +3042,211 @@ def test_partition_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_partition_and_global_concurrency_across_executors(dbos: DBOS) -> None:
+    """global_concurrency caps the queue across executors while partition_concurrency
+    caps each partition: a second executor may take a different partition, but neither
+    a partition already running one nor anything once the queue-wide budget is spent."""
+
+    @DBOS.workflow()
+    def noop() -> str:
+        return "done"
+
+    # A version this executor never runs, so the live queue worker leaves these rows alone.
+    parked_version = "parked-version"
+    queue = DBOS.register_queue(
+        "partition_global_queue", global_concurrency=3, partition_concurrency=1
+    )
+    ids: dict[str, List[str]] = {}
+    for partition, rows in [("p0", 2), ("p1", 1), ("p2", 1), ("p3", 1)]:
+        ids[partition] = []
+        for priority in range(1, rows + 1):
+            # Distinct priorities so a partition's head is deterministic.
+            with SetEnqueueOptions(
+                queue_partition_key=partition,
+                app_version=parked_version,
+                priority=priority,
+            ):
+                ids[partition].append(
+                    DBOS.enqueue_workflow(queue.name, noop).workflow_id
+                )
+
+    def claim(executor: str, partition: str) -> List[str]:
+        return dbos._sys_db.start_queued_workflows(
+            queue, executor, parked_version, partition
+        )
+
+    assert claim("executor-a", "p0") == [ids["p0"][0]]
+    # p0's follower is held back by partition_concurrency, though the queue has room.
+    assert claim("executor-b", "p0") == []
+    # Other partitions are free until the queue-wide budget runs out.
+    assert claim("executor-b", "p1") == [ids["p1"][0]]
+    assert claim("executor-a", "p2") == [ids["p2"][0]]
+    assert claim("executor-b", "p3") == []
+    # Freeing a queue-wide slot admits the idle partition.
+    set_workflow_status(dbos._sys_db, ids["p1"][0], WorkflowStatusString.SUCCESS.value)
+    assert claim("executor-b", "p3") == [ids["p3"][0]]
+
+
+def test_partition_concurrency_dequeue_blocks_on_peer_claim(
+    dbos: DBOS, skip_with_sqlite: None
+) -> None:
+    """A per-partition budget is shared across workers just as a queue-wide one is, so
+    a peer mid-claim must block the dequeue rather than be skipped past."""
+
+    @DBOS.workflow()
+    def noop() -> str:
+        return "done"
+
+    parked_version = "parked-version"
+    queue = DBOS.register_queue("partition_lock_queue", partition_concurrency=1)
+    ids = []
+    for priority in (1, 2):
+        with SetEnqueueOptions(
+            queue_partition_key="p0", app_version=parked_version, priority=priority
+        ):
+            ids.append(DBOS.enqueue_workflow(queue.name, noop).workflow_id)
+
+    ws = SystemSchema.workflow_status
+    head = (
+        sa.select(ws.c.workflow_uuid)
+        .where(ws.c.queue_name == queue.name)
+        .where(ws.c.status == WorkflowStatusString.ENQUEUED.value)
+        .order_by(ws.c.priority.asc(), ws.c.created_at.asc())
+        .limit(1)
+        .with_for_update()
+    )
+    with dbos._sys_db.engine.begin() as peer:
+        # A peer dequeuer holding an open claim on the partition's only free slot.
+        assert [row[0] for row in peer.execute(head)] == ids[:1]
+        with pytest.raises(OperationalError) as exc_info:
+            dbos._sys_db.start_queued_workflows(
+                queue, "test-executor", parked_version, "p0"
+            )
+    assert isinstance(exc_info.value.orig, errors.LockNotAvailable)
+
+    for id in ids:
+        status = dbos._sys_db.get_workflow_status(id)
+        assert status is not None
+        assert status["status"] == WorkflowStatusString.ENQUEUED.value
+
+
+def test_partition_concurrency_with_global_concurrency(dbos: DBOS) -> None:
+    """partition_concurrency above one routes to the per-partition sweep, where the
+    queue-wide global_concurrency still bounds every partition together."""
+
+    global_concurrency = 3
+    partition_concurrency = 2
+    partitions = [f"partition-{i}" for i in range(4)]
+
+    unblock_event = threading.Event()
+    lock = threading.Lock()
+    running: dict[str, int] = {p: 0 for p in partitions}
+    max_running: dict[str, int] = {p: 0 for p in partitions}
+    total_running = 0
+    max_total_running = 0
+
+    @DBOS.workflow()
+    def blocking_workflow(partition: str) -> str:
+        nonlocal total_running, max_total_running
+        with lock:
+            running[partition] += 1
+            total_running += 1
+            max_running[partition] = max(max_running[partition], running[partition])
+            max_total_running = max(max_total_running, total_running)
+        unblock_event.wait()
+        with lock:
+            running[partition] -= 1
+            total_running -= 1
+        assert DBOS.workflow_id is not None
+        return DBOS.workflow_id
+
+    queue = DBOS.register_queue(
+        "partition_and_global_queue",
+        global_concurrency=global_concurrency,
+        partition_concurrency=partition_concurrency,
+        polling_interval_sec=0.5,
+    )
+
+    handles: list[WorkflowHandle[str]] = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(3):
+                handles.append(
+                    DBOS.enqueue_workflow(queue.name, blocking_workflow, partition)
+                )
+
+    def queue_saturated() -> None:
+        with lock:
+            assert total_running == global_concurrency
+
+    retry_until_success(queue_saturated)
+
+    # Let several polling intervals pass: neither limit is ever exceeded.
+    time.sleep(2)
+    with lock:
+        assert max_total_running == global_concurrency
+        assert all(max_running[p] <= partition_concurrency for p in partitions)
+
+    unblock_event.set()
+    for handle in handles:
+        assert handle.get_result() is not None
+
+    with lock:
+        assert max_total_running == global_concurrency
+        assert all(max_running[p] <= partition_concurrency for p in partitions)
+    assert queue_entries_are_cleaned_up(dbos)
+
+
+def test_partition_concurrency_with_queue_wide_limiter(dbos: DBOS) -> None:
+    """A limiter alongside partition_concurrency is queue-wide: it spends its budget
+    across all partitions, not once per partition."""
+
+    @DBOS.workflow()
+    def noop(tag: str) -> str:
+        return tag
+
+    limit = 3
+    partitions = [f"p{i}" for i in range(5)]
+    queue = DBOS.register_queue(
+        "partition_limiter_queue",
+        partition_concurrency=1,
+        limiter={"limit": limit, "period": 60},
+        polling_interval_sec=0.25,
+    )
+
+    ids = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            ids.append(DBOS.enqueue_workflow(queue.name, noop, partition).workflow_id)
+
+    def statuses() -> List[str]:
+        return [dbos._sys_db.get_workflow_status(id)["status"] for id in ids]  # type: ignore
+
+    # Were the limiter per partition, every partition would start its own workflow.
+    def limiter_budget_spent() -> None:
+        assert statuses().count(WorkflowStatusString.SUCCESS.value) == limit
+
+    retry_until_success(limiter_budget_spent)
+
+    # Several polling intervals later the rest are still waiting on the rolling window.
+    time.sleep(1)
+    final = statuses()
+    assert final.count(WorkflowStatusString.SUCCESS.value) == limit
+    assert final.count(WorkflowStatusString.ENQUEUED.value) == len(partitions) - limit
+
+    # Claims made under a limiter are stamped so the window can count them.
+    ws = SystemSchema.workflow_status
+    with dbos._sys_db.engine.begin() as c:
+        rows = c.execute(
+            sa.select(ws.c.status, ws.c.rate_limited).where(
+                ws.c.queue_name == queue.name
+            )
+        ).fetchall()
+    started = [rate_limited for status, rate_limited in rows if status != "ENQUEUED"]
+    assert len(started) == limit
+    assert all(started)
+
+
 def _enqueue_partition_rows(
     dbos: DBOS,
     func: Any,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3489,9 +3489,9 @@ def _enqueue_partition_rows(
 def test_partitioned_batch_dequeue_sweep_cap(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads, chosen in random
-    partition order; admitted partitions are PENDING-gated, so the next sweep picks
-    up the remaining partitions."""
+    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads in partition
+    order; admitted partitions are PENDING-gated, so the next sweep rotates
+    onward to the remaining partitions."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3511,16 +3511,13 @@ def test_partitioned_batch_dequeue_sweep_cap(
             queue, GlobalParams.executor_id, GlobalParams.app_version
         )
 
-    capped, remainder = start(), start()
-    assert len(capped) == 5
-    assert len(remainder) == 3
-    # Which five come first varies with the random order; together they are every head.
-    assert set(capped) | set(remainder) == {ids[p][0] for p in partitions}
+    assert start() == [ids[p][0] for p in partitions[:5]]
+    assert start() == [ids[p][0] for p in partitions[5:]]
     assert start() == []
 
 
 def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
-    """max_tasks bounds a sweep to this worker's remaining room."""
+    """max_tasks bounds a sweep to this worker's remaining room, in partition order."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3538,47 +3535,11 @@ def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
             queue, GlobalParams.executor_id, GlobalParams.app_version, max_tasks
         )
 
-    # An exhausted budget claims nothing, a partial one only as many as it allows.
+    # An exhausted budget claims nothing, a partial one only the first partitions.
     assert start(0) == []
-    budgeted = start(2)
-    assert len(budgeted) == 2
+    assert start(2) == [ids[p][0] for p in partitions[:2]]
     # Those partitions are now PENDING-gated, so the rest follow.
-    remainder = start(10)
-    assert len(remainder) == 2
-    assert set(budgeted) | set(remainder) == {ids[p][0] for p in partitions}
-
-
-def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
-    """A budget below the partition count draws partitions at random, so no key is
-    starved for sorting late. A fixed order would pick the same partition every time."""
-
-    @DBOS.workflow()
-    def batch_wf(value: str) -> None:
-        pass
-
-    queue_name = f"unpolled-fair-{uuid.uuid4().hex[:8]}"
-    queue = Queue(
-        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
-    )
-    draws = 20
-    partitions = [f"p{i}" for i in range(5)]
-    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "fair", partitions, draws)
-    owner = {wfid: p for p in partitions for wfid in ids[p]}
-
-    chosen = set()
-    for _ in range(draws):
-        claimed = dbos._sys_db.start_queued_partitioned_workflows(
-            queue, GlobalParams.executor_id, GlobalParams.app_version, 1
-        )
-        assert len(claimed) == 1
-        chosen.add(owner[claimed[0]])
-        # Finish it, so its partition is eligible again for the next draw.
-        set_workflow_status(
-            dbos._sys_db, claimed[0], WorkflowStatusString.SUCCESS.value
-        )
-
-    # Twenty draws over five always-eligible partitions: fewer than three distinct winners has probability ~1e-7, while a fixed order would yield exactly one.
-    assert len(chosen) >= 3
+    assert start(10) == [ids[p][0] for p in partitions[2:]]
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
@@ -3602,7 +3563,7 @@ def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
         )
 
     # Heads only, one per partition
-    assert set(start()) == {ids[p][0] for p in partitions}
+    assert start() == [ids[p][0] for p in partitions]
     # Every partition has a PENDING head, so nothing else is admitted
     assert start() == []
     # Completing one partition's head opens that partition alone

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3,6 +3,7 @@ import gc
 import multiprocessing
 import multiprocessing.synchronize
 import os
+import random
 import subprocess
 import threading
 import time
@@ -2805,20 +2806,24 @@ def test_partitioned_queue_does_not_starve_partitions(dbos: DBOS) -> None:
             completed[partition] += 1
         return partition
 
-    queue = DBOS.register_queue(
-        f"starvation_{uuid.uuid4().hex[:8]}",
+    # Enqueue before registering, so the first sweep sees every partition at once.
+    # Registering first lets the worker drain the busy backlog while the small
+    # partitions are still being enqueued, which eats into the margin asserted below.
+    queue_name = f"starvation_{uuid.uuid4().hex[:8]}"
+    for partition in busy_partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(busy_backlog):
+                DBOS.enqueue_workflow(queue_name, quick_workflow, partition)
+    for partition in small_partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            DBOS.enqueue_workflow(queue_name, quick_workflow, partition)
+
+    DBOS.register_queue(
+        queue_name,
         partition_concurrency=1,
         worker_concurrency=2,
         polling_interval_sec=0.1,
     )
-
-    for partition in busy_partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            for _ in range(busy_backlog):
-                DBOS.enqueue_workflow(queue.name, quick_workflow, partition)
-    for partition in small_partitions:
-        with SetEnqueueOptions(queue_partition_key=partition):
-            DBOS.enqueue_workflow(queue.name, quick_workflow, partition)
 
     def every_small_partition_served() -> int:
         with lock:
@@ -2852,6 +2857,9 @@ def test_partition_serialization_failure_skips_key(
     # Sorts before the healthy key, so an escaping error would abort the sweep first.
     poisoned_key = "a_poisoned"
     healthy_key = "z_healthy"
+    # The sweep shuffles partitions to prevent starvation, which would visit the healthy
+    # key first half the time and let it drain even with the skip removed. Pin the order.
+    monkeypatch.setattr(random, "shuffle", lambda seq: None)
     poison_active = threading.Event()
     poison_active.set()
 
@@ -2893,6 +2901,12 @@ def test_partition_serialization_failure_skips_key(
         healthy_handle = queue.enqueue(wf)
 
     # The healthy partition drains even though the poisoned one fails every sweep.
+    # Bounded: without the per-partition skip the error aborts the sweep before the
+    # healthy key is reached, and a bare get_result() would block forever instead of failing.
+    def healthy_finished() -> None:
+        assert healthy_handle.get_status().status == WorkflowStatusString.SUCCESS.value
+
+    retry_until_success(healthy_finished, interval=0.1, max_attempts=100)
     assert healthy_handle.get_result()
     assert poisoned_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
 
@@ -3036,15 +3050,17 @@ def test_partition_limits_bound_both_scopes(
         with lock:
             assert total_running == queue_wide
 
-    retry_until_success(queue_saturated)
+    try:
+        retry_until_success(queue_saturated)
 
-    # Let several polling intervals pass: neither limit is ever exceeded, and the partitions with no room stay blocked rather than borrowing another's.
-    time.sleep(2)
-    with lock:
-        assert max_total_running == queue_wide
-        assert all(max_running[p] <= per_partition for p in partitions)
-
-    unblock_event.set()
+        # Let several polling intervals pass: neither limit is ever exceeded, and the partitions with no room stay blocked rather than borrowing another's.
+        time.sleep(2)
+        with lock:
+            assert max_total_running == queue_wide
+            assert all(max_running[p] <= per_partition for p in partitions)
+    finally:
+        # Always release the blocked workflows: leaving them parked would stall shutdown.
+        unblock_event.set()
     for handle in handles:
         assert handle.get_result() is not None
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -273,6 +273,14 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         queue.set_partition_concurrency(100)
     with pytest.raises(ValueError):
         queue.set_partition_worker_concurrency(100)
+    # Nor can partition_concurrency drop below the per-worker limit it bounds.
+    with pytest.raises(ValueError, match="greater than or equal to"):
+        queue.set_partition_concurrency(1)
+    # Both per-partition limits are floored at 1.
+    with pytest.raises(ValueError, match="at least 1"):
+        queue.set_partition_worker_concurrency(0)
+    with pytest.raises(ValueError, match="at least 1"):
+        queue.set_partition_concurrency(0)
     # polling_interval must be positive.
     with pytest.raises(ValueError):
         queue.set_polling_interval_sec(0.0)
@@ -289,11 +297,19 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     # ones read as unset. Re-scoping it would silently change what it enforces.
     legacy_name = f"test_legacy_queue_{uuid.uuid4()}"
     legacy_queue = DBOS.register_queue(
-        legacy_name, partition_queue=True, concurrency=2, worker_concurrency=1
+        legacy_name,
+        partition_queue=True,
+        concurrency=2,
+        worker_concurrency=1,
+        limiter={"limit": 7, "period": 2.0},
     )
     assert legacy_queue.partition_concurrency == 2
     assert legacy_queue.partition_worker_concurrency == 1
+    assert legacy_queue.partition_limiter == {"limit": 7, "period": 2.0}
+    # Every queue-wide getter reads as unset, so no limit is reported at both scopes.
     assert legacy_queue.global_concurrency is None
+    assert legacy_queue.worker_concurrency is None
+    assert legacy_queue.limiter is None
     with pytest.raises(DBOSException):
         legacy_queue.set_global_concurrency(5)
     with pytest.raises(DBOSException):
@@ -359,6 +375,8 @@ def test_partition_limit_validation(dbos: DBOS) -> None:
     # Malformed limits are rejected the same way their queue-wide counterparts are.
     with pytest.raises(ValueError, match="at least 1"):
         Queue(f"v8_{suffix}", partition_concurrency=0)
+    with pytest.raises(ValueError, match="at least 1"):
+        Queue(f"v12_{suffix}", partition_worker_concurrency=0)
     with pytest.raises(ValueError, match="both 'limit' and 'period'"):
         Queue(f"v9_{suffix}", partition_limiter={"limit": 1})  # type: ignore
 
@@ -3091,7 +3109,9 @@ def test_partition_sweep_fills_worker_concurrency_in_one_pass(dbos: DBOS) -> Non
         retry_until_success(
             all_partitions_started,
             interval=0.05,
-            max_attempts=int(polling_interval / 0.05),
+            # Half a polling interval: the next poll is at least 0.95x one away, so a
+            # second sweep cannot land inside the window and pass off two passes as one.
+            max_attempts=int(polling_interval * 0.5 / 0.05),
         )
     finally:
         # Always release the blocked workflows: leaving them parked would stall shutdown.
@@ -3173,13 +3193,28 @@ def test_queue_wide_limit_holds_across_executors(
             f"trial {trial}: two executors each spent the queue-wide budget, "
             f"claiming {claimed}"
         )
-        claimed_total += sum(len(c) for c in claimed)
-        # Retire this trial's claims so the next trial starts from a free budget.
+        trial_claims = sum(len(c) for c in claimed)
+        # Losing the race admits nothing, but one executor always wins: a trial that
+        # admits nothing at all tested the race with an already-spent budget.
+        assert trial_claims >= 1, (
+            f"trial {trial}: neither executor admitted anything, so the budget was "
+            f"not free at the start of this trial"
+        )
+        claimed_total += trial_claims
+        # Retire this trial's claims so the next trial starts from a free budget. A
+        # rate-limit slot is retired by its window, not by status -- rate_limit_remaining
+        # counts any non-ENQUEUED row inside the period -- so clear the flag too.
         for ids in claimed:
             for workflow_id in ids:
-                set_workflow_status(
-                    dbos._sys_db, workflow_id, WorkflowStatusString.SUCCESS.value
-                )
+                with dbos._sys_db.engine.begin() as c:
+                    c.execute(
+                        sa.update(ws)
+                        .where(ws.c.workflow_uuid == workflow_id)
+                        .values(
+                            status=WorkflowStatusString.SUCCESS.value,
+                            rate_limited=False,
+                        )
+                    )
 
     # The limit must bind by admitting work, not by admitting nothing at all.
     assert claimed_total > 0
@@ -3470,8 +3505,9 @@ def test_partitioned_queue_fallback_routing(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A partitioned config the batched path does not support -- a rate limiter --
-    routes to the per-partition sweep and drains. A zero worker limit at either scope
-    (the pause-dequeue idiom) exhausts this worker's budget before either path runs.
+    routes to the per-partition sweep and drains. A zero worker limit (the pause-dequeue
+    idiom, which a legacy queue resolves to the per-partition scope) exhausts this
+    worker's budget before either path runs.
     """
 
     @DBOS.workflow()
@@ -3491,16 +3527,6 @@ def test_partitioned_queue_fallback_routing(
         concurrency=1,
         worker_concurrency=0,
         partition_queue=True,
-        polling_interval_sec=0.25,
-    )
-
-    # Paused per partition, not queue-wide: the batched path enforces no per-partition
-    # worker limit itself, so the budget must stop it before it runs.
-    partition_paused_queue = Queue(
-        f"partition_paused_{uuid.uuid4().hex[:8]}",
-        partition_concurrency=1,
-        partition_worker_concurrency=0,
-        worker_concurrency=5,
         polling_interval_sec=0.25,
     )
 
@@ -3528,8 +3554,6 @@ def test_partitioned_queue_fallback_routing(
             handles.append(limiter_queue.enqueue(routed_wf, f"limited-{partition}"))
     with SetEnqueueOptions(queue_partition_key="p0"):
         paused_handle = paused_queue.enqueue(routed_wf, "paused")
-    with SetEnqueueOptions(queue_partition_key="p0"):
-        partition_paused_handle = partition_paused_queue.enqueue(routed_wf, "pp")
 
     for handle in handles:
         assert handle.get_result()
@@ -3543,12 +3567,6 @@ def test_partitioned_queue_fallback_routing(
     assert paused_queue.name not in batched_queues
     assert paused_queue.name not in swept_queues
     assert paused_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
-    assert partition_paused_queue.name not in batched_queues
-    assert partition_paused_queue.name not in swept_queues
-    assert (
-        partition_paused_handle.get_status().status
-        == WorkflowStatusString.ENQUEUED.value
-    )
 
 
 def test_partitioned_batch_dequeue_version_gating(dbos: DBOS) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2413,8 +2413,7 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
 
 
 def test_priority_queue(dbos: DBOS) -> None:
-    # Make sure that we can enqueue workflows with different priorities correctly.
-    # priority_enabled is deprecated and ignored: priority needs no opt-in.
+    # Enqueue workflows with different priorities; priority_enabled is deprecated and ignored, so priority needs no opt-in.
     DBOS.register_queue("test_queue_priority", concurrency=1)
     DBOS.register_queue("test_queue_child")
 
@@ -3119,8 +3118,7 @@ def test_partition_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
 
     retry_until_success(worker_saturated)
 
-    # Let several polling intervals pass: neither limit is ever exceeded, and the
-    # two partitions with no room stay blocked rather than sharing the worker's.
+    # Let several polling intervals pass: neither limit is ever exceeded, and the two partitions with no room stay blocked rather than sharing the worker's.
     time.sleep(2)
     with lock:
         assert max_total_running == worker_concurrency
@@ -3387,8 +3385,7 @@ def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
     def statuses() -> List[str]:
         return [dbos._sys_db.get_workflow_status(id)["status"] for id in ids]  # type: ignore
 
-    # The queue-wide window caps the total at three, one from each of three partitions:
-    # the per-partition window admits only one apiece.
+    # The queue-wide window caps the total at three, one from each of three partitions: the per-partition window admits only one apiece.
     def limiter_budget_spent() -> None:
         assert statuses().count(WorkflowStatusString.SUCCESS.value) == queue_limit
 
@@ -3580,8 +3577,7 @@ def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
             dbos._sys_db, claimed[0], WorkflowStatusString.SUCCESS.value
         )
 
-    # Twenty draws over five always-eligible partitions: fewer than three distinct
-    # winners has probability ~1e-7, while a fixed order would yield exactly one.
+    # Twenty draws over five always-eligible partitions: fewer than three distinct winners has probability ~1e-7, while a fixed order would yield exactly one.
     assert len(chosen) >= 3
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2759,6 +2759,59 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
     assert client_handle.get_result()
 
 
+def test_partitioned_queue_does_not_starve_partitions(dbos: DBOS) -> None:
+    """A partition with a little work is not starved by partitions with a lot, even
+    when the queue-wide limit is too small to serve every partition at once.
+
+    Measured in units of work rather than time so the assertion does not depend on
+    machine speed: the small partitions must be served while the busy ones still
+    have a backlog. Serving partitions in a fixed order would drain the busy ones
+    first, since they hold every slot and reclaim it the moment one frees up.
+    """
+
+    busy_backlog = 60
+    # The busy partitions sort first, so a fixed order would always prefer them.
+    busy_partitions = ["aaa-busy-1", "aaa-busy-2"]
+    small_partitions = [f"zzz-small-{i}" for i in range(4)]
+
+    lock = threading.Lock()
+    completed: dict[str, int] = {p: 0 for p in busy_partitions + small_partitions}
+
+    @DBOS.workflow()
+    def quick_workflow(partition: str) -> str:
+        with lock:
+            completed[partition] += 1
+        return partition
+
+    queue = DBOS.register_queue(
+        f"starvation_{uuid.uuid4().hex[:8]}",
+        partition_concurrency=1,
+        worker_concurrency=2,
+        polling_interval_sec=0.1,
+    )
+
+    for partition in busy_partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(busy_backlog):
+                DBOS.enqueue_workflow(queue.name, quick_workflow, partition)
+    for partition in small_partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            DBOS.enqueue_workflow(queue.name, quick_workflow, partition)
+
+    def every_small_partition_served() -> int:
+        with lock:
+            assert all(completed[p] > 0 for p in small_partitions)
+            return sum(completed[p] for p in busy_partitions)
+
+    busy_done = retry_until_success(
+        every_small_partition_served, interval=0.2, max_attempts=100
+    )
+    # The busy partitions drain at roughly the queue-wide limit per poll, so serving
+    # the small ones promptly leaves most of that backlog outstanding. A fixed order
+    # would leave none of it.
+    assert busy_done < busy_backlog * len(busy_partitions) // 2
+
+
 def test_partition_serialization_failure_skips_key(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3489,9 +3489,9 @@ def _enqueue_partition_rows(
 def test_partitioned_batch_dequeue_sweep_cap(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads in partition
-    order; admitted partitions are PENDING-gated, so the next sweep rotates
-    onward to the remaining partitions."""
+    """A sweep admits at most PARTITIONED_DEQUEUE_SWEEP_CAP heads, drawn in random
+    partition order; admitted partitions are PENDING-gated, so the next sweep picks
+    up the remaining partitions."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3511,13 +3511,16 @@ def test_partitioned_batch_dequeue_sweep_cap(
             queue, GlobalParams.executor_id, GlobalParams.app_version
         )
 
-    assert start() == [ids[p][0] for p in partitions[:5]]
-    assert start() == [ids[p][0] for p in partitions[5:]]
+    capped, remainder = start(), start()
+    assert len(capped) == 5
+    assert len(remainder) == 3
+    # Which five come first varies with the random order; together they are every head.
+    assert set(capped) | set(remainder) == {ids[p][0] for p in partitions}
     assert start() == []
 
 
 def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
-    """max_tasks bounds a sweep to this worker's remaining room, in partition order."""
+    """max_tasks bounds a sweep to this worker's remaining room."""
 
     @DBOS.workflow()
     def batch_wf(value: str) -> None:
@@ -3535,11 +3538,47 @@ def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
             queue, GlobalParams.executor_id, GlobalParams.app_version, max_tasks
         )
 
-    # An exhausted budget claims nothing, a partial one only the first partitions.
+    # An exhausted budget claims nothing, a partial one only as many as it allows.
     assert start(0) == []
-    assert start(2) == [ids[p][0] for p in partitions[:2]]
+    budgeted = start(2)
+    assert len(budgeted) == 2
     # Those partitions are now PENDING-gated, so the rest follow.
-    assert start(10) == [ids[p][0] for p in partitions[2:]]
+    remainder = start(10)
+    assert len(remainder) == 2
+    assert set(budgeted) | set(remainder) == {ids[p][0] for p in partitions}
+
+
+def test_partitioned_batch_dequeue_varies_partitions(dbos: DBOS) -> None:
+    """A budget below the partition count draws partitions at random, so no key is
+    starved for sorting late. A fixed order would pick the same partition every time."""
+
+    @DBOS.workflow()
+    def batch_wf(value: str) -> None:
+        pass
+
+    queue_name = f"unpolled-fair-{uuid.uuid4().hex[:8]}"
+    queue = Queue(
+        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
+    )
+    draws = 20
+    partitions = [f"p{i}" for i in range(5)]
+    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "fair", partitions, draws)
+    owner = {wfid: p for p in partitions for wfid in ids[p]}
+
+    chosen = set()
+    for _ in range(draws):
+        claimed = dbos._sys_db.start_queued_partitioned_workflows(
+            queue, GlobalParams.executor_id, GlobalParams.app_version, 1
+        )
+        assert len(claimed) == 1
+        chosen.add(owner[claimed[0]])
+        # Finish it, so its partition is eligible again for the next draw.
+        set_workflow_status(
+            dbos._sys_db, claimed[0], WorkflowStatusString.SUCCESS.value
+        )
+
+    # Twenty draws over five always-eligible partitions: fewer than three distinct winners has probability ~1e-7, while a fixed order would yield exactly one.
+    assert len(chosen) >= 3
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
@@ -3563,7 +3602,7 @@ def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
         )
 
     # Heads only, one per partition
-    assert start() == [ids[p][0] for p in partitions]
+    assert set(start()) == {ids[p][0] for p in partitions}
     # Every partition has a PENDING head, so nothing else is admitted
     assert start() == []
     # Completing one partition's head opens that partition alone

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3102,6 +3102,89 @@ def test_partition_sweep_fills_worker_concurrency_in_one_pass(dbos: DBOS) -> Non
     assert queue_entries_are_cleaned_up(dbos)
 
 
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"global_concurrency": 1, "partition_concurrency": 1},
+        {"limiter": {"limit": 1, "period": 60}, "partition_concurrency": 1},
+    ],
+    ids=["global-concurrency", "limiter"],
+)
+def test_queue_wide_limit_holds_across_executors(
+    dbos: DBOS, limits: dict[str, Any], skip_with_sqlite: None
+) -> None:
+    """A queue-wide limit on a partitioned queue binds the whole queue, so two executors
+    sweeping different partitions cannot each spend it."""
+    from sqlalchemy.exc import OperationalError
+
+    @DBOS.workflow()
+    def noop() -> str:
+        return "done"
+
+    # A version this executor never runs, so the live queue worker leaves these rows alone.
+    parked_version = "parked-version"
+    queue = DBOS.register_queue(f"cross_executor_{uuid.uuid4().hex[:8]}", **limits)
+    ws = SystemSchema.workflow_status
+
+    def pending_count() -> int:
+        with dbos._sys_db.engine.begin() as c:
+            return (
+                c.execute(
+                    sa.select(sa.func.count())
+                    .select_from(ws)
+                    .where(ws.c.queue_name == queue.name)
+                    .where(ws.c.status == WorkflowStatusString.PENDING.value)
+                ).scalar()
+                or 0
+            )
+
+    claimed_total = 0
+    for trial in range(5):
+        partitions = [f"a{trial}", f"b{trial}"]
+        for partition in partitions:
+            with SetEnqueueOptions(
+                queue_partition_key=partition, app_version=parked_version
+            ):
+                DBOS.enqueue_workflow(queue.name, noop)
+
+        barrier = threading.Barrier(len(partitions))
+        claimed: List[List[str]] = [[] for _ in partitions]
+
+        def sweep(index: int, partition: str) -> None:
+            barrier.wait()
+            try:
+                claimed[index] = dbos._sys_db.start_queued_workflows(
+                    queue, f"executor-{index}", parked_version, partition, 0, 0
+                )
+            except OperationalError:
+                # Losing the race is the correct outcome; admitting is not.
+                pass
+
+        threads = [
+            threading.Thread(target=sweep, args=(i, p))
+            for i, p in enumerate(partitions)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert pending_count() <= 1, (
+            f"trial {trial}: two executors each spent the queue-wide budget, "
+            f"claiming {claimed}"
+        )
+        claimed_total += sum(len(c) for c in claimed)
+        # Retire this trial's claims so the next trial starts from a free budget.
+        for ids in claimed:
+            for workflow_id in ids:
+                set_workflow_status(
+                    dbos._sys_db, workflow_id, WorkflowStatusString.SUCCESS.value
+                )
+
+    # The limit must bind by admitting work, not by admitting nothing at all.
+    assert claimed_total > 0
+
+
 def test_partition_limiter_with_queue_wide_limiter(dbos: DBOS) -> None:
     """Both rate limits bind at once: each partition spends its own window, and the
     queue-wide window caps the total across partitions."""

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2970,6 +2970,78 @@ async def test_partition_queue_worker_concurrency_async(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def test_partition_concurrency_with_worker_concurrency(dbos: DBOS) -> None:
+    """partition_concurrency caps each partition across all executors while
+    worker_concurrency caps the whole queue on this one: at most one workflow per
+    partition, and at most worker_concurrency of them running here."""
+
+    worker_concurrency = 3
+    partitions = [f"partition-{i}" for i in range(5)]
+    wfs_per_partition = 3
+
+    unblock_event = threading.Event()
+    lock = threading.Lock()
+    running: dict[str, int] = {p: 0 for p in partitions}
+    max_running: dict[str, int] = {p: 0 for p in partitions}
+    total_running = 0
+    max_total_running = 0
+
+    @DBOS.workflow()
+    def blocking_workflow(partition: str) -> str:
+        nonlocal total_running, max_total_running
+        with lock:
+            running[partition] += 1
+            total_running += 1
+            max_running[partition] = max(max_running[partition], running[partition])
+            max_total_running = max(max_total_running, total_running)
+        unblock_event.wait()
+        with lock:
+            running[partition] -= 1
+            total_running -= 1
+        assert DBOS.workflow_id is not None
+        return DBOS.workflow_id
+
+    queue = DBOS.register_queue(
+        "partition_and_worker_queue",
+        partition_concurrency=1,
+        worker_concurrency=worker_concurrency,
+        polling_interval_sec=0.5,
+    )
+
+    handles: list[WorkflowHandle[str]] = []
+    for partition in partitions:
+        with SetEnqueueOptions(queue_partition_key=partition):
+            for _ in range(wfs_per_partition):
+                handles.append(
+                    DBOS.enqueue_workflow(queue.name, blocking_workflow, partition)
+                )
+
+    # The worker saturates its queue-wide limit, drawing from distinct partitions.
+    def worker_saturated() -> None:
+        with lock:
+            assert total_running == worker_concurrency
+
+    retry_until_success(worker_saturated)
+
+    # Let several polling intervals pass: neither limit is ever exceeded, and the
+    # two partitions with no room stay blocked rather than sharing the worker's.
+    time.sleep(2)
+    with lock:
+        assert max_total_running == worker_concurrency
+        assert all(max_running[p] <= 1 for p in partitions)
+
+    unblock_event.set()
+    for handle in handles:
+        assert handle.get_result() is not None
+
+    # Every partition ran, and none ever ran two at once, through the drain as well.
+    with lock:
+        assert max_total_running == worker_concurrency
+        assert all(max_running[p] == 1 for p in partitions)
+
+    assert queue_entries_are_cleaned_up(dbos)
+
+
 def _enqueue_partition_rows(
     dbos: DBOS,
     func: Any,
@@ -3032,6 +3104,32 @@ def test_partitioned_batch_dequeue_sweep_cap(
     assert start() == [ids[p][0] for p in partitions[:5]]
     assert start() == [ids[p][0] for p in partitions[5:]]
     assert start() == []
+
+
+def test_partitioned_batch_dequeue_worker_budget(dbos: DBOS) -> None:
+    """max_tasks bounds a sweep to this worker's remaining room, in partition order."""
+
+    @DBOS.workflow()
+    def batch_wf(value: str) -> None:
+        pass
+
+    queue_name = f"unpolled-budget-{uuid.uuid4().hex[:8]}"
+    queue = Queue(
+        queue_name, concurrency=1, partition_queue=True, database_backed_queue=True
+    )
+    partitions = [f"p{i}" for i in range(4)]
+    ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "budget", partitions, 1)
+
+    def start(max_tasks: int) -> List[str]:
+        return dbos._sys_db.start_queued_partitioned_workflows(
+            queue, GlobalParams.executor_id, GlobalParams.app_version, max_tasks
+        )
+
+    # An exhausted budget claims nothing, a partial one only the first partitions.
+    assert start(0) == []
+    assert start(2) == [ids[p][0] for p in partitions[:2]]
+    # Those partitions are now PENDING-gated, so the rest follow.
+    assert start(10) == [ids[p][0] for p in partitions[2:]]
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
@@ -3209,9 +3307,9 @@ def test_partitioned_batch_dequeue_contention(dbos: DBOS) -> None:
 def test_partitioned_queue_fallback_routing(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Partitioned configs the batched path does not support -- a rate limiter, and
-    worker_concurrency=0 (the pause-dequeue idiom, which it would ignore) -- route to
-    the per-partition sweep, which drains the first and honors the pause on the second.
+    """A partitioned config the batched path does not support -- a rate limiter --
+    routes to the per-partition sweep and drains. worker_concurrency=0 (the
+    pause-dequeue idiom) exhausts this worker's budget before either path runs.
     """
 
     @DBOS.workflow()
@@ -3262,12 +3360,14 @@ def test_partitioned_queue_fallback_routing(
     for handle in handles:
         assert handle.get_result()
 
-    def paused_queue_swept() -> None:
-        assert paused_queue.name in swept_queues
+    def limiter_queue_swept() -> None:
+        assert limiter_queue.name in swept_queues
 
-    retry_until_success(paused_queue_swept, interval=0.1, max_attempts=100)
+    retry_until_success(limiter_queue_swept, interval=0.1, max_attempts=100)
     assert limiter_queue.name not in batched_queues
+    # The paused queue polls on the same interval, so it has had its turn by now.
     assert paused_queue.name not in batched_queues
+    assert paused_queue.name not in swept_queues
     assert paused_handle.get_status().status == WorkflowStatusString.ENQUEUED.value
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1022,6 +1022,9 @@ def test_multiple_queues(dbos: DBOS) -> None:
     for i in range(len(dequeued_at) - limit):
         assert dequeued_at[i + limit] - dequeued_at[i] >= period_ms - 10
 
+    # ...and it spends that whole budget rather than trickling one workflow at a time.
+    assert sum(1 for t in dequeued_at if t < dequeued_at[0] + period_ms) == limit
+
     # Verify all workflows get the SUCCESS status eventually
     for h in handles:
         assert h.get_status().status == WorkflowStatusString.SUCCESS.value

--- a/tests/test_workflow_introspection.py
+++ b/tests/test_workflow_introspection.py
@@ -1762,12 +1762,18 @@ def test_get_event_timeout_registration_is_instantaneous(dbos: DBOS) -> None:
         time.sleep(1.0)
         DBOS.set_event("k", "v")
 
+    getter_started = threading.Event()
+
     @DBOS.workflow()
     def getter(target: str) -> Any:
+        getter_started.set()
         return DBOS.get_event(target, "k", timeout_seconds=60)
 
-    target = DBOS.start_workflow(setter)
-    handle = DBOS.start_workflow(getter, target.workflow_id)
+    target_id = str(uuid.uuid4())
+    handle = DBOS.start_workflow(getter, target_id)
+    assert getter_started.wait(timeout=10)
+    with SetWorkflowID(target_id):
+        DBOS.start_workflow(setter)
     assert handle.get_result() == "v"
 
     steps = DBOS.list_workflow_steps(handle.workflow_id)


### PR DESCRIPTION
Queues can now enforce both full-queue and per-partition flow control limits. New interface:

```python
def register_queue(
    name: str,
    *,
    # Applied to the entire queue
    global_concurrency: Optional[int] = None,
    worker_concurrency: Optional[int] = None,
    limiter: Optional[QueueRateLimit] = None,
    # Applied per-partition
    partition_concurrency: Optional[int] = None,
    partition_worker_concurrency: Optional[int] = None,
    partition_limiter: Optional[QueueRateLimit] = None,
    # Control plane
    polling_interval_sec: float = 1.0,
    on_conflict: QueueConflictResolution = "update_if_latest_version",
) -> Queue:
```

For example, you can create a "fair queue" allows at most one workflow to run per partition, and at most 10 tasks to run on each worker:

```py
DBOS.register_queue("fair_queue", worker_concurrency=10, partition_concurrency=1)
```

Fully backwards-compatible. Old parameters (`concurrency=`, `partition_queue=`) are retained, marked deprecated, and mapped to new parameters.