### PR TITLE
Remove Legacy Partition Queue Interface

### DIFF
--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -373,8 +373,6 @@ class DBOSClient:
         application_name: Optional[str] = None,
         # Deprecated, retained for backwards compatibility
         concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
     ) -> Queue:
         """Register a queue from a client and persist it to the system database.
 
@@ -416,8 +414,6 @@ class DBOSClient:
             it. Defaults to the client's own application. Registering a queue
             already owned by a different application raises.
         :param concurrency: Deprecated. Use ``global_concurrency``.
-        :param priority_enabled: Deprecated. Priority is always enabled.
-        :param partition_queue: Deprecated. Use the ``partition_*`` limits.
 
         :returns: A :class:`Queue` bound to this client's system database.
         """
@@ -432,7 +428,6 @@ class DBOSClient:
             partition_concurrency=partition_concurrency,
             partition_worker_concurrency=partition_worker_concurrency,
             partition_limiter=partition_limiter,
-            partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
         )
@@ -456,8 +451,6 @@ class DBOSClient:
             worker_concurrency=worker_concurrency,
             rate_limit_max=limiter["limit"] if limiter else None,
             rate_limit_period_sec=limiter["period"] if limiter else None,
-            priority_enabled=priority_enabled,
-            partition_queue=partition_queue,
             partition_concurrency=partition_concurrency,
             partition_worker_concurrency=partition_worker_concurrency,
             partition_rate_limit_max=(
@@ -491,8 +484,6 @@ class DBOSClient:
         application_name: Optional[str] = None,
         # Deprecated, retained for backwards compatibility
         concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
     ) -> Queue:
         """Async version of :meth:`register_queue`."""
         return await asyncio.to_thread(
@@ -508,8 +499,6 @@ class DBOSClient:
                 on_conflict=on_conflict,
                 application_name=application_name,
                 concurrency=concurrency,
-                priority_enabled=priority_enabled,
-                partition_queue=partition_queue,
             )
         )
 

--- a/dbos/_conductor/protocol.py
+++ b/dbos/_conductor/protocol.py
@@ -907,8 +907,10 @@ class QueueOutput:
             worker_concurrency=q._worker_concurrency,
             rate_limit_max=q._limiter["limit"] if q._limiter else None,
             rate_limit_period_sec=q._limiter["period"] if q._limiter else None,
-            priority_enabled=q._priority_enabled,
-            partition_queue=q._partition_queue,
+            # Legacy fields: every queue is a priority queue, and any
+            # per-partition limit makes a queue partitioned.
+            priority_enabled=True,
+            partition_queue=q._has_partition_limits(),
             polling_interval_sec=q._polling_interval_sec,
             application_name=q.application_name,
             partition_concurrency=q._partition_concurrency,

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -975,8 +975,6 @@ class DBOS:
         on_conflict: QueueConflictResolution = "update_if_latest_version",
         # Deprecated, retained for backwards compatibility
         concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
     ) -> Queue:
         """
         Register a queue and persist its configuration to the system database.
@@ -1022,8 +1020,6 @@ class DBOS:
             mode: the name is its address, so a collision is not ours to resolve.
 
         :param concurrency: Deprecated. Use ``global_concurrency``.
-        :param priority_enabled: Deprecated. Priority is always enabled.
-        :param partition_queue: Deprecated. Use the ``partition_*`` limits.
 
         :returns: A :class:`Queue` reflecting the persisted configuration.
         """
@@ -1036,7 +1032,6 @@ class DBOS:
             partition_concurrency=partition_concurrency,
             partition_worker_concurrency=partition_worker_concurrency,
             partition_limiter=partition_limiter,
-            partition_queue=partition_queue,
             polling_interval_sec=polling_interval_sec,
             limiter=limiter,
         )
@@ -1058,8 +1053,6 @@ class DBOS:
             worker_concurrency=worker_concurrency,
             rate_limit_max=limiter["limit"] if limiter else None,
             rate_limit_period_sec=limiter["period"] if limiter else None,
-            priority_enabled=priority_enabled,
-            partition_queue=partition_queue,
             partition_concurrency=partition_concurrency,
             partition_worker_concurrency=partition_worker_concurrency,
             partition_rate_limit_max=(
@@ -1097,8 +1090,6 @@ class DBOS:
         on_conflict: QueueConflictResolution = "update_if_latest_version",
         # Deprecated, retained for backwards compatibility
         concurrency: Optional[int] = None,
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
     ) -> Queue:
         """Async version of :meth:`register_queue`."""
         await cls._configure_asyncio_thread_pool()
@@ -1114,8 +1105,6 @@ class DBOS:
                 polling_interval_sec=polling_interval_sec,
                 on_conflict=on_conflict,
                 concurrency=concurrency,
-                priority_enabled=priority_enabled,
-                partition_queue=partition_queue,
             )
         )
 

--- a/dbos/_debouncer.py
+++ b/dbos/_debouncer.py
@@ -82,9 +82,8 @@ def _reject_conflicting_options(
     """A debounce owns the workflow's deduplication ID (the debounce key) and its
     delay (the debounce period), so a caller must not also set them, nor a
     duplication policy over the key the debounce owns. Priority and partition keys
-    are rejected because they cannot apply to a debounced enqueue (the default
-    internal queue has no priority, and partitioned queues do not support the
-    deduplication a debounce requires)."""
+    are rejected because they cannot apply to a debounced enqueue (partitioned
+    queues do not support the deduplication a debounce requires)."""
     if has_deduplication_id:
         raise DBOSException(
             "Cannot debounce a workflow with a deduplication_id set: the debounce "

--- a/dbos/_kafka.py
+++ b/dbos/_kafka.py
@@ -92,8 +92,8 @@ def _validate_consumer_queue(dbos: "DBOS", func_name: str, queue_name: str) -> N
             return
     if queue is None:
         return
-    # Read the cached field: the property would re-fetch a database-backed queue.
-    if queue._partition_queue:
+    # Read the cached fields: the properties would re-fetch a database-backed queue.
+    if queue._has_partition_limits():
         raise DBOSInitializationError(
             f"Error: Kafka consumer {func_name}'s queue {queue_name} is a "
             "partitioned queue, which a custom Kafka queue must not be; "

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -112,9 +112,6 @@ class Queue:
         database_backed_queue: bool = False,
         client_system_database: Optional["SystemDatabase"] = None,
         application_name: Optional[str] = None,
-        # Deprecated, retained for backwards compatibility
-        priority_enabled: bool = False,
-        partition_queue: bool = False,
         # Proof the caller is DBOS itself; see _INTERNAL_QUEUE_CONSTRUCTION.
         token: object = None,
     ) -> None:
@@ -137,12 +134,9 @@ class Queue:
         )
         self._worker_concurrency = worker_concurrency
         self._limiter = limiter
-        self._priority_enabled = priority_enabled
         self._partition_concurrency = partition_concurrency
         self._partition_worker_concurrency = partition_worker_concurrency
         self._partition_limiter = partition_limiter
-        # Partitioning is inferred from any per-partition limit
-        self._partition_queue = partition_queue or self._has_partition_limits()
         self._polling_interval_sec = polling_interval_sec
 
     @staticmethod
@@ -157,7 +151,6 @@ class Queue:
         partition_concurrency: Optional[int] = None,
         partition_worker_concurrency: Optional[int] = None,
         partition_limiter: Optional[QueueRateLimit] = None,
-        partition_queue: bool = False,
     ) -> None:
         """Validate queue configuration parameters, raising ValueError on bad input."""
         if name.startswith(RESERVED_QUEUE_NAME_PREFIX):
@@ -168,18 +161,6 @@ class Queue:
         if concurrency is not None and global_concurrency is not None:
             raise ValueError(
                 "concurrency is deprecated in favor of global_concurrency; set only one of them"
-            )
-        if partition_queue and (
-            partition_concurrency is not None
-            or partition_worker_concurrency is not None
-            or partition_limiter is not None
-        ):
-            raise ValueError(
-                "partition_queue is deprecated in favor of the partition_* limits; set only one of them"
-            )
-        if partition_queue and global_concurrency is not None:
-            raise ValueError(
-                "partition_queue applies every limit per partition, so it cannot be combined with global_concurrency; use partition_concurrency instead"
             )
         if partition_concurrency is not None and partition_concurrency < 1:
             raise ValueError("partition_concurrency must be at least 1")
@@ -209,7 +190,6 @@ class Queue:
             raise ValueError(
                 "worker_concurrency must be greater than or equal to partition_worker_concurrency"
             )
-        # In the deprecated partition_queue mode concurrency is itself a per-partition limit, so the worker_concurrency check below compares like with like.
         queue_concurrency = (
             concurrency if global_concurrency is None else global_concurrency
         )
@@ -258,22 +238,8 @@ class Queue:
         values.update(overrides)
         return any(value is not None for value in values.values())
 
-    def _is_legacy_partitioned(self) -> bool:
-        """True when the queue uses the deprecated partition_queue mode, under
-        which concurrency, worker_concurrency, and limiter all apply per partition."""
-        return self._partition_queue and not self._has_partition_limits()
-
     def _resolve_limits(self) -> ResolvedQueueLimits:
         """Resolve every limit to the scope it is enforced at."""
-        if self._is_legacy_partitioned():
-            return ResolvedQueueLimits(
-                global_concurrency=None,
-                worker_concurrency=None,
-                limiter=None,
-                partition_concurrency=self._concurrency,
-                partition_worker_concurrency=self._worker_concurrency,
-                partition_limiter=self._limiter,
-            )
         return ResolvedQueueLimits(
             global_concurrency=self._concurrency,
             worker_concurrency=self._worker_concurrency,
@@ -282,16 +248,6 @@ class Queue:
             partition_worker_concurrency=self._partition_worker_concurrency,
             partition_limiter=self._partition_limiter,
         )
-
-    def _require_not_legacy_partitioned(self, field: str) -> None:
-        """Reject a write that would re-scope the other limits on a legacy queue."""
-        if self._is_legacy_partitioned():
-            raise DBOSException(
-                f"Cannot set {field} on queue {self.name}: it is registered with the "
-                "deprecated partition_queue option, under which concurrency, "
-                "worker_concurrency, and limiter apply per partition. Re-register the "
-                "queue with the partition_* limits instead."
-            )
 
     def _check_concurrency_bounds(self, value: Optional[int]) -> None:
         """Validate a new concurrency against the cached sibling limits."""
@@ -346,8 +302,6 @@ class Queue:
         self._concurrency = latest._concurrency
         self._worker_concurrency = latest._worker_concurrency
         self._limiter = latest._limiter
-        self._priority_enabled = latest._priority_enabled
-        self._partition_queue = latest._partition_queue
         self._partition_concurrency = latest._partition_concurrency
         self._partition_worker_concurrency = latest._partition_worker_concurrency
         self._partition_limiter = latest._partition_limiter
@@ -418,7 +372,6 @@ class Queue:
             "Queue.set_global_concurrency", "Queue.set_global_concurrency_async"
         )
         self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("global_concurrency")
         self._check_concurrency_bounds(value)
         self._write_to_db({"concurrency": value})
         self._concurrency = value
@@ -450,7 +403,6 @@ class Queue:
         if value is not None and value < 1:
             raise ValueError("partition_concurrency must be at least 1")
         self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("partition_concurrency")
         if value is not None:
             if self._concurrency is not None and value > self._concurrency:
                 raise ValueError(
@@ -463,13 +415,16 @@ class Queue:
                 raise ValueError(
                     "partition_concurrency must be greater than or equal to partition_worker_concurrency"
                 )
-        # Partitioning is inferred from the limits, so the deprecated flag follows them.
-        partitioned = self._partitioned_after(_partition_concurrency=value)
         self._write_to_db(
-            {"partition_concurrency": value, "partition_queue": partitioned}
+            {
+                "partition_concurrency": value,
+                # Legacy column, still read by other SDKs: keep it in step with the limits.
+                "partition_queue": self._partitioned_after(
+                    _partition_concurrency=value
+                ),
+            }
         )
         self._partition_concurrency = value
-        self._partition_queue = partitioned
 
     async def set_partition_concurrency_async(self, value: Optional[int]) -> None:
         await self._configure_thread_pool()
@@ -500,7 +455,6 @@ class Queue:
         if value is not None and value < 1:
             raise ValueError("partition_worker_concurrency must be at least 1")
         self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("partition_worker_concurrency")
         if value is not None:
             if (
                 self._partition_concurrency is not None
@@ -520,12 +474,15 @@ class Queue:
                 raise ValueError(
                     "partition_worker_concurrency must be less than or equal to concurrency"
                 )
-        partitioned = self._partitioned_after(_partition_worker_concurrency=value)
         self._write_to_db(
-            {"partition_worker_concurrency": value, "partition_queue": partitioned}
+            {
+                "partition_worker_concurrency": value,
+                "partition_queue": self._partitioned_after(
+                    _partition_worker_concurrency=value
+                ),
+            }
         )
         self._partition_worker_concurrency = value
-        self._partition_queue = partitioned
 
     async def set_partition_worker_concurrency_async(
         self, value: Optional[int]
@@ -557,18 +514,16 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_partition_limiter", "Queue.set_partition_limiter_async"
         )
+        # Refresh so the derived column below sees the latest partition limits.
         self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("partition_limiter")
-        partitioned = self._partitioned_after(_partition_limiter=value)
         self._write_to_db(
             {
                 "partition_rate_limit_max": value["limit"] if value else None,
                 "partition_rate_limit_period_sec": value["period"] if value else None,
-                "partition_queue": partitioned,
+                "partition_queue": self._partitioned_after(_partition_limiter=value),
             }
         )
         self._partition_limiter = value
-        self._partition_queue = partitioned
 
     async def set_partition_limiter_async(
         self, value: Optional[QueueRateLimit]
@@ -599,7 +554,6 @@ class Queue:
         # Refresh the local cache so the cross-field check below validates
         # against the latest concurrency stored in the database.
         self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("worker_concurrency")
         if value is not None:
             if self._concurrency is not None and value > self._concurrency:
                 raise ValueError(
@@ -643,9 +597,6 @@ class Queue:
         _warn_sync_db_call_in_async_context(
             "Queue.set_limiter", "Queue.set_limiter_async"
         )
-        # Refresh so the check below sees the latest partition limits.
-        self._refresh_fields(self._read_from_db())
-        self._require_not_legacy_partitioned("limiter")
         self._write_to_db(
             {
                 "rate_limit_max": value["limit"] if value else None,
@@ -657,75 +608,6 @@ class Queue:
     async def set_limiter_async(self, value: Optional[QueueRateLimit]) -> None:
         await self._configure_thread_pool()
         await asyncio.to_thread(self.set_limiter, value)
-
-    @property
-    def priority_enabled(self) -> bool:
-        """Deprecated. Priority is always enabled."""
-        if self.database_backed_queue:
-            _warn_sync_db_call_in_async_context(
-                "Queue.priority_enabled", "Queue.get_priority_enabled_async"
-            )
-            self._refresh_fields(self._read_from_db())
-        return self._priority_enabled
-
-    async def get_priority_enabled_async(self) -> bool:
-        """Deprecated. Priority is always enabled."""
-        if self.database_backed_queue:
-            await self._configure_thread_pool()
-            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._priority_enabled
-
-    def set_priority_enabled(self, value: bool) -> None:
-        """Deprecated. Priority is always enabled."""
-        self._require_database_backed()
-        _warn_sync_db_call_in_async_context(
-            "Queue.set_priority_enabled", "Queue.set_priority_enabled_async"
-        )
-        self._write_to_db({"priority_enabled": value})
-        self._priority_enabled = value
-
-    async def set_priority_enabled_async(self, value: bool) -> None:
-        """Deprecated. Priority is always enabled."""
-        await self._configure_thread_pool()
-        await asyncio.to_thread(self.set_priority_enabled, value)
-
-    @property
-    def partition_queue(self) -> bool:
-        """Deprecated. Use the partition_* limits."""
-        if self.database_backed_queue:
-            _warn_sync_db_call_in_async_context(
-                "Queue.partition_queue", "Queue.get_partition_queue_async"
-            )
-            self._refresh_fields(self._read_from_db())
-        return self._partition_queue
-
-    async def get_partition_queue_async(self) -> bool:
-        """Deprecated. Use the partition_* limits."""
-        if self.database_backed_queue:
-            await self._configure_thread_pool()
-            self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._partition_queue
-
-    def set_partition_queue(self, value: bool) -> None:
-        """Deprecated. Use the set_partition_* setters."""
-        self._require_database_backed()
-        _warn_sync_db_call_in_async_context(
-            "Queue.set_partition_queue", "Queue.set_partition_queue_async"
-        )
-        # Refresh so the check below sees the latest partition limits.
-        self._refresh_fields(self._read_from_db())
-        if self._has_partition_limits():
-            raise DBOSException(
-                f"Cannot set partition_queue on queue {self.name}: it is partitioned "
-                "by its partition_* limits. Clear those instead."
-            )
-        self._write_to_db({"partition_queue": value})
-        self._partition_queue = value
-
-    async def set_partition_queue_async(self, value: bool) -> None:
-        """Deprecated. Use the set_partition_*_async setters."""
-        await self._configure_thread_pool()
-        await asyncio.to_thread(self.set_partition_queue, value)
 
     @property
     def polling_interval_sec(self) -> float:
@@ -879,7 +761,7 @@ def queue_worker_thread(
 
         try:
             limits = queue._resolve_limits()
-            if not queue._partition_queue:
+            if not queue._has_partition_limits():
                 dequeued_workflows = dbos._sys_db.start_queued_workflows(
                     queue,
                     GlobalParams.executor_id,
@@ -1044,7 +926,7 @@ def queue_thread(stop_event: threading.Event, dbos: "DBOS") -> None:
 def log_queue(q: Queue) -> None:
     """Log a single queue's name and its set parameters. Unset parameters
     are omitted, matching ``Queue: <name> (concurrency=…, worker_concurrency=…,
-    limit=N/Ts, priority, partitioned)``."""
+    limit=N/Ts, partition_concurrency=…)``."""
     opts = []
     if q._has_partition_limits():
         if q._concurrency is not None:
@@ -1063,10 +945,6 @@ def log_queue(q: Queue) -> None:
         opts.append(
             f"partition_limit={q._partition_limiter['limit']}/{q._partition_limiter['period']}s"
         )
-    if q._priority_enabled:
-        opts.append("priority")
-    if q._partition_queue:
-        opts.append("partitioned")
     opts_str = f" ({', '.join(opts)})" if opts else ""
     dbos_logger.info(f"Queue: {q.name}{opts_str}")
 

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -3,7 +3,6 @@ import copy
 import random
 import sys
 import threading
-from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -74,18 +73,6 @@ class QueueRateLimit(TypedDict):
 
     limit: int
     period: float
-
-
-@dataclass
-class ResolvedQueueLimits:
-    """A snapshot of a queue's limits, named by the scope each is enforced at."""
-
-    global_concurrency: Optional[int]
-    worker_concurrency: Optional[int]
-    limiter: Optional[QueueRateLimit]
-    partition_concurrency: Optional[int]
-    partition_worker_concurrency: Optional[int]
-    partition_limiter: Optional[QueueRateLimit]
 
 
 class Queue:
@@ -237,17 +224,6 @@ class Queue:
         }
         values.update(overrides)
         return any(value is not None for value in values.values())
-
-    def _resolve_limits(self) -> ResolvedQueueLimits:
-        """Snapshot every limit for the dequeue paths, named by its scope."""
-        return ResolvedQueueLimits(
-            global_concurrency=self._concurrency,
-            worker_concurrency=self._worker_concurrency,
-            limiter=self._limiter,
-            partition_concurrency=self._partition_concurrency,
-            partition_worker_concurrency=self._partition_worker_concurrency,
-            partition_limiter=self._partition_limiter,
-        )
 
     def _check_concurrency_bounds(self, value: Optional[int]) -> None:
         """Validate a new concurrency against the cached sibling limits."""
@@ -718,17 +694,17 @@ def queue_worker_thread(
             except Exception as e:
                 dbos.logger.error(f"Error executing workflow {id}: {e}")
 
-    def worker_budget(limits: ResolvedQueueLimits, running: int) -> int:
+    def worker_budget(q: Queue, running: int) -> int:
         """Room left under this worker's queue-wide concurrency limit, given how many of
         its workflows are already running or claimed."""
         if (
-            limits.partition_worker_concurrency is not None
-            and limits.partition_worker_concurrency <= 0
+            q._partition_worker_concurrency is not None
+            and q._partition_worker_concurrency <= 0
         ):
             return 0
-        if limits.worker_concurrency is None:
+        if q._worker_concurrency is None:
             return sys.maxsize
-        return max(0, limits.worker_concurrency - running)
+        return max(0, q._worker_concurrency - running)
 
     while not stop_event.is_set():
         # Reload database-backed queue config once per iteration so dynamic
@@ -760,7 +736,6 @@ def queue_worker_thread(
             return
 
         try:
-            limits = queue._resolve_limits()
             if not queue._has_partition_limits():
                 dequeued_workflows = dbos._sys_db.start_queued_workflows(
                     queue,
@@ -771,14 +746,14 @@ def queue_worker_thread(
                 )
                 start_dequeued_workflows(dequeued_workflows)
             elif (
-                limits.partition_concurrency == 1
-                and limits.global_concurrency is None
-                and limits.limiter is None
-                and limits.partition_limiter is None
+                queue._partition_concurrency == 1
+                and queue._concurrency is None
+                and queue._limiter is None
+                and queue._partition_limiter is None
             ):
                 # Optimization: Batch dequeue if partition concurrency is 1
                 max_tasks = worker_budget(
-                    limits, dbos._active_workflows_set.count_for_queue(queue.name)
+                    queue, dbos._active_workflows_set.count_for_queue(queue.name)
                 )
                 if max_tasks > 0:
                     dequeued_workflows = (
@@ -798,7 +773,7 @@ def queue_worker_thread(
                 running = dbos._active_workflows_set.count_for_queue(queue.name)
                 claimed = 0
                 for key in partition_keys:
-                    if worker_budget(limits, running + claimed) <= 0:
+                    if worker_budget(queue, running + claimed) <= 0:
                         break
                     try:
                         dequeued_workflows = dbos._sys_db.start_queued_workflows(

--- a/dbos/_queue.py
+++ b/dbos/_queue.py
@@ -78,7 +78,7 @@ class QueueRateLimit(TypedDict):
 
 @dataclass
 class ResolvedQueueLimits:
-    """A queue's limits, each resolved to the scope it is enforced at."""
+    """A snapshot of a queue's limits, named by the scope each is enforced at."""
 
     global_concurrency: Optional[int]
     worker_concurrency: Optional[int]
@@ -239,7 +239,7 @@ class Queue:
         return any(value is not None for value in values.values())
 
     def _resolve_limits(self) -> ResolvedQueueLimits:
-        """Resolve every limit to the scope it is enforced at."""
+        """Snapshot every limit for the dequeue paths, named by its scope."""
         return ResolvedQueueLimits(
             global_concurrency=self._concurrency,
             worker_concurrency=self._worker_concurrency,
@@ -358,13 +358,13 @@ class Queue:
                 "Queue.global_concurrency", "Queue.get_global_concurrency_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().global_concurrency
+        return self._concurrency
 
     async def get_global_concurrency_async(self) -> Optional[int]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().global_concurrency
+        return self._concurrency
 
     def set_global_concurrency(self, value: Optional[int]) -> None:
         self._require_database_backed()
@@ -387,13 +387,13 @@ class Queue:
                 "Queue.partition_concurrency", "Queue.get_partition_concurrency_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().partition_concurrency
+        return self._partition_concurrency
 
     async def get_partition_concurrency_async(self) -> Optional[int]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().partition_concurrency
+        return self._partition_concurrency
 
     def set_partition_concurrency(self, value: Optional[int]) -> None:
         self._require_database_backed()
@@ -438,13 +438,13 @@ class Queue:
                 "Queue.get_partition_worker_concurrency_async",
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().partition_worker_concurrency
+        return self._partition_worker_concurrency
 
     async def get_partition_worker_concurrency_async(self) -> Optional[int]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().partition_worker_concurrency
+        return self._partition_worker_concurrency
 
     def set_partition_worker_concurrency(self, value: Optional[int]) -> None:
         self._require_database_backed()
@@ -497,13 +497,13 @@ class Queue:
                 "Queue.partition_limiter", "Queue.get_partition_limiter_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().partition_limiter
+        return self._partition_limiter
 
     async def get_partition_limiter_async(self) -> Optional[QueueRateLimit]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().partition_limiter
+        return self._partition_limiter
 
     def set_partition_limiter(self, value: Optional[QueueRateLimit]) -> None:
         self._require_database_backed()
@@ -538,13 +538,13 @@ class Queue:
                 "Queue.worker_concurrency", "Queue.get_worker_concurrency_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().worker_concurrency
+        return self._worker_concurrency
 
     async def get_worker_concurrency_async(self) -> Optional[int]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().worker_concurrency
+        return self._worker_concurrency
 
     def set_worker_concurrency(self, value: Optional[int]) -> None:
         self._require_database_backed()
@@ -580,13 +580,13 @@ class Queue:
                 "Queue.limiter", "Queue.get_limiter_async"
             )
             self._refresh_fields(self._read_from_db())
-        return self._resolve_limits().limiter
+        return self._limiter
 
     async def get_limiter_async(self) -> Optional[QueueRateLimit]:
         if self.database_backed_queue:
             await self._configure_thread_pool()
             self._refresh_fields(await asyncio.to_thread(self._read_from_db))
-        return self._resolve_limits().limiter
+        return self._limiter
 
     def set_limiter(self, value: Optional[QueueRateLimit]) -> None:
         self._require_database_backed()

--- a/dbos/_schemas/system_database.py
+++ b/dbos/_schemas/system_database.py
@@ -352,6 +352,8 @@ class SystemSchema:
         Column("worker_concurrency", Integer, nullable=True),
         Column("rate_limit_max", Integer, nullable=True),
         Column("rate_limit_period_sec", Float, nullable=True),
+        # Legacy columns, written for other SDKs but no longer read: every queue
+        # is a priority queue, and partitioning follows the partition_* limits.
         Column("priority_enabled", Boolean, nullable=False, server_default="false"),
         Column("partition_queue", Boolean, nullable=False, server_default="false"),
         # Any of these being set means the queue is partitioned; each applies per partition.

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -103,8 +103,6 @@ def queue_from_db_row(
         m["concurrency"],
         limiter,
         worker_concurrency=m["worker_concurrency"],
-        priority_enabled=bool(m["priority_enabled"]),
-        partition_queue=bool(m["partition_queue"]),
         partition_concurrency=m["partition_concurrency"],
         partition_worker_concurrency=m["partition_worker_concurrency"],
         partition_limiter=partition_limiter,
@@ -4704,7 +4702,7 @@ class SystemDatabase(ABC):
         from each active partition successively.
         """
         limits = queue._resolve_limits()
-        assert queue._partition_queue
+        assert queue._has_partition_limits()
         assert limits.partition_concurrency == 1
         assert limits.global_concurrency is None
         assert limits.limiter is None
@@ -6735,8 +6733,6 @@ class SystemDatabase(ABC):
         worker_concurrency: Optional[int],
         rate_limit_max: Optional[int],
         rate_limit_period_sec: Optional[float],
-        priority_enabled: bool,
-        partition_queue: bool,
         polling_interval_sec: float,
         update_existing: bool,
         application_name: Optional[str] = None,
@@ -6755,10 +6751,10 @@ class SystemDatabase(ABC):
             "worker_concurrency": worker_concurrency,
             "rate_limit_max": rate_limit_max,
             "rate_limit_period_sec": rate_limit_period_sec,
-            "priority_enabled": priority_enabled,
-            # Any per-partition limit implies partitioning, whichever mode was used.
-            "partition_queue": partition_queue
-            or partition_concurrency is not None
+            # Legacy columns, still read by other SDKs. Every queue is a priority
+            # queue now, and any per-partition limit implies partitioning.
+            "priority_enabled": True,
+            "partition_queue": partition_concurrency is not None
             or partition_worker_concurrency is not None
             or partition_rate_limit_max is not None,
             "partition_concurrency": partition_concurrency,

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -4439,18 +4439,17 @@ class SystemDatabase(ABC):
     ) -> List[str]:
         start_time_ms = int(time.time() * 1000)
         ws = SystemSchema.workflow_status
-        # Resolve from the queue's locally cached private state to avoid recursive DB reads
-        limits = queue._resolve_limits()
+        # Read the queue's cached private fields, not its accessors, which would re-fetch a database-backed queue. _concurrency is the queue-wide (global) limit.
         # Shares a concurrency or limiter budget with other executors
         has_shared_budget = (
-            limits.global_concurrency is not None
-            or limits.partition_concurrency is not None
-            or limits.limiter is not None
-            or limits.partition_limiter is not None
+            queue._concurrency is not None
+            or queue._partition_concurrency is not None
+            or queue._limiter is not None
+            or queue._partition_limiter is not None
         )
         # Shares a concurrency or limiter budget with other executors and other partitions
         has_write_skew = queue_partition_key is not None and (
-            limits.global_concurrency is not None or limits.limiter is not None
+            queue._concurrency is not None or queue._limiter is not None
         )
         with self.engine.begin() as c:
             # Otherwise READ COMMITTED
@@ -4507,53 +4506,53 @@ class SystemDatabase(ABC):
             # Compute max_tasks under every flow control limit enforced on this queue
             max_tasks = sys.maxsize
 
-            if limits.worker_concurrency is not None:
+            if queue._worker_concurrency is not None:
                 # Use the in-memory registry for this worker's running count — avoids a DB round trip.
                 max_tasks = min(
-                    max_tasks, max(0, limits.worker_concurrency - local_running_count)
+                    max_tasks, max(0, queue._worker_concurrency - local_running_count)
                 )
-            if limits.partition_worker_concurrency is not None:
+            if queue._partition_worker_concurrency is not None:
                 max_tasks = min(
                     max_tasks,
                     max(
                         0,
-                        limits.partition_worker_concurrency
+                        queue._partition_worker_concurrency
                         - partition_local_running_count,
                     ),
                 )
             if max_tasks <= 0:
                 return []
 
-            if limits.limiter is not None:
+            if queue._limiter is not None:
                 # Bound the claim by the limiter's remaining slots so a backlogged queue locks only what it can start.
-                max_tasks = min(max_tasks, rate_limit_remaining(limits.limiter, False))
-            if limits.partition_limiter is not None:
+                max_tasks = min(max_tasks, rate_limit_remaining(queue._limiter, False))
+            if queue._partition_limiter is not None:
                 max_tasks = min(
-                    max_tasks, rate_limit_remaining(limits.partition_limiter, True)
+                    max_tasks, rate_limit_remaining(queue._partition_limiter, True)
                 )
             if max_tasks <= 0:
                 return []
 
-            if limits.global_concurrency is not None:
+            if queue._concurrency is not None:
                 # Global concurrency still requires a DB query since other workers may be running workflows too.
                 global_pending_workflows = pending_count(False)
-                if global_pending_workflows > limits.global_concurrency:
+                if global_pending_workflows > queue._concurrency:
                     dbos_logger.warning(
-                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({limits.global_concurrency})"
+                        f"The total number of pending workflows ({global_pending_workflows}) on queue {queue.name} exceeds the global concurrency limit ({queue._concurrency})"
                     )
                 max_tasks = min(
                     max_tasks,
-                    max(0, limits.global_concurrency - global_pending_workflows),
+                    max(0, queue._concurrency - global_pending_workflows),
                 )
-            if limits.partition_concurrency is not None:
+            if queue._partition_concurrency is not None:
                 partition_pending_workflows = pending_count(True)
-                if partition_pending_workflows > limits.partition_concurrency:
+                if partition_pending_workflows > queue._partition_concurrency:
                     dbos_logger.warning(
-                        f"The total number of pending workflows ({partition_pending_workflows}) on partition {queue_partition_key} of queue {queue.name} exceeds the partition concurrency limit ({limits.partition_concurrency})"
+                        f"The total number of pending workflows ({partition_pending_workflows}) on partition {queue_partition_key} of queue {queue.name} exceeds the partition concurrency limit ({queue._partition_concurrency})"
                     )
                 max_tasks = min(
                     max_tasks,
-                    max(0, limits.partition_concurrency - partition_pending_workflows),
+                    max(0, queue._partition_concurrency - partition_pending_workflows),
                 )
             if max_tasks <= 0:
                 return []
@@ -4657,8 +4656,8 @@ class SystemDatabase(ABC):
                         # Claim it, so the unclaimed partition drains as workflows run.
                         application_name=self.app_name,
                         started_at_epoch_ms=self._now_ms_sql(),
-                        rate_limited=limits.limiter is not None
-                        or limits.partition_limiter is not None,
+                        rate_limited=queue._limiter is not None
+                        or queue._partition_limiter is not None,
                         # Count this dispatch against the DLQ limit; no later insert does it.
                         recovery_attempts=SystemSchema.workflow_status.c.recovery_attempts
                         + 1,
@@ -4701,12 +4700,11 @@ class SystemDatabase(ABC):
         case where partition_concurrency=1. All other cases iterate and dequeue
         from each active partition successively.
         """
-        limits = queue._resolve_limits()
         assert queue._has_partition_limits()
-        assert limits.partition_concurrency == 1
-        assert limits.global_concurrency is None
-        assert limits.limiter is None
-        assert limits.partition_limiter is None
+        assert queue._partition_concurrency == 1
+        assert queue._concurrency is None
+        assert queue._limiter is None
+        assert queue._partition_limiter is None
         start_time_ms = int(time.time() * 1000)
         ws = SystemSchema.workflow_status
         with self.engine.begin() as c:

--- a/tests/client_collateral.py
+++ b/tests/client_collateral.py
@@ -16,7 +16,7 @@ class Person(TypedDict):
 # the database-backed queues on the second pass.
 if _dbos_global_instance is not None and _dbos_global_instance._launched:
     DBOS.register_queue("test_queue")
-    DBOS.register_queue("inorder_queue", concurrency=1, priority_enabled=True)
+    DBOS.register_queue("inorder_queue", concurrency=1)
 inorder_results: List[str] = []
 
 

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -781,8 +781,6 @@ def test_conflicting_names_across_applications_raise(
                 worker_concurrency=None,
                 rate_limit_max=None,
                 rate_limit_period_sec=None,
-                priority_enabled=False,
-                partition_queue=False,
                 polling_interval_sec=1.0,
                 update_existing=update_existing,
             )
@@ -922,8 +920,6 @@ def test_two_applications_share_one_system_database(dbos: DBOS, config: Any) -> 
                 worker_concurrency=None,
                 rate_limit_max=None,
                 rate_limit_period_sec=None,
-                priority_enabled=False,
-                partition_queue=False,
                 polling_interval_sec=1.0,
                 update_existing=True,
             )

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -153,7 +153,7 @@ def test_debouncer_queue(dbos: DBOS) -> None:
         return x
 
     first_value, second_value, third_value, fourth_value = 0, 1, 2, 3
-    queue = DBOS.register_queue("test-queue", priority_enabled=True)
+    queue = DBOS.register_queue("test-queue")
 
     debouncer = Debouncer.create(workflow, queue=queue)
     debounce_period_sec = 2

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -1442,7 +1442,7 @@ def test_kafka_partitioned_queue_name_rejected_at_launch(
 
     # Register on the launched fixture instance; the row survives destroy.
     queue_name = f"dbos-test-kafka-partq-{random.randrange(1_000_000_000)}"
-    DBOS.register_queue(queue_name, partition_queue=True)
+    DBOS.register_queue(queue_name, partition_concurrency=1)
 
     DBOS.destroy(destroy_registry=True)
     DBOS(config=config)
@@ -1468,7 +1468,7 @@ def test_kafka_partitioned_queue_name_rejected_when_launched(dbos: DBOS) -> None
     from dbos._error import DBOSInitializationError
 
     queue_name = f"dbos-test-kafka-partq-live-{random.randrange(1_000_000_000)}"
-    DBOS.register_queue(queue_name, partition_queue=True)
+    DBOS.register_queue(queue_name, partition_concurrency=1)
 
     @DBOS.workflow()
     def live_partitioned_queue_wf(msg: KafkaMessage) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1810,7 +1810,7 @@ def test_resuming_queued_partitioned_workflows(
     def regular_workflow() -> None:
         return
 
-    # Enqueue a blocked workflow and two regular workflows on a queue with concurrency 1
+    # Enqueue a blocked workflow and two regular workflows on a queue with partition concurrency 1
     DBOS.register_queue("test_queue", partition_concurrency=1)
     wfid = str(uuid.uuid4())
     with SetEnqueueOptions(queue_partition_key="key"):
@@ -2315,10 +2315,6 @@ async def test_enqueue_async_validation(dbos: DBOS) -> None:
     ):
         with SetEnqueueOptions(queue_partition_key="key", deduplication_id="dedupe"):
             await queue.enqueue_async(noop_workflow)
-
-    # Every queue is a priority queue: priority needs no opt-in.
-    with SetEnqueueOptions(priority=1):
-        await queue.enqueue_async(noop_workflow)
 
 
 def test_worker_concurrency_across_versions(dbos: DBOS, client: DBOSClient) -> None:
@@ -3173,7 +3169,7 @@ def test_partitioned_batch_dequeue_sweep_cap(
 
 
 def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
-    """With concurrency=1, one batched call admits exactly each partition's
+    """With partition_concurrency=1, one batched call admits exactly each partition's
     head-of-line row; a partition admits nothing more until its head finishes."""
 
     @DBOS.workflow()
@@ -3617,7 +3613,7 @@ def test_partitioned_queue_global_exclusivity(
     monkeypatch: pytest.MonkeyPatch,
     skip_with_sqlite_imprecise_time: None,
 ) -> None:
-    """End-to-end concurrency=1: the queue worker dispatches to the batched path, and a
+    """End-to-end partition_concurrency=1: the queue worker dispatches to the batched path, and a
     partition runs strictly one workflow at a time in FIFO order, gated globally (no
     worker_concurrency is set, so only the PENDING-row check holds followers back)."""
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -33,6 +33,7 @@ from dbos import (
     SetWorkflowTimeout,
     WorkflowHandle,
 )
+from dbos._conductor.protocol import QueueOutput
 from dbos._context import assert_current_dbos_context
 from dbos._dbos import WorkflowHandleAsync
 from dbos._error import (
@@ -53,6 +54,19 @@ from tests.conftest import (
     set_workflow_status,
     using_sqlite,
 )
+
+
+def legacy_queue_columns(dbos: DBOS, name: str) -> tuple[bool, bool]:
+    """Read (priority_enabled, partition_queue) straight from the row. DBOS no longer
+    reads these columns, but other SDKs sharing the system database do."""
+    with dbos._sys_db.engine.begin() as c:
+        row = c.execute(
+            sa.select(
+                SystemSchema.queues.c.priority_enabled,
+                SystemSchema.queues.c.partition_queue,
+            ).where(SystemSchema.queues.c.name == name)
+        ).one()
+    return bool(row[0]), bool(row[1])
 
 
 def unpolled_queue(name: str, **kwargs: Any) -> Queue:
@@ -159,6 +173,13 @@ def test_queue_crud(dbos: DBOS) -> None:
         assert q.polling_interval_sec == 2.5
         assert q.database_backed_queue is True
 
+    # Priority is always on, and the partition_* limits make the queue partitioned.
+    assert legacy_queue_columns(dbos, queue_name) == (True, True)
+    # Conductor is told the same two things.
+    wire = QueueOutput.from_queue(retrieved)
+    assert wire.priority_enabled is True
+    assert wire.partition_queue is True
+
     # on_conflict="never_update" leaves the existing row alone.
     DBOS.register_queue(queue_name, concurrency=99, on_conflict="never_update")
     retrieved = DBOS.retrieve_queue(queue_name)
@@ -178,6 +199,9 @@ def test_queue_crud(dbos: DBOS) -> None:
     assert retrieved.partition_concurrency is None
     assert retrieved.partition_worker_concurrency is None
     assert retrieved.partition_limiter is None
+    # Clearing them clears the derived column, and priority stays on.
+    assert legacy_queue_columns(dbos, queue_name) == (True, False)
+    assert QueueOutput.from_queue(retrieved).partition_queue is False
 
     # on_conflict="update_if_latest_version" updates when the running version
     # is the latest registered version.
@@ -210,6 +234,7 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         worker_concurrency=2,
         polling_interval_sec=1.0,
     )
+    assert legacy_queue_columns(dbos, queue_name) == (True, False)
 
     # Setters write to the database; getters read from it.
     queue.set_global_concurrency(8)
@@ -230,6 +255,8 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         assert q.partition_worker_concurrency == 2
         assert q.partition_limiter == {"limit": 4, "period": 3.0}
         assert q.polling_interval_sec == 0.5
+    # Setting a per-partition limit partitions the queue for the other SDKs too.
+    assert legacy_queue_columns(dbos, queue_name) == (True, True)
 
     # Setters validate. worker_concurrency cannot exceed concurrency.
     with pytest.raises(ValueError):
@@ -251,10 +278,13 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     with pytest.raises(ValueError):
         queue.set_polling_interval_sec(0.0)
 
-    # Every per-partition limit can be cleared, un-partitioning the queue.
+    # Every per-partition limit can be cleared, un-partitioning the queue. The derived
+    # column tracks the limits, so it only clears with the last of them.
     queue.set_partition_concurrency(None)
     queue.set_partition_limiter(None)
+    assert legacy_queue_columns(dbos, queue_name) == (True, True)
     queue.set_partition_worker_concurrency(None)
+    assert legacy_queue_columns(dbos, queue_name) == (True, False)
     unpartitioned = DBOS.retrieve_queue(queue_name)
     assert unpartitioned is not None
     assert unpartitioned.partition_concurrency is None

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -136,7 +136,6 @@ def test_queue_crud(dbos: DBOS) -> None:
         partition_concurrency=4,
         partition_worker_concurrency=2,
         partition_limiter={"limit": 3, "period": 1.0},
-        priority_enabled=True,
         polling_interval_sec=2.5,
     )
     assert registered.name == queue_name
@@ -157,9 +156,6 @@ def test_queue_crud(dbos: DBOS) -> None:
         assert q.partition_concurrency == 4
         assert q.partition_worker_concurrency == 2
         assert q.partition_limiter == {"limit": 3, "period": 1.0}
-        # Setting any per-partition limit partitions the queue.
-        assert q.partition_queue is True
-        assert q.priority_enabled is True
         assert q.polling_interval_sec == 2.5
         assert q.database_backed_queue is True
 
@@ -177,13 +173,11 @@ def test_queue_crud(dbos: DBOS) -> None:
     assert retrieved.concurrency == 20
     assert retrieved.worker_concurrency is None
     assert retrieved.limiter is None
-    assert retrieved.priority_enabled is False
     assert retrieved.polling_interval_sec == 1.0
-    # Clearing every per-partition limit un-partitions the queue.
+    # Every per-partition limit is cleared too, un-partitioning the queue.
     assert retrieved.partition_concurrency is None
     assert retrieved.partition_worker_concurrency is None
     assert retrieved.partition_limiter is None
-    assert retrieved.partition_queue is False
 
     # on_conflict="update_if_latest_version" updates when the running version
     # is the latest registered version.
@@ -214,7 +208,6 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         queue_name,
         concurrency=4,
         worker_concurrency=2,
-        priority_enabled=False,
         polling_interval_sec=1.0,
     )
 
@@ -222,7 +215,6 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     queue.set_global_concurrency(8)
     queue.set_worker_concurrency(3)
     queue.set_limiter({"limit": 7, "period": 2.0})
-    queue.set_priority_enabled(True)
     queue.set_partition_concurrency(6)
     queue.set_partition_worker_concurrency(2)
     queue.set_partition_limiter({"limit": 4, "period": 3.0})
@@ -234,11 +226,9 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
         assert q.global_concurrency == 8
         assert q.worker_concurrency == 3
         assert q.limiter == {"limit": 7, "period": 2.0}
-        assert q.priority_enabled is True
         assert q.partition_concurrency == 6
         assert q.partition_worker_concurrency == 2
         assert q.partition_limiter == {"limit": 4, "period": 3.0}
-        assert q.partition_queue is True
         assert q.polling_interval_sec == 0.5
 
     # Setters validate. worker_concurrency cannot exceed concurrency.
@@ -261,45 +251,15 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     with pytest.raises(ValueError):
         queue.set_polling_interval_sec(0.0)
 
-    # Clearing the last per-partition limit un-partitions the queue.
+    # Every per-partition limit can be cleared, un-partitioning the queue.
     queue.set_partition_concurrency(None)
     queue.set_partition_limiter(None)
-    assert queue.partition_queue is True
     queue.set_partition_worker_concurrency(None)
-    assert queue.partition_queue is False
-
-    # A queue registered the deprecated way keeps applying every limit per
-    # partition, so the new getters report them at that scope and the queue-wide
-    # ones read as unset. Re-scoping it would silently change what it enforces.
-    legacy_name = f"test_legacy_queue_{uuid.uuid4()}"
-    legacy_queue = DBOS.register_queue(
-        legacy_name,
-        partition_queue=True,
-        concurrency=2,
-        worker_concurrency=1,
-        limiter={"limit": 7, "period": 2.0},
-    )
-    assert legacy_queue.partition_concurrency == 2
-    assert legacy_queue.partition_worker_concurrency == 1
-    assert legacy_queue.partition_limiter == {"limit": 7, "period": 2.0}
-    # Every queue-wide getter reads as unset, so no limit is reported at both scopes.
-    assert legacy_queue.global_concurrency is None
-    assert legacy_queue.worker_concurrency is None
-    assert legacy_queue.limiter is None
-    with pytest.raises(DBOSException):
-        legacy_queue.set_global_concurrency(5)
-    with pytest.raises(DBOSException):
-        legacy_queue.set_partition_concurrency(1)
-    # Every queue-wide setter is blocked too, not just the renamed ones: their getters
-    # read as None here, so a read-modify-write would otherwise clear the per-partition
-    # limit the queue actually enforces.
-    with pytest.raises(DBOSException):
-        legacy_queue.set_worker_concurrency(legacy_queue.worker_concurrency)
-    with pytest.raises(DBOSException):
-        legacy_queue.set_limiter(legacy_queue.limiter)
-    # The limits it actually enforces are untouched by the rejected writes.
-    assert legacy_queue.partition_worker_concurrency == 1
-    assert legacy_queue.partition_limiter == {"limit": 7, "period": 2.0}
+    unpartitioned = DBOS.retrieve_queue(queue_name)
+    assert unpartitioned is not None
+    assert unpartitioned.partition_concurrency is None
+    assert unpartitioned.partition_worker_concurrency is None
+    assert unpartitioned.partition_limiter is None
 
     # Limiter can be cleared.
     queue.set_limiter(None)
@@ -335,20 +295,6 @@ def test_queue_dynamic_config(dbos: DBOS) -> None:
     [
         # A deprecated argument cannot be combined with the one replacing it.
         ({"concurrency": 1, "global_concurrency": 1}, "only one of them"),
-        ({"partition_queue": True, "partition_concurrency": 1}, "only one of them"),
-        (
-            {"partition_queue": True, "partition_worker_concurrency": 1},
-            "only one of them",
-        ),
-        (
-            {"partition_queue": True, "partition_limiter": {"limit": 1, "period": 1.0}},
-            "only one of them",
-        ),
-        # partition_queue already applies every limit per partition.
-        (
-            {"global_concurrency": 5, "partition_queue": True},
-            "cannot be combined with global_concurrency",
-        ),
         # A per-partition limit above its queue-wide counterpart could never bind.
         (
             {"global_concurrency": 1, "partition_concurrency": 2},
@@ -396,7 +342,6 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
         global_concurrency=4,
         limiter={"limit": 5, "period": 1.5},
         worker_concurrency=2,
-        priority_enabled=True,
         polling_interval_sec=2.5,
     )
     assert queue.name == queue_name
@@ -410,7 +355,6 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     assert retrieved.concurrency == 4
     assert retrieved.worker_concurrency == 2
     assert retrieved.limiter == {"limit": 5, "period": 1.5}
-    assert retrieved.priority_enabled is True
     assert retrieved.polling_interval_sec == 2.5
 
     # list_queues returns queues bound to the client's SystemDatabase.
@@ -421,7 +365,6 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
     assert only.concurrency == 4
     assert only.worker_concurrency == 2
     assert only.limiter == {"limit": 5, "period": 1.5}
-    assert only.priority_enabled is True
     assert only.polling_interval_sec == 2.5
 
     # Setters write through the client's SystemDatabase too.
@@ -480,7 +423,6 @@ def test_client_queue_crud(dbos: DBOS, client: DBOSClient) -> None:
         assert q.partition_concurrency == 2
         assert q.partition_worker_concurrency == 1
         assert q.partition_limiter == {"limit": 2, "period": 1.0}
-        assert q.partition_queue is True
 
 
 @pytest.mark.asyncio
@@ -501,7 +443,6 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
         partition_concurrency=4,
         partition_worker_concurrency=2,
         partition_limiter={"limit": 3, "period": 1.0},
-        priority_enabled=True,
         polling_interval_sec=2.5,
     )
     assert registered.name == queue_name
@@ -518,8 +459,6 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
         assert await q.get_partition_concurrency_async() == 4
         assert await q.get_partition_worker_concurrency_async() == 2
         assert await q.get_partition_limiter_async() == {"limit": 3, "period": 1.0}
-        assert await q.get_partition_queue_async() is True
-        assert await q.get_priority_enabled_async() is True
         assert await q.get_polling_interval_sec_async() == 2.5
         assert q.database_backed_queue is True
 
@@ -528,7 +467,6 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
     await retrieved.set_global_concurrency_async(8)
     await retrieved.set_worker_concurrency_async(3)
     await retrieved.set_limiter_async({"limit": 7, "period": 2.0})
-    await retrieved.set_priority_enabled_async(True)
     await retrieved.set_partition_concurrency_async(6)
     await retrieved.set_partition_worker_concurrency_async(2)
     await retrieved.set_partition_limiter_async({"limit": 4, "period": 3.0})
@@ -539,11 +477,9 @@ async def test_queue_crud_async(dbos: DBOS) -> None:
     assert await fresh.get_global_concurrency_async() == 8
     assert await fresh.get_worker_concurrency_async() == 3
     assert await fresh.get_limiter_async() == {"limit": 7, "period": 2.0}
-    assert await fresh.get_priority_enabled_async() is True
     assert await fresh.get_partition_concurrency_async() == 6
     assert await fresh.get_partition_worker_concurrency_async() == 2
     assert await fresh.get_partition_limiter_async() == {"limit": 4, "period": 3.0}
-    assert await fresh.get_partition_queue_async() is True
     assert await fresh.get_polling_interval_sec_async() == 0.5
 
     # Async setters validate. worker_concurrency cannot exceed concurrency.
@@ -590,7 +526,6 @@ async def test_client_queue_crud_async(dbos: DBOS, client: DBOSClient) -> None:
         concurrency=4,
         limiter={"limit": 5, "period": 1.5},
         worker_concurrency=2,
-        priority_enabled=True,
         polling_interval_sec=2.5,
     )
     assert queue.name == queue_name
@@ -603,7 +538,6 @@ async def test_client_queue_crud_async(dbos: DBOS, client: DBOSClient) -> None:
     assert await retrieved.get_concurrency_async() == 4
     assert await retrieved.get_worker_concurrency_async() == 2
     assert await retrieved.get_limiter_async() == {"limit": 5, "period": 1.5}
-    assert await retrieved.get_priority_enabled_async() is True
     assert await retrieved.get_polling_interval_sec_async() == 2.5
 
     # list_queues_async returns queues bound to the client's SystemDatabase.
@@ -614,7 +548,6 @@ async def test_client_queue_crud_async(dbos: DBOS, client: DBOSClient) -> None:
     assert await only.get_concurrency_async() == 4
     assert await only.get_worker_concurrency_async() == 2
     assert await only.get_limiter_async() == {"limit": 5, "period": 1.5}
-    assert await only.get_priority_enabled_async() is True
     assert await only.get_polling_interval_sec_async() == 2.5
 
     await retrieved.set_concurrency_async(8)
@@ -1878,7 +1811,7 @@ def test_resuming_queued_partitioned_workflows(
         return
 
     # Enqueue a blocked workflow and two regular workflows on a queue with concurrency 1
-    DBOS.register_queue("test_queue", concurrency=1, partition_queue=True)
+    DBOS.register_queue("test_queue", partition_concurrency=1)
     wfid = str(uuid.uuid4())
     with SetEnqueueOptions(queue_partition_key="key"):
         blocked_handle = DBOS.enqueue_workflow("test_queue", stuck_workflow)
@@ -2244,7 +2177,7 @@ async def test_queue_deduplication_async(dbos: DBOS) -> None:
 
 
 def test_priority_queue(dbos: DBOS) -> None:
-    # Enqueue workflows with different priorities; priority_enabled is deprecated and ignored, so priority needs no opt-in.
+    # Enqueue workflows with different priorities; every queue is a priority queue, so priority needs no opt-in.
     DBOS.register_queue("test_queue_priority", concurrency=1)
     DBOS.register_queue("test_queue_child")
 
@@ -2383,7 +2316,7 @@ async def test_enqueue_async_validation(dbos: DBOS) -> None:
         with SetEnqueueOptions(queue_partition_key="key", deduplication_id="dedupe"):
             await queue.enqueue_async(noop_workflow)
 
-    # priority_enabled is deprecated and ignored: priority needs no opt-in.
+    # Every queue is a priority queue: priority needs no opt-in.
     with SetEnqueueOptions(priority=1):
         await queue.enqueue_async(noop_workflow)
 
@@ -2692,7 +2625,7 @@ def test_queue_partitions(dbos: DBOS, client: DBOSClient) -> None:
         assert DBOS.workflow_id
         return DBOS.workflow_id
 
-    DBOS.register_queue("queue", partition_queue=True, worker_concurrency=1)
+    DBOS.register_queue("queue", partition_worker_concurrency=1)
 
     blocked_partition_key = "blocked"
     normal_partition_key = "normal"
@@ -2803,11 +2736,10 @@ def test_partition_serialization_failure_skips_key(
     from psycopg import errors
     from sqlalchemy.exc import OperationalError
 
-    # concurrency=2 keeps this queue on the per-partition sweep loop; only concurrency=1 uses the batched path.
+    # partition_concurrency=2 keeps this queue on the per-partition sweep loop; only partition_concurrency=1 uses the batched path.
     queue = DBOS.register_queue(
         f"serialization_skip_{uuid.uuid4().hex[:8]}",
-        concurrency=2,
-        partition_queue=True,
+        partition_concurrency=2,
         polling_interval_sec=0.25,
     )
     # Sorts before the healthy key, so an escaping error would abort the sweep first.
@@ -2872,12 +2804,12 @@ def test_partition_serialization_failure_skips_key(
 
 
 @pytest.mark.asyncio
-async def test_partition_queue_worker_concurrency_async(dbos: DBOS) -> None:
-    """worker_concurrency is enforced *per partition* on a partitioned queue.
+async def test_partition_worker_concurrency_async(dbos: DBOS) -> None:
+    """partition_worker_concurrency is enforced *per partition*.
 
-    Each partition independently runs up to worker_concurrency async workflows
-    concurrently on this worker; partitions neither share the limit nor block
-    one another.
+    Each partition independently runs up to partition_worker_concurrency async
+    workflows concurrently on this worker; partitions neither share the limit nor
+    block one another.
     """
 
     worker_concurrency = 2
@@ -2904,7 +2836,7 @@ async def test_partition_queue_worker_concurrency_async(dbos: DBOS) -> None:
         return DBOS.workflow_id
 
     await DBOS.register_queue_async(
-        "queue", partition_queue=True, worker_concurrency=worker_concurrency
+        "queue", partition_worker_concurrency=worker_concurrency
     )
 
     # Enqueue more workflows per partition than the worker may run at once.
@@ -3224,7 +3156,7 @@ def test_partitioned_batch_dequeue_sweep_cap(
         pass
 
     queue_name = f"unpolled-sweep-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     partitions = [f"p{i}" for i in range(8)]
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "sweep", partitions, 1)
 
@@ -3249,7 +3181,7 @@ def test_partitioned_batch_dequeue_exclusive_direct(dbos: DBOS) -> None:
         pass
 
     queue_name = f"unpolled-excl-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     partitions = ["p0", "p1", "p2"]
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "excl", partitions, 3)
 
@@ -3278,7 +3210,7 @@ def test_partitioned_batch_dequeue_skips_requeued_rows(dbos: DBOS) -> None:
         pass
 
     queue_name = f"unpolled-requeue-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "requeue", ["p0"], 3)
     head_id = ids["p0"][0]
     # Resume onto another unpolled queue: the internal queue is live, and its worker would drain the row before the assertions below.
@@ -3371,7 +3303,7 @@ def test_partitioned_batch_dequeue_contention(dbos: DBOS) -> None:
         pass
 
     queue_name = f"unpolled-race-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     partitions = [f"p{i}" for i in range(4)]
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "race", partitions, 2)
 
@@ -3410,28 +3342,25 @@ def test_partitioned_queue_fallback_routing(
     dbos: DBOS, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A partitioned config the batched path does not support -- a rate limiter --
-    routes to the per-partition sweep and drains. A zero worker limit (the pause-dequeue
-    idiom, which a legacy queue resolves to the per-partition scope) exhausts this
-    worker's budget before either path runs.
+    routes to the per-partition sweep and drains. A zero worker limit (the
+    pause-dequeue idiom) exhausts this worker's budget before either path runs.
     """
 
     @DBOS.workflow()
     def routed_wf(tag: str) -> str:
         return tag
 
-    # Both are concurrency=1 partitioned queues, so only the limiter / the pause excludes them.
+    # Both are partition_concurrency=1 queues, so only the limiter / the pause excludes them.
     limiter_queue = DBOS.register_queue(
         f"limiter_fallback_{uuid.uuid4().hex[:8]}",
-        concurrency=1,
-        limiter={"limit": 10, "period": 60},
-        partition_queue=True,
+        partition_concurrency=1,
+        partition_limiter={"limit": 10, "period": 60},
         polling_interval_sec=0.25,
     )
     paused_queue = DBOS.register_queue(
         f"paused_fallback_{uuid.uuid4().hex[:8]}",
-        concurrency=1,
+        partition_concurrency=1,
         worker_concurrency=0,
-        partition_queue=True,
         polling_interval_sec=0.25,
     )
 
@@ -3499,7 +3428,7 @@ def test_partitioned_batch_dequeue_version_gating(dbos: DBOS) -> None:
         pass
 
     queue_name = f"unpolled-ver-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "ver", ["p0", "p1"], 3)
 
     def pin_version(wfid: str, version: Any) -> None:
@@ -3557,7 +3486,7 @@ def test_partitioned_batch_dequeue_sqlite_plan(dbos: DBOS) -> None:
         pass
 
     queue_name = f"unpolled-plan-{uuid.uuid4().hex[:8]}"
-    queue = unpolled_queue(queue_name, concurrency=1, partition_queue=True)
+    queue = unpolled_queue(queue_name, partition_concurrency=1)
     ids = _enqueue_partition_rows(dbos, batch_wf, queue_name, "plan", ["p0", "p1"], 2)
 
     captured: List[Any] = []
@@ -3714,8 +3643,7 @@ def test_partitioned_queue_global_exclusivity(
 
     queue = DBOS.register_queue(
         f"exclusive_{uuid.uuid4().hex[:8]}",
-        concurrency=1,
-        partition_queue=True,
+        partition_concurrency=1,
         polling_interval_sec=0.25,
     )
 


### PR DESCRIPTION
This PR will release in the next major version (3.0). It removes the deprecated legacy partition queue interface, which did not allow combining per-partition and per-queue flow control limits.