### PR TITLE
Simplify Workflow Retention

### DIFF
--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5324,16 +5324,17 @@ class SystemDatabase(ABC):
             raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
         if rows_threshold is not None:
             with self.engine.begin() as c:
-                # Get the created_at timestamp of the rows_threshold newest row
+                # Get the completed_at timestamp of the rows_threshold newest completed row
                 result = c.execute(
-                    sa.select(SystemSchema.workflow_status.c.created_at)
+                    sa.select(SystemSchema.workflow_status.c.completed_at)
                     .where(
+                        SystemSchema.workflow_status.c.completed_at.isnot(None),
                         self._name_filter(
                             SystemSchema.workflow_status.c.application_name,
                             self.app_name,
-                        )
+                        ),
                     )
-                    .order_by(SystemSchema.workflow_status.c.created_at.desc())
+                    .order_by(SystemSchema.workflow_status.c.completed_at.desc())
                     .limit(1)
                     .offset(rows_threshold - 1)
                 ).fetchone()
@@ -5350,17 +5351,11 @@ class SystemDatabase(ABC):
         if cutoff_epoch_timestamp_ms is None:
             return None
 
-        # Delete all workflows older than cutoff that are NOT PENDING, ENQUEUED, or DELAYED
+        # completed_at is set on every terminal transition and cleared on resume, so one
+        # predicate covers eligibility: in-flight rows hold NULL and never compare true.
         gc_filter = sa.and_(
-            SystemSchema.workflow_status.c.created_at
+            SystemSchema.workflow_status.c.completed_at
             < sa.literal(cutoff_epoch_timestamp_ms, sa.BigInteger),
-            ~SystemSchema.workflow_status.c.status.in_(
-                [
-                    WorkflowStatusString.PENDING.value,
-                    WorkflowStatusString.ENQUEUED.value,
-                    WorkflowStatusString.DELAYED.value,
-                ]
-            ),
             # Unclaimed rows included: excluding them would leak pre-upgrade rows forever.
             self._name_filter(
                 SystemSchema.workflow_status.c.application_name, self.app_name
@@ -5400,35 +5395,33 @@ class SystemDatabase(ABC):
 
             retry_on_serialization_error(delete_all)
         else:
-            # Batch-delete by advancing a created_at watermark, one committed transaction per batch
+            # Batch-delete by advancing a completed_at watermark, one committed transaction per batch
             def delete_batch(watermark: int) -> Optional[int]:
                 """Delete one batch, returning the watermark to resume from, or None when done."""
                 with self.engine.begin() as c:
-                    # Find the created_at of the batch_size-th oldest eligible row above the watermark
+                    # Find the completed_at of the batch_size-th oldest eligible row above the watermark
                     step: Optional[int] = c.execute(
-                        sa.select(SystemSchema.workflow_status.c.created_at)
+                        sa.select(SystemSchema.workflow_status.c.completed_at)
                         .where(
                             gc_filter,
-                            SystemSchema.workflow_status.c.created_at > watermark,
+                            SystemSchema.workflow_status.c.completed_at > watermark,
                         )
-                        .order_by(SystemSchema.workflow_status.c.created_at)
+                        .order_by(SystemSchema.workflow_status.c.completed_at)
                         .limit(1)
                         .offset(batch_size - 1)
                     ).scalar()
-                    if step is None:
-                        # Final batch: delete every remaining eligible row, even below the watermark
-                        c.execute(
-                            sa.delete(SystemSchema.workflow_status).where(gc_filter)
+                    # A row that terminalizes mid-pass takes completed_at > cutoff, so it can
+                    # never fall below the watermark: the tail above it is all that remains.
+                    bounds: List[sa.ColumnElement[bool]] = [
+                        gc_filter,
+                        SystemSchema.workflow_status.c.completed_at > watermark,
+                    ]
+                    if step is not None:
+                        # completed_at ties may push the batch slightly over batch_size
+                        bounds.append(
+                            SystemSchema.workflow_status.c.completed_at <= step
                         )
-                        return None
-                    # Delete the batch; created_at ties may push it slightly over batch_size
-                    c.execute(
-                        sa.delete(SystemSchema.workflow_status).where(
-                            gc_filter,
-                            SystemSchema.workflow_status.c.created_at > watermark,
-                            SystemSchema.workflow_status.c.created_at <= step,
-                        )
-                    )
+                    c.execute(sa.delete(SystemSchema.workflow_status).where(*bounds))
                     return step
 
             watermark = 0

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -5317,7 +5317,9 @@ class SystemDatabase(ABC):
         cutoff_epoch_timestamp_ms: Optional[int],
         rows_threshold: Optional[int],
         batch_size: Optional[int],
-    ) -> Optional[tuple[int, list[str]]]:
+    ) -> Optional[int]:
+        """Delete this application's old terminal workflows, returning the cutoff
+        actually used, or None when there is nothing to collect."""
         if batch_size is not None and batch_size < 1:
             raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
         if rows_threshold is not None:
@@ -5438,22 +5440,25 @@ class SystemDatabase(ABC):
                     break
                 watermark = next_watermark
 
-        with self.engine.begin() as c:
-            # Then, get the IDs of all remaining old workflows
-            pending_enqueued_result = c.execute(
-                sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
-                    SystemSchema.workflow_status.c.created_at
-                    < sa.literal(cutoff_epoch_timestamp_ms, sa.BigInteger),
-                    self._name_filter(
-                        SystemSchema.workflow_status.c.application_name, self.app_name
-                    ),
-                )
-            ).fetchall()
+        return cutoff_epoch_timestamp_ms
 
-            # Return the final cutoff and workflow IDs
-            return cutoff_epoch_timestamp_ms, [
-                row[0] for row in pending_enqueued_result
-            ]
+    def list_retained_workflow_ids(self, cutoff_epoch_timestamp_ms: int) -> List[str]:
+        """IDs of this application's pre-cutoff workflows that garbage collection kept.
+        Only the deprecated application database needs them, to spare the transaction
+        outputs of workflows that may still run."""
+        with self.engine.begin() as c:
+            return list(
+                c.execute(
+                    sa.select(SystemSchema.workflow_status.c.workflow_uuid).where(
+                        SystemSchema.workflow_status.c.created_at
+                        < sa.literal(cutoff_epoch_timestamp_ms, sa.BigInteger),
+                        self._name_filter(
+                            SystemSchema.workflow_status.c.application_name,
+                            self.app_name,
+                        ),
+                    )
+                ).scalars()
+            )
 
     def list_timed_out_workflow_ids(self, cutoff_epoch_timestamp_ms: int) -> List[str]:
         """IDs of this application's in-flight workflows created before the cutoff.

--- a/dbos/_workflow_commands.py
+++ b/dbos/_workflow_commands.py
@@ -93,17 +93,15 @@ def garbage_collect(
 ) -> None:
     if cutoff_epoch_timestamp_ms is None and rows_threshold is None:
         return
-    result = dbos._sys_db.garbage_collect(
+    cutoff = dbos._sys_db.garbage_collect(
         cutoff_epoch_timestamp_ms=cutoff_epoch_timestamp_ms,
         rows_threshold=rows_threshold,
         batch_size=batch_size,
     )
-    if result is not None:
-        cutoff_epoch_timestamp_ms, pending_workflow_ids = result
-        if dbos._app_db:
-            dbos._app_db.garbage_collect(
-                cutoff_epoch_timestamp_ms, pending_workflow_ids, batch_size=batch_size
-            )
+    # The application database is deprecated: only pay for its cleanup when one exists.
+    if cutoff is not None and dbos._app_db is not None:
+        retained_ids = dbos._sys_db.list_retained_workflow_ids(cutoff)
+        dbos._app_db.garbage_collect(cutoff, retained_ids, batch_size=batch_size)
 
 
 def global_timeout(dbos: "DBOS", cutoff_epoch_timestamp_ms: int) -> None:

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -744,7 +744,9 @@ def test_admin_garbage_collect(dbos: DBOS) -> None:
 
     response = requests.post(
         f"http://localhost:3001/dbos-garbage-collect",
-        json={"cutoff_epoch_timestamp_ms": int(time.time() * 1000)},
+        # +1s: completed_at is DB-stamped and rounded, so a bare wall-clock cutoff
+        # taken right after the workflow finishes can tie with it and spare the row.
+        json={"cutoff_epoch_timestamp_ms": int(time.time() * 1000) + 1000},
         timeout=5,
     )
     response.raise_for_status()

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -84,6 +84,10 @@ def insert_foreign_workflow(
                 queue_name=queue_name,
                 created_at=1,
                 updated_at=1,
+                # Terminal rows carry completed_at, as ones written by DBOS itself do
+                completed_at=(
+                    None if status in ("PENDING", "ENQUEUED", "DELAYED") else 1
+                ),
                 priority=0,
                 application_name=application_name,
                 inputs='{"args": [], "kwargs": {}}',

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -1,7 +1,7 @@
 import threading
 import time
 import uuid
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 import sqlalchemy as sa
@@ -1363,6 +1363,18 @@ def test_resume_and_fork_to_queue(dbos: DBOS) -> None:
     assert queue_entries_are_cleaned_up(dbos)
 
 
+def _status_timestamp(dbos: DBOS, workflow_id: str, column: str) -> Optional[int]:
+    """Read a DB-stamped timestamp, so a test can derive its cutoff from the same
+    clock the rows were written with instead of racing the Python clock against it."""
+    with dbos._sys_db.engine.begin() as c:
+        value = c.execute(
+            sa.select(SystemSchema.workflow_status.c[column]).where(
+                SystemSchema.workflow_status.c.workflow_uuid == workflow_id
+            )
+        ).scalar()
+    return None if value is None else int(value)
+
+
 def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> None:
     event = threading.Event()
     started = threading.Event()
@@ -1396,6 +1408,11 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
     handle = DBOS.start_workflow(blocked_workflow)
     # Wait for its txn output to commit so GC assertions can count on it
     assert started.wait(timeout=30)
+    # A cutoff taken from this row's own created_at while it is provably still
+    # running. +1 is the smallest value that puts its creation behind the cutoff.
+    blocked_created_at = _status_timestamp(dbos, handle.workflow_id, "created_at")
+    assert blocked_created_at is not None
+    blocked_cutoff = blocked_created_at + 1
     for i in range(num_workflows):
         assert workflow(i) == i
 
@@ -1434,15 +1451,23 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
         ).all()
         assert len(rows) == 1
 
-    # Finish the blocked workflow, garbage collect everything
+    # Finish the blocked workflow
     event.set()
     assert handle.get_result() is not None
+    blocked_completed_at = _status_timestamp(dbos, handle.workflow_id, "completed_at")
+    assert blocked_completed_at is not None
+    # Retention keys on completion, not creation. Asserted rather than assumed: if
+    # these collapsed to one instant the survival check below would be vacuous.
+    assert blocked_created_at < blocked_cutoff <= blocked_completed_at
+    # So the cutoff from while it was running spares it, though it was created first
+    garbage_collect(dbos, cutoff_epoch_timestamp_ms=blocked_cutoff, rows_threshold=None)
+    assert [w.workflow_id for w in DBOS.list_workflows()] == [handle.workflow_id]
+
+    # Once the cutoff passes its completion, it is collected
     garbage_collect(
-        dbos, cutoff_epoch_timestamp_ms=int(time.time() * 1000), rows_threshold=None
+        dbos, cutoff_epoch_timestamp_ms=blocked_completed_at + 1, rows_threshold=None
     )
-    # Verify only the blocked workflow remains
-    workflows = DBOS.list_workflows()
-    assert len(workflows) == 0
+    assert len(DBOS.list_workflows()) == 0
 
     # ENQUEUED and DELAYED workflows must not be garbage collected
     # worker_concurrency=0 blocks dequeue so the workflow deterministically stays ENQUEUED
@@ -1464,9 +1489,23 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
     assert enqueued_handle.workflow_id in wf_ids
     assert delayed_handle.workflow_id in wf_ids
 
-    # Clean up so they don't interfere with the rest of the test
+    # Cancelling stamps completed_at, making the row eligible for this cutoff
     DBOS.cancel_workflow(enqueued_handle.workflow_id)
     DBOS.cancel_workflow(delayed_handle.workflow_id)
+    cancelled_at = _status_timestamp(dbos, enqueued_handle.workflow_id, "completed_at")
+    assert cancelled_at is not None
+
+    # Resuming must clear completed_at: it is the only thing stopping GC from
+    # deleting a workflow that can run again. The queue still blocks dequeue.
+    DBOS.resume_workflow(enqueued_handle.workflow_id, queue_name="gc_test_queue")
+    assert _status_timestamp(dbos, enqueued_handle.workflow_id, "completed_at") is None
+    garbage_collect(
+        dbos, cutoff_epoch_timestamp_ms=cancelled_at + 1, rows_threshold=None
+    )
+    assert enqueued_handle.workflow_id in {w.workflow_id for w in DBOS.list_workflows()}
+
+    # Clean up so it doesn't interfere with the rest of the test
+    DBOS.cancel_workflow(enqueued_handle.workflow_id)
 
     # Verify GC runs without error on a blank table
     garbage_collect(dbos, cutoff_epoch_timestamp_ms=None, rows_threshold=1)
@@ -1491,35 +1530,6 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
     )
     workflows = DBOS.list_workflows()
     assert len(workflows) == num_workflows
-
-
-def test_garbage_collection_keys_on_completion(
-    dbos: DBOS, skip_with_sqlite_imprecise_time: None
-) -> None:
-    """A workflow created before the cutoff but finished after it must survive."""
-    event = threading.Event()
-    started = threading.Event()
-
-    @DBOS.workflow()
-    def blocked_workflow() -> None:
-        started.set()
-        event.wait()
-
-    handle = DBOS.start_workflow(blocked_workflow)
-    # Capture the cutoff while the workflow is provably still running
-    assert started.wait(timeout=30)
-    cutoff = int(time.time() * 1000)
-    event.set()
-    handle.get_result()
-
-    garbage_collect(dbos, cutoff_epoch_timestamp_ms=cutoff, rows_threshold=None)
-    assert [w.workflow_id for w in DBOS.list_workflows()] == [handle.workflow_id]
-
-    # Once its completion falls before the cutoff, it is collected
-    garbage_collect(
-        dbos, cutoff_epoch_timestamp_ms=int(time.time() * 1000), rows_threshold=None
-    )
-    assert len(DBOS.list_workflows()) == 0
 
 
 # batch_size: 3 = short final batch, 5 = exact multiple, 20 = larger than all eligible rows
@@ -1675,6 +1685,13 @@ def test_garbage_collection_batched_rows_threshold(
         workflow_ids.append(handle.workflow_id)
         time.sleep(0.005)
 
+    # worker_concurrency=0 blocks dequeue, so these stay ENQUEUED with no completed_at
+    DBOS.register_queue("gc_threshold_queue", worker_concurrency=0)
+    enqueued_ids = [
+        DBOS.enqueue_workflow("gc_threshold_queue", workflow, i).workflow_id
+        for i in range(3)
+    ]
+
     garbage_collect(
         dbos,
         cutoff_epoch_timestamp_ms=None,
@@ -1682,9 +1699,13 @@ def test_garbage_collection_batched_rows_threshold(
         batch_size=3,
     )
 
-    # exactly newest rows_threshold workflows survive
+    # The threshold counts completions, not rows: exactly the newest rows_threshold
+    # completed workflows survive, and the in-flight rows all survive besides.
     surviving_ids = {w.workflow_id for w in DBOS.list_workflows()}
-    assert surviving_ids == set(workflow_ids[-rows_threshold:])
+    assert surviving_ids == set(workflow_ids[-rows_threshold:]) | set(enqueued_ids)
+
+    for workflow_id in enqueued_ids:
+        DBOS.cancel_workflow(workflow_id)
 
 
 def test_garbage_collection_batched_resumable(

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -1375,6 +1375,14 @@ def _status_timestamp(dbos: DBOS, workflow_id: str, column: str) -> Optional[int
     return None if value is None else int(value)
 
 
+def _cutoff_past_all_completions() -> int:
+    """A cutoff every completion so far falls strictly before. completed_at is stamped
+    by the database and rounded to the millisecond, while a wall-clock cutoff taken
+    right after a workflow finishes truncates, so the two can land on the same value
+    and spare the row. Only rows with no completed_at need to survive these cutoffs."""
+    return int(time.time() * 1000) + 1000
+
+
 def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -> None:
     event = threading.Event()
     started = threading.Event()
@@ -1436,7 +1444,9 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
 
     # Garbage collect all previous workflows
     garbage_collect(
-        dbos, cutoff_epoch_timestamp_ms=int(time.time() * 1000), rows_threshold=None
+        dbos,
+        cutoff_epoch_timestamp_ms=_cutoff_past_all_completions(),
+        rows_threshold=None,
     )
     # Verify only the blocked workflow remains
     workflows = DBOS.list_workflows()
@@ -1606,7 +1616,7 @@ def test_garbage_collection_batched(
     try:
         garbage_collect(
             dbos,
-            cutoff_epoch_timestamp_ms=int(time.time() * 1000),
+            cutoff_epoch_timestamp_ms=_cutoff_past_all_completions(),
             rows_threshold=None,
             batch_size=batch_size,
         )
@@ -1645,7 +1655,7 @@ def test_garbage_collection_batched(
     assert handle.get_result() is not None
     garbage_collect(
         dbos,
-        cutoff_epoch_timestamp_ms=int(time.time() * 1000),
+        cutoff_epoch_timestamp_ms=_cutoff_past_all_completions(),
         rows_threshold=None,
         batch_size=1,
     )
@@ -1746,7 +1756,7 @@ def test_garbage_collection_batched_resumable(
     try:
         with pytest.raises(Exception, match="injected garbage collection failure"):
             dbos._sys_db.garbage_collect(
-                cutoff_epoch_timestamp_ms=int(time.time() * 1000),
+                cutoff_epoch_timestamp_ms=_cutoff_past_all_completions(),
                 rows_threshold=None,
                 batch_size=batch_size,
             )
@@ -1760,7 +1770,7 @@ def test_garbage_collection_batched_resumable(
 
     # rerunning GC completes deletion
     dbos._sys_db.garbage_collect(
-        cutoff_epoch_timestamp_ms=int(time.time() * 1000),
+        cutoff_epoch_timestamp_ms=_cutoff_past_all_completions(),
         rows_threshold=None,
         batch_size=batch_size,
     )

--- a/tests/test_workflow_management.py
+++ b/tests/test_workflow_management.py
@@ -1493,6 +1493,35 @@ def test_garbage_collection(dbos: DBOS, skip_with_sqlite_imprecise_time: None) -
     assert len(workflows) == num_workflows
 
 
+def test_garbage_collection_keys_on_completion(
+    dbos: DBOS, skip_with_sqlite_imprecise_time: None
+) -> None:
+    """A workflow created before the cutoff but finished after it must survive."""
+    event = threading.Event()
+    started = threading.Event()
+
+    @DBOS.workflow()
+    def blocked_workflow() -> None:
+        started.set()
+        event.wait()
+
+    handle = DBOS.start_workflow(blocked_workflow)
+    # Capture the cutoff while the workflow is provably still running
+    assert started.wait(timeout=30)
+    cutoff = int(time.time() * 1000)
+    event.set()
+    handle.get_result()
+
+    garbage_collect(dbos, cutoff_epoch_timestamp_ms=cutoff, rows_threshold=None)
+    assert [w.workflow_id for w in DBOS.list_workflows()] == [handle.workflow_id]
+
+    # Once its completion falls before the cutoff, it is collected
+    garbage_collect(
+        dbos, cutoff_epoch_timestamp_ms=int(time.time() * 1000), rows_threshold=None
+    )
+    assert len(DBOS.list_workflows()) == 0
+
+
 # batch_size: 3 = short final batch, 5 = exact multiple, 20 = larger than all eligible rows
 @pytest.mark.parametrize("batch_size", [3, 5, 20])
 def test_garbage_collection_batched(


### PR DESCRIPTION
Using `completed_at` instead of `created_at`, which also improve semantics