### PR TITLE
fix: avoid starving the async client executor while waiting for workflows

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -616,10 +616,8 @@ class DBOSClient:
         handle_map: Dict[str, "WorkflowHandleAsync[Any]"] = {
             h.workflow_id: h for h in handles
         }
-        completed_id = await asyncio.to_thread(
-            self._sys_db.await_first_workflow_id,
-            workflow_ids,
-            polling_interval_sec,
+        completed_id = await self._sys_db.await_first_workflow_id_async(
+            workflow_ids, polling_interval_sec
         )
         return handle_map[completed_id]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Optional, TypedDict
 
@@ -29,6 +30,7 @@ from dbos import (
 )
 from dbos._dbos import WorkflowHandle, WorkflowHandleAsync
 from dbos._error import DBOSException, DBOSNonExistentWorkflowError
+from dbos._outcome import NoResult
 from dbos._schemas.system_database import SystemSchema
 from dbos._sys_db import db_retry
 from dbos._utils import retriable_sqlite_exception
@@ -41,6 +43,69 @@ class Person(TypedDict):
     first: str
     last: str
     age: int
+
+
+@pytest.mark.parametrize("cancel_waiter", [False, True], ids=["waiting", "cancelled"])
+def test_wait_first_async_does_not_starve_client_executor(
+    dbos: DBOS, client: DBOSClient, monkeypatch: pytest.MonkeyPatch, cancel_waiter: bool
+) -> None:
+    release = threading.Event()
+
+    @DBOS.workflow()
+    def blocked_workflow() -> str:
+        assert release.wait(timeout=15)
+        return "finished"
+
+    handle = DBOS.start_workflow(blocked_workflow)
+
+    async def run_client() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
+        first_poll = asyncio.Event()
+        check_first = client._sys_db.check_first_workflow_id
+
+        def observe_poll(workflow_ids: list[str]) -> NoResult | str:
+            result = check_first(workflow_ids)
+            loop.call_soon_threadsafe(first_poll.set)
+            return result
+
+        monkeypatch.setattr(client._sys_db, "check_first_workflow_id", observe_poll)
+        client_handle: WorkflowHandleAsync[str] = await client.retrieve_workflow_async(
+            handle.get_workflow_id()
+        )
+        waiter = asyncio.create_task(
+            client.wait_first_async([client_handle], polling_interval_sec=0.01)
+        )
+        try:
+            await asyncio.wait_for(first_poll.wait(), timeout=5)
+            if cancel_waiter:
+                waiter.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await waiter
+
+            # This real database read shares the client's bounded executor.
+            # A polling thread held until workflow completion would starve it,
+            # including after its wait_first_async caller has been cancelled.
+            status = await asyncio.wait_for(client_handle.get_status(), timeout=2)
+            assert status.status == "PENDING"
+            release.set()
+            if not cancel_waiter:
+                assert await asyncio.wait_for(waiter, timeout=5) is client_handle
+            assert (
+                await asyncio.wait_for(client_handle.get_result(), timeout=5)
+                == "finished"
+            )
+        finally:
+            release.set()
+            waiter.cancel()
+            await asyncio.gather(waiter, return_exceptions=True)
+
+    try:
+        # A client-only event loop keeps DBOS's workflow executor separate.
+        asyncio.run(run_client())
+    finally:
+        release.set()
+        assert handle.get_result() == "finished"
 
 
 def run_client_collateral() -> None:


### PR DESCRIPTION
`DBOSClient.wait_first_async()` runs the entire synchronous polling loop in `asyncio.to_thread()`. Each pending wait holds a worker until a workflow finishes, and cancelling the caller leaves that polling thread alive. Enough waits can starve other client operations using the same executor, including operations needed to advance the workflows being awaited.

Use the existing `await_first_workflow_id_async()` helper, as `DBOS.wait_first_async()` already does. Database queries still run off the event loop, but the interval between queries uses an async sleep and caller cancellation stops polling.

Validation on Windows / Python 3.13 with a real SQLite database:

- Two regressions fail before the change and pass after it. A client-only loop has a one-worker executor: a workflow status query must succeed while `wait_first_async()` is pending and after it is cancelled. The normal wait also returns the original handle and the persisted workflow result.
- `tests/test_client.py` passes 51 tests with five SQLite-inapplicable skips and the three unreachable-PostgreSQL cases below deselected. Another 48 tests in `tests/test_async.py` and `tests/test_async_workflow_management.py`, plus four existing wait-first/queue tests, pass (103 passed across these runs).
- Black, isort, scoped mypy and scoped Pyright pass. Full mypy with the CI Linux platform target reports an existing redundant cast in `dbos/cli/cli.py`; full Pyright reports existing FastAPI lifespan and Windows `SIGKILL` diagnostics. Both were reproduced on unmodified base `6c9c7d0` with the same interpreter and dependencies.
- The entire repository suite and PostgreSQL integration matrix were not run locally. Broader client-suite attempts hit the existing unreachable-PostgreSQL tests `test_client_lazy_defers_connecting`, `test_client_bad_url`, and `test_client_no_retry_raises_on_unreachable_database`; all three also fail or time out on the unmodified base.

Found through source inspection. Current open PRs and searches for `wait_first`/cancellation were checked; this addresses the client polling path, separate from #840's shared workflow-result future.
