### PR TITLE
fix: finalize background async generators during shutdown

### DIFF
--- a/dbos/_event_loop.py
+++ b/dbos/_event_loop.py
@@ -73,6 +73,8 @@ class BackgroundEventLoop:
             task.cancel()
 
         await asyncio.gather(*tasks, return_exceptions=True)
+        # Suspended async generators are not tasks, but may still own resources.
+        await self._loop.shutdown_asyncgens()
         self._loop.stop()
 
     def set_main_loop(self) -> None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,7 +4,8 @@ import gc
 import threading
 import time
 import uuid
-from typing import Any, Dict, List, Optional, cast
+from pathlib import Path
+from typing import Any, AsyncGenerator, Dict, List, Optional, cast
 
 import pytest
 import sqlalchemy as sa
@@ -1371,6 +1372,58 @@ def test_destroy_from_adopted_main_loop_does_not_deadlock(
     )
     if scenario_error:
         raise scenario_error[0]
+
+
+@pytest.mark.parametrize("adopt_main_loop", [False, True], ids=["owned", "adopted"])
+def test_destroy_finalizes_only_owned_async_generators(
+    config: DBOSConfig,
+    cleanup_test_databases: None,
+    tmp_path: Path,
+    adopt_main_loop: bool,
+) -> None:
+    resource = (tmp_path / "stream.txt").open("w")
+
+    async def source() -> AsyncGenerator[str, None]:
+        try:
+            yield "ready"
+        finally:
+            # Stream cleanup may need the event loop for another await.
+            await asyncio.sleep(0)
+            resource.close()
+
+    stream = source()
+
+    @DBOS.workflow()
+    async def consume_one() -> str:
+        # Keep the suspended stream alive so garbage collection cannot mask
+        # whether runtime shutdown actually finalizes it.
+        return await anext(stream)
+
+    DBOS(config=config)
+    try:
+        if adopt_main_loop:
+
+            async def scenario() -> None:
+                DBOS.launch()
+                handle = await DBOS.start_workflow_async(consume_one)
+                assert await handle.get_result() == "ready"
+                DBOS.destroy()
+                # An application-owned loop and its streams remain usable.
+                assert not resource.closed
+                await stream.aclose()
+
+            asyncio.run(scenario())
+        else:
+            DBOS.launch()
+            handle = cast(WorkflowHandle[str], DBOS.start_workflow(consume_one))
+            assert handle.get_result() == "ready"
+            assert not resource.closed
+            DBOS.destroy()
+            assert resource.closed
+    finally:
+        DBOS.destroy(destroy_registry=True)
+        asyncio.run(stream.aclose())
+        resource.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When an async workflow leaves a generator suspended, `DBOS.destroy()` cancels tasks and closes the background loop without running the generator's finalizer. Resources held by the stream can remain open after shutdown.

Await `shutdown_asyncgens()` after task cancellation and before stopping the DBOS-owned loop. The regression exercises `DBOS.start_workflow()` and `DBOS.destroy()` with a real file whose finalizer includes an await; a control verifies that streams on an adopted application loop remain open for the application to manage.

Validation:
- The owned-loop regression fails before the fix; the adopted-loop control passes.
- Python 3.13 / SQLite: 100 related tests pass, 7 skipped. Python 3.10: all 4 new/adjacent shutdown tests pass.
- Configured Black/isort hooks and scoped mypy pass. Full Windows mypy reports the same 5 baseline diagnostics in the CLI and package tests. PostgreSQL tests were not run locally.
