### PR TITLE
Fix Async Thread Blocking

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -33,7 +33,7 @@ from typing import (
     cast,
 )
 
-from dbos._outcome import DeferredResult, NoResult, Outcome, Pending
+from dbos._outcome import DeferredResult, NoResult, Outcome, Pending, resolve_deferred
 from dbos._utils import GlobalParams, retriable_postgres_exception
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
@@ -148,18 +148,29 @@ TEMP_SEND_WF_NAME = "<temp>.temp_send_workflow"
 DEFAULT_POLLING_INTERVAL = 1.0
 
 
-def _deferred_workflow_result(dbos: "DBOS", workflow_id: str) -> DeferredResult[Any]:
+def _deferred_workflow_result(
+    dbos: "DBOS", workflow_id: str, *, fail_if_missing: bool = False
+) -> DeferredResult[Any]:
     """Wait for a workflow's result, deferred so the Outcome layer picks the mode:
     a sync (Immediate) caller blocks in-thread, but an async (Pending) workflow
     awaits on the event loop instead of pinning a thread-pool worker in a blocking
     poll. Pinning could otherwise starve the shared executor and deadlock recovery
-    when many async parents wait on directly-invoked children."""
+    when many async parents wait on directly-invoked children, or when many async
+    duplicates park on the executions that own their outcomes.
+
+    fail_if_missing is for callers that know the row exists (a run parking on an
+    outcome it could not write): a missing row means it was deleted, so fail fast
+    instead of polling for a row that will never reappear."""
     return DeferredResult(
         lambda: dbos._sys_db.await_workflow_result(
-            workflow_id, polling_interval=DEFAULT_POLLING_INTERVAL
+            workflow_id,
+            polling_interval=DEFAULT_POLLING_INTERVAL,
+            fail_if_missing=fail_if_missing,
         ),
         lambda: dbos._sys_db.await_workflow_result_async(
-            workflow_id, polling_interval=DEFAULT_POLLING_INTERVAL
+            workflow_id,
+            polling_interval=DEFAULT_POLLING_INTERVAL,
+            fail_if_missing=fail_if_missing,
         ),
     )
 
@@ -789,18 +800,22 @@ def _get_wf_invoke_func(
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
         def adopt_recorded_outcome(warning: str) -> R:
+            # Deferred, not waited for here: persist runs on a thread pool worker
+            # (asyncio.to_thread) for an async workflow, and the owning execution
+            # may take arbitrarily long to record its outcome. The Outcome layer
+            # awaits this on the event loop instead of pinning that worker.
             # This run inserted or read the workflow's row, so it is known to
             # have existed: a missing row here means it was deleted. Fail fast
             # with DBOSNonExistentWorkflowError (which propagates to the
             # handle/caller) rather than polling for a row that will never
             # reappear.
             dbos.logger.warning(warning)
-            recorded_outcome: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"],
-                polling_interval=DEFAULT_POLLING_INTERVAL,
-                fail_if_missing=True,
+            return cast(
+                R,
+                _deferred_workflow_result(
+                    dbos, status["workflow_uuid"], fail_if_missing=True
+                ),
             )
-            return recorded_outcome
 
         def not_recorded_warning() -> str:
             return f"Workflow {status['workflow_uuid']} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome"
@@ -812,13 +827,15 @@ def _get_wf_invoke_func(
             dbos.logger.debug(
                 f"Workflow {status['workflow_uuid']} is already completed with status {status['status']}"
             )
-            # Directly return the result if the workflow is already completed
-            recorded_result: R = dbos._sys_db.await_workflow_result(
-                status["workflow_uuid"],
-                polling_interval=DEFAULT_POLLING_INTERVAL,
-                fail_if_missing=True,  # We expect the workflow to be present (success/error come from init wf status), throw if the row is not found
+            # Directly return the result if the workflow is already completed.
+            # fail_if_missing: we expect the workflow to be present (success/error
+            # come from init wf status), throw if the row is not found.
+            return cast(
+                R,
+                _deferred_workflow_result(
+                    dbos, status["workflow_uuid"], fail_if_missing=True
+                ),
             )
-            return recorded_result
         try:
             if inspect.iscoroutinefunction(func):
                 output = dbos._background_event_loop.submit_coroutine(
@@ -1079,8 +1096,13 @@ def _execute_workflow_wthread(
 
             try:
                 if owned:
-                    return _get_wf_invoke_func(dbos, status, release_active)(
-                        functools.partial(func, *args, **kwargs)
+                    # Resolved here, not by the Outcome layer: this path invokes
+                    # persist directly. A parked run blocks this thread, which it
+                    # owns for the workflow's duration either way.
+                    return resolve_deferred(
+                        _get_wf_invoke_func(dbos, status, release_active)(
+                            functools.partial(func, *args, **kwargs)
+                        )
                     )
                 else:
                     # Parked on the concurrent execution that owns the active

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -155,12 +155,11 @@ def _deferred_workflow_result(
     a sync (Immediate) caller blocks in-thread, but an async (Pending) workflow
     awaits on the event loop instead of pinning a thread-pool worker in a blocking
     poll. Pinning could otherwise starve the shared executor and deadlock recovery
-    when many async parents wait on directly-invoked children, or when many async
-    duplicates park on the executions that own their outcomes.
+    when many async runs wait on other executions: directly-invoked children, or the
+    runs that own their outcomes.
 
-    fail_if_missing is for callers that know the row exists (a run parking on an
-    outcome it could not write): a missing row means it was deleted, so fail fast
-    instead of polling for a row that will never reappear."""
+    fail_if_missing fails fast for callers that know the row exists, so one that was
+    deleted is not polled for forever."""
     return DeferredResult(
         lambda: dbos._sys_db.await_workflow_result(
             workflow_id,
@@ -800,15 +799,11 @@ def _get_wf_invoke_func(
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
         def adopt_recorded_outcome(warning: str) -> R:
-            # Deferred, not waited for here: persist runs on a thread pool worker
-            # (asyncio.to_thread) for an async workflow, and the owning execution
-            # may take arbitrarily long to record its outcome. The Outcome layer
-            # awaits this on the event loop instead of pinning that worker.
-            # This run inserted or read the workflow's row, so it is known to
-            # have existed: a missing row here means it was deleted. Fail fast
-            # with DBOSNonExistentWorkflowError (which propagates to the
-            # handle/caller) rather than polling for a row that will never
-            # reappear.
+            # Deferred, not waited for here: persist runs on a to_thread worker for
+            # an async workflow, and the owning execution may take arbitrarily long
+            # to record its outcome. fail_if_missing: this run inserted or read the
+            # row, so a missing one was deleted -- fail fast with
+            # DBOSNonExistentWorkflowError instead of polling forever.
             dbos.logger.warning(warning)
             return cast(
                 R,
@@ -827,9 +822,8 @@ def _get_wf_invoke_func(
             dbos.logger.debug(
                 f"Workflow {status['workflow_uuid']} is already completed with status {status['status']}"
             )
-            # Directly return the result if the workflow is already completed.
-            # fail_if_missing: we expect the workflow to be present (success/error
-            # come from init wf status), throw if the row is not found.
+            # Directly return the result if the workflow is already completed: the
+            # row holds it, so a missing one throws rather than polling.
             return cast(
                 R,
                 _deferred_workflow_result(
@@ -1096,9 +1090,8 @@ def _execute_workflow_wthread(
 
             try:
                 if owned:
-                    # Resolved here, not by the Outcome layer: this path invokes
-                    # persist directly. A parked run blocks this thread, which it
-                    # owns for the workflow's duration either way.
+                    # Resolved here: this path invokes persist outside the Outcome
+                    # layer, and a park blocks the thread it already owns.
                     return resolve_deferred(
                         _get_wf_invoke_func(dbos, status, release_active)(
                             functools.partial(func, *args, **kwargs)

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -820,8 +820,6 @@ def _get_wf_invoke_func(
             dbos.logger.debug(
                 f"Workflow {status['workflow_uuid']} is already completed with status {status['status']}"
             )
-            # Directly return the result if the workflow is already completed: the
-            # row holds it, so a missing one throws rather than polling.
             return cast(
                 R,
                 _deferred_workflow_result(

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -799,11 +799,9 @@ def _get_wf_invoke_func(
 ) -> Callable[[Callable[[], R]], R]:
     def persist(func: Callable[[], R]) -> R:
         def adopt_recorded_outcome(warning: str) -> R:
-            # Deferred, not waited for here: persist runs on a to_thread worker for
-            # an async workflow, and the owning execution may take arbitrarily long
-            # to record its outcome. fail_if_missing: this run inserted or read the
-            # row, so a missing one was deleted -- fail fast with
-            # DBOSNonExistentWorkflowError instead of polling forever.
+            # If a duplicate workflow execution was detected, "park"
+            # this execution and poll for the outcome of the winning
+            # execution.
             dbos.logger.warning(warning)
             return cast(
                 R,

--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -33,7 +33,7 @@ from typing import (
     cast,
 )
 
-from dbos._outcome import DeferredResult, NoResult, Outcome, Pending, resolve_deferred
+from dbos._outcome import DeferredResult, Immediate, NoResult, Outcome, Pending
 from dbos._utils import GlobalParams, retriable_postgres_exception
 
 from ._app_db import ApplicationDatabase, TransactionResultInternal
@@ -1086,13 +1086,9 @@ def _execute_workflow_wthread(
 
             try:
                 if owned:
-                    # Resolved here: this path invokes persist outside the Outcome
-                    # layer, and a park blocks the thread it already owns.
-                    return resolve_deferred(
-                        _get_wf_invoke_func(dbos, status, release_active)(
-                            functools.partial(func, *args, **kwargs)
-                        )
-                    )
+                    return Immediate[R](functools.partial(func, *args, **kwargs)).then(
+                        _get_wf_invoke_func(dbos, status, release_active)
+                    )()
                 else:
                     # Parked on the concurrent execution that owns the active
                     # entry. The row is known to exist (this dispatch inserted

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -63,9 +63,9 @@ class DeferredResult(Generic[T]):
         return await self._async_resolve()
 
 
-def resolve_deferred(value: Union[R, "DeferredResult[R]"]) -> R:
-    """Resolve a stage that returned a wait, blocking this thread for it: for
-    callers outside the Outcome layer, which have no event loop to await on."""
+def resolve_deferred(value: R) -> R:
+    """Resolve a stage result that is a wait, blocking this thread for it; pass any
+    other value straight through."""
     if isinstance(value, DeferredResult):
         return cast(R, value.resolve())
     return value

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -37,14 +37,16 @@ class NoResult:
 
 
 class DeferredResult(Generic[T]):
-    """An interceptor return value that short-circuits the body with a result
-    that must be *waited* for (e.g. another workflow's output).
+    """A stage return value that stands in for a result which must be *waited*
+    for (e.g. another workflow's output), rather than one already in hand.
 
-    The Outcome layer resolves it: ``Immediate`` blocks in-thread, while
-    ``Pending`` awaits it on the event loop. This lets an async workflow that
-    directly invokes a child await the child's result without pinning a
-    thread-pool worker in a blocking poll (which can starve the shared executor
-    during recovery)."""
+    Returned by an interceptor to short-circuit the body, or by a ``then``/``wrap``
+    stage to hand its own wait back to the Outcome layer. Either way the Outcome
+    layer resolves it: ``Immediate`` blocks in-thread, while ``Pending`` awaits it
+    on the event loop. This lets an async workflow that waits on another execution
+    -- a directly invoked child, or the run that owns a duplicate's outcome -- do
+    so without pinning a thread-pool worker in a blocking poll (which can starve
+    the shared executor during recovery)."""
 
     __slots__ = ("_sync_resolve", "_async_resolve")
 
@@ -61,6 +63,16 @@ class DeferredResult(Generic[T]):
 
     async def resolve_async(self) -> T:
         return await self._async_resolve()
+
+
+def resolve_deferred(value: Union[R, "DeferredResult[R]"]) -> R:
+    """Resolve a stage that returned a wait, blocking this thread for it.
+
+    For callers outside the Outcome layer, which have no event loop to await on.
+    """
+    if isinstance(value, DeferredResult):
+        return cast(R, value.resolve())
+    return value
 
 
 # define Outcome protocol w/ common composition methods
@@ -122,14 +134,14 @@ class Immediate(Outcome[T]):
         next: Callable[[Callable[[], T]], R],
         dbos: Optional["DBOS"] = None,
     ) -> "Immediate[R]":
-        return Immediate(lambda: next(self._func))
+        return Immediate(lambda: resolve_deferred(next(self._func)))
 
     def wrap(
         self,
         before: Callable[[], Callable[[Callable[[], T]], R]],
         dbos: Optional["DBOS"] = None,
     ) -> "Immediate[R]":
-        return Immediate(lambda: before()(self._func))
+        return Immediate(lambda: resolve_deferred(before()(self._func)))
 
     @staticmethod
     def _intercept(
@@ -229,7 +241,7 @@ class Pending(Outcome[T]):
         after = await asyncio.to_thread(before)
         try:
             value = await func()
-            return await asyncio.to_thread(after, lambda: value)
+            result = await asyncio.to_thread(after, lambda: value)
         except asyncio.CancelledError:
             dbos_logger.warning(f"Asyncio task cancelled for workflow or step {func}")
             raise
@@ -241,7 +253,13 @@ class Pending(Outcome[T]):
             # "cannot access free variable 'exp'" when it runs later on
             # the asyncio thread pool.
             saved_exp = exp
-            return await asyncio.to_thread(after, lambda: Pending._raise(saved_exp))
+            result = await asyncio.to_thread(after, lambda: Pending._raise(saved_exp))
+        # Resolve the wait on the event loop so it does not pin a to_thread worker.
+        # Outside the try: a stage's wait that ends in an exception propagates, rather
+        # than re-entering the stage the way an exception from the stage itself does.
+        if isinstance(result, DeferredResult):
+            return cast(R, await result.resolve_async())
+        return result
 
     def wrap(
         self,

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -37,16 +37,14 @@ class NoResult:
 
 
 class DeferredResult(Generic[T]):
-    """A stage return value that stands in for a result which must be *waited*
-    for (e.g. another workflow's output), rather than one already in hand.
+    """An interceptor or ``then``/``wrap`` stage return value that stands in for a
+    result which must be *waited* for (e.g. another workflow's output).
 
-    Returned by an interceptor to short-circuit the body, or by a ``then``/``wrap``
-    stage to hand its own wait back to the Outcome layer. Either way the Outcome
-    layer resolves it: ``Immediate`` blocks in-thread, while ``Pending`` awaits it
-    on the event loop. This lets an async workflow that waits on another execution
-    -- a directly invoked child, or the run that owns a duplicate's outcome -- do
-    so without pinning a thread-pool worker in a blocking poll (which can starve
-    the shared executor during recovery)."""
+    The Outcome layer resolves it: ``Immediate`` blocks in-thread, while ``Pending``
+    awaits it on the event loop. This lets an async workflow that waits on another
+    execution -- a directly invoked child, or the run that owns a duplicate's
+    outcome -- do so without pinning a thread-pool worker in a blocking poll (which
+    can starve the shared executor during recovery)."""
 
     __slots__ = ("_sync_resolve", "_async_resolve")
 
@@ -66,10 +64,8 @@ class DeferredResult(Generic[T]):
 
 
 def resolve_deferred(value: Union[R, "DeferredResult[R]"]) -> R:
-    """Resolve a stage that returned a wait, blocking this thread for it.
-
-    For callers outside the Outcome layer, which have no event loop to await on.
-    """
+    """Resolve a stage that returned a wait, blocking this thread for it: for
+    callers outside the Outcome layer, which have no event loop to await on."""
     if isinstance(value, DeferredResult):
         return cast(R, value.resolve())
     return value
@@ -254,9 +250,9 @@ class Pending(Outcome[T]):
             # the asyncio thread pool.
             saved_exp = exp
             result = await asyncio.to_thread(after, lambda: Pending._raise(saved_exp))
-        # Resolve the wait on the event loop so it does not pin a to_thread worker.
-        # Outside the try: a stage's wait that ends in an exception propagates, rather
-        # than re-entering the stage the way an exception from the stage itself does.
+        # Resolve on the event loop, so the wait does not pin a to_thread worker.
+        # Outside the try: a wait that ends in an exception propagates, rather than
+        # re-entering the stage the way an exception from the stage itself does.
         if isinstance(result, DeferredResult):
             return cast(R, await result.resolve_async())
         return result

--- a/tests/test_singleexec_async.py
+++ b/tests/test_singleexec_async.py
@@ -333,17 +333,16 @@ async def test_parked_duplicate_does_not_hold_a_thread(
     dbos: DBOS, config: DBOSConfig, park_entry: str, dispatch: str
 ) -> None:
     """A duplicate async execution that cannot own its workflow's outcome parks on the
-    execution that does. That wait must happen on the event loop: the park runs inside
-    asyncio.to_thread, so a blocking poll there pins one of DBOS's executor threads for
-    as long as the owner takes to finish, and enough parked duplicates leave no thread
-    for any other async work in the process."""
+    execution that does. That park runs inside asyncio.to_thread, so waiting there
+    blocking pins an executor thread until the owner finishes -- enough parked
+    duplicates and no other async work in the process can run."""
     workers = 2
     config["max_executor_threads"] = workers
     DBOS.destroy(destroy_registry=True)
     dbos = DBOS(config=config)
     DBOS.launch()
 
-    # The IDs of the duplicates: the executions that lose their workflow to another run.
+    # The duplicates: executions that lose their workflow to another run.
     lost_ids: set[str] = set()
     parked_ids: set[str] = set()
 
@@ -414,7 +413,7 @@ async def test_parked_duplicate_does_not_hold_a_thread(
         return "unblocked"
 
     async def start_duplicate() -> "asyncio.Future[str]":
-        """Start a duplicate the way the parametrization asks, started either way."""
+        """Start a duplicate however this parametrization dispatches it."""
         wfid = str(uuid.uuid4())
         lost_ids.add(wfid)
         if dispatch == "start_workflow_async":
@@ -435,8 +434,8 @@ async def test_parked_duplicate_does_not_hold_a_thread(
 
         await retry_until_success_async(all_parked, interval=0.1, max_attempts=300)
 
-        # Every duplicate now waits for an outcome only the owning execution can write.
-        # Unrelated async work must still be able to run.
+        # Every duplicate now waits for an outcome only the owner can write, so
+        # unrelated async work is what proves the pool is still usable.
         try:
             assert (
                 await asyncio.wait_for(unrelated_workflow(), timeout=20) == "unblocked"
@@ -446,8 +445,8 @@ async def test_parked_duplicate_does_not_hold_a_thread(
                 f"parked duplicates hold every executor thread: {blocked_executor_threads()}"
             )
     finally:
-        # Publish the outcome the parked duplicates wait for, as the owner would.
-        # In a finally: a failed assertion must not strand them polling forever.
+        # Publish the outcome the parked duplicates wait for, as the owner would. In
+        # a finally: a failed assertion must not strand them polling forever.
         serval, _ = serialize_value_as("owner outcome", None, dbos._serializer)
         with dbos._sys_db.engine.begin() as c:
             c.execute(

--- a/tests/test_singleexec_async.py
+++ b/tests/test_singleexec_async.py
@@ -330,7 +330,11 @@ async def test_commit_hiccup(dbos: DBOS) -> None:
 @pytest.mark.parametrize("dispatch", ["start_workflow_async", "direct_invocation"])
 @pytest.mark.parametrize("park_entry", ["checkpoint_conflict", "outcome_not_recorded"])
 async def test_parked_duplicate_does_not_hold_a_thread(
-    dbos: DBOS, config: DBOSConfig, park_entry: str, dispatch: str
+    dbos: DBOS,
+    config: DBOSConfig,
+    park_entry: str,
+    dispatch: str,
+    skip_with_sqlite: None,
 ) -> None:
     """A duplicate async execution that cannot own its workflow's outcome parks on the
     execution that does. That park runs inside asyncio.to_thread, so waiting there
@@ -434,8 +438,14 @@ async def test_parked_duplicate_does_not_hold_a_thread(
 
         await retry_until_success_async(all_parked, interval=0.1, max_attempts=300)
 
-        # Every duplicate now waits for an outcome only the owner can write, so
-        # unrelated async work is what proves the pool is still usable.
+        # The property under test: every park now waits on the event loop, so no executor
+        # thread is inside the blocking await_workflow_result. A poll's brief to_thread hop
+        # runs check_workflow_result, which this does not match.
+        assert (
+            blocked_executor_threads() == []
+        ), f"parked duplicates hold executor threads: {blocked_executor_threads()}"
+
+        # And the consequence: unrelated async work still gets a worker.
         try:
             assert (
                 await asyncio.wait_for(unrelated_workflow(), timeout=20) == "unblocked"

--- a/tests/test_singleexec_async.py
+++ b/tests/test_singleexec_async.py
@@ -436,7 +436,8 @@ async def test_parked_duplicate_does_not_hold_a_thread(
         def all_parked() -> None:
             assert parked_ids == lost_ids, f"parked so far: {parked_ids}"
 
-        await retry_until_success_async(all_parked, interval=0.1, max_attempts=300)
+        # Bounds sized so a hang fails on the assertion below, not at the 120s global timeout.
+        await retry_until_success_async(all_parked, interval=0.1, max_attempts=150)
 
         # The property under test: every park now waits on the event loop, so no executor
         # thread is inside the blocking await_workflow_result. A poll's brief to_thread hop
@@ -448,7 +449,7 @@ async def test_parked_duplicate_does_not_hold_a_thread(
         # And the consequence: unrelated async work still gets a worker.
         try:
             assert (
-                await asyncio.wait_for(unrelated_workflow(), timeout=20) == "unblocked"
+                await asyncio.wait_for(unrelated_workflow(), timeout=10) == "unblocked"
             )
         except asyncio.TimeoutError:
             pytest.fail(
@@ -466,4 +467,4 @@ async def test_parked_duplicate_does_not_hold_a_thread(
             )
 
     for run in runs:
-        assert await asyncio.wait_for(run, timeout=30) == "owner outcome"
+        assert await asyncio.wait_for(run, timeout=15) == "owner outcome"

--- a/tests/test_singleexec_async.py
+++ b/tests/test_singleexec_async.py
@@ -1,14 +1,27 @@
 import asyncio
+import sys
+import threading
+import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
+from typing import Any, Optional
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.exc import OperationalError
 
-from dbos import DBOS, SetWorkflowID
+from dbos import DBOS, DBOSConfig, SetWorkflowID, WorkflowHandleAsync
 from dbos._debug_trigger import DebugAction, DebugTriggers
-from tests.conftest import reexecute_workflow_by_id, set_workflow_status
+from dbos._error import DBOSWorkflowConflictIDError
+from dbos._schemas.system_database import SystemSchema
+from dbos._serialization import serialize_value_as
+from dbos._sys_db import OperationResultInternal, WorkflowStatusString
+from tests.conftest import (
+    reexecute_workflow_by_id,
+    retry_until_success_async,
+    set_workflow_status,
+)
 
 
 @pytest.mark.asyncio
@@ -311,3 +324,111 @@ async def test_commit_hiccup(dbos: DBOS) -> None:
     )
 
     assert await TryDbGlitch.testWorkflow() == "Yay!"
+
+
+@pytest.mark.asyncio
+async def test_parked_duplicate_does_not_hold_a_thread(
+    dbos: DBOS, config: DBOSConfig
+) -> None:
+    """A duplicate async execution that loses the checkpoint race parks on the owning
+    execution's outcome. That wait must happen on the event loop: the park runs inside
+    asyncio.to_thread, so a blocking poll there pins one of DBOS's executor threads for
+    as long as the owner takes to finish, and enough parked duplicates leave no thread
+    for any other async work in the process."""
+    workers = 2
+    config["max_executor_threads"] = workers
+    DBOS.destroy(destroy_registry=True)
+    dbos = DBOS(config=config)
+    DBOS.launch()
+
+    # The IDs whose step checkpoint loses the race to a concurrent execution.
+    lost_ids: set[str] = set()
+    parked_ids: set[str] = set()
+
+    original_record = dbos._sys_db.record_operation_result
+
+    def losing_record(
+        result: OperationResultInternal,
+        *,
+        completed_at_epoch_ms: Optional[int] = None,
+    ) -> None:
+        # What the loser of a checkpoint race sees: the owner's row is already there.
+        if result["workflow_uuid"] in lost_ids:
+            raise DBOSWorkflowConflictIDError(result["workflow_uuid"])
+        original_record(result, completed_at_epoch_ms=completed_at_epoch_ms)
+
+    original_check = dbos._sys_db.check_workflow_result
+
+    def tracking_check(workflow_id: str, *, fail_if_missing: bool = False) -> Any:
+        # Every park polls this, blocking or not: a check is proof the run reached it.
+        if workflow_id in lost_ids:
+            parked_ids.add(workflow_id)
+        return original_check(workflow_id, fail_if_missing=fail_if_missing)
+
+    dbos._sys_db.record_operation_result = losing_record  # type: ignore[method-assign]
+    dbos._sys_db.check_workflow_result = tracking_check  # type: ignore[method-assign]
+
+    def blocked_executor_threads() -> list[str]:
+        """Executor threads sitting inside the blocking park, for the failure message."""
+        frames = sys._current_frames()
+        return [
+            thread.name
+            for thread in threading.enumerate()
+            if thread.name.startswith("dbos-executor-")
+            and thread.ident in frames
+            and any(
+                frame.name == "await_workflow_result"
+                for frame in traceback.extract_stack(frames[thread.ident])
+            )
+        ]
+
+    @DBOS.step()
+    async def duplicated_step() -> str:
+        return "step output"
+
+    @DBOS.workflow()
+    async def duplicate_workflow() -> str:
+        return await duplicated_step()
+
+    @DBOS.workflow()
+    async def unrelated_workflow() -> str:
+        return "unblocked"
+
+    handles: list[WorkflowHandleAsync[str]] = []
+    try:
+        for _ in range(workers):
+            wfid = str(uuid.uuid4())
+            lost_ids.add(wfid)
+            with SetWorkflowID(wfid):
+                handles.append(await DBOS.start_workflow_async(duplicate_workflow))
+
+        def all_parked() -> None:
+            assert parked_ids == lost_ids, f"parked so far: {parked_ids}"
+
+        await retry_until_success_async(all_parked, interval=0.1, max_attempts=300)
+
+        # Every duplicate now waits for an outcome only the owning execution can write.
+        # Unrelated async work must still be able to run.
+        try:
+            assert (
+                await asyncio.wait_for(unrelated_workflow(), timeout=20) == "unblocked"
+            )
+        except asyncio.TimeoutError:
+            pytest.fail(
+                f"parked duplicates hold every executor thread: {blocked_executor_threads()}"
+            )
+    finally:
+        # Publish the outcome the parked duplicates wait for, as the owner would.
+        # In a finally: a failed assertion must not strand them polling forever.
+        serval, _ = serialize_value_as("owner outcome", None, dbos._serializer)
+        with dbos._sys_db.engine.begin() as c:
+            c.execute(
+                sa.update(SystemSchema.workflow_status)
+                .values(status=WorkflowStatusString.SUCCESS.value, output=serval)
+                .where(SystemSchema.workflow_status.c.workflow_uuid.in_(lost_ids))
+            )
+
+    for handle in handles:
+        assert (
+            await asyncio.wait_for(handle.get_result(), timeout=30) == "owner outcome"
+        )

--- a/tests/test_singleexec_async.py
+++ b/tests/test_singleexec_async.py
@@ -16,7 +16,7 @@ from dbos._debug_trigger import DebugAction, DebugTriggers
 from dbos._error import DBOSWorkflowConflictIDError
 from dbos._schemas.system_database import SystemSchema
 from dbos._serialization import serialize_value_as
-from dbos._sys_db import OperationResultInternal, WorkflowStatusString
+from dbos._sys_db import OperationResultInternal, WorkflowStatuses, WorkflowStatusString
 from tests.conftest import (
     reexecute_workflow_by_id,
     retry_until_success_async,
@@ -327,11 +327,13 @@ async def test_commit_hiccup(dbos: DBOS) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("dispatch", ["start_workflow_async", "direct_invocation"])
+@pytest.mark.parametrize("park_entry", ["checkpoint_conflict", "outcome_not_recorded"])
 async def test_parked_duplicate_does_not_hold_a_thread(
-    dbos: DBOS, config: DBOSConfig
+    dbos: DBOS, config: DBOSConfig, park_entry: str, dispatch: str
 ) -> None:
-    """A duplicate async execution that loses the checkpoint race parks on the owning
-    execution's outcome. That wait must happen on the event loop: the park runs inside
+    """A duplicate async execution that cannot own its workflow's outcome parks on the
+    execution that does. That wait must happen on the event loop: the park runs inside
     asyncio.to_thread, so a blocking poll there pins one of DBOS's executor threads for
     as long as the owner takes to finish, and enough parked duplicates leave no thread
     for any other async work in the process."""
@@ -341,7 +343,7 @@ async def test_parked_duplicate_does_not_hold_a_thread(
     dbos = DBOS(config=config)
     DBOS.launch()
 
-    # The IDs whose step checkpoint loses the race to a concurrent execution.
+    # The IDs of the duplicates: the executions that lose their workflow to another run.
     lost_ids: set[str] = set()
     parked_ids: set[str] = set()
 
@@ -357,6 +359,20 @@ async def test_parked_duplicate_does_not_hold_a_thread(
             raise DBOSWorkflowConflictIDError(result["workflow_uuid"])
         original_record(result, completed_at_epoch_ms=completed_at_epoch_ms)
 
+    original_update = dbos._sys_db.update_workflow_outcome
+
+    def losing_update(
+        workflow_id: str,
+        status: WorkflowStatuses,
+        *,
+        output: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> bool:
+        # What a run whose row moved on sees: its terminal write does not land.
+        if workflow_id in lost_ids:
+            return False
+        return original_update(workflow_id, status, output=output, error=error)
+
     original_check = dbos._sys_db.check_workflow_result
 
     def tracking_check(workflow_id: str, *, fail_if_missing: bool = False) -> Any:
@@ -365,7 +381,10 @@ async def test_parked_duplicate_does_not_hold_a_thread(
             parked_ids.add(workflow_id)
         return original_check(workflow_id, fail_if_missing=fail_if_missing)
 
-    dbos._sys_db.record_operation_result = losing_record  # type: ignore[method-assign]
+    if park_entry == "checkpoint_conflict":
+        dbos._sys_db.record_operation_result = losing_record  # type: ignore[method-assign]
+    else:
+        dbos._sys_db.update_workflow_outcome = losing_update  # type: ignore[method-assign]
     dbos._sys_db.check_workflow_result = tracking_check  # type: ignore[method-assign]
 
     def blocked_executor_threads() -> list[str]:
@@ -394,13 +413,22 @@ async def test_parked_duplicate_does_not_hold_a_thread(
     async def unrelated_workflow() -> str:
         return "unblocked"
 
-    handles: list[WorkflowHandleAsync[str]] = []
+    async def start_duplicate() -> "asyncio.Future[str]":
+        """Start a duplicate the way the parametrization asks, started either way."""
+        wfid = str(uuid.uuid4())
+        lost_ids.add(wfid)
+        if dispatch == "start_workflow_async":
+            with SetWorkflowID(wfid):
+                handle = await DBOS.start_workflow_async(duplicate_workflow)
+            return asyncio.ensure_future(handle.get_result())
+        with SetWorkflowID(wfid):
+            # create_task copies the context, so the run adopts this ID when it starts.
+            return asyncio.create_task(duplicate_workflow())
+
+    runs: list["asyncio.Future[str]"] = []
     try:
         for _ in range(workers):
-            wfid = str(uuid.uuid4())
-            lost_ids.add(wfid)
-            with SetWorkflowID(wfid):
-                handles.append(await DBOS.start_workflow_async(duplicate_workflow))
+            runs.append(await start_duplicate())
 
         def all_parked() -> None:
             assert parked_ids == lost_ids, f"parked so far: {parked_ids}"
@@ -428,7 +456,5 @@ async def test_parked_duplicate_does_not_hold_a_thread(
                 .where(SystemSchema.workflow_status.c.workflow_uuid.in_(lost_ids))
             )
 
-    for handle in handles:
-        assert (
-            await asyncio.wait_for(handle.get_result(), timeout=30) == "owner outcome"
-        )
+    for run in runs:
+        assert await asyncio.wait_for(run, timeout=30) == "owner outcome"


### PR DESCRIPTION
Fix an issue where a duplicate async workflow execution "parking" would consume a thread.