### PR TITLE
Async Step Timeouts

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -3,6 +3,7 @@ import copy
 import functools
 import inspect
 import json
+import math
 import sys
 import threading
 import time
@@ -2411,11 +2412,13 @@ async def _run_step_with_timeout(
         if step_task in done:
             return step_task.result()
         # Timed out: cancel the step and let its cleanup finish before the
-        # timeout is checkpointed. asyncio.wait, rather than awaiting the task
-        # directly, so an outer cancellation still propagates while the step's
-        # own outcome cannot displace the timeout — a body that suppresses
-        # CancelledError fails the step on every supported Python version
-        # (asyncio.wait_for would return its value on 3.10/3.11).
+        # timeout is checkpointed. asyncio.wait, rather than asyncio.wait_for:
+        # a body that catches CancelledError and returns normally makes
+        # wait_for hand back that value instead of raising (verified on 3.10
+        # through 3.13 — this is not version-specific), which would let a step
+        # silently outlive its deadline. asyncio.wait never yields the task's
+        # value, so the timeout always wins. Awaiting the task directly is not
+        # an option either: it would re-raise the step's own outcome here.
         step_task.cancel()
         await asyncio.wait({step_task})
         if not step_task.cancelled():
@@ -2470,10 +2473,13 @@ def invoke_step(
                 f"Step {step_name} is sync but timeout_seconds is set. "
                 f"Step timeouts are only supported for async steps."
             )
-        if timeout_seconds <= 0:
+        if not (timeout_seconds > 0 and math.isfinite(timeout_seconds)):
+            # `not > 0` rather than `<= 0` so NaN is rejected too: NaN passes
+            # every comparison, and asyncio.wait(timeout=nan) never fires,
+            # silently disabling the timeout. Matches SetWorkflowTimeout.
             raise DBOSException(
                 f"Step {step_name} has timeout_seconds={timeout_seconds}. "
-                f"Step timeouts must be positive."
+                f"Step timeouts must be positive and finite."
             )
 
     attributes: TracedAttributes = {
@@ -2732,10 +2738,10 @@ def decorate_step(
                     f"Step {name or func.__qualname__} is sync but timeout_seconds is set. "
                     f"Step timeouts are only supported for async steps."
                 )
-            if timeout_seconds <= 0:
+            if not (timeout_seconds > 0 and math.isfinite(timeout_seconds)):
                 raise DBOSException(
                     f"Step {name or func.__qualname__} has timeout_seconds={timeout_seconds}. "
-                    f"Step timeouts must be positive."
+                    f"Step timeouts must be positive and finite."
                 )
 
         step_name = name if name is not None else func.__qualname__

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -66,6 +66,7 @@ from ._error import (
     DBOSNotAuthorizedError,
     DBOSQueueDeduplicatedError,
     DBOSRecoveryError,
+    DBOSStepTimeoutError,
     DBOSUnexpectedStepError,
     DBOSWorkflowCancelledError,
     DBOSWorkflowConflictIDError,
@@ -384,6 +385,12 @@ class StepOptions(TypedDict, total=False):
         preemptible:
             If True, cancel the (async) step if its workflow is cancelled.
             Only supported for async steps.
+
+        timeout_seconds:
+            If set, cancel the (async) step and raise DBOSStepTimeoutError if it
+            runs for longer than this many seconds. Only supported for async
+            steps. Each retry attempt gets a fresh timeout. Inert outside a
+            workflow, where the step runs as a normal function call.
     """
 
     name: Optional[str]
@@ -393,6 +400,7 @@ class StepOptions(TypedDict, total=False):
     backoff_rate: float
     should_retry: Optional[Callable[[BaseException], Union[bool, Awaitable[bool]]]]
     preemptible: bool
+    timeout_seconds: Optional[float]
 
 
 DEFAULT_STEP_OPTIONS: StepOptions = {
@@ -403,6 +411,7 @@ DEFAULT_STEP_OPTIONS: StepOptions = {
     "backoff_rate": 2.0,
     "should_retry": None,
     "preemptible": False,
+    "timeout_seconds": None,
 }
 
 
@@ -2389,6 +2398,40 @@ async def _run_preemptible_step(
                 pass
 
 
+async def _run_step_with_timeout(
+    step_name: str,
+    timeout_seconds: float,
+    func: Callable[..., Coroutine[Any, Any, R]],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> R:
+    step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
+    try:
+        done, _ = await asyncio.wait({step_task}, timeout=timeout_seconds)
+        if step_task in done:
+            return step_task.result()
+        # Timed out: cancel the step and let its cleanup finish before the
+        # timeout is checkpointed. asyncio.wait, rather than awaiting the task
+        # directly, so an outer cancellation still propagates while the step's
+        # own outcome cannot displace the timeout — a body that suppresses
+        # CancelledError fails the step on every supported Python version
+        # (asyncio.wait_for would return its value on 3.10/3.11).
+        step_task.cancel()
+        await asyncio.wait({step_task})
+        if not step_task.cancelled():
+            # Consume it so asyncio doesn't log it as never retrieved.
+            step_task.exception()
+        raise DBOSStepTimeoutError(step_name, timeout_seconds)
+    finally:
+        # Don't leak the step task if the outer coroutine was itself cancelled.
+        if not step_task.done():
+            step_task.cancel()
+            try:
+                await step_task
+            except BaseException:
+                pass
+
+
 def invoke_step(
     dbos: "DBOS",
     step_ctx: DBOSContext,
@@ -2405,6 +2448,7 @@ def invoke_step(
         Callable[[BaseException], Union[bool, Awaitable[bool]]]
     ] = None,
     preemptible: bool = False,
+    timeout_seconds: Optional[float] = None,
 ) -> R | Coroutine[Any, Any, R]:
     if (
         should_retry is not None
@@ -2420,6 +2464,17 @@ def invoke_step(
             f"Step {step_name} is sync but preemptible=True. "
             f"Preemption is only supported for async steps."
         )
+    if timeout_seconds is not None:
+        if not inspect.iscoroutinefunction(func):
+            raise DBOSException(
+                f"Step {step_name} is sync but timeout_seconds is set. "
+                f"Step timeouts are only supported for async steps."
+            )
+        if timeout_seconds <= 0:
+            raise DBOSException(
+                f"Step {step_name} has timeout_seconds={timeout_seconds}. "
+                f"Step timeouts must be positive."
+            )
 
     attributes: TracedAttributes = {
         "name": step_name,
@@ -2529,6 +2584,18 @@ def invoke_step(
         )
     else:
         step_partial = functools.partial(func, *args, **kwargs)
+    if timeout_seconds is not None:
+        # Wrap the innermost callable: inside the retry layer, so each attempt
+        # gets a fresh timeout and retry sleeps aren't charged against it, and
+        # outside preemption, so a timeout tears the poller down with the step.
+        step_partial = functools.partial(
+            _run_step_with_timeout,
+            step_name,
+            timeout_seconds,
+            cast(Callable[..., Coroutine[Any, Any, R]], step_partial),
+            (),
+            {},
+        )
     stepOutcome = Outcome[R].make(step_partial)
     if retries_allowed:
         stepOutcome = stepOutcome.retry(
@@ -2571,6 +2638,7 @@ def run_step(
             backoff_rate=options["backoff_rate"],
             should_retry=options["should_retry"],
             preemptible=options["preemptible"],
+            timeout_seconds=options["timeout_seconds"],
         )
         if inspect.iscoroutinefunction(func):
             return dbos._background_event_loop.submit_coroutine(
@@ -2618,6 +2686,7 @@ async def run_step_async(
                 backoff_rate=options["backoff_rate"],
                 should_retry=options["should_retry"],
                 preemptible=options["preemptible"],
+                timeout_seconds=options["timeout_seconds"],
             )
 
         if inspect.iscoroutinefunction(func):
@@ -2649,6 +2718,7 @@ def decorate_step(
         Callable[[BaseException], Union[bool, Awaitable[bool]]]
     ] = None,
     preemptible: bool = False,
+    timeout_seconds: Optional[float] = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         if preemptible and not inspect.iscoroutinefunction(func):
@@ -2656,6 +2726,17 @@ def decorate_step(
                 f"Step {name or func.__qualname__} is sync but preemptible=True. "
                 f"Preemption is only supported for async steps."
             )
+        if timeout_seconds is not None:
+            if not inspect.iscoroutinefunction(func):
+                raise DBOSException(
+                    f"Step {name or func.__qualname__} is sync but timeout_seconds is set. "
+                    f"Step timeouts are only supported for async steps."
+                )
+            if timeout_seconds <= 0:
+                raise DBOSException(
+                    f"Step {name or func.__qualname__} has timeout_seconds={timeout_seconds}. "
+                    f"Step timeouts must be positive."
+                )
 
         step_name = name if name is not None else func.__qualname__
 
@@ -2686,6 +2767,7 @@ def decorate_step(
                         backoff_rate=backoff_rate,
                         should_retry=should_retry,
                         preemptible=preemptible,
+                        timeout_seconds=timeout_seconds,
                     )
             else:
                 return func(*args, **kwargs)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -2340,93 +2340,100 @@ def decorate_transaction(
     return decorator
 
 
-async def _run_preemptible_step(
+_PREEMPTIBLE_POLL_INTERVAL_SEC = 1.0
+
+
+async def _poll_for_workflow_cancellation(dbos: "DBOS", workflow_id: str) -> bool:
+    """Return True once the workflow is observed CANCELLED. Never cancels
+    anything itself: the supervisor owns that decision."""
+    while True:
+        await asyncio.sleep(_PREEMPTIBLE_POLL_INTERVAL_SEC)
+        try:
+            status = await asyncio.to_thread(
+                dbos._sys_db.get_workflow_status, workflow_id
+            )
+        except Exception as e:
+            dbos.logger.warning(
+                f"Error polling status for preemptible step in workflow {workflow_id}: {e}"
+            )
+            continue
+        if (
+            status is not None
+            and status["status"] == WorkflowStatusString.CANCELLED.value
+        ):
+            return True
+
+
+async def _supervise_step(
     dbos: "DBOS",
     workflow_id: str,
     func: Callable[..., Coroutine[Any, Any, R]],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> R:
-    PREEMPTIBLE_POLL_INTERVAL_SEC = 1.0
-    step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
-    poller_cancelled_step = False
-
-    async def poller() -> None:
-        nonlocal poller_cancelled_step
-        while True:
-            await asyncio.sleep(PREEMPTIBLE_POLL_INTERVAL_SEC)
-            try:
-                status = await asyncio.to_thread(
-                    dbos._sys_db.get_workflow_status, workflow_id
-                )
-            except Exception as e:
-                dbos.logger.warning(
-                    f"Error polling status for preemptible step in workflow {workflow_id}: {e}"
-                )
-                continue
-            if (
-                status is not None
-                and status["status"] == WorkflowStatusString.CANCELLED.value
-            ):
-                poller_cancelled_step = True
-                step_task.cancel()
-                return
-
-    poller_task = asyncio.create_task(poller())
-    try:
-        try:
-            return await step_task
-        except asyncio.CancelledError:
-            if poller_cancelled_step:
-                raise DBOSWorkflowCancelledError(
-                    f"Workflow {workflow_id} is cancelled. Aborting preemptible step."
-                )
-            raise
-    finally:
-        # Cancel both tasks so neither leaks if the outer coroutine itself
-        # was cancelled (or the step task is somehow still running).
-        if not step_task.done():
-            step_task.cancel()
-            try:
-                await step_task
-            except BaseException:
-                pass
-        if not poller_task.done():
-            poller_task.cancel()
-            try:
-                await poller_task
-            except BaseException:
-                pass
-
-
-async def _run_step_with_timeout(
+    *,
     step_name: str,
-    timeout_seconds: float,
-    func: Callable[..., Coroutine[Any, Any, R]],
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
+    preemptible: bool,
+    timeout_seconds: Optional[float],
 ) -> R:
+    """Run an async step under the watchdogs its options ask for, deciding in
+    one place whether it completed, was preempted, or blew its deadline."""
+    loop = asyncio.get_running_loop()
     step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
+    poller_task: Optional[asyncio.Task[bool]] = (
+        asyncio.create_task(_poll_for_workflow_cancellation(dbos, workflow_id))
+        if preemptible
+        else None
+    )
+    deadline = None if timeout_seconds is None else loop.time() + timeout_seconds
+    abort: Optional[BaseException] = None
     try:
-        done, _ = await asyncio.wait({step_task}, timeout=timeout_seconds)
-        if step_task in done:
-            return step_task.result()
-        # Cancel the step and let its cleanup finish before checkpointing.
+        watched: set[asyncio.Task[Any]] = {step_task}
+        if poller_task is not None:
+            watched.add(poller_task)
+        while abort is None:
+            remaining = None if deadline is None else max(0.0, deadline - loop.time())
+            done, _ = await asyncio.wait(
+                watched, timeout=remaining, return_when=asyncio.FIRST_COMPLETED
+            )
+            # A step that finished keeps its outcome, whatever else happened.
+            if step_task in done:
+                return step_task.result()
+            if poller_task is not None and poller_task in done:
+                watched.discard(poller_task)
+                observed = (
+                    not poller_task.cancelled() and poller_task.exception() is None
+                )
+                # A cancellation outranks a deadline reached at the same moment:
+                # not checkpointing a cancelled workflow's step is the safer error.
+                if observed and poller_task.result():
+                    abort = DBOSWorkflowCancelledError(
+                        f"Workflow {workflow_id} is cancelled. Aborting preemptible step."
+                    )
+                continue
+            assert timeout_seconds is not None
+            abort = DBOSStepTimeoutError(step_name, timeout_seconds)
+        # Stop the step and let its cleanup finish before surfacing the reason.
         # wait_for would hand back a suppressed-cancel body's value (3.10-3.13).
         step_task.cancel()
         await asyncio.wait({step_task})
-        if not step_task.cancelled():
-            # Consume it so asyncio doesn't log it as never retrieved.
-            step_task.exception()
-        raise DBOSStepTimeoutError(step_name, timeout_seconds)
+        outcome = None if step_task.cancelled() else step_task.exception()
+        if outcome is not None and not isinstance(outcome, Exception):
+            raise outcome
+        raise abort from outcome
     finally:
-        # Don't leak the step task if the outer coroutine was itself cancelled.
-        if not step_task.done():
-            step_task.cancel()
-            try:
-                await step_task
-            except BaseException:
-                pass
+        # Don't leak either task if the outer coroutine was itself cancelled,
+        # and retrieve any outcome so asyncio doesn't log it as unhandled.
+        for task in (step_task, poller_task):
+            if task is None:
+                continue
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except BaseException:
+                    pass
+            elif not task.cancelled():
+                task.exception()
 
 
 def invoke_step(
@@ -2568,31 +2575,25 @@ def invoke_step(
             )
             return NoResult()
 
-    if preemptible:
+    if preemptible or timeout_seconds is not None:
         async_func = cast(Callable[..., Coroutine[Any, Any, R]], func)
         step_partial: Callable[[], Union[R, Coroutine[Any, Any, R]]] = (
             functools.partial(
-                _run_preemptible_step,
+                _supervise_step,
                 dbos,
                 step_ctx.workflow_id,
                 async_func,
                 args,
                 kwargs,
+                step_name=step_name,
+                preemptible=preemptible,
+                timeout_seconds=timeout_seconds,
             )
         )
     else:
         step_partial = functools.partial(func, *args, **kwargs)
-    if timeout_seconds is not None:
-        # Inside retry, so each attempt gets a fresh timeout; outside
-        # preemption, so a timeout tears the poller down with the step.
-        step_partial = functools.partial(
-            _run_step_with_timeout,
-            step_name,
-            timeout_seconds,
-            cast(Callable[..., Coroutine[Any, Any, R]], step_partial),
-            (),
-            {},
-        )
+    # The supervisor sits inside the retry layer, so each attempt gets a fresh
+    # deadline and retry sleeps are not charged against it.
     stepOutcome = Outcome[R].make(step_partial)
     if retries_allowed:
         stepOutcome = stepOutcome.retry(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -2411,14 +2411,8 @@ async def _run_step_with_timeout(
         done, _ = await asyncio.wait({step_task}, timeout=timeout_seconds)
         if step_task in done:
             return step_task.result()
-        # Timed out: cancel the step and let its cleanup finish before the
-        # timeout is checkpointed. asyncio.wait, rather than asyncio.wait_for:
-        # a body that catches CancelledError and returns normally makes
-        # wait_for hand back that value instead of raising (verified on 3.10
-        # through 3.13 — this is not version-specific), which would let a step
-        # silently outlive its deadline. asyncio.wait never yields the task's
-        # value, so the timeout always wins. Awaiting the task directly is not
-        # an option either: it would re-raise the step's own outcome here.
+        # Cancel the step and let its cleanup finish before checkpointing.
+        # wait_for would hand back a suppressed-cancel body's value (3.10-3.13).
         step_task.cancel()
         await asyncio.wait({step_task})
         if not step_task.cancelled():
@@ -2474,9 +2468,7 @@ def invoke_step(
                 f"Step timeouts are only supported for async steps."
             )
         if not (timeout_seconds > 0 and math.isfinite(timeout_seconds)):
-            # `not > 0` rather than `<= 0` so NaN is rejected too: NaN passes
-            # every comparison, and asyncio.wait(timeout=nan) never fires,
-            # silently disabling the timeout. Matches SetWorkflowTimeout.
+            # `<= 0` would admit NaN, which silently disables the timeout.
             raise DBOSException(
                 f"Step {step_name} has timeout_seconds={timeout_seconds}. "
                 f"Step timeouts must be positive and finite."
@@ -2591,9 +2583,8 @@ def invoke_step(
     else:
         step_partial = functools.partial(func, *args, **kwargs)
     if timeout_seconds is not None:
-        # Wrap the innermost callable: inside the retry layer, so each attempt
-        # gets a fresh timeout and retry sleeps aren't charged against it, and
-        # outside preemption, so a timeout tears the poller down with the step.
+        # Inside retry, so each attempt gets a fresh timeout; outside
+        # preemption, so a timeout tears the poller down with the step.
         step_partial = functools.partial(
             _run_step_with_timeout,
             step_name,

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -2343,27 +2343,6 @@ def decorate_transaction(
 _PREEMPTIBLE_POLL_INTERVAL_SEC = 1.0
 
 
-async def _poll_for_workflow_cancellation(dbos: "DBOS", workflow_id: str) -> bool:
-    """Return True once the workflow is observed CANCELLED. Never cancels
-    anything itself: the supervisor owns that decision."""
-    while True:
-        await asyncio.sleep(_PREEMPTIBLE_POLL_INTERVAL_SEC)
-        try:
-            status = await asyncio.to_thread(
-                dbos._sys_db.get_workflow_status, workflow_id
-            )
-        except Exception as e:
-            dbos.logger.warning(
-                f"Error polling status for preemptible step in workflow {workflow_id}: {e}"
-            )
-            continue
-        if (
-            status is not None
-            and status["status"] == WorkflowStatusString.CANCELLED.value
-        ):
-            return True
-
-
 async def _supervise_step(
     dbos: "DBOS",
     workflow_id: str,
@@ -2377,12 +2356,31 @@ async def _supervise_step(
 ) -> R:
     """Run an async step under the watchdogs its options ask for, deciding in
     one place whether it completed, was preempted, or blew its deadline."""
+
+    async def poll_for_cancellation() -> bool:
+        """Return True once the workflow is observed CANCELLED. Never cancels
+        anything itself: the supervisor owns that decision."""
+        while True:
+            await asyncio.sleep(_PREEMPTIBLE_POLL_INTERVAL_SEC)
+            try:
+                status = await asyncio.to_thread(
+                    dbos._sys_db.get_workflow_status, workflow_id
+                )
+            except Exception as e:
+                dbos.logger.warning(
+                    f"Error polling status for preemptible step in workflow {workflow_id}: {e}"
+                )
+                continue
+            if (
+                status is not None
+                and status["status"] == WorkflowStatusString.CANCELLED.value
+            ):
+                return True
+
     loop = asyncio.get_running_loop()
     step_task: asyncio.Task[R] = asyncio.create_task(func(*args, **kwargs))
     poller_task: Optional[asyncio.Task[bool]] = (
-        asyncio.create_task(_poll_for_workflow_cancellation(dbos, workflow_id))
-        if preemptible
-        else None
+        asyncio.create_task(poll_for_cancellation()) if preemptible else None
     )
     deadline = None if timeout_seconds is None else loop.time() + timeout_seconds
     abort: Optional[BaseException] = None

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -1197,6 +1197,7 @@ class DBOS:
             Callable[[BaseException], Union[bool, Awaitable[bool]]]
         ] = None,
         preemptible: bool = False,
+        timeout_seconds: Optional[float] = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """
         Decorate and configure a function for use as a DBOS step.
@@ -1213,6 +1214,11 @@ class DBOS:
                 retries. Async validators are only supported for async steps.
             preemptible(bool): If True, cancel the (async) step if its workflow is cancelled.
                 Only supported for async steps.
+            timeout_seconds(Optional[float]): If set, cancel the (async) step and raise
+                DBOSStepTimeoutError if it runs for longer than this many seconds. Only
+                supported for async steps. Each retry attempt gets a fresh timeout. The
+                timeout is inert outside a workflow, where the step runs as a normal
+                function call.
 
         """
 
@@ -1225,6 +1231,7 @@ class DBOS:
             backoff_rate=backoff_rate,
             should_retry=should_retry,
             preemptible=preemptible,
+            timeout_seconds=timeout_seconds,
         )
 
     @classmethod

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -65,6 +65,7 @@ class DBOSErrorCode(Enum):
     AwaitedWorkflowCancelled = 13
     AwaitedWorkflowMaxRecoveryAttemptsExceeded = 14
     PatchNondeterminism = 15
+    StepTimeout = 16
     ConflictingRegistrationError = 25
 
 
@@ -169,6 +170,22 @@ class DBOSMaxStepRetriesExceeded(DBOSException):
     def __reduce__(self) -> Any:
         # Tell pickle how to reconstruct this object
         return (self.__class__, (self.step_name, self.max_retries, self.errors))
+
+
+class DBOSStepTimeoutError(DBOSException):
+    """Exception raised when a step was cancelled because it exceeded its timeout."""
+
+    def __init__(self, step_name: str, timeout_seconds: float) -> None:
+        self.step_name = step_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"Step {step_name} was cancelled after exceeding its timeout of {timeout_seconds} seconds",
+            dbos_error_code=DBOSErrorCode.StepTimeout.value,
+        )
+
+    def __reduce__(self) -> Any:
+        # Tell pickle how to reconstruct this object
+        return (self.__class__, (self.step_name, self.timeout_seconds))
 
 
 class DBOSConflictingRegistrationError(DBOSException):

--- a/tests/test_async_workflow_management.py
+++ b/tests/test_async_workflow_management.py
@@ -429,9 +429,9 @@ def test_preemptible_rejected_for_sync_step(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_preemptible_step_no_leak_on_outer_cancel(dbos: DBOS) -> None:
-    """If the outer coroutine running _run_preemptible_step is cancelled,
-    the inner step task is also cancelled (no leak)."""
-    from dbos._core import _run_preemptible_step
+    """If the outer coroutine running the step supervisor is cancelled, the
+    inner step task is also cancelled (no leak)."""
+    from dbos._core import _supervise_step
 
     step_started = asyncio.Event()
     step_cancelled = asyncio.Event()
@@ -449,7 +449,16 @@ async def test_preemptible_step_no_leak_on_outer_cancel(dbos: DBOS) -> None:
     # task being cancelled.
     fake_wfid = "test-no-leak-" + str(uuid.uuid4())
     outer = asyncio.create_task(
-        _run_preemptible_step(dbos, fake_wfid, long_step, (), {})
+        _supervise_step(
+            dbos,
+            fake_wfid,
+            long_step,
+            (),
+            {},
+            step_name="long_step",
+            preemptible=True,
+            timeout_seconds=None,
+        )
     )
     await step_started.wait()
     outer.cancel()

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1249,8 +1249,11 @@ async def test_step_timeout_cancels_step(dbos: DBOS) -> None:
     async def timeout_wf() -> str:
         return await slow_step()
 
+    start = time.time()
     with pytest.raises(DBOSStepTimeoutError) as exc_info:
         await timeout_wf()
+    # The 60s body was cut short at ~0.2s, not run to completion.
+    assert time.time() - start < 2.0
     assert exc_info.value.timeout_seconds == 0.2
     assert "slow_step" in exc_info.value.step_name
     # The step observed the cancellation, and its cleanup ran before the
@@ -1341,9 +1344,10 @@ async def test_step_timeout_per_attempt_with_retries(dbos: DBOS) -> None:
     async def retry_wf() -> None:
         await slow_step()
 
-    with pytest.raises(DBOSMaxStepRetriesExceeded):
+    with pytest.raises(DBOSMaxStepRetriesExceeded) as exc_info:
         await retry_wf()
     assert invocations == max_attempts
+    assert all(isinstance(e, DBOSStepTimeoutError) for e in exc_info.value.errors)
 
 
 @pytest.mark.asyncio
@@ -1425,10 +1429,24 @@ def test_step_timeout_rejected_for_sync_step(dbos: DBOS) -> None:
         def sync_step() -> None:
             pass
 
-    with pytest.raises(DBOSException, match="must be positive"):
+    with pytest.raises(DBOSException, match="positive and finite"):
 
         @DBOS.step(timeout_seconds=0)
         async def zero_timeout_step() -> None:
+            pass
+
+    # NaN passes every comparison, so `<= 0` would let it through and silently
+    # disable the timeout; inf disables it outright.
+    with pytest.raises(DBOSException, match="positive and finite"):
+
+        @DBOS.step(timeout_seconds=float("nan"))
+        async def nan_timeout_step() -> None:
+            pass
+
+    with pytest.raises(DBOSException, match="positive and finite"):
+
+        @DBOS.step(timeout_seconds=float("inf"))
+        async def inf_timeout_step() -> None:
             pass
 
 
@@ -1504,7 +1522,7 @@ async def test_step_timeout_step_suppressing_cancellation(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_step_timeout_with_preemptible(dbos: DBOS) -> None:
     """Timeout and preemption compose: the timeout fires and tears down the
-    preemption poller along with the step."""
+    preemption poller along with the step, leaving no lingering task."""
 
     @DBOS.step(preemptible=True, timeout_seconds=0.2)
     async def slow_step() -> None:
@@ -1516,6 +1534,15 @@ async def test_step_timeout_with_preemptible(dbos: DBOS) -> None:
 
     with pytest.raises(DBOSStepTimeoutError):
         await preemptible_timeout_wf()
+
+    # The poller re-reads the workflow status every second forever; if the
+    # timeout had not torn it down it would still be pending here.
+    lingering = [
+        t
+        for t in asyncio.all_tasks()
+        if "poller" in getattr(t.get_coro(), "__qualname__", "")
+    ]
+    assert not lingering, f"preemption poller leaked: {lingering}"
 
 
 @pytest.mark.asyncio
@@ -1552,3 +1579,121 @@ async def test_workflow_cancel_beats_step_timeout(dbos: DBOS) -> None:
     resumed = await DBOS.resume_workflow_async(wfid)
     assert (await resumed.get_result()) == "done"
     assert invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_bounds_actual_duration(dbos: DBOS) -> None:
+    """timeout_seconds is used as the real deadline, not just as a label on the
+    error. The same 0.5s body times out under a 0.2s timeout and completes
+    under a 20s one, so scaling the timeout in either direction fails a half."""
+    invocations = 0
+
+    async def half_second_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(0.5)
+        return "done"
+
+    @DBOS.workflow()
+    async def short_timeout_wf() -> str:
+        return await DBOS.run_step_async({"timeout_seconds": 0.2}, half_second_step)
+
+    @DBOS.workflow()
+    async def long_timeout_wf() -> str:
+        return await DBOS.run_step_async({"timeout_seconds": 20}, half_second_step)
+
+    start = time.time()
+    with pytest.raises(DBOSStepTimeoutError):
+        await short_timeout_wf()
+    assert time.time() - start < 2.0
+
+    assert await long_timeout_wf() == "done"
+    assert invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_fresh_budget_per_attempt(dbos: DBOS) -> None:
+    """Each retry attempt gets its own timeout budget and the retry sleep is not
+    charged against it. Attempt 1 is cancelled at 0.2s; after a 0.3s retry sleep
+    attempt 2 succeeds. One deadline shared across attempts would leave attempt
+    2 with no budget and exhaust all retries instead."""
+    invocations = 0
+
+    @DBOS.step(
+        timeout_seconds=0.2,
+        retries_allowed=True,
+        max_attempts=3,
+        interval_seconds=0.3,
+    )
+    async def flaky_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        if invocations == 1:
+            await asyncio.sleep(60)
+            return "should-not-reach"
+        await asyncio.sleep(0)
+        return "done"
+
+    @DBOS.workflow()
+    async def fresh_budget_wf() -> str:
+        return await flaky_step()
+
+    assert await fresh_budget_wf() == "done"
+    assert invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_normal_exception_propagates(dbos: DBOS) -> None:
+    """A step that fails for an ordinary reason under a timeout propagates that
+    exception and checkpoints it as itself, not as a timeout."""
+
+    @DBOS.step(timeout_seconds=30)
+    async def boom_step() -> None:
+        raise ValueError("boom")
+
+    @DBOS.workflow()
+    async def boom_wf() -> None:
+        await boom_step()
+
+    wfid = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="boom"):
+        with SetWorkflowID(wfid):
+            await boom_wf()
+
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    entries = [s for s in steps if "boom_step" in s["function_name"]]
+    assert len(entries) == 1
+    assert entries[0]["output"] is None
+    assert isinstance(entries[0]["error"], ValueError)
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_no_leak_on_outer_cancel(dbos: DBOS) -> None:
+    """If the coroutine running _run_step_with_timeout is itself cancelled, the
+    inner step task is cancelled too. asyncio.wait — unlike wait_for — does not
+    cancel what it awaits, so the finally block is the only thing standing
+    between an outer cancellation and a step that keeps running."""
+    from dbos._core import _run_step_with_timeout
+
+    step_started = asyncio.Event()
+    step_cancelled = asyncio.Event()
+
+    async def long_step() -> None:
+        step_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            step_cancelled.set()
+            raise
+
+    # A timeout long enough that it can never be what cancels the step.
+    outer = asyncio.create_task(
+        _run_step_with_timeout("long_step", 30, long_step, (), {})
+    )
+    await step_started.wait()
+    outer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    # If the step task leaked, this would time out.
+    await asyncio.wait_for(step_cancelled.wait(), timeout=5.0)

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1613,10 +1613,9 @@ async def test_step_timeout_bounds_actual_duration(dbos: DBOS) -> None:
 
 @pytest.mark.asyncio
 async def test_step_timeout_fresh_budget_per_attempt(dbos: DBOS) -> None:
-    """Each retry attempt gets its own timeout budget and the retry sleep is not
-    charged against it. Attempt 1 is cancelled at 0.2s; after a 0.3s retry sleep
-    attempt 2 succeeds. One deadline shared across attempts would leave attempt
-    2 with no budget and exhaust all retries instead."""
+    """Each attempt gets its own budget and retry sleeps aren't charged against
+    it: attempt 1 is cancelled at 0.2s, then attempt 2 succeeds after a 0.3s
+    retry sleep. A shared deadline would leave attempt 2 nothing and exhaust."""
     invocations = 0
 
     @DBOS.step(
@@ -1670,9 +1669,8 @@ async def test_step_timeout_normal_exception_propagates(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_step_timeout_no_leak_on_outer_cancel(dbos: DBOS) -> None:
     """If the coroutine running _run_step_with_timeout is itself cancelled, the
-    inner step task is cancelled too. asyncio.wait — unlike wait_for — does not
-    cancel what it awaits, so the finally block is the only thing standing
-    between an outer cancellation and a step that keeps running."""
+    inner step task is cancelled too. asyncio.wait — unlike wait_for — doesn't
+    cancel what it awaits, so the finally block is all that prevents a leak."""
     from dbos._core import _run_step_with_timeout
 
     step_started = asyncio.Event()

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1226,19 +1226,20 @@ def test_record_get_result_increments_function_id_once_on_db_retry(
 
 
 @pytest.mark.asyncio
-async def test_step_timeout_cancels_step(dbos: DBOS) -> None:
-    """An async step that exceeds timeout_seconds is cancelled: the body
-    observes CancelledError, its cleanup runs, and the step raises
-    DBOSStepTimeoutError."""
+async def test_step_timeout_bounds_step_duration(dbos: DBOS) -> None:
+    """The same body is cancelled under a short timeout and completes under a
+    long one, so the value is the real deadline and not just a label on the
+    error. The cancelled step observes CancelledError and runs its cleanup."""
+    invocations = 0
     step_cancelled = False
     cleanup_ran = False
 
-    @DBOS.step(timeout_seconds=0.2)
-    async def slow_step() -> str:
-        nonlocal step_cancelled, cleanup_ran
+    async def half_second_step() -> str:
+        nonlocal invocations, step_cancelled, cleanup_ran
+        invocations += 1
         try:
-            await asyncio.sleep(60)
-            return "should-not-reach"
+            await asyncio.sleep(0.5)
+            return "done"
         except asyncio.CancelledError:
             step_cancelled = True
             raise
@@ -1246,46 +1247,30 @@ async def test_step_timeout_cancels_step(dbos: DBOS) -> None:
             cleanup_ran = True
 
     @DBOS.workflow()
-    async def timeout_wf() -> str:
-        return await slow_step()
+    async def short_timeout_wf() -> str:
+        return await DBOS.run_step_async({"timeout_seconds": 0.2}, half_second_step)
+
+    @DBOS.workflow()
+    async def long_timeout_wf() -> str:
+        return await DBOS.run_step_async({"timeout_seconds": 20}, half_second_step)
 
     start = time.time()
     with pytest.raises(DBOSStepTimeoutError) as exc_info:
-        await timeout_wf()
-    # The 60s body was cut short at ~0.2s, not run to completion.
+        await short_timeout_wf()
     assert time.time() - start < 2.0
     assert exc_info.value.timeout_seconds == 0.2
-    assert "slow_step" in exc_info.value.step_name
-    # The step observed the cancellation, and its cleanup ran before the
-    # timeout surfaced.
+    assert "half_second_step" in exc_info.value.step_name
     assert step_cancelled
     assert cleanup_ran
 
-
-@pytest.mark.asyncio
-async def test_step_timeout_not_triggered(dbos: DBOS) -> None:
-    """A step that finishes within its timeout is unaffected."""
-    invocations = 0
-
-    @DBOS.step(timeout_seconds=30)
-    async def fast_step() -> str:
-        nonlocal invocations
-        invocations += 1
-        await asyncio.sleep(0)
-        return "done"
-
-    @DBOS.workflow()
-    async def fast_wf() -> str:
-        return await fast_step()
-
-    assert await fast_wf() == "done"
-    assert invocations == 1
+    assert await long_timeout_wf() == "done"
+    assert invocations == 2
 
 
 @pytest.mark.asyncio
 async def test_step_timeout_is_checkpointed_and_replayed(dbos: DBOS) -> None:
-    """A timeout is a durable step failure: it is checkpointed as the step's
-    error and replayed from the checkpoint without re-running the body."""
+    """A timeout is a durable step failure: it is recorded as the step's error
+    and replayed from that record without re-running the body."""
     invocations = 0
 
     @DBOS.step(timeout_seconds=0.2)
@@ -1315,18 +1300,88 @@ async def test_step_timeout_is_checkpointed_and_replayed(dbos: DBOS) -> None:
     assert isinstance(recorded_error, DBOSStepTimeoutError)
     assert recorded_error.timeout_seconds == 0.2
 
-    # Forking past the step replays its checkpointed timeout rather than
-    # re-invoking the body.
+    # Forking past the step replays the recorded timeout instead of re-running.
     forked = await DBOS.fork_workflow_async(wfid, entries[0]["function_id"] + 1)
     assert (await forked.get_result()) == "caught"
     assert invocations == 1
 
 
 @pytest.mark.asyncio
-async def test_step_timeout_per_attempt_with_retries(dbos: DBOS) -> None:
-    """Each retry attempt gets a fresh timeout, and a timeout is retried like
-    any other step failure."""
-    invocations = 0
+async def test_step_timeout_preserves_step_outcomes(dbos: DBOS) -> None:
+    """A timeout doesn't distort ordinary outcomes: a step that fails for its
+    own reason is recorded as that failure, and one that swallows the
+    cancellation still fails with a timeout rather than returning a value."""
+
+    @DBOS.step(timeout_seconds=30)
+    async def boom_step() -> None:
+        raise ValueError("boom")
+
+    @DBOS.workflow()
+    async def boom_wf() -> None:
+        await boom_step()
+
+    boom_wfid = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="boom"):
+        with SetWorkflowID(boom_wfid):
+            await boom_wf()
+
+    steps = await DBOS.list_workflow_steps_async(boom_wfid)
+    entries = [s for s in steps if "boom_step" in s["function_name"]]
+    assert len(entries) == 1
+    assert entries[0]["output"] is None
+    assert isinstance(entries[0]["error"], ValueError)
+
+    @DBOS.step(timeout_seconds=0.2)
+    async def stubborn_step() -> str:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            pass
+        return "suppressed"
+
+    @DBOS.workflow()
+    async def stubborn_wf() -> str:
+        return await stubborn_step()
+
+    stubborn_wfid = str(uuid.uuid4())
+    with pytest.raises(DBOSStepTimeoutError):
+        with SetWorkflowID(stubborn_wfid):
+            await stubborn_wf()
+
+    steps = await DBOS.list_workflow_steps_async(stubborn_wfid)
+    entries = [s for s in steps if "stubborn_step" in s["function_name"]]
+    assert len(entries) == 1
+    assert entries[0]["output"] is None
+    assert isinstance(entries[0]["error"], DBOSStepTimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_with_retries(dbos: DBOS) -> None:
+    """A timeout is a retryable failure and each attempt gets its own budget:
+    attempt 1 is cancelled at 0.2s and attempt 2 succeeds after a 0.3s retry
+    sleep. Exhausting the attempts raises, and should_retry can opt out."""
+    fresh_invocations = 0
+
+    @DBOS.step(
+        timeout_seconds=0.2, retries_allowed=True, max_attempts=3, interval_seconds=0.3
+    )
+    async def flaky_step() -> str:
+        nonlocal fresh_invocations
+        fresh_invocations += 1
+        if fresh_invocations == 1:
+            await asyncio.sleep(60)
+            return "should-not-reach"
+        await asyncio.sleep(0)
+        return "done"
+
+    @DBOS.workflow()
+    async def fresh_budget_wf() -> str:
+        return await flaky_step()
+
+    assert await fresh_budget_wf() == "done"
+    assert fresh_invocations == 2
+
+    exhausted_invocations = 0
     max_attempts = 3
 
     @DBOS.step(
@@ -1335,25 +1390,21 @@ async def test_step_timeout_per_attempt_with_retries(dbos: DBOS) -> None:
         max_attempts=max_attempts,
         interval_seconds=0,
     )
-    async def slow_step() -> None:
-        nonlocal invocations
-        invocations += 1
+    async def always_slow_step() -> None:
+        nonlocal exhausted_invocations
+        exhausted_invocations += 1
         await asyncio.sleep(60)
 
     @DBOS.workflow()
-    async def retry_wf() -> None:
-        await slow_step()
+    async def exhausted_wf() -> None:
+        await always_slow_step()
 
     with pytest.raises(DBOSMaxStepRetriesExceeded) as exc_info:
-        await retry_wf()
-    assert invocations == max_attempts
+        await exhausted_wf()
+    assert exhausted_invocations == max_attempts
     assert all(isinstance(e, DBOSStepTimeoutError) for e in exc_info.value.errors)
 
-
-@pytest.mark.asyncio
-async def test_step_timeout_should_retry_opt_out(dbos: DBOS) -> None:
-    """should_retry can opt a timeout out of the retry loop."""
-    invocations = 0
+    opted_out_invocations = 0
 
     @DBOS.step(
         timeout_seconds=0.2,
@@ -1362,45 +1413,23 @@ async def test_step_timeout_should_retry_opt_out(dbos: DBOS) -> None:
         interval_seconds=0,
         should_retry=lambda e: not isinstance(e, DBOSStepTimeoutError),
     )
-    async def slow_step() -> None:
-        nonlocal invocations
-        invocations += 1
+    async def no_retry_step() -> None:
+        nonlocal opted_out_invocations
+        opted_out_invocations += 1
         await asyncio.sleep(60)
 
     @DBOS.workflow()
     async def no_retry_wf() -> None:
-        await slow_step()
+        await no_retry_step()
 
     with pytest.raises(DBOSStepTimeoutError):
         await no_retry_wf()
-    assert invocations == 1
+    assert opted_out_invocations == 1
 
 
-@pytest.mark.asyncio
-async def test_step_timeout_via_run_step_async_options(dbos: DBOS) -> None:
-    """timeout_seconds passed through StepOptions to run_step_async times out."""
-    step_cancelled = False
-
-    async def slow_step() -> None:
-        nonlocal step_cancelled
-        try:
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
-            step_cancelled = True
-            raise
-
-    @DBOS.workflow()
-    async def run_step_timeout_wf() -> None:
-        await DBOS.run_step_async({"timeout_seconds": 0.2}, slow_step)
-
-    with pytest.raises(DBOSStepTimeoutError):
-        await run_step_timeout_wf()
-    assert step_cancelled
-
-
-def test_step_timeout_via_run_step_from_sync_workflow(dbos: DBOS) -> None:
-    """An async step with a timeout, invoked from a sync workflow, times out on
-    the background event loop."""
+def test_step_timeout_via_run_step(dbos: DBOS) -> None:
+    """An async step invoked through run_step from a sync workflow, where it
+    runs on the background event loop, still times out."""
     step_cancelled = False
 
     async def slow_step() -> None:
@@ -1420,60 +1449,10 @@ def test_step_timeout_via_run_step_from_sync_workflow(dbos: DBOS) -> None:
     assert step_cancelled
 
 
-def test_step_timeout_rejected_for_sync_step(dbos: DBOS) -> None:
-    """timeout_seconds on a sync step, or a non-positive timeout, is rejected
-    at decoration time."""
-    with pytest.raises(DBOSException, match="only supported for async steps"):
-
-        @DBOS.step(timeout_seconds=1)
-        def sync_step() -> None:
-            pass
-
-    with pytest.raises(DBOSException, match="positive and finite"):
-
-        @DBOS.step(timeout_seconds=0)
-        async def zero_timeout_step() -> None:
-            pass
-
-    # NaN passes every comparison, so `<= 0` would let it through and silently
-    # disable the timeout; inf disables it outright.
-    with pytest.raises(DBOSException, match="positive and finite"):
-
-        @DBOS.step(timeout_seconds=float("nan"))
-        async def nan_timeout_step() -> None:
-            pass
-
-    with pytest.raises(DBOSException, match="positive and finite"):
-
-        @DBOS.step(timeout_seconds=float("inf"))
-        async def inf_timeout_step() -> None:
-            pass
-
-
-def test_step_timeout_rejected_for_sync_run_step(dbos: DBOS) -> None:
-    """timeout_seconds passed via StepOptions for a sync function is rejected
-    at invocation time."""
-
-    def sync_step() -> None:
-        pass
-
-    async def async_step() -> None:
-        pass
-
-    @DBOS.workflow()
-    def run_step_wf() -> None:
-        with pytest.raises(DBOSException, match="only supported for async steps"):
-            DBOS.run_step({"timeout_seconds": 1}, sync_step)
-        with pytest.raises(DBOSException, match="must be positive"):
-            DBOS.run_step({"timeout_seconds": -1}, async_step)
-
-    run_step_wf()
-
-
 @pytest.mark.asyncio
 async def test_step_timeout_inert_outside_workflow(dbos: DBOS) -> None:
-    """Outside a workflow a step is a normal function call, so its timeout
-    does not apply."""
+    """Outside a workflow a step is a normal function call, so the timeout does
+    not apply."""
     invocations = 0
 
     @DBOS.step(timeout_seconds=0.1)
@@ -1490,70 +1469,60 @@ async def test_step_timeout_inert_outside_workflow(dbos: DBOS) -> None:
     assert invocations == 2
 
 
-@pytest.mark.asyncio
-async def test_step_timeout_step_suppressing_cancellation(dbos: DBOS) -> None:
-    """A step that swallows the cancellation still fails with a timeout, and
-    its (ignored) return value is never checkpointed as the step's output."""
+def test_step_timeout_rejects_invalid_config(dbos: DBOS) -> None:
+    """A timeout on a sync step, or one that isn't a positive finite number, is
+    rejected — at decoration time, and at invocation time via StepOptions."""
+    with pytest.raises(DBOSException, match="only supported for async steps"):
 
-    @DBOS.step(timeout_seconds=0.2)
-    async def stubborn_step() -> str:
-        try:
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
+        @DBOS.step(timeout_seconds=1)
+        def sync_step() -> None:
             pass
-        return "suppressed"
+
+    for bad in (0, float("nan"), float("inf")):
+        with pytest.raises(DBOSException, match="positive and finite"):
+
+            @DBOS.step(timeout_seconds=bad)
+            async def bad_timeout_step() -> None:
+                pass
+
+    def plain_sync_step() -> None:
+        pass
+
+    async def plain_async_step() -> None:
+        pass
 
     @DBOS.workflow()
-    async def stubborn_wf() -> str:
-        return await stubborn_step()
+    def run_step_wf() -> None:
+        with pytest.raises(DBOSException, match="only supported for async steps"):
+            DBOS.run_step({"timeout_seconds": 1}, plain_sync_step)
+        with pytest.raises(DBOSException, match="positive and finite"):
+            DBOS.run_step({"timeout_seconds": -1}, plain_async_step)
 
-    wfid = str(uuid.uuid4())
-    with pytest.raises(DBOSStepTimeoutError):
-        with SetWorkflowID(wfid):
-            await stubborn_wf()
-
-    steps = await DBOS.list_workflow_steps_async(wfid)
-    entries = [s for s in steps if "stubborn_step" in s["function_name"]]
-    assert len(entries) == 1
-    assert entries[0]["output"] is None
-    assert isinstance(entries[0]["error"], DBOSStepTimeoutError)
+    run_step_wf()
 
 
 @pytest.mark.asyncio
-async def test_step_timeout_with_preemptible(dbos: DBOS) -> None:
-    """Timeout and preemption compose: the timeout fires and tears down the
-    preemption poller along with the step, leaving no lingering task."""
+async def test_step_timeout_with_workflow_cancellation(dbos: DBOS) -> None:
+    """Timeout and preemption compose. The timeout fires when it is reached
+    first; a cancellation reached first preempts the step instead, recording no
+    outcome so the step re-runs on resume."""
 
     @DBOS.step(preemptible=True, timeout_seconds=0.2)
     async def slow_step() -> None:
         await asyncio.sleep(60)
 
     @DBOS.workflow()
-    async def preemptible_timeout_wf() -> None:
+    async def timeout_first_wf() -> None:
         await slow_step()
 
     with pytest.raises(DBOSStepTimeoutError):
-        await preemptible_timeout_wf()
+        await timeout_first_wf()
 
-    # The poller re-reads the workflow status every second forever; if the
-    # timeout had not torn it down it would still be pending here.
-    lingering = [
-        t
-        for t in asyncio.all_tasks()
-        if "poller" in getattr(t.get_coro(), "__qualname__", "")
-    ]
-    assert not lingering, f"preemption poller leaked: {lingering}"
-
-
-@pytest.mark.asyncio
-async def test_workflow_cancel_beats_step_timeout(dbos: DBOS) -> None:
-    """A workflow cancellation landing before the timeout still preempts the
-    step, leaving no checkpoint so the step re-runs on resume."""
     invocations = 0
     step_started = asyncio.Event()
 
     @DBOS.step(preemptible=True, timeout_seconds=30)
-    async def slow_step() -> str:
+    async def cancellable_step() -> str:
         nonlocal invocations
         invocations += 1
         if invocations == 1:
@@ -1563,135 +1532,25 @@ async def test_workflow_cancel_beats_step_timeout(dbos: DBOS) -> None:
         return "done"
 
     @DBOS.workflow()
-    async def cancel_wf() -> str:
-        return await slow_step()
+    async def cancel_first_wf() -> str:
+        return await cancellable_step()
 
     wfid = str(uuid.uuid4())
     with SetWorkflowID(wfid):
-        handle = await DBOS.start_workflow_async(cancel_wf)
+        handle = await DBOS.start_workflow_async(cancel_first_wf)
 
     await step_started.wait()
     await DBOS.cancel_workflow_async(wfid)
     with pytest.raises(DBOSAwaitedWorkflowCancelledError):
         await handle.get_result()
 
-    # No timeout checkpoint was recorded, so the step re-runs on resume.
     resumed = await DBOS.resume_workflow_async(wfid)
     assert (await resumed.get_result()) == "done"
     assert invocations == 2
 
-
-@pytest.mark.asyncio
-async def test_step_timeout_bounds_actual_duration(dbos: DBOS) -> None:
-    """timeout_seconds is used as the real deadline, not just as a label on the
-    error. The same 0.5s body times out under a 0.2s timeout and completes
-    under a 20s one, so scaling the timeout in either direction fails a half."""
-    invocations = 0
-
-    async def half_second_step() -> str:
-        nonlocal invocations
-        invocations += 1
-        await asyncio.sleep(0.5)
-        return "done"
-
-    @DBOS.workflow()
-    async def short_timeout_wf() -> str:
-        return await DBOS.run_step_async({"timeout_seconds": 0.2}, half_second_step)
-
-    @DBOS.workflow()
-    async def long_timeout_wf() -> str:
-        return await DBOS.run_step_async({"timeout_seconds": 20}, half_second_step)
-
-    start = time.time()
-    with pytest.raises(DBOSStepTimeoutError):
-        await short_timeout_wf()
-    assert time.time() - start < 2.0
-
-    assert await long_timeout_wf() == "done"
-    assert invocations == 2
-
-
-@pytest.mark.asyncio
-async def test_step_timeout_fresh_budget_per_attempt(dbos: DBOS) -> None:
-    """Each attempt gets its own budget and retry sleeps aren't charged against
-    it: attempt 1 is cancelled at 0.2s, then attempt 2 succeeds after a 0.3s
-    retry sleep. A shared deadline would leave attempt 2 nothing and exhaust."""
-    invocations = 0
-
-    @DBOS.step(
-        timeout_seconds=0.2,
-        retries_allowed=True,
-        max_attempts=3,
-        interval_seconds=0.3,
-    )
-    async def flaky_step() -> str:
-        nonlocal invocations
-        invocations += 1
-        if invocations == 1:
-            await asyncio.sleep(60)
-            return "should-not-reach"
-        await asyncio.sleep(0)
-        return "done"
-
-    @DBOS.workflow()
-    async def fresh_budget_wf() -> str:
-        return await flaky_step()
-
-    assert await fresh_budget_wf() == "done"
-    assert invocations == 2
-
-
-@pytest.mark.asyncio
-async def test_step_timeout_normal_exception_propagates(dbos: DBOS) -> None:
-    """A step that fails for an ordinary reason under a timeout propagates that
-    exception and checkpoints it as itself, not as a timeout."""
-
-    @DBOS.step(timeout_seconds=30)
-    async def boom_step() -> None:
-        raise ValueError("boom")
-
-    @DBOS.workflow()
-    async def boom_wf() -> None:
-        await boom_step()
-
-    wfid = str(uuid.uuid4())
-    with pytest.raises(ValueError, match="boom"):
-        with SetWorkflowID(wfid):
-            await boom_wf()
-
+    # The preempted attempt left no record, so only the successful run is kept.
     steps = await DBOS.list_workflow_steps_async(wfid)
-    entries = [s for s in steps if "boom_step" in s["function_name"]]
+    entries = [s for s in steps if "cancellable_step" in s["function_name"]]
     assert len(entries) == 1
-    assert entries[0]["output"] is None
-    assert isinstance(entries[0]["error"], ValueError)
-
-
-@pytest.mark.asyncio
-async def test_step_timeout_no_leak_on_outer_cancel(dbos: DBOS) -> None:
-    """If the coroutine running _run_step_with_timeout is itself cancelled, the
-    inner step task is cancelled too. asyncio.wait — unlike wait_for — doesn't
-    cancel what it awaits, so the finally block is all that prevents a leak."""
-    from dbos._core import _run_step_with_timeout
-
-    step_started = asyncio.Event()
-    step_cancelled = asyncio.Event()
-
-    async def long_step() -> None:
-        step_started.set()
-        try:
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
-            step_cancelled.set()
-            raise
-
-    # A timeout long enough that it can never be what cancels the step.
-    outer = asyncio.create_task(
-        _run_step_with_timeout("long_step", 30, long_step, (), {})
-    )
-    await step_started.wait()
-    outer.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await outer
-
-    # If the step task leaked, this would time out.
-    await asyncio.wait_for(step_cancelled.wait(), timeout=5.0)
+    assert entries[0]["output"] == "done"
+    assert entries[0]["error"] is None

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -21,6 +21,7 @@ from dbos._error import (
     DBOSMaxStepRetriesExceeded,
     DBOSNotAuthorizedError,
     DBOSQueueDeduplicatedError,
+    DBOSStepTimeoutError,
     DBOSUnexpectedStepError,
     DBOSWorkflowConflictIDError,
 )
@@ -1222,3 +1223,332 @@ def test_record_get_result_increments_function_id_once_on_db_retry(
             )
         ).fetchall()
     assert [r[0] for r in rows] == [1]
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_cancels_step(dbos: DBOS) -> None:
+    """An async step that exceeds timeout_seconds is cancelled: the body
+    observes CancelledError, its cleanup runs, and the step raises
+    DBOSStepTimeoutError."""
+    step_cancelled = False
+    cleanup_ran = False
+
+    @DBOS.step(timeout_seconds=0.2)
+    async def slow_step() -> str:
+        nonlocal step_cancelled, cleanup_ran
+        try:
+            await asyncio.sleep(60)
+            return "should-not-reach"
+        except asyncio.CancelledError:
+            step_cancelled = True
+            raise
+        finally:
+            cleanup_ran = True
+
+    @DBOS.workflow()
+    async def timeout_wf() -> str:
+        return await slow_step()
+
+    with pytest.raises(DBOSStepTimeoutError) as exc_info:
+        await timeout_wf()
+    assert exc_info.value.timeout_seconds == 0.2
+    assert "slow_step" in exc_info.value.step_name
+    # The step observed the cancellation, and its cleanup ran before the
+    # timeout surfaced.
+    assert step_cancelled
+    assert cleanup_ran
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_not_triggered(dbos: DBOS) -> None:
+    """A step that finishes within its timeout is unaffected."""
+    invocations = 0
+
+    @DBOS.step(timeout_seconds=30)
+    async def fast_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(0)
+        return "done"
+
+    @DBOS.workflow()
+    async def fast_wf() -> str:
+        return await fast_step()
+
+    assert await fast_wf() == "done"
+    assert invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_is_checkpointed_and_replayed(dbos: DBOS) -> None:
+    """A timeout is a durable step failure: it is checkpointed as the step's
+    error and replayed from the checkpoint without re-running the body."""
+    invocations = 0
+
+    @DBOS.step(timeout_seconds=0.2)
+    async def slow_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(60)
+        return "should-not-reach"
+
+    @DBOS.workflow()
+    async def catching_wf() -> str:
+        try:
+            return await slow_step()
+        except DBOSStepTimeoutError:
+            return "caught"
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        assert await catching_wf() == "caught"
+    assert invocations == 1
+
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    entries = [s for s in steps if "slow_step" in s["function_name"]]
+    assert len(entries) == 1
+    assert entries[0]["output"] is None
+    recorded_error = entries[0]["error"]
+    assert isinstance(recorded_error, DBOSStepTimeoutError)
+    assert recorded_error.timeout_seconds == 0.2
+
+    # Forking past the step replays its checkpointed timeout rather than
+    # re-invoking the body.
+    forked = await DBOS.fork_workflow_async(wfid, entries[0]["function_id"] + 1)
+    assert (await forked.get_result()) == "caught"
+    assert invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_per_attempt_with_retries(dbos: DBOS) -> None:
+    """Each retry attempt gets a fresh timeout, and a timeout is retried like
+    any other step failure."""
+    invocations = 0
+    max_attempts = 3
+
+    @DBOS.step(
+        timeout_seconds=0.2,
+        retries_allowed=True,
+        max_attempts=max_attempts,
+        interval_seconds=0,
+    )
+    async def slow_step() -> None:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(60)
+
+    @DBOS.workflow()
+    async def retry_wf() -> None:
+        await slow_step()
+
+    with pytest.raises(DBOSMaxStepRetriesExceeded):
+        await retry_wf()
+    assert invocations == max_attempts
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_should_retry_opt_out(dbos: DBOS) -> None:
+    """should_retry can opt a timeout out of the retry loop."""
+    invocations = 0
+
+    @DBOS.step(
+        timeout_seconds=0.2,
+        retries_allowed=True,
+        max_attempts=3,
+        interval_seconds=0,
+        should_retry=lambda e: not isinstance(e, DBOSStepTimeoutError),
+    )
+    async def slow_step() -> None:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(60)
+
+    @DBOS.workflow()
+    async def no_retry_wf() -> None:
+        await slow_step()
+
+    with pytest.raises(DBOSStepTimeoutError):
+        await no_retry_wf()
+    assert invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_via_run_step_async_options(dbos: DBOS) -> None:
+    """timeout_seconds passed through StepOptions to run_step_async times out."""
+    step_cancelled = False
+
+    async def slow_step() -> None:
+        nonlocal step_cancelled
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            step_cancelled = True
+            raise
+
+    @DBOS.workflow()
+    async def run_step_timeout_wf() -> None:
+        await DBOS.run_step_async({"timeout_seconds": 0.2}, slow_step)
+
+    with pytest.raises(DBOSStepTimeoutError):
+        await run_step_timeout_wf()
+    assert step_cancelled
+
+
+def test_step_timeout_via_run_step_from_sync_workflow(dbos: DBOS) -> None:
+    """An async step with a timeout, invoked from a sync workflow, times out on
+    the background event loop."""
+    step_cancelled = False
+
+    async def slow_step() -> None:
+        nonlocal step_cancelled
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            step_cancelled = True
+            raise
+
+    @DBOS.workflow()
+    def sync_timeout_wf() -> None:
+        DBOS.run_step({"timeout_seconds": 0.2}, slow_step)
+
+    with pytest.raises(DBOSStepTimeoutError):
+        sync_timeout_wf()
+    assert step_cancelled
+
+
+def test_step_timeout_rejected_for_sync_step(dbos: DBOS) -> None:
+    """timeout_seconds on a sync step, or a non-positive timeout, is rejected
+    at decoration time."""
+    with pytest.raises(DBOSException, match="only supported for async steps"):
+
+        @DBOS.step(timeout_seconds=1)
+        def sync_step() -> None:
+            pass
+
+    with pytest.raises(DBOSException, match="must be positive"):
+
+        @DBOS.step(timeout_seconds=0)
+        async def zero_timeout_step() -> None:
+            pass
+
+
+def test_step_timeout_rejected_for_sync_run_step(dbos: DBOS) -> None:
+    """timeout_seconds passed via StepOptions for a sync function is rejected
+    at invocation time."""
+
+    def sync_step() -> None:
+        pass
+
+    async def async_step() -> None:
+        pass
+
+    @DBOS.workflow()
+    def run_step_wf() -> None:
+        with pytest.raises(DBOSException, match="only supported for async steps"):
+            DBOS.run_step({"timeout_seconds": 1}, sync_step)
+        with pytest.raises(DBOSException, match="must be positive"):
+            DBOS.run_step({"timeout_seconds": -1}, async_step)
+
+    run_step_wf()
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_inert_outside_workflow(dbos: DBOS) -> None:
+    """Outside a workflow a step is a normal function call, so its timeout
+    does not apply."""
+    invocations = 0
+
+    @DBOS.step(timeout_seconds=0.1)
+    async def slow_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        await asyncio.sleep(0.5)
+        return "done"
+
+    assert await slow_step() == "done"
+    assert invocations == 1
+
+    assert await DBOS.run_step_async({"timeout_seconds": 0.1}, slow_step) == "done"
+    assert invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_step_suppressing_cancellation(dbos: DBOS) -> None:
+    """A step that swallows the cancellation still fails with a timeout, and
+    its (ignored) return value is never checkpointed as the step's output."""
+
+    @DBOS.step(timeout_seconds=0.2)
+    async def stubborn_step() -> str:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            pass
+        return "suppressed"
+
+    @DBOS.workflow()
+    async def stubborn_wf() -> str:
+        return await stubborn_step()
+
+    wfid = str(uuid.uuid4())
+    with pytest.raises(DBOSStepTimeoutError):
+        with SetWorkflowID(wfid):
+            await stubborn_wf()
+
+    steps = await DBOS.list_workflow_steps_async(wfid)
+    entries = [s for s in steps if "stubborn_step" in s["function_name"]]
+    assert len(entries) == 1
+    assert entries[0]["output"] is None
+    assert isinstance(entries[0]["error"], DBOSStepTimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_with_preemptible(dbos: DBOS) -> None:
+    """Timeout and preemption compose: the timeout fires and tears down the
+    preemption poller along with the step."""
+
+    @DBOS.step(preemptible=True, timeout_seconds=0.2)
+    async def slow_step() -> None:
+        await asyncio.sleep(60)
+
+    @DBOS.workflow()
+    async def preemptible_timeout_wf() -> None:
+        await slow_step()
+
+    with pytest.raises(DBOSStepTimeoutError):
+        await preemptible_timeout_wf()
+
+
+@pytest.mark.asyncio
+async def test_workflow_cancel_beats_step_timeout(dbos: DBOS) -> None:
+    """A workflow cancellation landing before the timeout still preempts the
+    step, leaving no checkpoint so the step re-runs on resume."""
+    invocations = 0
+    step_started = asyncio.Event()
+
+    @DBOS.step(preemptible=True, timeout_seconds=30)
+    async def slow_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        if invocations == 1:
+            step_started.set()
+            await asyncio.sleep(60)
+            return "should-not-reach"
+        return "done"
+
+    @DBOS.workflow()
+    async def cancel_wf() -> str:
+        return await slow_step()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(cancel_wf)
+
+    await step_started.wait()
+    await DBOS.cancel_workflow_async(wfid)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        await handle.get_result()
+
+    # No timeout checkpoint was recorded, so the step re-runs on resume.
+    resumed = await DBOS.resume_workflow_async(wfid)
+    assert (await resumed.get_result()) == "done"
+    assert invocations == 2

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1554,3 +1554,47 @@ async def test_step_timeout_with_workflow_cancellation(dbos: DBOS) -> None:
     assert len(entries) == 1
     assert entries[0]["output"] == "done"
     assert entries[0]["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_does_not_claim_a_cancelled_step(dbos: DBOS) -> None:
+    """A cancellation that reaches the step first keeps it even when the
+    deadline elapses while the step is still cleaning up: no outcome is
+    recorded, so the step re-runs on resume rather than replaying a timeout."""
+    invocations = 0
+    step_started = asyncio.Event()
+
+    # The poller notices the cancellation ~1s in and the step then spends 3s
+    # cleaning up, so the 2.5s deadline lands squarely inside that window.
+    @DBOS.step(preemptible=True, timeout_seconds=2.5)
+    async def slow_cleanup_step() -> str:
+        nonlocal invocations
+        invocations += 1
+        if invocations == 1:
+            step_started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                await asyncio.sleep(3)
+                raise
+            return "should-not-reach"
+        return "done"
+
+    @DBOS.workflow()
+    async def slow_cleanup_wf() -> str:
+        return await slow_cleanup_step()
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        handle = await DBOS.start_workflow_async(slow_cleanup_wf)
+
+    await step_started.wait()
+    await DBOS.cancel_workflow_async(wfid)
+    with pytest.raises(DBOSAwaitedWorkflowCancelledError):
+        await handle.get_result()
+
+    assert not await DBOS.list_workflow_steps_async(wfid)
+
+    resumed = await DBOS.resume_workflow_async(wfid)
+    assert (await resumed.get_result()) == "done"
+    assert invocations == 2

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1358,12 +1358,14 @@ async def test_step_timeout_preserves_step_outcomes(dbos: DBOS) -> None:
 @pytest.mark.asyncio
 async def test_step_timeout_with_retries(dbos: DBOS) -> None:
     """A timeout is a retryable failure and each attempt gets its own budget:
-    attempt 1 is cancelled at 0.2s and attempt 2 succeeds after a 0.3s retry
-    sleep. Exhausting the attempts raises, and should_retry can opt out."""
+    attempt 1 burns the whole 0.6s, and attempt 2 then sleeps 0.2s and still
+    succeeds — which it can only do against a fresh budget, since a budget
+    shared across attempts would already be spent. Exhausting the attempts
+    raises, and should_retry can opt out."""
     fresh_invocations = 0
 
     @DBOS.step(
-        timeout_seconds=0.2, retries_allowed=True, max_attempts=3, interval_seconds=0.3
+        timeout_seconds=0.6, retries_allowed=True, max_attempts=3, interval_seconds=0.3
     )
     async def flaky_step() -> str:
         nonlocal fresh_invocations
@@ -1371,7 +1373,9 @@ async def test_step_timeout_with_retries(dbos: DBOS) -> None:
         if fresh_invocations == 1:
             await asyncio.sleep(60)
             return "should-not-reach"
-        await asyncio.sleep(0)
+        # Must actually await real time: a bare `sleep(0)` completes even on a
+        # zero-length budget, so it would pass under a shared deadline too.
+        await asyncio.sleep(0.2)
         return "done"
 
     @DBOS.workflow()
@@ -1557,16 +1561,28 @@ async def test_step_timeout_with_workflow_cancellation(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
-async def test_step_timeout_does_not_claim_a_cancelled_step(dbos: DBOS) -> None:
+async def test_step_timeout_does_not_claim_a_cancelled_step(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A cancellation that reaches the step first keeps it even when the
     deadline elapses while the step is still cleaning up: no outcome is
-    recorded, so the step re-runs on resume rather than replaying a timeout."""
+    recorded, so the step re-runs on resume rather than replaying a timeout.
+
+    Guards the unbounded cleanup wait in the supervisor — refactoring it to
+    re-check the deadline would let the timeout reclaim the cancelled step."""
+    from dbos import _core as dbos_core
+
+    # At the 1s production interval the poller gets one chance to observe the
+    # cancellation before the deadline, so a single slow status query flips the
+    # outcome. Poll fast enough that the observation is not the thing under test.
+    monkeypatch.setattr(dbos_core, "_PREEMPTIBLE_POLL_INTERVAL_SEC", 0.05)
+
     invocations = 0
     step_started = asyncio.Event()
 
-    # The poller notices the cancellation ~1s in and the step then spends 3s
-    # cleaning up, so the 2.5s deadline lands squarely inside that window.
-    @DBOS.step(preemptible=True, timeout_seconds=2.5)
+    # The poller notices the cancellation well inside the 1.5s deadline; the
+    # step then spends 2s cleaning up, so the deadline elapses mid-cleanup.
+    @DBOS.step(preemptible=True, timeout_seconds=1.5)
     async def slow_cleanup_step() -> str:
         nonlocal invocations
         invocations += 1
@@ -1575,7 +1591,7 @@ async def test_step_timeout_does_not_claim_a_cancelled_step(dbos: DBOS) -> None:
             try:
                 await asyncio.sleep(60)
             except asyncio.CancelledError:
-                await asyncio.sleep(3)
+                await asyncio.sleep(2)
                 raise
             return "should-not-reach"
         return "done"


### PR DESCRIPTION
You can now specify a timeout for async steps. When the timeout is reached, the step is cancelled and `DBOSStepTimeoutError` is thrown. 

Timeouts are only supported for async steps because Python has no preemption mechanism for sync steps.