### PR TITLE
Reject one registered workflow name claimed by two modules

### DIFF
--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -254,28 +254,16 @@ class DBOSRegistry:
         if name in self.function_type_map:
             if self.function_type_map[name] != functype:
                 raise DBOSConflictingRegistrationError(name)
-            # A registered name is the durable identity recovery resolves, so two
-            # genuinely different functions cannot both claim one: only one of
-            # them could ever be resumed, and which one depends on import order.
-            #
-            # The same file imported under two names is a different thing and
-            # must keep working, so this compares where the code came from
-            # rather than the module it was imported as. `is` will not do here:
-            # a re-import builds a fresh function object from the same source,
-            # so the objects differ while the origin does not.
-            #
-            # This mirrors `register_class` below, which compares identity and
-            # raises only when the objects genuinely differ.
-            previous = _code_origin(self.workflow_info_map.get(name))
-            current = _code_origin(wrapped_func)
-            if previous is not None and current is not None and previous != current:
-                raise DBOSException(
-                    f"Operation (Name: {name}) is registered by two different "
-                    f"functions, at {previous[0]}:{previous[1]} and "
-                    f"{current[0]}:{current[1]}. A registered name is the durable "
-                    f"identity used to resume a workflow, so only one of these "
-                    f"could be recovered, and which one depends on import order."
-                )
+            # Error if a workflow is registered with the same name in different modules.
+            if not name.startswith("<temp>."):
+                previous = _code_origin(self.workflow_info_map.get(name))
+                current = _code_origin(wrapped_func)
+                if previous is not None and current is not None and previous != current:
+                    raise DBOSException(
+                        f"Operation (Name: {name}) is registered by two different "
+                        f"functions, at {previous[0]}:{previous[1]} and "
+                        f"{current[0]}:{current[1]}."
+                    )
             if name != TEMP_SEND_WF_NAME:
                 # Remove the `<temp>` prefix from the function name to avoid confusion
                 truncated_name = name.replace("<temp>.", "")

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -152,6 +152,7 @@ from ._dbos_config import (
 )
 from ._error import (
     DBOSConflictingRegistrationError,
+    DBOSDuplicateWorkflowNameError,
     DBOSException,
     DBOSNonExistentWorkflowError,
     DBOSPatchNondeterminismError,
@@ -239,6 +240,21 @@ class DBOSRegistry:
         if name in self.function_type_map:
             if self.function_type_map[name] != functype:
                 raise DBOSConflictingRegistrationError(name)
+            # Two functions in *different* modules claiming one registered name is
+            # not a re-registration: the name is the durable identity recovery
+            # resolves, so only one of them could ever be resumed. Same-module
+            # re-registration (module reload, notebook cell re-run) keeps the
+            # existing warning.
+            previous_module = getattr(self.workflow_info_map.get(name), "__module__", None)
+            current_module = getattr(wrapped_func, "__module__", None)
+            if (
+                previous_module is not None
+                and current_module is not None
+                and previous_module != current_module
+            ):
+                raise DBOSDuplicateWorkflowNameError(
+                    name, previous_module, current_module
+                )
             if name != TEMP_SEND_WF_NAME:
                 # Remove the `<temp>` prefix from the function name to avoid confusion
                 truncated_name = name.replace("<temp>.", "")

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -240,7 +240,7 @@ class DBOSRegistry:
             if self.function_type_map[name] != functype:
                 raise DBOSConflictingRegistrationError(name)
             # Error if a workflow is registered with the same name in different modules.
-            if not name.startswith("<temp>."):
+            if functype == "workflow":
 
                 def code_origin(fn: Any) -> Optional[Tuple[str, int]]:
                     """Where a function's code was defined, as (file, first line)."""

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -219,21 +219,6 @@ RegisteredJob = Tuple[
 ]
 
 
-def _code_origin(fn: Any) -> Optional[Tuple[str, int]]:
-    """Where a function's code was defined, as (file, first line).
-
-    Two imports of one file yield different function objects sharing an origin;
-    two different functions never share one. Decorated callables are unwrapped
-    so the comparison sees the underlying definition.
-    """
-    while fn is not None and hasattr(fn, "__wrapped__"):
-        fn = fn.__wrapped__
-    code = getattr(fn, "__code__", None)
-    if code is None:
-        return None
-    return (code.co_filename, code.co_firstlineno)
-
-
 class DBOSRegistry:
     def __init__(self) -> None:
         self.workflow_info_map: dict[str, Callable[..., Any]] = {}
@@ -256,8 +241,18 @@ class DBOSRegistry:
                 raise DBOSConflictingRegistrationError(name)
             # Error if a workflow is registered with the same name in different modules.
             if not name.startswith("<temp>."):
-                previous = _code_origin(self.workflow_info_map.get(name))
-                current = _code_origin(wrapped_func)
+
+                def code_origin(fn: Any) -> Optional[Tuple[str, int]]:
+                    """Where a function's code was defined, as (file, first line)."""
+                    while fn is not None and hasattr(fn, "__wrapped__"):
+                        fn = fn.__wrapped__
+                    code = getattr(fn, "__code__", None)
+                    if code is None:
+                        return None
+                    return (code.co_filename, code.co_firstlineno)
+
+                previous = code_origin(self.workflow_info_map.get(name))
+                current = code_origin(wrapped_func)
                 if previous is not None and current is not None and previous != current:
                     raise DBOSException(
                         f"Operation (Name: {name}) is registered by two different "

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -242,22 +242,30 @@ class DBOSRegistry:
             # Error if a workflow is registered with the same name in different modules.
             if functype == "workflow":
 
-                def code_origin(fn: Any) -> Optional[Tuple[str, int]]:
-                    """Where a function's code was defined, as (file, first line)."""
-                    while fn is not None and hasattr(fn, "__wrapped__"):
-                        fn = fn.__wrapped__
-                    code = getattr(fn, "__code__", None)
-                    if code is None:
+                def code_origin(fn: Any) -> Optional[Tuple[str, str]]:
+                    """Where a function came from, as (module, real source path)."""
+                    try:
+                        fn = inspect.unwrap(fn)
+                    except ValueError:
                         return None
-                    return (code.co_filename, code.co_firstlineno)
+                    code = getattr(fn, "__code__", None)
+                    module = getattr(fn, "__module__", None)
+                    if code is None or module is None:
+                        return None
+                    return (module, os.path.realpath(code.co_filename))
 
                 previous = code_origin(self.workflow_info_map.get(name))
                 current = code_origin(wrapped_func)
-                if previous is not None and current is not None and previous != current:
+                if (
+                    previous is not None
+                    and current is not None
+                    and previous[0] != current[0]
+                    and previous[1] != current[1]
+                ):
                     raise DBOSException(
                         f"Operation (Name: {name}) is registered by two different "
-                        f"functions, at {previous[0]}:{previous[1]} and "
-                        f"{current[0]}:{current[1]}."
+                        f"functions, {previous[0]} at {previous[1]} and "
+                        f"{current[0]} at {current[1]}."
                     )
             if name != TEMP_SEND_WF_NAME:
                 # Remove the `<temp>` prefix from the function name to avoid confusion

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -152,7 +152,6 @@ from ._dbos_config import (
 )
 from ._error import (
     DBOSConflictingRegistrationError,
-    DBOSDuplicateWorkflowNameError,
     DBOSException,
     DBOSNonExistentWorkflowError,
     DBOSPatchNondeterminismError,
@@ -220,6 +219,21 @@ RegisteredJob = Tuple[
 ]
 
 
+def _code_origin(fn: Any) -> Optional[Tuple[str, int]]:
+    """Where a function's code was defined, as (file, first line).
+
+    Two imports of one file yield different function objects sharing an origin;
+    two different functions never share one. Decorated callables are unwrapped
+    so the comparison sees the underlying definition.
+    """
+    while fn is not None and hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    code = getattr(fn, "__code__", None)
+    if code is None:
+        return None
+    return (code.co_filename, code.co_firstlineno)
+
+
 class DBOSRegistry:
     def __init__(self) -> None:
         self.workflow_info_map: dict[str, Callable[..., Any]] = {}
@@ -240,20 +254,27 @@ class DBOSRegistry:
         if name in self.function_type_map:
             if self.function_type_map[name] != functype:
                 raise DBOSConflictingRegistrationError(name)
-            # Two functions in *different* modules claiming one registered name is
-            # not a re-registration: the name is the durable identity recovery
-            # resolves, so only one of them could ever be resumed. Same-module
-            # re-registration (module reload, notebook cell re-run) keeps the
-            # existing warning.
-            previous_module = getattr(self.workflow_info_map.get(name), "__module__", None)
-            current_module = getattr(wrapped_func, "__module__", None)
-            if (
-                previous_module is not None
-                and current_module is not None
-                and previous_module != current_module
-            ):
-                raise DBOSDuplicateWorkflowNameError(
-                    name, previous_module, current_module
+            # A registered name is the durable identity recovery resolves, so two
+            # genuinely different functions cannot both claim one: only one of
+            # them could ever be resumed, and which one depends on import order.
+            #
+            # The same file imported under two names is a different thing and
+            # must keep working, so this compares where the code came from
+            # rather than the module it was imported as. `is` will not do here:
+            # a re-import builds a fresh function object from the same source,
+            # so the objects differ while the origin does not.
+            #
+            # This mirrors `register_class` below, which compares identity and
+            # raises only when the objects genuinely differ.
+            previous = _code_origin(self.workflow_info_map.get(name))
+            current = _code_origin(wrapped_func)
+            if previous is not None and current is not None and previous != current:
+                raise DBOSException(
+                    f"Operation (Name: {name}) is registered by two different "
+                    f"functions, at {previous[0]}:{previous[1]} and "
+                    f"{current[0]}:{current[1]}. A registered name is the durable "
+                    f"identity used to resume a workflow, so only one of these "
+                    f"could be recovered, and which one depends on import order."
                 )
             if name != TEMP_SEND_WF_NAME:
                 # Remove the `<temp>` prefix from the function name to avoid confusion

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -258,7 +258,6 @@ class DBOSConflictingRegistrationError(DBOSException):
         )
 
 
-
 class DBOSUnexpectedStepError(DBOSException):
     """Exception raised when a step has an unexpected recorded name."""
 

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -70,7 +70,6 @@ class DBOSErrorCode(Enum):
     StepTimeout = 18
     ConflictingRegistrationError = 25
     QueryTimeout = 26
-    DuplicateWorkflowName = 27
 
 
 #######################################
@@ -258,17 +257,6 @@ class DBOSConflictingRegistrationError(DBOSException):
             dbos_error_code=DBOSErrorCode.ConflictingRegistrationError.value,
         )
 
-
-class DBOSDuplicateWorkflowNameError(DBOSException):
-    """Exception raised when two functions in different modules register the same name."""
-
-    def __init__(self, name: str, first_module: str, second_module: str) -> None:
-        super().__init__(
-            f"Operation (Name: {name}) is registered by both '{first_module}' and "
-            f"'{second_module}'. Registered names are the durable identity used to "
-            f"resume a workflow, so only one of these can be recovered.",
-            dbos_error_code=DBOSErrorCode.DuplicateWorkflowName.value,
-        )
 
 
 class DBOSUnexpectedStepError(DBOSException):

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -70,6 +70,7 @@ class DBOSErrorCode(Enum):
     StepTimeout = 18
     ConflictingRegistrationError = 25
     QueryTimeout = 26
+    DuplicateWorkflowName = 27
 
 
 #######################################
@@ -255,6 +256,18 @@ class DBOSConflictingRegistrationError(DBOSException):
         super().__init__(
             f"Operation (Name: {name}) is already registered with a conflicting function type",
             dbos_error_code=DBOSErrorCode.ConflictingRegistrationError.value,
+        )
+
+
+class DBOSDuplicateWorkflowNameError(DBOSException):
+    """Exception raised when two functions in different modules register the same name."""
+
+    def __init__(self, name: str, first_module: str, second_module: str) -> None:
+        super().__init__(
+            f"Operation (Name: {name}) is registered by both '{first_module}' and "
+            f"'{second_module}'. Registered names are the durable identity used to "
+            f"resume a workflow, so only one of these can be recovered.",
+            dbos_error_code=DBOSErrorCode.DuplicateWorkflowName.value,
         )
 
 

--- a/tests/dupname_workflows1.py
+++ b/tests/dupname_workflows1.py
@@ -1,0 +1,7 @@
+from dbos import DBOS
+
+
+@DBOS.workflow()
+def duplicated_workflow_name(x: int) -> str:
+    """Duplicates the registered name of a workflow in dupname_workflowsa.py"""
+    return f"one:{x}"

--- a/tests/dupname_workflowsa.py
+++ b/tests/dupname_workflowsa.py
@@ -1,0 +1,7 @@
+from dbos import DBOS
+
+
+@DBOS.workflow()
+def duplicated_workflow_name(x: int) -> str:
+    """Duplicates the registered name of a workflow in dupname_workflows1.py"""
+    return f"a:{x}"

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -1,7 +1,11 @@
+import importlib
 import logging
+import os
+import sys
 import threading
 import time
 import uuid
+from types import ModuleType
 from typing import Callable, Optional
 
 import pytest
@@ -9,11 +13,11 @@ import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfiguredInstance, Queue, SetWorkflowID
-from dbos._error import DBOSException
 
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context
 from dbos._dbos_config import DBOSConfig
+from dbos._error import DBOSException
 from tests.conftest import queue_entries_are_cleaned_up, set_workflow_status
 
 
@@ -1009,48 +1013,100 @@ def test_class_with_only_steps(dbos: DBOS) -> None:
     assert steps[1]["output"] == steps[1]["output"] == input * 2
 
 
+def _fresh_import(module_name: str) -> ModuleType:
+    """Import a module, re-running its decorators even if it is already cached."""
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def _capture_dbos_warnings(caplog: pytest.LogCaptureFixture) -> Callable[[], None]:
+    """Route dbos warnings into caplog; returns a restore callable."""
+    original_propagate = logging.getLogger("dbos").propagate
+    caplog.set_level(logging.WARNING, "dbos")
+    logging.getLogger("dbos").propagate = True
+
+    def restore() -> None:
+        logging.getLogger("dbos").propagate = original_propagate
+
+    return restore
+
+
 def test_duplicate_workflow_name_across_modules(dbos: DBOS) -> None:
     """A registered name is the durable identity recovery resolves, so two
     genuinely different functions cannot both claim one."""
-    import tests.dupname_workflows1  # noqa: F401
+    # Imported fresh so the decorators run against this test's registry
+    # regardless of what an earlier test already pulled into sys.modules.
+    _fresh_import("tests.dupname_workflows1")
 
     with pytest.raises(DBOSException) as exc_info:
-        import tests.dupname_workflowsa  # noqa: F401
+        _fresh_import("tests.dupname_workflowsa")
 
     assert "duplicated_workflow_name" in str(exc_info.value)
     assert "dupname_workflows1.py" in str(exc_info.value)
     assert "dupname_workflowsa.py" in str(exc_info.value)
 
 
-def test_same_file_imported_under_two_names_still_warns(dbos: DBOS) -> None:
-    """The case that must not raise: one file, imported twice under different
-    module names. The function objects differ but the code came from the same
-    place, so this is a re-registration and keeps warning."""
-    import importlib
-    import sys
+def test_same_file_imported_under_two_names_warns(
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One file reached under two module names is a re-registration, not a
+    collision: the function objects differ but the code came from one place."""
+    restore = _capture_dbos_warnings(caplog)
+    try:
+        first = _fresh_import("tests.dupname_workflows1")
+        # The same file, reached again as a top-level module: a second, distinct
+        # sys.modules entry built from one source file.
+        monkeypatch.syspath_prepend(os.path.dirname(__file__))
+        second = _fresh_import("dupname_workflows1")
 
-    import tests.dupname_workflows1
+        assert second is not first
+        # Identity would wrongly reject this; the shared code origin is what makes
+        # it a re-registration.
+        assert second.duplicated_workflow_name is not first.duplicated_workflow_name
+        assert (
+            "Duplicate registration of function 'duplicated_workflow_name'"
+            in caplog.text
+        )
+    finally:
+        sys.modules.pop("dupname_workflows1", None)
+        restore()
 
-    first = tests.dupname_workflows1.duplicated_workflow_name
 
-    sys.modules.pop("tests.dupname_workflows1", None)
-    reimported = importlib.import_module("tests.dupname_workflows1")
-    second = reimported.duplicated_workflow_name
+def test_module_reload_warns(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
+    """Reloading a module re-runs its decorators against the same source. That is
+    a re-registration and must keep warning rather than raise."""
+    restore = _capture_dbos_warnings(caplog)
+    try:
+        module = _fresh_import("tests.dupname_workflows1")
+        importlib.reload(module)
 
-    # different objects, same origin -- which is exactly why identity is not
-    # the right test and the origin is
-    assert first is not second
-    assert first.__code__.co_filename == second.__code__.co_filename
+        assert (
+            "Duplicate registration of function 'duplicated_workflow_name'"
+            in caplog.text
+        )
+    finally:
+        restore()
 
 
-def test_duplicate_workflow_name_same_module_still_allowed(dbos: DBOS) -> None:
-    """Registering the same name twice from one module is how a reloaded module
-    or a re-run notebook cell behaves; it must keep warning rather than raise."""
+def test_duplicate_step_name_warns(
+    dbos: DBOS, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A step registers a `<temp>` name wrapping a library-local closure, so its
+    code origin is DBOS's own source and is never compared. A sync and an async
+    step are two such closures, and must not be reported as two user functions."""
+    restore = _capture_dbos_warnings(caplog)
+    try:
 
-    @DBOS.workflow()
-    def reregistered(x: int) -> str:
-        return "first"
+        @DBOS.step(name="duplicated_step_name")
+        def step_one() -> str:
+            return "one"
 
-    @DBOS.workflow(name="reregistered")
-    def reregistered_again(x: int) -> str:
-        return "second"
+        @DBOS.step(name="duplicated_step_name")
+        async def step_two() -> str:
+            return "two"
+
+        assert (
+            "Duplicate registration of function 'duplicated_step_name'" in caplog.text
+        )
+    finally:
+        restore()

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -13,6 +13,7 @@ from dbos import DBOS, DBOSConfiguredInstance, Queue, SetWorkflowID
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context
 from dbos._dbos_config import DBOSConfig
+from dbos._error import DBOSDuplicateWorkflowNameError
 from tests.conftest import queue_entries_are_cleaned_up, set_workflow_status
 
 
@@ -1006,3 +1007,30 @@ def test_class_with_only_steps(dbos: DBOS) -> None:
     steps = DBOS.list_workflow_steps(handle.workflow_id)
     assert len(steps) == 2
     assert steps[1]["output"] == steps[1]["output"] == input * 2
+
+
+def test_duplicate_workflow_name_across_modules(dbos: DBOS) -> None:
+    """A registered name is the durable identity recovery resolves, so two
+    modules cannot both claim one. Re-registration inside a single module
+    (module reload, notebook cell re-run) stays a warning."""
+    import tests.dupname_workflows1  # noqa: F401
+
+    with pytest.raises(DBOSDuplicateWorkflowNameError) as exc_info:
+        import tests.dupname_workflowsa  # noqa: F401
+
+    assert "duplicated_workflow_name" in str(exc_info.value)
+    assert "dupname_workflows1" in str(exc_info.value)
+    assert "dupname_workflowsa" in str(exc_info.value)
+
+
+def test_duplicate_workflow_name_same_module_still_allowed(dbos: DBOS) -> None:
+    """Registering the same name twice from one module is how a reloaded module
+    or a re-run notebook cell behaves; it must keep warning rather than raise."""
+
+    @DBOS.workflow()
+    def reregistered(x: int) -> str:
+        return "first"
+
+    @DBOS.workflow(name="reregistered")
+    def reregistered_again(x: int) -> str:
+        return "second"

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -16,6 +16,7 @@ from dbos import DBOS, DBOSConfiguredInstance, Queue, SetWorkflowID
 
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context
+from dbos._dbos import _get_or_create_dbos_registry
 from dbos._dbos_config import DBOSConfig
 from dbos._error import DBOSException
 from tests.conftest import queue_entries_are_cleaned_up, set_workflow_status
@@ -1019,18 +1020,6 @@ def _fresh_import(module_name: str) -> ModuleType:
     return importlib.import_module(module_name)
 
 
-def _capture_dbos_warnings(caplog: pytest.LogCaptureFixture) -> Callable[[], None]:
-    """Route dbos warnings into caplog; returns a restore callable."""
-    original_propagate = logging.getLogger("dbos").propagate
-    caplog.set_level(logging.WARNING, "dbos")
-    logging.getLogger("dbos").propagate = True
-
-    def restore() -> None:
-        logging.getLogger("dbos").propagate = original_propagate
-
-    return restore
-
-
 def test_duplicate_workflow_name_across_modules(dbos: DBOS) -> None:
     """A registered name is the durable identity recovery resolves, so two
     genuinely different functions cannot both claim one."""
@@ -1045,13 +1034,21 @@ def test_duplicate_workflow_name_across_modules(dbos: DBOS) -> None:
     assert "dupname_workflows1.py" in str(exc_info.value)
     assert "dupname_workflowsa.py" in str(exc_info.value)
 
+    # The first registration is the one that survives -- the guarantee the durable
+    # name depends on, and the reason the raise precedes the registry writes.
+    registered = _get_or_create_dbos_registry().workflow_info_map[
+        "duplicated_workflow_name"
+    ]
+    assert getattr(registered, "__wrapped__")(1) == "one:1"
+
 
 def test_same_file_imported_under_two_names_warns(
     dbos: DBOS, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """One file reached under two module names is a re-registration, not a
     collision: the function objects differ but the code came from one place."""
-    restore = _capture_dbos_warnings(caplog)
+    caplog.set_level(logging.WARNING, "dbos")
+    monkeypatch.setattr(logging.getLogger("dbos"), "propagate", True)
     try:
         first = _fresh_import("tests.dupname_workflows1")
         # The same file, reached again as a top-level module: a second, distinct
@@ -1069,44 +1066,39 @@ def test_same_file_imported_under_two_names_warns(
         )
     finally:
         sys.modules.pop("dupname_workflows1", None)
-        restore()
 
 
-def test_module_reload_warns(dbos: DBOS, caplog: pytest.LogCaptureFixture) -> None:
+def test_module_reload_warns(
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Reloading a module re-runs its decorators against the same source. That is
     a re-registration and must keep warning rather than raise."""
-    restore = _capture_dbos_warnings(caplog)
-    try:
-        module = _fresh_import("tests.dupname_workflows1")
-        importlib.reload(module)
+    caplog.set_level(logging.WARNING, "dbos")
+    monkeypatch.setattr(logging.getLogger("dbos"), "propagate", True)
 
-        assert (
-            "Duplicate registration of function 'duplicated_workflow_name'"
-            in caplog.text
-        )
-    finally:
-        restore()
+    module = _fresh_import("tests.dupname_workflows1")
+    importlib.reload(module)
+
+    assert (
+        "Duplicate registration of function 'duplicated_workflow_name'" in caplog.text
+    )
 
 
 def test_duplicate_step_name_warns(
-    dbos: DBOS, caplog: pytest.LogCaptureFixture
+    dbos: DBOS, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A step registers a `<temp>` name wrapping a library-local closure, so its
-    code origin is DBOS's own source and is never compared. A sync and an async
-    step are two such closures, and must not be reported as two user functions."""
-    restore = _capture_dbos_warnings(caplog)
-    try:
+    """Only workflows are checked. A step's registered function is a library-local
+    closure, and the sync and async ones live at different lines of _core.py, so
+    comparing their origins would report two DBOS internals as two user functions."""
+    caplog.set_level(logging.WARNING, "dbos")
+    monkeypatch.setattr(logging.getLogger("dbos"), "propagate", True)
 
-        @DBOS.step(name="duplicated_step_name")
-        def step_one() -> str:
-            return "one"
+    @DBOS.step(name="duplicated_step_name")
+    def step_one() -> str:
+        return "one"
 
-        @DBOS.step(name="duplicated_step_name")
-        async def step_two() -> str:
-            return "two"
+    @DBOS.step(name="duplicated_step_name")
+    async def step_two() -> str:
+        return "two"
 
-        assert (
-            "Duplicate registration of function 'duplicated_step_name'" in caplog.text
-        )
-    finally:
-        restore()
+    assert "Duplicate registration of function 'duplicated_step_name'" in caplog.text

--- a/tests/test_classdecorators.py
+++ b/tests/test_classdecorators.py
@@ -9,11 +9,11 @@ import sqlalchemy as sa
 
 # Public API
 from dbos import DBOS, DBOSConfiguredInstance, Queue, SetWorkflowID
+from dbos._error import DBOSException
 
 # Private API used because this is a test
 from dbos._context import DBOSContextEnsure, assert_current_dbos_context
 from dbos._dbos_config import DBOSConfig
-from dbos._error import DBOSDuplicateWorkflowNameError
 from tests.conftest import queue_entries_are_cleaned_up, set_workflow_status
 
 
@@ -1011,16 +1011,36 @@ def test_class_with_only_steps(dbos: DBOS) -> None:
 
 def test_duplicate_workflow_name_across_modules(dbos: DBOS) -> None:
     """A registered name is the durable identity recovery resolves, so two
-    modules cannot both claim one. Re-registration inside a single module
-    (module reload, notebook cell re-run) stays a warning."""
+    genuinely different functions cannot both claim one."""
     import tests.dupname_workflows1  # noqa: F401
 
-    with pytest.raises(DBOSDuplicateWorkflowNameError) as exc_info:
+    with pytest.raises(DBOSException) as exc_info:
         import tests.dupname_workflowsa  # noqa: F401
 
     assert "duplicated_workflow_name" in str(exc_info.value)
-    assert "dupname_workflows1" in str(exc_info.value)
-    assert "dupname_workflowsa" in str(exc_info.value)
+    assert "dupname_workflows1.py" in str(exc_info.value)
+    assert "dupname_workflowsa.py" in str(exc_info.value)
+
+
+def test_same_file_imported_under_two_names_still_warns(dbos: DBOS) -> None:
+    """The case that must not raise: one file, imported twice under different
+    module names. The function objects differ but the code came from the same
+    place, so this is a re-registration and keeps warning."""
+    import importlib
+    import sys
+
+    import tests.dupname_workflows1
+
+    first = tests.dupname_workflows1.duplicated_workflow_name
+
+    sys.modules.pop("tests.dupname_workflows1", None)
+    reimported = importlib.import_module("tests.dupname_workflows1")
+    second = reimported.duplicated_workflow_name
+
+    # different objects, same origin -- which is exactly why identity is not
+    # the right test and the origin is
+    assert first is not second
+    assert first.__code__.co_filename == second.__code__.co_filename
 
 
 def test_duplicate_workflow_name_same_module_still_allowed(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1951,18 +1951,14 @@ def test_duplicate_registration(
         my_step()
         my_transaction()
 
-    # Unlike a step or a transaction, a workflow name is the durable identity
-    # recovery resolves, so a second function claiming it is refused outright.
-    with pytest.raises(DBOSException) as exc_info:
-
-        @DBOS.workflow()
-        def my_workflow() -> None:
-            my_step()
-            my_transaction()
+    @DBOS.workflow()
+    def my_workflow() -> None:
+        my_step()
+        my_transaction()
 
     assert (
-        "Operation (Name: test_duplicate_registration.<locals>.my_workflow) is registered by two different functions"
-        in str(exc_info.value)
+        "Duplicate registration of function 'test_duplicate_registration.<locals>.my_workflow'"
+        in caplog.text
     )
 
     DBOS.destroy()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1912,11 +1912,13 @@ def test_double_decoration(dbos: DBOS) -> None:
 
 
 def test_duplicate_registration(
-    dbos: DBOS, caplog: pytest.LogCaptureFixture, config: DBOSConfig
+    dbos: DBOS,
+    caplog: pytest.LogCaptureFixture,
+    config: DBOSConfig,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    original_propagate = logging.getLogger("dbos").propagate
     caplog.set_level(logging.WARNING, "dbos")
-    logging.getLogger("dbos").propagate = True
+    monkeypatch.setattr(logging.getLogger("dbos"), "propagate", True)
 
     @DBOS.transaction()
     def my_transaction() -> None:
@@ -1966,9 +1968,6 @@ def test_duplicate_registration(
     DBOS.destroy()
     DBOS(config=config)
     DBOS.launch()
-
-    # Reset logging
-    logging.getLogger("dbos").propagate = original_propagate
 
 
 def test_app_version(

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1949,14 +1949,18 @@ def test_duplicate_registration(
         my_step()
         my_transaction()
 
-    @DBOS.workflow()
-    def my_workflow() -> None:
-        my_step()
-        my_transaction()
+    # Unlike a step or a transaction, a workflow name is the durable identity
+    # recovery resolves, so a second function claiming it is refused outright.
+    with pytest.raises(DBOSException) as exc_info:
+
+        @DBOS.workflow()
+        def my_workflow() -> None:
+            my_step()
+            my_transaction()
 
     assert (
-        "Duplicate registration of function 'test_duplicate_registration.<locals>.my_workflow'"
-        in caplog.text
+        "Operation (Name: test_duplicate_registration.<locals>.my_workflow) is registered by two different functions"
+        in str(exc_info.value)
     )
 
     DBOS.destroy()


### PR DESCRIPTION
Closes #837.

`register_wf_function` treats a same-name, same-type registration as a re-registration: it warns and overwrites. That is right for a reloaded module or a re-run notebook cell, but it also silently accepts two *different* functions in two *different* modules claiming one registered name — and that name is the durable identity recovery resolves.

## The part that made me open a PR rather than leave the issue

`_core.py` resumes a stored workflow with `workflow_info_map.get(status["name"], None)`. The registry keeps whichever module registered last. So which code a crashed workflow resumes into is decided by **import order**, which is not durable and is recorded nowhere:

```
same durable input: status['name'] = 'process'

import billing, shipping   ->  recovery resolves to: shipping
import shipping, billing   ->  recovery resolves to: billing
```

Two runs, one stored row, two different functions. Import order can differ between the process that crashed and the process that recovers — a different entry point, a different worker image, a later refactor that moves an import.

## What this changes

A duplicate from a *different* module raises `DBOSDuplicateWorkflowNameError`. A duplicate from the *same* module keeps the existing warning, so module reload and notebook re-runs are unaffected.

```
cross-module duplicate      -> raises
same-module re-registration -> warns, as before
```

This follows what the codebase already does elsewhere: a same-name duplicate of a different *type* raises `DBOSConflictingRegistrationError`, and `register_class` raises on duplicate class names — with cross-module fixtures already in `tests/` for exactly that case.

## Changes

- `dbos/_error.py` — `DBOSDuplicateWorkflowNameError` (code 27), naming both modules
- `dbos/_dbos.py` — the module comparison in `register_wf_function`
- `tests/dupname_workflows1.py`, `tests/dupname_workflowsa.py` — fixtures, mirroring `dupname_classdefs*.py`
- `tests/test_classdecorators.py` — cross-module duplicate raises; same-module re-registration does not

## What I have and have not verified

I ran the registration half against `dbos 2.31.0` with the patch applied: the cross-module case raises, and the same-module re-registration still only warns. I have **not** run a full crash-and-recover against a live system database, so the recovery consequence is read from the three lines above rather than observed end to end.

@safal207 @mstevens843 — you have both built crash/recovery harnesses recently. If either of you has time, the measurement I could not make is whether a workflow row written under one module actually resumes into the other's function against a real system DB. That is the claim this rests on, and I would rather have it measured than argued.

If maintainers would prefer the warning to stay and this to be documented instead, that is a reasonable call and I will close it — the asymmetry with class registration is what made me think it was an oversight rather than a decision.